### PR TITLE
fix(auto-update): resolve stale state and dismissed flag bugs

### DIFF
--- a/src/stores/updateStore.test.ts
+++ b/src/stores/updateStore.test.ts
@@ -70,13 +70,34 @@ describe("updateStore", () => {
     });
   });
 
+  describe("dismiss and clearDismissed", () => {
+    it("dismiss sets dismissed to true", () => {
+      const { dismiss } = useUpdateStore.getState();
+
+      dismiss();
+
+      expect(useUpdateStore.getState().dismissed).toBe(true);
+    });
+
+    it("clearDismissed resets dismissed to false", () => {
+      const { dismiss, clearDismissed } = useUpdateStore.getState();
+
+      dismiss();
+      expect(useUpdateStore.getState().dismissed).toBe(true);
+
+      clearDismissed();
+      expect(useUpdateStore.getState().dismissed).toBe(false);
+    });
+  });
+
   describe("reset", () => {
     it("resets all state to initial values", () => {
-      const { setError, setStatus, setUpdateInfo, reset } = useUpdateStore.getState();
+      const { setError, setStatus, setUpdateInfo, dismiss, reset } = useUpdateStore.getState();
 
       setError("Error");
       setStatus("error");
       setUpdateInfo({ version: "1.0.0", notes: "", pubDate: "", currentVersion: "0.9.0" });
+      dismiss();
 
       reset();
 
@@ -84,6 +105,7 @@ describe("updateStore", () => {
       expect(state.status).toBe("idle");
       expect(state.error).toBeNull();
       expect(state.updateInfo).toBeNull();
+      expect(state.dismissed).toBe(false);
     });
   });
 });

--- a/src/stores/updateStore.ts
+++ b/src/stores/updateStore.ts
@@ -43,6 +43,7 @@ interface UpdateActions {
   setDownloadProgress: (progress: ProgressUpdater) => void;
   setError: (error: string | null) => void;
   dismiss: () => void;
+  clearDismissed: () => void;
   reset: () => void;
 }
 
@@ -78,5 +79,6 @@ export const useUpdateStore = create<UpdateState & UpdateActions>()((set) => ({
       status: error !== null ? "error" : state.status,
     })),
   dismiss: () => set({ dismissed: true }),
+  clearDismissed: () => set({ dismissed: false }),
   reset: () => set(initialState),
 }));


### PR DESCRIPTION
## Summary

- Fix download progress accumulation bug that caused incorrect progress display during rapid updates
- Reset dismissed flag when new update is found so notification banner shows for new versions
- Only update lastCheckTimestamp on successful checks, not on errors

## Changes

### Bug Fixes

1. **Download progress stale state** - Changed from functional updater pattern to local variables to avoid stale closure issues during rapid `Progress` events

2. **Dismissed flag not resetting** - Added `clearDismissed()` call when new update is found, so users see the notification banner for new updates even after dismissing an older one

3. **lastCheckTimestamp on error** - Moved from `finally` block to success paths only, so the timestamp accurately reflects when the last *successful* check occurred

### New Features

- Added `clearDismissed` action to `updateStore` for resetting the dismissed state

## Test plan

- [x] All 2097 tests passing
- [x] Linting clean
- [ ] Manual test: Check for updates, dismiss banner, check again - banner should reappear
- [ ] Manual test: Download update and verify progress bar shows accurate percentage