### PR TITLE
fix: prevent IME cleanup from deleting text at block start (fixes #66)

### DIFF
--- a/src/plugins/compositionGuard/tiptap.ts
+++ b/src/plugins/compositionGuard/tiptap.ts
@@ -66,6 +66,14 @@ export const compositionGuardExtension = Extension.create({
         return;
       }
 
+      // Skip cleanup if composition started at the beginning of the parent block.
+      // This prevents incorrect deletion when typing fresh content (e.g., after
+      // pressing Enter following bold text). Cleanup is only needed when editing
+      // mid-content where pinyin residue might remain.
+      if (compositionStartPos === $start.start()) {
+        return;
+      }
+
       let cleanupEnd = $start.end();
       let allowNewlines = false;
 


### PR DESCRIPTION
## Summary

Fixes #66 - Chinese IME input would disappear after pressing Enter following bold text.

## Root Cause

The `scheduleImeCleanup` function was designed to remove leftover pinyin prefixes after IME composition. However, it was running even when composition started at the beginning of an empty paragraph (e.g., after pressing Enter following formatted text).

In this scenario:
1. User types bold Chinese text
2. Presses Enter → new empty paragraph
3. Starts typing Chinese with IME
4. After composition ends, cleanup incorrectly treats the fresh input as residue

## Fix

Added a check to skip cleanup when `compositionStartPos === $start.start()` (composition started at block beginning). This:
- Prevents incorrect deletion of fresh content
- Preserves cleanup for mid-content edits where pinyin residue actually occurs
- Specifically fixes the reported issue with bold text + newline + Chinese input

## Testing

Manual testing needed:
- [ ] Type bold Chinese text (e.g., `**你好**`)
- [ ] Press Enter to create new paragraph
- [ ] Type Chinese with IME - verify text appears and persists
- [ ] Type English after bold + Enter - verify still works (no regression)
- [ ] Edit mid-paragraph with Chinese IME - verify pinyin cleanup still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)