### PR TITLE
fix: prevent false document reload after save with line ending normalization

### DIFF
--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -3,7 +3,11 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
+
+/// Minimum interval between emitting events for the same path (debounce).
+const DEBOUNCE_INTERVAL: Duration = Duration::from_millis(200);
 
 /// Watchers keyed by watch_id (typically window label or unique identifier)
 static WATCHERS: Mutex<Option<HashMap<String, WatcherEntry>>> = Mutex::new(None);
@@ -81,19 +85,42 @@ fn should_ignore_path(path: &Path) -> bool {
     false
 }
 
+/// Per-path debounce state to suppress duplicate events from macOS FSEvents.
+/// Key: (watch_id, path), Value: last emitted time.
+static LAST_EMITTED: Mutex<Option<HashMap<(String, String), Instant>>> = Mutex::new(None);
+
 /// Handle a notify event and emit it to the frontend.
+/// Deduplicates events for the same path within DEBOUNCE_INTERVAL.
 fn handle_event(app: &AppHandle, watch_id: &str, root_path: &str, event: Event) {
     let Some(kind_str) = event_kind_to_string(&event.kind) else {
         return;
     };
 
-    // Filter out paths from ignored directories before emitting
+    let now = Instant::now();
+
+    // Collect paths, filtering ignored dirs and those within the debounce window
+    let mut guard = LAST_EMITTED.lock().unwrap();
+    let map = guard.get_or_insert_with(HashMap::new);
+
     let paths: Vec<String> = event
         .paths
         .iter()
         .filter(|p| !should_ignore_path(p))
-        .map(|p| p.to_string_lossy().to_string())
+        .filter_map(|p| {
+            let path_str = p.to_string_lossy().to_string();
+            let key = (watch_id.to_string(), path_str.clone());
+
+            if let Some(last) = map.get(&key) {
+                if now.duration_since(*last) < DEBOUNCE_INTERVAL {
+                    return None; // Skip: within debounce window
+                }
+            }
+            map.insert(key, now);
+            Some(path_str)
+        })
         .collect();
+
+    drop(guard); // Release lock before emitting
 
     if paths.is_empty() {
         return;
@@ -156,6 +183,12 @@ pub fn stop_watching(watch_id: String) -> Result<(), String> {
     let mut guard = WATCHERS.lock().map_err(|e| format!("Lock error: {e}"))?;
     if let Some(watchers) = guard.as_mut() {
         watchers.remove(&watch_id);
+    }
+    // Clean up debounce entries for this watch_id
+    if let Ok(mut debounce_guard) = LAST_EMITTED.lock() {
+        if let Some(map) = debounce_guard.as_mut() {
+            map.retain(|(wid, _), _| wid != &watch_id);
+        }
     }
     Ok(())
 }

--- a/src/hooks/mcpBridge/workspaceHandlers.ts
+++ b/src/hooks/mcpBridge/workspaceHandlers.ts
@@ -168,7 +168,7 @@ export async function handleWorkspaceSaveDocument(id: string): Promise<void> {
 
     const content = serializeMarkdown(editor.state.schema, editor.state.doc);
     await writeTextFile(doc.filePath, content);
-    docStore.markSaved(activeTabId);
+    docStore.markSaved(activeTabId, content);
 
     await respond({ id, success: true, data: null });
   } catch (error) {
@@ -238,7 +238,7 @@ export async function handleWorkspaceSaveDocumentAs(
     tabStore.updateTabPath(activeTabId, path);
     tabStore.updateTabTitle(activeTabId, getFileName(path) || "Untitled");
     docStore.setFilePath(activeTabId, path);
-    docStore.markSaved(activeTabId);
+    docStore.markSaved(activeTabId, content);
 
     await respond({ id, success: true, data: null });
   } catch (error) {

--- a/src/hooks/useExternalFileChanges.ts
+++ b/src/hooks/useExternalFileChanges.ts
@@ -313,13 +313,13 @@ export function useExternalFileChanges(): void {
               continue;
             }
 
-            // Check 2: Does disk match our last saved content?
+            // Check 2: Does disk match what we last wrote?
             // If so, no actual external change occurred (file was touched but not modified)
-            if (diskContent === doc.savedContent) {
+            if (diskContent === doc.lastDiskContent) {
               continue;
             }
 
-            // Real external change detected - disk content differs from savedContent
+            // Real external change detected - disk content differs from lastDiskContent
             const action = resolveExternalChangeAction({
               isDirty: doc.isDirty,
               hasFilePath: Boolean(doc.filePath),

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -9,6 +9,8 @@ export type { NodeType, CursorInfo } from "@/types/cursorSync";
 export interface DocumentState {
   content: string;
   savedContent: string;
+  /** Content as written to disk (post-normalization). Used for external-change detection. */
+  lastDiskContent: string;
   filePath: string | null;
   isDirty: boolean;
   documentId: number;
@@ -40,8 +42,8 @@ interface DocumentStore {
   clearMissing: (tabId: string) => void;
   markDivergent: (tabId: string) => void;
   clearDivergent: (tabId: string) => void;
-  markSaved: (tabId: string) => void;
-  markAutoSaved: (tabId: string) => void;
+  markSaved: (tabId: string, lastDiskContent?: string) => void;
+  markAutoSaved: (tabId: string, lastDiskContent?: string) => void;
   setCursorInfo: (tabId: string, info: CursorInfo | null) => void;
   setLineMetadata: (
     tabId: string,
@@ -57,6 +59,7 @@ interface DocumentStore {
 const createInitialDocument = (content = "", filePath: string | null = null): DocumentState => ({
   content,
   savedContent: content,
+  lastDiskContent: content,
   filePath,
   isDirty: false,
   documentId: 0,
@@ -111,6 +114,7 @@ export const useDocumentStore = create<DocumentStore>((set, get) => ({
       updateDoc(state, tabId, (doc) => ({
         content,
         savedContent: content,
+        lastDiskContent: content,
         filePath: filePath ?? null,
         isDirty: false,
         isDivergent: false, // Reload from disk clears divergent state
@@ -135,19 +139,21 @@ export const useDocumentStore = create<DocumentStore>((set, get) => ({
   clearDivergent: (tabId) =>
     set((state) => updateDoc(state, tabId, () => ({ isDivergent: false }))),
 
-  markSaved: (tabId) =>
+  markSaved: (tabId, lastDiskContent) =>
     set((state) =>
       updateDoc(state, tabId, (doc) => ({
         savedContent: doc.content,
+        lastDiskContent: lastDiskContent ?? doc.content,
         isDirty: false,
         isDivergent: false, // Manual save syncs local with disk
       }))
     ),
 
-  markAutoSaved: (tabId) =>
+  markAutoSaved: (tabId, lastDiskContent) =>
     set((state) =>
       updateDoc(state, tabId, (doc) => ({
         savedContent: doc.content,
+        lastDiskContent: lastDiskContent ?? doc.content,
         isDirty: false,
         isDivergent: false, // Auto-save syncs local with disk
         lastAutoSave: Date.now(),

--- a/src/utils/saveToPath.test.ts
+++ b/src/utils/saveToPath.test.ts
@@ -3,7 +3,7 @@
  *
  * @module utils/saveToPath.test
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { saveToPath } from "./saveToPath";
 
 vi.mock("@tauri-apps/plugin-fs", () => ({
@@ -61,6 +61,7 @@ describe("saveToPath", () => {
   const mockGetDocument = vi.fn();
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
     vi.mocked(useDocumentStore.getState).mockReturnValue({
       setFilePath: mockSetFilePath,
@@ -89,6 +90,10 @@ describe("saveToPath", () => {
     mockGetDocument.mockReturnValue({ lineEnding: "unknown" });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("writes content and updates stores on success", async () => {
     vi.mocked(writeTextFile).mockResolvedValue(undefined);
 
@@ -97,7 +102,7 @@ describe("saveToPath", () => {
     expect(result).toBe(true);
     expect(writeTextFile).toHaveBeenCalledWith("/tmp/doc.md", "Hello");
     expect(mockSetFilePath).toHaveBeenCalledWith("tab-1", "/tmp/doc.md");
-    expect(mockMarkSaved).toHaveBeenCalledWith("tab-1");
+    expect(mockMarkSaved).toHaveBeenCalledWith("tab-1", "Hello");
     expect(mockUpdateTabPath).toHaveBeenCalledWith("tab-1", "/tmp/doc.md");
     expect(mockAddFile).toHaveBeenCalledWith("/tmp/doc.md");
     expect(createSnapshot).toHaveBeenCalledWith("/tmp/doc.md", "Hello", "manual", {
@@ -186,7 +191,7 @@ describe("saveToPath", () => {
 
       await saveToPath("tab-1", "/tmp/doc.md", "content", "manual");
 
-      expect(mockMarkSaved).toHaveBeenCalledWith("tab-1");
+      expect(mockMarkSaved).toHaveBeenCalledWith("tab-1", "content");
       expect(mockMarkAutoSaved).not.toHaveBeenCalled();
     });
 
@@ -195,7 +200,7 @@ describe("saveToPath", () => {
 
       await saveToPath("tab-1", "/tmp/doc.md", "content", "auto");
 
-      expect(mockMarkAutoSaved).toHaveBeenCalledWith("tab-1");
+      expect(mockMarkAutoSaved).toHaveBeenCalledWith("tab-1", "content");
       expect(mockMarkSaved).not.toHaveBeenCalled();
     });
 
@@ -229,11 +234,14 @@ describe("saveToPath", () => {
       expect(registerCall).toBeLessThan(writeCall);
     });
 
-    it("clears pending save after successful write", async () => {
+    it("clears pending save after successful write (delayed)", async () => {
       vi.mocked(writeTextFile).mockResolvedValue(undefined);
 
       await saveToPath("tab-1", "/tmp/doc.md", "content", "manual");
 
+      // clearPendingSave is delayed via setTimeout to handle late watcher events
+      expect(clearPendingSave).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(500);
       expect(clearPendingSave).toHaveBeenCalledWith("/tmp/doc.md");
     });
 

--- a/src/utils/saveToPath.ts
+++ b/src/utils/saveToPath.ts
@@ -56,13 +56,14 @@ export async function saveToPath(
     .getState()
     .setLineMetadata(tabId, { lineEnding: targetLineEnding, hardBreakStyle: targetHardBreakStyle });
   if (saveType === "auto") {
-    useDocumentStore.getState().markAutoSaved(tabId);
+    useDocumentStore.getState().markAutoSaved(tabId, output);
   } else {
-    useDocumentStore.getState().markSaved(tabId);
+    useDocumentStore.getState().markSaved(tabId, output);
   }
 
-  // Clear pending save after state is updated
-  clearPendingSave(path);
+  // Delay clearing pending save to allow late-arriving watcher events
+  // to still match against our save (macOS FSEvents can batch/delay events)
+  setTimeout(() => clearPendingSave(path), 500);
 
   // Update tab path for title sync
   useTabStore.getState().updateTabPath(tabId, path);


### PR DESCRIPTION
## Summary

- Fixes a bug where documents occasionally auto-close and reopen, displaying a "Reloaded: [filename]" toast after saving
- Root cause: `savedContent` stored raw editor content while the disk had normalized content (line endings/hard breaks), causing the file watcher to falsely detect an "external change" and trigger an auto-reload
- Adds `lastDiskContent` field to separate dirty-checking (`savedContent`) from external-change detection (`lastDiskContent`)
- Adds 200ms per-path debounce in the Rust file watcher to suppress duplicate macOS FSEvents
- Delays `clearPendingSave` by 500ms to catch late-arriving watcher events

## Details

The causal chain was:

1. Auto-save normalizes line endings and writes to disk
2. `markSaved()` stores raw editor content as `savedContent` (not the normalized output)
3. File watcher fires after `clearPendingSave` has already run
4. `diskContent !== savedContent` because one is normalized, the other isn't
5. System treats it as an external change → calls `loadContent()` → increments `documentId` → editor remounts → user sees "Reloaded: filename.md" toast

The fix introduces a `lastDiskContent` field that stores exactly what was written to disk, and uses that for external-change comparison instead of `savedContent` (which remains for `isDirty` checking to avoid a permanent dirty state).

## Test plan

- [x] All existing `documentStore` tests pass (18/18)
- [x] All existing `saveToPath` tests pass with updated assertions (12/12)
- [x] No regressions in full test suite (2640 passed, same pre-existing failures from unrelated localStorage mock issue)
- [ ] Manual test: open a file with CRLF line endings, enable LF normalization on save, auto-save triggers — document should NOT reload
- [ ] Manual test: externally modify a file while open in VMark — should still correctly detect and reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)