### PR TITLE
fix: inline code backtick auto-pair and cursor behavior

### DIFF
--- a/src/plugins/autoPair/__tests__/backtickCodeToggle.test.ts
+++ b/src/plugins/autoPair/__tests__/backtickCodeToggle.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Backtick Code Mark Toggle Tests (Issue #58 Problem 2)
+ *
+ * Verifies that backtick in WYSIWYG mode toggles inline code mark
+ * instead of inserting backtick text.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Schema } from "@tiptap/pm/model";
+import { EditorState, TextSelection } from "@tiptap/pm/state";
+import { EditorView } from "@tiptap/pm/view";
+import { handleTextInput, type AutoPairConfig } from "../handlers";
+
+// Minimal schema with code mark
+const schema = new Schema({
+  nodes: {
+    doc: { content: "paragraph+" },
+    paragraph: { content: "text*", group: "block" },
+    text: { inline: true },
+  },
+  marks: {
+    code: {
+      excludes: "_",
+      parseDOM: [{ tag: "code" }],
+      toDOM() {
+        return ["code", 0];
+      },
+    },
+  },
+});
+
+const defaultConfig: AutoPairConfig = {
+  enabled: true,
+  includeCJK: false,
+  includeCurlyQuotes: false,
+  normalizeRightDoubleQuote: false,
+};
+
+function createState(text: string, cursorPos?: number): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, text ? [schema.text(text)] : []),
+  ]);
+  const state = EditorState.create({ doc });
+  if (cursorPos != null) {
+    return state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, cursorPos))
+    );
+  }
+  return state;
+}
+
+function createStateWithCodeMark(
+  before: string,
+  code: string,
+  after: string,
+  cursorInCode?: number
+): EditorState {
+  const codeMark = schema.marks.code.create();
+  const children = [];
+  if (before) children.push(schema.text(before));
+  if (code) children.push(schema.text(code, [codeMark]));
+  if (after) children.push(schema.text(after));
+
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, children),
+  ]);
+  const state = EditorState.create({ doc });
+
+  if (cursorInCode != null) {
+    // Position: 1 (paragraph start) + before.length + cursorInCode
+    const pos = 1 + before.length + cursorInCode;
+    return state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, pos))
+    );
+  }
+  return state;
+}
+
+/**
+ * Call handleTextInput with a mock EditorView.
+ * Returns the resulting EditorState if handled, or null if not handled.
+ */
+function callHandleTextInput(
+  state: EditorState,
+  text: string,
+  config = defaultConfig
+): { handled: boolean; newState: EditorState } {
+  let newState = state;
+  const mockView = {
+    state,
+    dispatch: (tr: ReturnType<EditorState["tr"]["setSelection"]>) => {
+      newState = state.apply(tr);
+    },
+  } as unknown as EditorView;
+
+  const { from, to } = state.selection;
+  const handled = handleTextInput(mockView, from, to, text, config);
+  return { handled, newState };
+}
+
+describe("backtick code mark toggle (WYSIWYG)", () => {
+  it("activates code mark when typing backtick outside code", () => {
+    // Cursor at position 1 (start of paragraph content)
+    const state = createState("", 1);
+    const { handled, newState } = callHandleTextInput(state, "`");
+
+    expect(handled).toBe(true);
+    // Should NOT insert backtick text
+    expect(newState.doc.textContent).toBe("");
+    // Should have code mark in stored marks
+    const storedMarks = newState.storedMarks;
+    expect(storedMarks).not.toBeNull();
+    expect(storedMarks?.some((m) => m.type.name === "code")).toBe(true);
+  });
+
+  it("wraps selection with code mark when backtick typed with selection", () => {
+    // Create state with "hello" selected
+    const state = createState("hello");
+    const withSelection = state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, 1, 6))
+    );
+
+    const { handled, newState } = callHandleTextInput(withSelection, "`");
+
+    expect(handled).toBe(true);
+    // Text should still be "hello"
+    expect(newState.doc.textContent).toBe("hello");
+    // "hello" should have code mark
+    const para = newState.doc.firstChild!;
+    const firstChild = para.firstChild!;
+    expect(firstChild.marks.some((m) => m.type.name === "code")).toBe(true);
+  });
+
+  it("escapes code mark when typing backtick inside code", () => {
+    // "hello" with code mark, cursor at end (position 6 = 1 + 5)
+    const state = createStateWithCodeMark("", "hello", " world", 5);
+
+    const { handled, newState } = callHandleTextInput(state, "`");
+
+    expect(handled).toBe(true);
+    // Should NOT insert backtick text
+    expect(newState.doc.textContent).toBe("hello world");
+    // Cursor should be after the code mark
+    expect(newState.selection.from).toBe(6); // After "hello"
+  });
+
+  it("does not handle backtick when auto-pair is disabled", () => {
+    const state = createState("", 1);
+    const { handled } = callHandleTextInput(state, "`", {
+      ...defaultConfig,
+      enabled: false,
+    });
+
+    expect(handled).toBe(false);
+  });
+
+  it("does not handle backtick after escape backslash", () => {
+    const state = createState("\\", 2); // Cursor after backslash
+    const { handled } = callHandleTextInput(state, "`");
+
+    expect(handled).toBe(false);
+  });
+});

--- a/src/plugins/autoPair/handlers.ts
+++ b/src/plugins/autoPair/handlers.ts
@@ -6,6 +6,7 @@
 
 import type { EditorView } from "@tiptap/pm/view";
 import { TextSelection } from "@tiptap/pm/state";
+import type { EditorState } from "@tiptap/pm/state";
 import {
   getClosingChar,
   isClosingChar,
@@ -13,7 +14,7 @@ import {
   normalizeForPairing,
   type PairConfig,
 } from "./pairs";
-import { shouldAutoPair, getCharAt, getCharBefore } from "./utils";
+import { shouldAutoPair, isInCodeBlock, getCharAt, getCharBefore } from "./utils";
 
 export interface AutoPairConfig {
   enabled: boolean;
@@ -42,6 +43,94 @@ function isAllowedClosingChar(char: string, config: AutoPairConfig): boolean {
 }
 
 /**
+ * Handle backtick as code mark toggle in WYSIWYG mode.
+ * - Outside code: activate code mark (or wrap selection)
+ * - Inside code: escape to end of code mark
+ * Returns true if handled.
+ */
+function handleBacktickCodeToggle(
+  view: EditorView,
+  from: number,
+  to: number
+): boolean {
+  const { state, dispatch } = view;
+
+  // Don't handle if preceded by backslash (escaped)
+  if (from > 0) {
+    const $pos = state.doc.resolve(from);
+    const textBefore = $pos.parent.textBetween(
+      Math.max(0, $pos.parentOffset - 1),
+      $pos.parentOffset,
+      ""
+    );
+    if (textBefore === "\\") return false;
+  }
+
+  // Don't handle in code blocks
+  if (isInCodeBlock(state)) return false;
+
+  const codeMarkType = state.schema.marks.code;
+  if (!codeMarkType) return false;
+
+  // Check if cursor is in inline code
+  const $from = state.doc.resolve(from);
+  const inCode = $from.marks().some((m) => m.type === codeMarkType);
+
+  if (inCode) {
+    // Escape: move cursor to end of code mark
+    const endPos = findCodeMarkEnd(state, from, codeMarkType);
+    if (endPos !== null) {
+      const tr = state.tr.setSelection(TextSelection.create(state.doc, endPos));
+      tr.removeStoredMark(codeMarkType);
+      dispatch(tr);
+      return true;
+    }
+    return false;
+  }
+
+  // Outside code: toggle code mark
+  if (from !== to) {
+    // Selection: wrap with code mark
+    const tr = state.tr.addMark(from, to, codeMarkType.create());
+    dispatch(tr);
+    return true;
+  }
+
+  // No selection: activate code mark for subsequent typing
+  const tr = state.tr.addStoredMark(codeMarkType.create());
+  dispatch(tr);
+  return true;
+}
+
+/**
+ * Find the end position of the code mark containing the given position.
+ */
+function findCodeMarkEnd(
+  state: EditorState,
+  pos: number,
+  codeMarkType: ReturnType<EditorState["schema"]["marks"]["code"]["create"]>["type"]
+): number | null {
+  const $pos = state.doc.resolve(pos);
+  const parent = $pos.parent;
+  const parentStart = $pos.start();
+
+  let offset = 0;
+  for (let i = 0; i < parent.childCount; i++) {
+    const child = parent.child(i);
+    const childStart = parentStart + offset;
+    const childEnd = childStart + child.nodeSize;
+
+    if (pos >= childStart && pos <= childEnd) {
+      if (child.marks.some((m) => m.type === codeMarkType)) {
+        return childEnd;
+      }
+    }
+    offset += child.nodeSize;
+  }
+  return null;
+}
+
+/**
  * Handle text input - auto-pair opening characters.
  * Returns true if the input was handled.
  */
@@ -56,6 +145,11 @@ export function handleTextInput(
 
   // Only handle single character input
   if (text.length !== 1) return false;
+
+  // Handle backtick as code mark toggle (before normal auto-pair)
+  if (text === "`") {
+    return handleBacktickCodeToggle(view, from, to);
+  }
 
   // Normalize right double curly quote → left double curly (IME compat)
   const inputChar = config.normalizeRightDoubleQuote

--- a/src/plugins/codemirror/__tests__/markdownAutoPairBacktickSingle.test.ts
+++ b/src/plugins/codemirror/__tests__/markdownAutoPairBacktickSingle.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Single Backtick Auto-Pair Tests (Issue #58 Problem 1)
+ *
+ * Verifies that single backtick auto-pairs in Source mode.
+ * Uses delay-based approach to avoid collision with code fence (```).
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { EditorView } from "@codemirror/view";
+import { EditorState } from "@codemirror/state";
+
+vi.mock("@/utils/imeGuard", () => ({
+  isCodeMirrorComposing: () => false,
+  guardCodeMirrorKeyBinding: (binding: unknown) => binding,
+}));
+
+import { createMarkdownAutoPairPlugin, markdownPairBackspace } from "../markdownAutoPair";
+
+/**
+ * Helper: simulate a single-character user input transaction.
+ */
+function simulateTyping(view: EditorView, char: string): void {
+  const pos = view.state.selection.main.head;
+  view.dispatch({
+    changes: { from: pos, to: pos, insert: char },
+    selection: { anchor: pos + 1 },
+    userEvent: "input.type",
+  });
+}
+
+/**
+ * Create an EditorView attached to the document body.
+ */
+function createView(doc: string, cursorPos?: number): EditorView {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+
+  const state = EditorState.create({
+    doc,
+    selection: cursorPos != null ? { anchor: cursorPos } : undefined,
+    extensions: [createMarkdownAutoPairPlugin()],
+  });
+  return new EditorView({ state, parent });
+}
+
+describe("single backtick auto-pair (Source mode)", () => {
+  let activeView: EditorView | null = null;
+
+  afterEach(() => {
+    const parent = activeView?.dom.parentElement;
+    activeView?.destroy();
+    parent?.remove();
+    activeView = null;
+  });
+
+  it("auto-pairs single backtick after delay", async () => {
+    activeView = createView("");
+
+    simulateTyping(activeView, "`");
+
+    // Before delay: just one backtick
+    expect(activeView.state.doc.toString()).toBe("`");
+
+    // After delay: paired backticks with cursor between
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(activeView.state.doc.toString()).toBe("``");
+    expect(activeView.state.selection.main.head).toBe(1);
+  });
+
+  it("does not pair when double backtick typed quickly", async () => {
+    activeView = createView("");
+
+    simulateTyping(activeView, "`");
+    simulateTyping(activeView, "`");
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Two backticks, no extra pair
+    expect(activeView.state.doc.toString()).toBe("``");
+  });
+
+  it("triple backtick at line start still produces code fence", async () => {
+    activeView = createView("");
+
+    simulateTyping(activeView, "`");
+    simulateTyping(activeView, "`");
+    simulateTyping(activeView, "`");
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(activeView.state.doc.toString()).toBe("```\n\n```");
+  });
+
+  it("single backtick mid-line auto-pairs after delay", async () => {
+    activeView = createView("hello ", 6);
+
+    simulateTyping(activeView, "`");
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(activeView.state.doc.toString()).toBe("hello ``");
+    expect(activeView.state.selection.main.head).toBe(7);
+  });
+});
+
+describe("backtick backspace pair deletion (Source mode)", () => {
+  let activeView: EditorView | null = null;
+
+  afterEach(() => {
+    const parent = activeView?.dom.parentElement;
+    activeView?.destroy();
+    parent?.remove();
+    activeView = null;
+  });
+
+  it("deletes both backticks when backspace between paired backticks", () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+
+    const state = EditorState.create({
+      doc: "``",
+      selection: { anchor: 1 },
+      extensions: [
+        createMarkdownAutoPairPlugin(),
+        EditorView.domEventHandlers({
+          keydown: () => false,
+        }),
+      ],
+    });
+    activeView = new EditorView({ state, parent });
+
+    // Simulate backspace using the handler directly
+    const handled = markdownPairBackspace.run!(activeView);
+
+    expect(handled).toBe(true);
+    expect(activeView.state.doc.toString()).toBe("");
+  });
+});

--- a/src/plugins/codemirror/markdownAutoPair.ts
+++ b/src/plugins/codemirror/markdownAutoPair.ts
@@ -28,6 +28,7 @@ const SYMMETRIC_PAIRS: Record<string, string> = {
   "_": "_",
   "=": "=",
   "^": "^",
+  "`": "`",
 };
 
 interface PendingPair {
@@ -174,22 +175,60 @@ export function createMarkdownAutoPairPlugin() {
 
       handleBacktick(pos: number) {
         const doc = this.view.state.doc;
-        const before = doc.sliceString(Math.max(0, pos - 2), pos);
+        const twoBefore = doc.sliceString(Math.max(0, pos - 2), pos);
 
-        // Check if we just completed ``` (three backticks)
-        if (before !== "``") return;
+        // Triple backtick (```): code fence
+        if (twoBefore === "``") {
+          // Cancel any pending
+          if (this.pending) {
+            clearTimeout(this.pending.timeout);
+            this.pending = null;
+          }
 
-        // Bounds check for lineAt
-        if (pos < 0 || pos > doc.length) return;
+          // Bounds check for lineAt
+          if (pos < 0 || pos > doc.length) return;
 
-        const lineStart = doc.lineAt(pos).from;
-        const textBeforeOnLine = doc.sliceString(lineStart, pos - 2).trim();
+          const lineStart = doc.lineAt(pos).from;
+          const textBeforeOnLine = doc.sliceString(lineStart, pos - 2).trim();
 
-        if (textBeforeOnLine === "") {
-          // Insert: cursor stays after ```, then \n\n```
-          // Result: ```|cursor\n\n```
-          this.insertClosingPair("\n\n```");
+          if (textBeforeOnLine === "") {
+            // Insert: cursor stays after ```, then \n\n```
+            // Result: ```|cursor\n\n```
+            this.insertClosingPair("\n\n```");
+          }
+          return;
         }
+
+        // Double backtick (``): cancel pending single pair, no double pair
+        if (
+          this.pending &&
+          this.pending.char === "`" &&
+          this.pending.pos === pos - 1
+        ) {
+          clearTimeout(this.pending.timeout);
+          this.pending = null;
+          return;
+        }
+
+        // Single backtick: delay-based pair
+        if (this.pending) {
+          clearTimeout(this.pending.timeout);
+          this.pending = null;
+        }
+
+        const timeout = setTimeout(() => {
+          const currentPos = this.view.state.selection.main.head;
+          if (currentPos === pos + 1) {
+            safeDispatch(
+              this.view,
+              { from: currentPos, to: currentPos, insert: "`" },
+              currentPos
+            );
+          }
+          this.pending = null;
+        }, PAIR_DELAY);
+
+        this.pending = { char: "`", pos, timeout };
       }
 
       handleAlwaysDoubleChar(char: string, pos: number) {

--- a/src/plugins/inlineCodeBoundary/__tests__/inlineCodeBoundary.test.ts
+++ b/src/plugins/inlineCodeBoundary/__tests__/inlineCodeBoundary.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Inline Code Boundary Tests (Issue #58 Problem 3)
+ *
+ * Verifies that cursor at the left boundary of inline code
+ * gets storedMarks set to include the code mark.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Schema } from "@tiptap/pm/model";
+import { EditorState, TextSelection } from "@tiptap/pm/state";
+import { createInlineCodeBoundaryPlugin } from "../plugin";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "paragraph+" },
+    paragraph: { content: "text*", group: "block" },
+    text: { inline: true },
+  },
+  marks: {
+    code: {
+      excludes: "_",
+      parseDOM: [{ tag: "code" }],
+      toDOM() {
+        return ["code", 0];
+      },
+    },
+    bold: {
+      parseDOM: [{ tag: "strong" }],
+      toDOM() {
+        return ["strong", 0];
+      },
+    },
+  },
+});
+
+function createStateWithPlugin(
+  before: string,
+  code: string,
+  after: string
+): EditorState {
+  const codeMark = schema.marks.code.create();
+  const children = [];
+  if (before) children.push(schema.text(before));
+  if (code) children.push(schema.text(code, [codeMark]));
+  if (after) children.push(schema.text(after));
+
+  return EditorState.create({
+    doc: schema.node("doc", null, [
+      schema.node("paragraph", null, children),
+    ]),
+    plugins: [createInlineCodeBoundaryPlugin()],
+  });
+}
+
+describe("inline code boundary plugin", () => {
+  it("sets storedMarks with code mark when cursor is at left boundary", () => {
+    // "Hello " + ["code" with code mark] + " world"
+    const state = createStateWithPlugin("Hello ", "code", " world");
+
+    // Move cursor to left boundary of code mark (position 7 = 1 + 6)
+    const tr = state.tr.setSelection(TextSelection.create(state.doc, 7));
+    const newState = state.apply(tr);
+
+    // The appendTransaction should have set storedMarks
+    const storedMarks = newState.storedMarks;
+    expect(storedMarks).not.toBeNull();
+    expect(storedMarks?.some((m) => m.type.name === "code")).toBe(true);
+  });
+
+  it("does not set storedMarks when cursor is NOT at code boundary", () => {
+    const state = createStateWithPlugin("Hello ", "code", " world");
+
+    // Move cursor to middle of "Hello " (position 4 = 1 + 3)
+    const tr = state.tr.setSelection(TextSelection.create(state.doc, 4));
+    const newState = state.apply(tr);
+
+    // Should NOT have code mark in storedMarks
+    const storedMarks = newState.storedMarks;
+    const hasCode = storedMarks?.some((m) => m.type.name === "code") ?? false;
+    expect(hasCode).toBe(false);
+  });
+
+  it("does not set storedMarks when cursor is inside code (not at boundary)", () => {
+    const state = createStateWithPlugin("Hello ", "code", " world");
+
+    // Move cursor to middle of "code" (position 9 = 1 + 6 + 2)
+    const tr = state.tr.setSelection(TextSelection.create(state.doc, 9));
+    const newState = state.apply(tr);
+
+    // storedMarks should be null (normal mark resolution handles this)
+    const storedMarks = newState.storedMarks;
+    expect(storedMarks).toBeNull();
+  });
+
+  it("does not set storedMarks when there is a selection", () => {
+    const state = createStateWithPlugin("Hello ", "code", " world");
+
+    // Select across the boundary
+    const tr = state.tr.setSelection(TextSelection.create(state.doc, 5, 9));
+    const newState = state.apply(tr);
+
+    const storedMarks = newState.storedMarks;
+    expect(storedMarks).toBeNull();
+  });
+
+  it("handles code mark at paragraph start", () => {
+    // Code mark at very start of paragraph
+    const state = createStateWithPlugin("", "code", " world");
+
+    // Move cursor to position 1 (start of paragraph content)
+    const tr = state.tr.setSelection(TextSelection.create(state.doc, 1));
+    const newState = state.apply(tr);
+
+    // At start of paragraph, ProseMirror's inclusive should handle this,
+    // but our plugin should also set storedMarks for consistency
+    const storedMarks = newState.storedMarks;
+    expect(storedMarks).not.toBeNull();
+    expect(storedMarks?.some((m) => m.type.name === "code")).toBe(true);
+  });
+});

--- a/src/plugins/inlineCodeBoundary/plugin.ts
+++ b/src/plugins/inlineCodeBoundary/plugin.ts
@@ -1,0 +1,62 @@
+/**
+ * Inline Code Boundary Plugin
+ *
+ * Fixes cursor behavior at the left boundary of inline code marks.
+ *
+ * Problem: ProseMirror resolves marks at a cursor position from the text
+ * BEFORE the position. At the left boundary of inline code (mid-paragraph),
+ * this means the code mark is NOT included, so typing inserts text outside
+ * the code node instead of inside.
+ *
+ * Solution: An appendTransaction that detects when the cursor is at the
+ * left boundary of a code-marked text node and explicitly sets storedMarks
+ * to include the code mark.
+ */
+
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import type { Transaction, EditorState } from "@tiptap/pm/state";
+
+const inlineCodeBoundaryKey = new PluginKey("inlineCodeBoundary");
+
+/**
+ * Create the inline code boundary plugin.
+ * Returns a ProseMirror plugin (not a Tiptap extension) for testability.
+ */
+export function createInlineCodeBoundaryPlugin(): Plugin {
+  return new Plugin({
+    key: inlineCodeBoundaryKey,
+
+    appendTransaction(
+      transactions: readonly Transaction[],
+      _oldState: EditorState,
+      newState: EditorState
+    ) {
+      // Only act when selection or doc changed
+      const changed = transactions.some((tr) => tr.selectionSet || tr.docChanged);
+      if (!changed) return null;
+
+      const { selection } = newState;
+      const { from, to, $from } = selection;
+
+      // Only handle cursor, not selection
+      if (from !== to) return null;
+
+      // Must be at a text node boundary (not in the middle of a node)
+      if ($from.textOffset !== 0) return null;
+
+      // Check if the node after cursor has the code mark
+      const nodeAfter = $from.nodeAfter;
+      if (!nodeAfter) return null;
+
+      const codeMarkType = newState.schema.marks.code;
+      if (!codeMarkType) return null;
+
+      const hasCodeAfter = nodeAfter.marks.some((m) => m.type === codeMarkType);
+      if (!hasCodeAfter) return null;
+
+      // Set storedMarks to include the code mark so typing goes inside code
+      const codeMark = codeMarkType.create();
+      return newState.tr.setStoredMarks([codeMark]);
+    },
+  });
+}

--- a/src/plugins/inlineCodeBoundary/tiptap.ts
+++ b/src/plugins/inlineCodeBoundary/tiptap.ts
@@ -1,0 +1,17 @@
+/**
+ * Inline Code Boundary Extension for Tiptap
+ *
+ * Wraps the ProseMirror plugin that fixes cursor behavior at the
+ * left boundary of inline code marks.
+ */
+
+import { Extension } from "@tiptap/core";
+import { createInlineCodeBoundaryPlugin } from "./plugin";
+
+export const inlineCodeBoundaryExtension = Extension.create({
+  name: "inlineCodeBoundary",
+
+  addProseMirrorPlugins() {
+    return [createInlineCodeBoundaryPlugin()];
+  },
+});

--- a/src/plugins/tabIndent/__tests__/tabEscapeCode.test.ts
+++ b/src/plugins/tabIndent/__tests__/tabEscapeCode.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tab Escape from Inline Code Tests (Issue #58 Problem 4)
+ *
+ * Verifies that Tab escapes from inline code mark when cursor
+ * is at the end of the mark.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Schema } from "@tiptap/pm/model";
+import { EditorState, TextSelection } from "@tiptap/pm/state";
+import { canTabEscape, getMarkEndPos } from "../tabEscape";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "paragraph+" },
+    paragraph: { content: "text*", group: "block" },
+    text: { inline: true },
+  },
+  marks: {
+    code: {
+      excludes: "_",
+      parseDOM: [{ tag: "code" }],
+      toDOM() {
+        return ["code", 0];
+      },
+    },
+    bold: {
+      parseDOM: [{ tag: "strong" }],
+      toDOM() {
+        return ["strong", 0];
+      },
+    },
+    link: {
+      attrs: { href: {} },
+      parseDOM: [{ tag: "a[href]" }],
+      toDOM(mark) {
+        return ["a", { href: mark.attrs.href }, 0];
+      },
+    },
+  },
+});
+
+function createStateWithCodeMark(
+  before: string,
+  code: string,
+  after: string,
+  cursorInCode?: number
+): EditorState {
+  const codeMark = schema.marks.code.create();
+  const children = [];
+  if (before) children.push(schema.text(before));
+  if (code) children.push(schema.text(code, [codeMark]));
+  if (after) children.push(schema.text(after));
+
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, children),
+  ]);
+  let state = EditorState.create({ doc });
+
+  if (cursorInCode != null) {
+    const pos = 1 + before.length + cursorInCode;
+    state = state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, pos))
+    );
+  }
+  return state;
+}
+
+describe("getMarkEndPos with code mark", () => {
+  it("returns end position when cursor is inside code mark", () => {
+    // "Hello " + ["this" with code mark] + " world"
+    // Cursor at position 9 (inside "this", after "th")
+    const state = createStateWithCodeMark("Hello ", "this", " world", 2);
+    const endPos = getMarkEndPos(state);
+
+    // End of "this" is at position 1 + 6 + 4 = 11
+    expect(endPos).toBe(11);
+  });
+
+  it("returns end position when cursor is at the end of code mark", () => {
+    // "Hello " + ["this" with code mark] + " world"
+    // Cursor at position 11 (right at end of "this")
+    const state = createStateWithCodeMark("Hello ", "this", " world", 4);
+
+    // The code mark should still be active at this position (inclusive)
+    // getMarkEndPos should still return the end position
+    const endPos = getMarkEndPos(state);
+    expect(endPos).toBe(11);
+  });
+});
+
+describe("canTabEscape with code mark", () => {
+  it("returns escape result when cursor is inside code mark", () => {
+    const state = createStateWithCodeMark("Hello ", "this", " world", 2);
+    const result = canTabEscape(state);
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty("type", "mark");
+    expect(result).toHaveProperty("targetPos", 11);
+  });
+
+  it("returns escape result when cursor is at end of code mark", () => {
+    // Cursor at the very end of the code-marked text
+    const state = createStateWithCodeMark("Hello ", "this", " world", 4);
+    const result = canTabEscape(state);
+
+    // Should still return an escape result (to clear storedMarks)
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty("type", "mark");
+    expect(result).toHaveProperty("targetPos", 11);
+  });
+
+  it("returns null when cursor is outside code mark", () => {
+    const state = createStateWithCodeMark("Hello ", "this", " world");
+    // Default cursor at start of doc
+    const result = canTabEscape(state);
+    expect(result).toBeNull();
+  });
+
+  it("returns escape result for code mark at end of paragraph", () => {
+    // "Hello " + ["this" with code mark] (no text after)
+    const state = createStateWithCodeMark("Hello ", "this", "", 4);
+    const result = canTabEscape(state);
+
+    // Should return escape result even at end of paragraph
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty("type", "mark");
+  });
+});

--- a/src/plugins/tabIndent/tabEscape.ts
+++ b/src/plugins/tabIndent/tabEscape.ts
@@ -130,8 +130,8 @@ export function getMarkEndPos(state: EditorState): number | null {
     const childStart = parentStart + offset;
     const childEnd = childStart + child.nodeSize;
 
-    // Check if cursor is in this child node
-    if (from >= childStart && from < childEnd) {
+    // Check if cursor is in this child node (inclusive of end boundary)
+    if (from >= childStart && from <= childEnd) {
       // Check if this node has our mark
       if (child.marks.some((m) => m.type === markType)) {
         // Return position right after this text node
@@ -245,19 +245,20 @@ function calculateEscapeForPosition(
     const parent = $pos.parent;
     const parentStart = $pos.start();
 
-    // Find the text node we're currently in
+    // Find the text node we're currently in (inclusive of end boundary)
     let offset = 0;
     for (let i = 0; i < parent.childCount; i++) {
       const child = parent.child(i);
       const childStart = parentStart + offset;
       const childEnd = childStart + child.nodeSize;
 
-      // Check if cursor is in this child node
-      if (pos >= childStart && pos < childEnd) {
+      // Check if cursor is in this child node (inclusive of end boundary)
+      if (pos >= childStart && pos <= childEnd) {
         // Check if this node has our mark
         if (child.marks.some((m) => m.type === markType)) {
           // Return position right after this text node if it's different
-          return childEnd > pos ? childEnd : null;
+          // When pos === childEnd, return childEnd to clear storedMarks
+          return childEnd >= pos ? childEnd : null;
         }
       }
 
@@ -356,7 +357,7 @@ export function canTabEscape(state: EditorState): TabEscapeResult | MultiSelecti
   // Check for escapable mark
   if (isInEscapableMark(state)) {
     const endPos = getMarkEndPos(state);
-    if (endPos !== null && endPos > from) {
+    if (endPos !== null && endPos >= from) {
       return { type: "mark", targetPos: endPos };
     }
   }

--- a/src/plugins/tabIndent/tiptap.ts
+++ b/src/plugins/tabIndent/tiptap.ts
@@ -110,6 +110,14 @@ export const tabIndentExtension = Extension.create({
                       tr.removeStoredMark(linkMarkType);
                     }
                   }
+                  // When escaping an inline mark, clear it from stored marks
+                  // so subsequent typing produces unmarked text.
+                  if (escapeResult.type === "mark") {
+                    const { $from } = state.selection;
+                    for (const mark of $from.marks()) {
+                      tr.removeStoredMark(mark.type);
+                    }
+                  }
                   dispatch(tr);
                   return true;
                 }

--- a/src/utils/tiptapExtensions.ts
+++ b/src/utils/tiptapExtensions.ts
@@ -62,6 +62,7 @@ import { wikiLinkPopupExtension } from "@/plugins/wikiLinkPopup";
 import { CJKLetterSpacing } from "@/plugins/cjkLetterSpacing";
 import { sourcePeekInlineExtension } from "@/plugins/sourcePeekInline";
 import { smartSelectAllExtension } from "@/plugins/smartSelectAll/tiptap";
+import { inlineCodeBoundaryExtension } from "@/plugins/inlineCodeBoundary/tiptap";
 
 /**
  * Creates the array of Tiptap extensions for the WYSIWYG editor.
@@ -166,5 +167,6 @@ export function createTiptapExtensions(): Extensions {
     CJKLetterSpacing,
     sourcePeekInlineExtension,
     smartSelectAllExtension,
+    inlineCodeBoundaryExtension,
   ];
 }


### PR DESCRIPTION
## Summary

Fixes four problems with inline code backtick handling reported in #58:

- **Source mode**: single backtick now auto-pairs with delay-based logic (150ms), avoiding collision with triple-backtick code fence. Double backtick cancels the pair.
- **WYSIWYG mode**: backtick toggles code mark instead of inserting literal backtick text — activates code mark outside code, escapes to end when inside, wraps selection with code mark.
- **Cursor at left boundary**: new `inlineCodeBoundary` plugin (appendTransaction) sets storedMarks so typing at the left edge of inline code goes inside the code node, not outside.
- **Tab escape**: fixed boundary comparisons (`<` to `<=`, `>` to `>=`) in `getMarkEndPos`, `canTabEscape`, and `calculateEscapeForPosition` so Tab at the end of inline code escapes the mark and clears storedMarks.

Closes #58

## Test plan

- [x] 16 new unit tests across 4 test files — all passing
- [x] `pnpm check:all` passes (lint + coverage + build)
- [ ] Manual: in Source mode, type single backtick mid-line → should auto-pair after 150ms
- [ ] Manual: in Source mode, type triple backtick at line start → code fence still works
- [ ] Manual: in WYSIWYG, type backtick → code mark activates (no visible backtick text)
- [ ] Manual: in WYSIWYG, type backtick inside code → cursor escapes to end of code
- [ ] Manual: in WYSIWYG, click at left edge of inline code, type → text appears inside code
- [ ] Manual: in WYSIWYG, press Tab at end of inline code → cursor jumps out