### PR TITLE
Fix #59: Guard terminal against IME composition events

### DIFF
--- a/src/components/Terminal/createTerminalInstance.ts
+++ b/src/components/Terminal/createTerminalInstance.ts
@@ -12,6 +12,7 @@ import { useDocumentStore } from "@/stores/documentStore";
 import { getCurrentWindowLabel } from "@/utils/workspaceStorage";
 import { createFileLinkProvider } from "./fileLinkProvider";
 import { createTerminalKeyHandler } from "./terminalKeyHandler";
+import { terminalLog } from "@/utils/debug";
 
 import "@xterm/xterm/css/xterm.css";
 
@@ -41,12 +42,15 @@ export interface TerminalInstance {
   searchAddon: SearchAddon;
   serializeAddon: SerializeAddon;
   container: HTMLDivElement;
+  /** Whether an IME composition is active (diagnostic). */
+  composing: boolean;
   dispose: () => void;
 }
 
 export interface TerminalInstanceSettings {
   fontSize: number;
   lineHeight: number;
+  useWebGL: boolean;
 }
 
 interface CreateOptions {
@@ -95,18 +99,36 @@ export function createTerminalInstance(options: CreateOptions): TerminalInstance
   // Open terminal
   term.open(container);
 
+  // IME composition tracking (diagnostic + safety net)
+  let composing = false;
+  const textarea = container.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea");
+  const onCompositionStart = () => {
+    composing = true;
+    terminalLog("compositionstart");
+  };
+  const onCompositionEnd = () => {
+    composing = false;
+    terminalLog("compositionend");
+  };
+  if (textarea) {
+    textarea.addEventListener("compositionstart", onCompositionStart);
+    textarea.addEventListener("compositionend", onCompositionEnd);
+  }
+
   // Unicode 11
   const unicode11 = new Unicode11Addon();
   term.loadAddon(unicode11);
   term.unicode.activeVersion = "11";
 
-  // WebGL renderer
-  try {
-    const webglAddon = new WebglAddon();
-    webglAddon.onContextLoss(() => webglAddon.dispose());
-    term.loadAddon(webglAddon);
-  } catch {
-    // Fallback to canvas
+  // WebGL renderer (conditional — can be disabled to troubleshoot IME issues)
+  if (settings.useWebGL) {
+    try {
+      const webglAddon = new WebglAddon();
+      webglAddon.onContextLoss(() => webglAddon.dispose());
+      term.loadAddon(webglAddon);
+    } catch {
+      // Fallback to canvas
+    }
   }
 
   // Web links
@@ -142,11 +164,20 @@ export function createTerminalInstance(options: CreateOptions): TerminalInstance
   });
 
   const dispose = () => {
+    if (textarea) {
+      textarea.removeEventListener("compositionstart", onCompositionStart);
+      textarea.removeEventListener("compositionend", onCompositionEnd);
+    }
     term.dispose();
     if (container.parentElement) {
       container.parentElement.removeChild(container);
     }
   };
 
-  return { term, fitAddon, searchAddon, serializeAddon, container, dispose };
+  const instance: TerminalInstance = {
+    term, fitAddon, searchAddon, serializeAddon, container, dispose,
+    get composing() { return composing; },
+  };
+
+  return instance;
 }

--- a/src/components/Terminal/terminalKeyHandler.test.ts
+++ b/src/components/Terminal/terminalKeyHandler.test.ts
@@ -16,8 +16,20 @@ function makeTerm(overrides: Partial<Terminal> = {}): Terminal {
   } as unknown as Terminal;
 }
 
-function makeEvent(key: string, meta = true): KeyboardEvent {
-  return { type: "keydown", key, metaKey: meta, ctrlKey: false } as unknown as KeyboardEvent;
+function makeEvent(
+  key: string,
+  meta = true,
+  overrides: Partial<KeyboardEvent> = {},
+): KeyboardEvent {
+  return {
+    type: "keydown",
+    key,
+    metaKey: meta,
+    ctrlKey: false,
+    isComposing: false,
+    keyCode: 0,
+    ...overrides,
+  } as unknown as KeyboardEvent;
 }
 
 describe("createTerminalKeyHandler", () => {
@@ -90,5 +102,23 @@ describe("createTerminalKeyHandler", () => {
     const handler = createTerminalKeyHandler(term, ptyRef, callbacks);
     expect(handler(makeEvent("a"))).toBe(true);
     expect(handler(makeEvent("z"))).toBe(true);
+  });
+
+  it("passes through IME composition events (isComposing)", () => {
+    const term = makeTerm();
+    const handler = createTerminalKeyHandler(term, ptyRef, callbacks);
+    // Cmd+V during IME composition should NOT trigger paste
+    const result = handler(makeEvent("v", true, { isComposing: true }));
+    expect(result).toBe(true);
+    expect(readText).not.toHaveBeenCalled();
+  });
+
+  it("passes through IME keyCode 229 events", () => {
+    const term = makeTerm();
+    const handler = createTerminalKeyHandler(term, ptyRef, callbacks);
+    const result = handler(makeEvent("v", true, { keyCode: 229 }));
+    expect(result).toBe(true);
+    // Should not trigger paste
+    expect(readText).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Terminal/terminalKeyHandler.ts
+++ b/src/components/Terminal/terminalKeyHandler.ts
@@ -2,6 +2,7 @@ import type { IPty } from "tauri-pty";
 import { readText, writeText } from "@tauri-apps/plugin-clipboard-manager";
 import type { Terminal } from "@xterm/xterm";
 import { useTerminalSessionStore } from "@/stores/terminalSessionStore";
+import { isImeKeyEvent } from "@/utils/imeGuard";
 
 export interface KeyHandlerCallbacks {
   onSearch: () => void;
@@ -20,6 +21,8 @@ export function createTerminalKeyHandler(
 ): (event: KeyboardEvent) => boolean {
   return (event: KeyboardEvent): boolean => {
     if (event.type !== "keydown") return true;
+    // Never interfere during IME composition (CJK input, etc.)
+    if (isImeKeyEvent(event)) return true;
     const isMod = event.metaKey || event.ctrlKey;
     if (!isMod) return true;
 

--- a/src/components/Terminal/useTerminalSessions.ts
+++ b/src/components/Terminal/useTerminalSessions.ts
@@ -167,13 +167,14 @@ export function useTerminalSessions(
       const termSettings = useSettingsStore.getState().terminal;
       const fontSize = termSettings?.fontSize ?? 13;
       const lineHeight = termSettings?.lineHeight ?? 1.2;
+      const useWebGL = termSettings?.useWebGL ?? true;
 
       // Create a shared ptyRef that we'll update as the pty changes
       const ptyRefForKeys: React.RefObject<IPty | null> = { current: null };
 
       const instance = createTerminalInstance({
         parentEl: parent,
-        settings: { fontSize, lineHeight },
+        settings: { fontSize, lineHeight, useWebGL },
         ptyRef: ptyRefForKeys,
         onSearch: () => callbacksRef.current?.onSearch?.(),
       });

--- a/src/pages/settings/TerminalSettings.tsx
+++ b/src/pages/settings/TerminalSettings.tsx
@@ -57,6 +57,13 @@ export function TerminalSettings() {
             onChange={(v) => updateTerminalSetting("copyOnSelect", v)}
           />
         </SettingRow>
+
+        <SettingRow label="WebGL Renderer" description="Use GPU-accelerated rendering. Disable if you experience IME input issues. Requires terminal restart.">
+          <Toggle
+            checked={terminal.useWebGL}
+            onChange={(v) => updateTerminalSetting("useWebGL", v)}
+          />
+        </SettingRow>
       </SettingsGroup>
     </div>
   );

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -191,6 +191,7 @@ export interface TerminalSettings {
   fontSize: number;    // Default: 13 (range: 10–24)
   lineHeight: number;  // Default: 1.4 (range: 1.0–2.0)
   copyOnSelect: boolean; // Default: false — auto-copy selected text to clipboard
+  useWebGL: boolean;   // Default: true — use WebGL renderer (disable to troubleshoot IME issues)
 }
 
 export interface AdvancedSettingsState {
@@ -395,6 +396,7 @@ const initialState: SettingsState = {
     fontSize: 13,
     lineHeight: 1.2,
     copyOnSelect: false,
+    useWebGL: true,
   },
   advanced: {
     mcpServer: {

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -22,3 +22,11 @@ export const historyLog = isDev
 export const autoSaveLog = isDev
   ? (...args: unknown[]) => console.log("[AutoSave]", ...args)
   : () => {};
+
+/**
+ * Debug logger for Terminal operations (IME composition, PTY events).
+ * Only logs in development mode.
+ */
+export const terminalLog = isDev
+  ? (...args: unknown[]) => console.log("[Terminal]", ...args)
+  : () => {};


### PR DESCRIPTION
## Summary

- Add `isImeKeyEvent()` guard in the terminal custom key handler so it never intercepts keystrokes during CJK IME composition — fixes erratic cursor and backspace behavior
- Track composition state on xterm's hidden textarea with `compositionstart`/`compositionend` listeners for diagnostics
- Add `useWebGL` terminal setting (Settings > Terminal) so users can disable the WebGL renderer to isolate IME issues
- Add `terminalLog` debug logger for composition event tracing in dev mode

## Test plan

- [x] 2 new unit tests for IME guard (`isComposing` and `keyCode 229`)
- [x] All 4138 existing tests pass
- [x] `pnpm check:all` gate passes
- [ ] Manual: open terminal, activate CJK IME (e.g. Pinyin), type and select characters — should work cleanly
- [ ] Manual: press Backspace during/after composition — should delete correctly
- [ ] Manual: disable WebGL in Settings > Terminal, restart terminal, repeat above tests
- [ ] Manual: check browser console for `[Terminal] compositionstart/end` logs in dev mode

Closes #59