### PR TITLE
fix: handle escape sequences correctly in all MCP tools

### DIFF
--- a/src/hooks/mcpBridge/batchOpHandlers.ts
+++ b/src/hooks/mcpBridge/batchOpHandlers.ts
@@ -7,6 +7,7 @@
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { respond, getEditor, isAutoApproveEnabled } from "./utils";
 import { validateBaseRevision, getCurrentRevision } from "./revisionTracker";
+import { parseMarkdown } from "@/utils/markdownPipeline";
 
 // Types
 type OperationMode = "apply" | "suggest" | "dryRun";
@@ -395,7 +396,10 @@ export async function handleListBatchModify(
             // Split list item and add new content
             editor.commands.splitListItem("listItem");
             if (op.text) {
-              editor.commands.insertContent(op.text);
+              // Parse markdown content to ProseMirror nodes to handle escape sequences correctly
+              const parsedDoc = parseMarkdown(editor.schema, op.text, { preserveLineBreaks: false });
+              const contentNodes = parsedDoc.content.toJSON();
+              editor.commands.insertContent(contentNodes);
             }
             appliedCount++;
             break;

--- a/src/hooks/mcpBridge/mutationHandlers.ts
+++ b/src/hooks/mcpBridge/mutationHandlers.ts
@@ -17,6 +17,7 @@ import {
 import { useAiSuggestionStore } from "@/stores/aiSuggestionStore";
 import { idempotencyCache } from "./idempotencyCache";
 import { validateBaseRevision, getCurrentRevision } from "./revisionTracker";
+import { parseMarkdown } from "@/utils/markdownPipeline";
 
 // Types
 type OperationMode = "apply" | "suggest" | "dryRun";
@@ -281,10 +282,14 @@ export async function handleBatchEdit(
       switch (op.type) {
         case "insert":
           if (typeof op.content === "string" && resolved) {
+            // Parse markdown content to ProseMirror nodes to handle escape sequences correctly
+            const parsedDoc = parseMarkdown(editor.schema, op.content, { preserveLineBreaks: false });
+            const contentNodes = parsedDoc.content.toJSON();
+
             editor.chain()
               .focus()
               .setTextSelection(resolved.from)
-              .insertContent(op.content)
+              .insertContent(contentNodes)
               .run();
             addedNodeIds.push(`inserted-${addedNodeIds.length}`);
           }
@@ -292,12 +297,16 @@ export async function handleBatchEdit(
 
         case "update":
           if (op.text && resolved) {
+            // Parse markdown content to ProseMirror nodes to handle escape sequences correctly
+            const parsedDoc = parseMarkdown(editor.schema, op.text, { preserveLineBreaks: false });
+            const contentNodes = parsedDoc.content.toJSON();
+
             // Get the text content range
             const textRange = getTextRange(editor, resolved.from, resolved.to);
             editor.chain()
               .focus()
               .setTextSelection({ from: textRange.from, to: textRange.to })
-              .insertContent(op.text)
+              .insertContent(contentNodes)
               .run();
             changedNodeIds.push(op.nodeId || `updated-${changedNodeIds.length}`);
           }
@@ -550,6 +559,10 @@ export async function handleApplyDiff(
     }
 
     // Apply replacements
+    // Parse markdown content to ProseMirror nodes to handle escape sequences correctly
+    const parsedDoc = parseMarkdown(editor.schema, replacement, { preserveLineBreaks: false });
+    const contentNodes = parsedDoc.content.toJSON();
+
     let appliedCount = 0;
 
     if (matchPolicy === "first") {
@@ -557,7 +570,7 @@ export async function handleApplyDiff(
       editor.chain()
         .focus()
         .setTextSelection({ from: match.from, to: match.to })
-        .insertContent(replacement)
+        .insertContent(contentNodes)
         .run();
       appliedCount = 1;
     } else if (matchPolicy === "all") {
@@ -567,7 +580,7 @@ export async function handleApplyDiff(
         editor.chain()
           .focus()
           .setTextSelection({ from: match.from, to: match.to })
-          .insertContent(replacement)
+          .insertContent(contentNodes)
           .run();
         appliedCount++;
       }
@@ -576,7 +589,7 @@ export async function handleApplyDiff(
       editor.chain()
         .focus()
         .setTextSelection({ from: match.from, to: match.to })
-        .insertContent(replacement)
+        .insertContent(contentNodes)
         .run();
       appliedCount = 1;
     }
@@ -752,10 +765,14 @@ export async function handleReplaceAnchored(
     }
 
     // Apply replacement
+    // Parse markdown content to ProseMirror nodes to handle escape sequences correctly
+    const parsedDoc = parseMarkdown(editor.schema, replacement, { preserveLineBreaks: false });
+    const contentNodes = parsedDoc.content.toJSON();
+
     editor.chain()
       .focus()
       .setTextSelection({ from: match.from, to: match.to })
-      .insertContent(replacement)
+      .insertContent(contentNodes)
       .run();
 
     const newRevision = getCurrentRevision();

--- a/src/hooks/mcpBridge/paragraphHandlers.ts
+++ b/src/hooks/mcpBridge/paragraphHandlers.ts
@@ -8,6 +8,7 @@ import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { respond, getEditor, isAutoApproveEnabled, getActiveTabId } from "./utils";
 import { useAiSuggestionStore } from "@/stores/aiSuggestionStore";
 import { validateBaseRevision, getCurrentRevision } from "./revisionTracker";
+import { parseMarkdown } from "@/utils/markdownPipeline";
 
 // Types
 type OperationMode = "apply" | "suggest";
@@ -309,10 +310,14 @@ export async function handleParagraphWrite(
         .deleteSelection()
         .run();
     } else {
+      // Parse markdown content to ProseMirror nodes to handle escape sequences correctly
+      const parsedDoc = parseMarkdown(editor.schema, newContent, { preserveLineBreaks: false });
+      const contentNodes = parsedDoc.content.toJSON();
+
       editor.chain()
         .focus()
         .setTextSelection({ from, to })
-        .insertContent(newContent)
+        .insertContent(contentNodes)
         .run();
     }
 

--- a/src/hooks/mcpBridge/sectionHandlers.ts
+++ b/src/hooks/mcpBridge/sectionHandlers.ts
@@ -8,6 +8,7 @@ import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { respond, getEditor, isAutoApproveEnabled, getActiveTabId } from "./utils";
 import { useAiSuggestionStore } from "@/stores/aiSuggestionStore";
 import { validateBaseRevision, getCurrentRevision } from "./revisionTracker";
+import { parseMarkdown } from "@/utils/markdownPipeline";
 
 // Types
 type OperationMode = "apply" | "suggest" | "dryRun";
@@ -209,10 +210,14 @@ export async function handleSectionUpdate(
     }
 
     // Apply the update
+    // Parse markdown content to ProseMirror nodes to handle escape sequences correctly
+    const parsedDoc = parseMarkdown(editor.schema, newContent, { preserveLineBreaks: false });
+    const contentNodes = parsedDoc.content.toJSON();
+
     editor.chain()
       .focus()
       .setTextSelection({ from: contentStart, to: section.to })
-      .insertContent(newContent)
+      .insertContent(contentNodes)
       .run();
 
     const newRevision = getCurrentRevision();
@@ -335,10 +340,14 @@ export async function handleSectionInsert(
     }
 
     // Apply the insert
+    // Parse markdown content to ProseMirror nodes to handle escape sequences correctly
+    const parsedDoc = parseMarkdown(editor.schema, fullContent, { preserveLineBreaks: false });
+    const contentNodes = parsedDoc.content.toJSON();
+
     editor.chain()
       .focus()
       .setTextSelection(insertPos)
-      .insertContent(fullContent)
+      .insertContent(contentNodes)
       .run();
 
     const newRevision = getCurrentRevision();
@@ -482,6 +491,10 @@ export async function handleSectionMove(
     }
 
     // Apply the move (delete then insert)
+    // Parse markdown content to ProseMirror nodes to handle escape sequences correctly
+    const parsedDoc = parseMarkdown(editor.schema, sectionContent, { preserveLineBreaks: false });
+    const contentNodes = parsedDoc.content.toJSON();
+
     // We need to be careful about position adjustments
     if (targetPos > sectionRange.to) {
       // Moving forward - insert first (positions will shift)
@@ -489,7 +502,7 @@ export async function handleSectionMove(
       editor.chain()
         .focus()
         .setTextSelection(adjustedTarget)
-        .insertContent(sectionContent)
+        .insertContent(contentNodes)
         .setTextSelection({ from: sectionRange.from, to: sectionRange.to })
         .deleteSelection()
         .run();
@@ -500,7 +513,7 @@ export async function handleSectionMove(
         .setTextSelection({ from: sectionRange.from, to: sectionRange.to })
         .deleteSelection()
         .setTextSelection(targetPos)
-        .insertContent(sectionContent)
+        .insertContent(contentNodes)
         .run();
     }
 

--- a/src/hooks/mcpBridge/smartInsertHandlers.ts
+++ b/src/hooks/mcpBridge/smartInsertHandlers.ts
@@ -12,6 +12,7 @@ import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { respond, getEditor, isAutoApproveEnabled, getActiveTabId } from "./utils";
 import { useAiSuggestionStore } from "@/stores/aiSuggestionStore";
 import { validateBaseRevision, getCurrentRevision } from "./revisionTracker";
+import { parseMarkdown } from "@/utils/markdownPipeline";
 
 // Types
 type OperationMode = "apply" | "suggest";
@@ -201,8 +202,11 @@ export async function handleSmartInsert(
 
     const insertPos = insertPosResult;
 
-    // Create content with proper paragraph wrapping
-    const contentToInsert = `\n\n${content}\n\n`;
+    // Parse markdown content to ProseMirror nodes
+    // Add newlines for proper spacing
+    const markdownWithSpacing = `\n\n${content}\n\n`;
+    const parsedDoc = parseMarkdown(editor.schema, markdownWithSpacing, { preserveLineBreaks: false });
+    const contentNodes = parsedDoc.content.toJSON();
 
     // For suggest mode or non-auto-approve, create suggestion
     if (mode === "suggest" || !isAutoApproveEnabled()) {
@@ -211,7 +215,7 @@ export async function handleSmartInsert(
         type: "insert",
         from: insertPos,
         to: insertPos,
-        newContent: contentToInsert,
+        newContent: markdownWithSpacing,
         originalContent: undefined,
       });
 
@@ -232,10 +236,11 @@ export async function handleSmartInsert(
     }
 
     // Apply the insert directly
+    // Use parsed ProseMirror nodes instead of raw markdown string
     editor.chain()
       .focus()
       .setTextSelection(insertPos)
-      .insertContent(contentToInsert)
+      .insertContent(contentNodes)
       .run();
 
     const newRevision = getCurrentRevision();


### PR DESCRIPTION
Fixed markdown escape sequence handling (\==, \++, \^, \~) across all MCP handlers by using parseMarkdown() before insertContent().

Modified handlers:
- paragraphHandlers.ts: write_paragraph (replace/append/prepend)
- sectionHandlers.ts: update_section, insert_section, move_section
- mutationHandlers.ts: batch_edit (insert/update), apply_diff, replace_text_anchored
- batchOpHandlers.ts: list_modify (add_item)
- smartInsertHandlers.ts: smart_insert (already fixed)

Implementation:
- Parse markdown content to ProseMirror nodes using parseMarkdown()
- Convert to JSON format via .toJSON()
- Insert structured nodes instead of raw strings
- Leverages existing preprocessEscapedMarkers() and restoreEscapedMarkers()

This fixes the issue where escaped custom markers (\==text\==) were incorrectly rendered with formatting instead of as literal text.

All 8 handlers tested and verified working correctly.