### PR TITLE
fix: allow reading/writing dot-files and files in dot-directories

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -37,90 +37,130 @@
       "identifier": "fs:allow-read-text-file",
       "allow": [
         { "path": "$HOME/**/*" },
+        { "path": "$HOME/**/.*" },
         { "path": "/Volumes/**/*" },
+        { "path": "/Volumes/**/.*" },
         { "path": "/mnt/**/*" },
-        { "path": "/media/**/*" }
+        { "path": "/mnt/**/.*" },
+        { "path": "/media/**/*" },
+        { "path": "/media/**/.*" }
       ]
     },
     {
       "identifier": "fs:allow-write-text-file",
       "allow": [
         { "path": "$HOME/**/*" },
+        { "path": "$HOME/**/.*" },
         { "path": "/Volumes/**/*" },
+        { "path": "/Volumes/**/.*" },
         { "path": "/mnt/**/*" },
-        { "path": "/media/**/*" }
+        { "path": "/mnt/**/.*" },
+        { "path": "/media/**/*" },
+        { "path": "/media/**/.*" }
       ]
     },
     {
       "identifier": "fs:allow-write-file",
       "allow": [
         { "path": "$HOME/**/*" },
+        { "path": "$HOME/**/.*" },
         { "path": "/Volumes/**/*" },
+        { "path": "/Volumes/**/.*" },
         { "path": "/mnt/**/*" },
-        { "path": "/media/**/*" }
+        { "path": "/mnt/**/.*" },
+        { "path": "/media/**/*" },
+        { "path": "/media/**/.*" }
       ]
     },
     {
       "identifier": "fs:allow-exists",
       "allow": [
         { "path": "$HOME/**/*" },
+        { "path": "$HOME/**/.*" },
         { "path": "/Volumes/**/*" },
+        { "path": "/Volumes/**/.*" },
         { "path": "/mnt/**/*" },
-        { "path": "/media/**/*" }
+        { "path": "/mnt/**/.*" },
+        { "path": "/media/**/*" },
+        { "path": "/media/**/.*" }
       ]
     },
     {
       "identifier": "fs:allow-mkdir",
       "allow": [
         { "path": "$HOME/**/*" },
+        { "path": "$HOME/**/.*" },
         { "path": "/Volumes/**/*" },
+        { "path": "/Volumes/**/.*" },
         { "path": "/mnt/**/*" },
-        { "path": "/media/**/*" }
+        { "path": "/mnt/**/.*" },
+        { "path": "/media/**/*" },
+        { "path": "/media/**/.*" }
       ]
     },
     {
       "identifier": "fs:allow-read-dir",
       "allow": [
         { "path": "$HOME/**/*" },
+        { "path": "$HOME/**/.*" },
         { "path": "/Volumes/**/*" },
+        { "path": "/Volumes/**/.*" },
         { "path": "/mnt/**/*" },
-        { "path": "/media/**/*" }
+        { "path": "/mnt/**/.*" },
+        { "path": "/media/**/*" },
+        { "path": "/media/**/.*" }
       ]
     },
     {
       "identifier": "fs:allow-copy-file",
       "allow": [
         { "path": "$HOME/**/*" },
+        { "path": "$HOME/**/.*" },
         { "path": "/Volumes/**/*" },
+        { "path": "/Volumes/**/.*" },
         { "path": "/mnt/**/*" },
-        { "path": "/media/**/*" }
+        { "path": "/mnt/**/.*" },
+        { "path": "/media/**/*" },
+        { "path": "/media/**/.*" }
       ]
     },
     {
       "identifier": "fs:allow-read-file",
       "allow": [
         { "path": "$HOME/**/*" },
+        { "path": "$HOME/**/.*" },
         { "path": "/Volumes/**/*" },
+        { "path": "/Volumes/**/.*" },
         { "path": "/mnt/**/*" },
-        { "path": "/media/**/*" }
+        { "path": "/mnt/**/.*" },
+        { "path": "/media/**/*" },
+        { "path": "/media/**/.*" }
       ]
     },
     {
       "identifier": "fs:allow-rename",
       "allow": [
         { "path": "$HOME/**/*" },
+        { "path": "$HOME/**/.*" },
         { "path": "/Volumes/**/*" },
+        { "path": "/Volumes/**/.*" },
         { "path": "/mnt/**/*" },
-        { "path": "/media/**/*" }
+        { "path": "/mnt/**/.*" },
+        { "path": "/media/**/*" },
+        { "path": "/media/**/.*" }
       ]
     },
     {
       "identifier": "fs:allow-remove",
       "allow": [
         { "path": "$HOME/**/*" },
+        { "path": "$HOME/**/.*" },
         { "path": "/Volumes/**/*" },
+        { "path": "/Volumes/**/.*" },
         { "path": "/mnt/**/*" },
-        { "path": "/media/**/*" }
+        { "path": "/mnt/**/.*" },
+        { "path": "/media/**/*" },
+        { "path": "/media/**/.*" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Fixes issue where opening markdown files in dot-directories (e.g., `.github/README.md`) or dot-files (e.g., `.template.md`) directly from Finder results in a blank document, even though the tab shows the correct filename.

## Root Cause

Tauri's glob pattern matcher treats `**/*` as matching only non-hidden files. Files and directories starting with `.` require explicit glob patterns like `**/.*`.

When `readTextFile()` was called on a dot-file, Tauri's fs permission scope rejected it, causing a permission error. The error handler in `useFinderFileOpen` caught this and initialized the document with empty content, resulting in a blank editor.

## Fix

Added explicit `**/.*` glob patterns to all fs permissions in `src-tauri/capabilities/default.json`:
- `fs:allow-read-text-file`  
- `fs:allow-write-text-file`
- `fs:allow-read-file`
- `fs:allow-write-file`
- `fs:allow-exists`
- `fs:allow-mkdir`
- `fs:allow-read-dir`
- `fs:allow-copy-file`
- `fs:allow-rename`
- `fs:allow-remove`

This allows VMark to:
- Open dot-files like `.template.md` directly
- Open files in dot-directories like `.github/README.md`  
- Read/write/manage these files normally
- Properly detect external changes to dot-files (via file watcher)

## Testing

Manual testing needed:
- [ ] Cold-open a file in a dot-directory (e.g., `.github/CONTRIBUTING.md`) from Finder
- [ ] Cold-open a dot-file (e.g., `.env.example.md`) from Finder
- [ ] Verify content loads correctly (not blank)
- [ ] Edit and save the file
- [ ] Verify file watcher detects external changes to dot-files
- [ ] Verify non-dot files still work normally (no regression)

## Related

- Builds on commit 8ea7eff which fixed file watcher to allow dot-directories
- Complements commit 123f896 which added error handling for failed file opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)