### PR TITLE
Improve heading font size hierarchy

### DIFF
--- a/src/components/Editor/editor.css
+++ b/src/components/Editor/editor.css
@@ -176,29 +176,29 @@
 }
 
 .tiptap-editor h1 {
-  font-size: 1.75em;
+  font-size: 1.8em;
   padding-bottom: 0.3em;
   border-bottom: 1px solid var(--border-color);
 }
 
 .tiptap-editor h2 {
-  font-size: 1.5em;
+  font-size: 1.65em;
 }
 
 .tiptap-editor h3 {
-  font-size: 1.25em;
+  font-size: 1.5em;
 }
 
 .tiptap-editor h4 {
-  font-size: 1em;
+  font-size: 1.35em;
 }
 
 .tiptap-editor h5 {
-  font-size: 0.875em;
+  font-size: 1.25em;
 }
 
 .tiptap-editor h6 {
-  font-size: 0.85em;
+  font-size: 1.1em;
   color: var(--meta-content-color);
 }
 


### PR DESCRIPTION
## Summary
- Adjusted all heading font sizes to create a more consistent visual hierarchy
- H6 (smallest heading) is now 1.1em, ensuring it's visibly larger than base font size (1em)
- H1 increased from 1.75em to 1.8em
- All heading levels now follow a linear progression with ~0.15em steps

## Changes
| Heading | Before | After | Change |
|---------|--------|-------|--------|
| H1 | 1.75em | 1.8em | +0.05em |
| H2 | 1.5em | 1.65em | +0.15em |
| H3 | 1.25em | 1.5em | +0.25em |
| H4 | 1em | 1.35em | +0.35em |
| H5 | 0.875em | 1.25em | +0.375em |
| H6 | 0.85em | 1.1em | +0.25em |

## Rationale
Previously, H4 was the same size as body text (1em) and H5-H6 were actually smaller than body text. This made lower-level headings hard to distinguish. The new sizing ensures all headings are clearly differentiated from body text while maintaining proper hierarchy.

## Test plan
- [ ] Build and run the application
- [ ] Create a document with all heading levels (H1-H6)
- [ ] Verify visual hierarchy is clear and headings are distinguishable
- [ ] Check that H6 is visibly larger than body text