### PR TITLE
feat: crash recovery for unsaved documents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,9 @@ import { useHotExitCapture } from "@/utils/hotExit/useHotExitCapture";
 import { useHotExitRestore } from "@/utils/hotExit/useHotExitRestore";
 import { useHotExitStartup } from "@/utils/hotExit/useHotExitStartup";
 import { useGenieShortcuts } from "@/hooks/useGenieShortcuts";
+import { useCrashRecoveryWriter } from "@/hooks/useCrashRecoveryWriter";
+import { useCrashRecoveryStartup } from "@/hooks/useCrashRecoveryStartup";
+import { useCrashRecoveryCleanup } from "@/hooks/useCrashRecoveryCleanup";
 import { GeniePicker } from "@/components/GeniePicker/GeniePicker";
 
 /** Height of the title bar area in pixels */
@@ -144,6 +147,8 @@ function DocumentWindowHooks() {
   useExternalFileChanges(); // Handle external file changes (auto-reload or prompt)
   useHotExitCapture(); // Respond to hot exit capture requests
   useHotExitRestore(); // Handle hot exit restore on restart
+  useCrashRecoveryWriter(); // Periodically snapshot dirty docs for crash recovery
+  useCrashRecoveryCleanup(); // Clean up recovery files on save/close/exit
   return null;
 }
 
@@ -160,6 +165,7 @@ function MainWindowHooks() {
   useUpdateChecker(); // Check for updates on startup
   useUpdateBroadcast(); // Broadcast update state to other windows
   useHotExitStartup(); // Check for saved session and restore if present (MUST run before Finder)
+  useCrashRecoveryStartup(); // Restore docs from crash recovery (waits for hot exit)
   useFinderFileOpen(); // Handle files opened from Finder (waits for hot exit to complete)
   return null;
 }

--- a/src/hooks/__tests__/useCrashRecoveryCleanup.test.ts
+++ b/src/hooks/__tests__/useCrashRecoveryCleanup.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCrashRecoveryCleanup } from "../useCrashRecoveryCleanup";
+import { useTabStore } from "@/stores/tabStore";
+import { useDocumentStore } from "@/stores/documentStore";
+
+// Mock crashRecovery module
+const mockDeleteRecoverySnapshot = vi.fn();
+const mockDeleteRecoveryFilesForTabs = vi.fn();
+vi.mock("@/utils/crashRecovery", () => ({
+  deleteRecoverySnapshot: (...args: unknown[]) => mockDeleteRecoverySnapshot(...args),
+  deleteRecoveryFilesForTabs: (...args: unknown[]) => mockDeleteRecoveryFilesForTabs(...args),
+}));
+
+// Mock WindowContext
+vi.mock("@/contexts/WindowContext", () => ({
+  useWindowLabel: () => "main",
+}));
+
+describe("useCrashRecoveryCleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteRecoverySnapshot.mockResolvedValue(undefined);
+    mockDeleteRecoveryFilesForTabs.mockResolvedValue(undefined);
+
+    // Setup initial state with two tabs
+    useTabStore.setState({
+      tabs: {
+        main: [
+          { id: "tab-1", filePath: null, title: "Untitled-1", isPinned: false },
+          { id: "tab-2", filePath: "/path/doc.md", title: "doc.md", isPinned: false },
+        ],
+      },
+      activeTabId: { main: "tab-1" },
+    });
+
+    useDocumentStore.setState({
+      documents: {
+        "tab-1": {
+          content: "# Content",
+          savedContent: "",
+          lastDiskContent: "",
+          filePath: null,
+          isDirty: true,
+          isMissing: false,
+          isDivergent: false,
+          documentId: 1,
+          cursorInfo: null,
+          lastAutoSave: null,
+          lineEnding: "lf" as const,
+          hardBreakStyle: "backslash" as const,
+        },
+        "tab-2": {
+          content: "# Saved",
+          savedContent: "# Saved",
+          lastDiskContent: "# Saved",
+          filePath: "/path/doc.md",
+          isDirty: false,
+          isMissing: false,
+          isDivergent: false,
+          documentId: 2,
+          cursorInfo: null,
+          lastAutoSave: null,
+          lineEnding: "lf" as const,
+          hardBreakStyle: "backslash" as const,
+        },
+      },
+    });
+  });
+
+  it("deletes recovery file when tab is removed from store", async () => {
+    renderHook(() => useCrashRecoveryCleanup());
+
+    // Remove tab-1 from tabStore (simulating tab close)
+    act(() => {
+      useTabStore.setState({
+        tabs: {
+          main: [
+            { id: "tab-2", filePath: "/path/doc.md", title: "doc.md", isPinned: false },
+          ],
+        },
+      });
+    });
+
+    // Wait for async operation
+    await vi.waitFor(() => {
+      expect(mockDeleteRecoverySnapshot).toHaveBeenCalledWith("tab-1");
+    });
+  });
+
+  it("deletes recovery file when document transitions from dirty to clean", async () => {
+    renderHook(() => useCrashRecoveryCleanup());
+
+    // tab-1 becomes clean (e.g., saved)
+    act(() => {
+      useDocumentStore.setState({
+        documents: {
+          ...useDocumentStore.getState().documents,
+          "tab-1": {
+            ...useDocumentStore.getState().documents["tab-1"],
+            isDirty: false,
+            savedContent: "# Content",
+          },
+        },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(mockDeleteRecoverySnapshot).toHaveBeenCalledWith("tab-1");
+    });
+  });
+
+  it("does not delete recovery file for already-clean documents", () => {
+    renderHook(() => useCrashRecoveryCleanup());
+
+    // tab-2 is already clean — changing unrelated field should not trigger deletion
+    act(() => {
+      useDocumentStore.setState({
+        documents: {
+          ...useDocumentStore.getState().documents,
+          "tab-2": {
+            ...useDocumentStore.getState().documents["tab-2"],
+            content: "# Still saved",
+            savedContent: "# Still saved",
+          },
+        },
+      });
+    });
+
+    // Should not be called — tab-2 was already clean
+    expect(mockDeleteRecoverySnapshot).not.toHaveBeenCalled();
+  });
+
+  it("deletes only this window's tab snapshots on beforeunload", () => {
+    renderHook(() => useCrashRecoveryCleanup());
+
+    // Simulate beforeunload
+    window.dispatchEvent(new Event("beforeunload"));
+
+    // Should call per-window cleanup, not global deleteAll
+    expect(mockDeleteRecoveryFilesForTabs).toHaveBeenCalledWith(["tab-1", "tab-2"]);
+  });
+
+  it("cleans up subscriptions and listener on unmount", () => {
+    const { unmount } = renderHook(() => useCrashRecoveryCleanup());
+    unmount();
+
+    // After unmount, store changes should not trigger deletion
+    act(() => {
+      useTabStore.setState({
+        tabs: { main: [] },
+      });
+    });
+
+    expect(mockDeleteRecoverySnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useCrashRecoveryStartup.test.ts
+++ b/src/hooks/__tests__/useCrashRecoveryStartup.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCrashRecoveryStartup } from "../useCrashRecoveryStartup";
+import { useTabStore } from "@/stores/tabStore";
+import { useDocumentStore } from "@/stores/documentStore";
+
+// Mock crashRecovery module
+const mockReadRecoverySnapshots = vi.fn();
+const mockDeleteStaleRecoveryFiles = vi.fn();
+const mockDeleteRecoverySnapshot = vi.fn();
+vi.mock("@/utils/crashRecovery", () => ({
+  readRecoverySnapshots: () => mockReadRecoverySnapshots(),
+  deleteStaleRecoveryFiles: (...args: unknown[]) => mockDeleteStaleRecoveryFiles(...args),
+  deleteRecoverySnapshot: (...args: unknown[]) => mockDeleteRecoverySnapshot(...args),
+}));
+
+// Mock hot exit coordination
+const mockWaitForRestoreComplete = vi.fn();
+vi.mock("@/utils/hotExit/hotExitCoordination", () => ({
+  waitForRestoreComplete: () => mockWaitForRestoreComplete(),
+}));
+
+// Mock sonner toast
+const mockToastInfo = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { info: (...args: unknown[]) => mockToastInfo(...args) },
+}));
+
+// Mock WindowContext
+vi.mock("@/contexts/WindowContext", () => ({
+  useWindowLabel: () => "main",
+}));
+
+function makeSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    version: 1,
+    tabId: "recovered-tab-1",
+    windowLabel: "main",
+    content: "# Recovered content",
+    filePath: null,
+    title: "Untitled-1",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("useCrashRecoveryStartup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWaitForRestoreComplete.mockResolvedValue(true);
+    mockDeleteStaleRecoveryFiles.mockResolvedValue(undefined);
+    mockDeleteRecoverySnapshot.mockResolvedValue(undefined);
+    mockReadRecoverySnapshots.mockResolvedValue([]);
+
+    // Reset stores
+    useTabStore.setState({
+      tabs: { main: [] },
+      activeTabId: { main: null },
+      untitledCounter: 0,
+    });
+    useDocumentStore.setState({ documents: {} });
+  });
+
+  it("waits for hot exit restore before proceeding", async () => {
+    mockWaitForRestoreComplete.mockResolvedValue(true);
+    renderHook(() => useCrashRecoveryStartup());
+
+    await vi.waitFor(() => {
+      expect(mockWaitForRestoreComplete).toHaveBeenCalled();
+    });
+  });
+
+  it("cleans stale files before reading snapshots", async () => {
+    renderHook(() => useCrashRecoveryStartup());
+
+    await vi.waitFor(() => {
+      expect(mockDeleteStaleRecoveryFiles).toHaveBeenCalledWith(7);
+    });
+  });
+
+  it("restores untitled document from recovery snapshot", async () => {
+    const snapshot = makeSnapshot({
+      content: "# My recovered content",
+      filePath: null,
+      title: "Untitled-1",
+    });
+    mockReadRecoverySnapshots.mockResolvedValue([snapshot]);
+
+    renderHook(() => useCrashRecoveryStartup());
+
+    await vi.waitFor(() => {
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        expect.stringContaining("1")
+      );
+    });
+
+    // Should have created a tab
+    const tabs = useTabStore.getState().getTabsByWindow("main");
+    expect(tabs.length).toBe(1);
+
+    // Should have initialized document as dirty
+    const doc = useDocumentStore.getState().getDocument(tabs[0].id);
+    expect(doc).toBeDefined();
+    expect(doc!.content).toBe("# My recovered content");
+    expect(doc!.isDirty).toBe(true);
+  });
+
+  it("restores document with filePath from recovery snapshot", async () => {
+    const snapshot = makeSnapshot({
+      content: "# Modified file content",
+      filePath: "/path/to/file.md",
+      title: "file.md",
+    });
+    mockReadRecoverySnapshots.mockResolvedValue([snapshot]);
+
+    renderHook(() => useCrashRecoveryStartup());
+
+    await vi.waitFor(() => {
+      expect(mockToastInfo).toHaveBeenCalled();
+    });
+
+    const tabs = useTabStore.getState().getTabsByWindow("main");
+    expect(tabs.length).toBe(1);
+    expect(tabs[0].filePath).toBe("/path/to/file.md");
+
+    const doc = useDocumentStore.getState().getDocument(tabs[0].id);
+    expect(doc!.content).toBe("# Modified file content");
+    expect(doc!.isDirty).toBe(true);
+  });
+
+  it("restores multiple documents and shows correct count", async () => {
+    mockReadRecoverySnapshots.mockResolvedValue([
+      makeSnapshot({ tabId: "t1", content: "Doc 1" }),
+      makeSnapshot({ tabId: "t2", content: "Doc 2" }),
+      makeSnapshot({ tabId: "t3", content: "Doc 3" }),
+    ]);
+
+    renderHook(() => useCrashRecoveryStartup());
+
+    await vi.waitFor(() => {
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        expect.stringContaining("3")
+      );
+    });
+
+    const tabs = useTabStore.getState().getTabsByWindow("main");
+    expect(tabs.length).toBe(3);
+  });
+
+  it("deletes recovery files after successful restore", async () => {
+    const snapshot = makeSnapshot();
+    mockReadRecoverySnapshots.mockResolvedValue([snapshot]);
+
+    renderHook(() => useCrashRecoveryStartup());
+
+    await vi.waitFor(() => {
+      expect(mockDeleteRecoverySnapshot).toHaveBeenCalledWith(
+        snapshot.tabId
+      );
+    });
+  });
+
+  it("does nothing when no recovery snapshots exist", async () => {
+    mockReadRecoverySnapshots.mockResolvedValue([]);
+    renderHook(() => useCrashRecoveryStartup());
+
+    await vi.waitFor(() => {
+      expect(mockReadRecoverySnapshots).toHaveBeenCalled();
+    });
+
+    expect(mockToastInfo).not.toHaveBeenCalled();
+    expect(useTabStore.getState().getTabsByWindow("main")).toHaveLength(0);
+  });
+
+  it("deduplicates snapshots by filePath, keeping newest", async () => {
+    const olderSnapshot = makeSnapshot({
+      tabId: "t-old",
+      filePath: "/path/same.md",
+      content: "# Older version",
+      timestamp: 1000,
+    });
+    const newerSnapshot = makeSnapshot({
+      tabId: "t-new",
+      filePath: "/path/same.md",
+      content: "# Newer version",
+      timestamp: 2000,
+    });
+    const untitledSnapshot = makeSnapshot({
+      tabId: "t-untitled",
+      filePath: null,
+      content: "# Untitled doc",
+      timestamp: 500,
+    });
+
+    mockReadRecoverySnapshots.mockResolvedValue([
+      olderSnapshot,
+      newerSnapshot,
+      untitledSnapshot,
+    ]);
+
+    renderHook(() => useCrashRecoveryStartup());
+
+    await vi.waitFor(() => {
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        expect.stringContaining("2")
+      );
+    });
+
+    // Should restore 2 tabs: the newer filePath snapshot + the untitled one
+    const tabs = useTabStore.getState().getTabsByWindow("main");
+    expect(tabs.length).toBe(2);
+
+    // The older duplicate should be deleted without restoring
+    expect(mockDeleteRecoverySnapshot).toHaveBeenCalledWith("t-old");
+    // The kept ones should also be deleted after restore
+    expect(mockDeleteRecoverySnapshot).toHaveBeenCalledWith("t-new");
+    expect(mockDeleteRecoverySnapshot).toHaveBeenCalledWith("t-untitled");
+  });
+
+  it("does not throw on errors during restore", async () => {
+    mockReadRecoverySnapshots.mockRejectedValue(new Error("read failed"));
+    renderHook(() => useCrashRecoveryStartup());
+
+    // Should not throw — just log the error
+    await vi.waitFor(() => {
+      expect(mockReadRecoverySnapshots).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/__tests__/useCrashRecoveryWriter.test.ts
+++ b/src/hooks/__tests__/useCrashRecoveryWriter.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCrashRecoveryWriter } from "../useCrashRecoveryWriter";
+import { useTabStore } from "@/stores/tabStore";
+import { useDocumentStore } from "@/stores/documentStore";
+
+// Mock crashRecovery module
+const mockWriteRecoverySnapshot = vi.fn();
+vi.mock("@/utils/crashRecovery", () => ({
+  writeRecoverySnapshot: (...args: unknown[]) => mockWriteRecoverySnapshot(...args),
+}));
+
+// Mock WindowContext
+vi.mock("@/contexts/WindowContext", () => ({
+  useWindowLabel: () => "main",
+}));
+
+function makeDocState(overrides: Record<string, unknown> = {}) {
+  return {
+    content: "",
+    savedContent: "",
+    lastDiskContent: "",
+    filePath: null,
+    isDirty: false,
+    isMissing: false,
+    isDivergent: false,
+    documentId: 1,
+    cursorInfo: null,
+    lastAutoSave: null,
+    lineEnding: "lf" as const,
+    hardBreakStyle: "backslash" as const,
+    ...overrides,
+  };
+}
+
+describe("useCrashRecoveryWriter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockWriteRecoverySnapshot.mockResolvedValue(true);
+
+    // Setup tab store with test tabs
+    useTabStore.setState({
+      tabs: {
+        main: [
+          { id: "tab-1", filePath: null, title: "Untitled-1", isPinned: false },
+          { id: "tab-2", filePath: "/path/doc.md", title: "doc.md", isPinned: false },
+          { id: "tab-3", filePath: null, title: "Untitled-2", isPinned: false },
+        ],
+      },
+      activeTabId: { main: "tab-1" },
+    });
+
+    // Setup document store — tab-1 and tab-2 dirty, tab-3 clean
+    useDocumentStore.setState({
+      documents: {
+        "tab-1": makeDocState({
+          content: "# Dirty untitled",
+          isDirty: true,
+        }),
+        "tab-2": makeDocState({
+          content: "# Modified saved doc",
+          savedContent: "# Original",
+          lastDiskContent: "# Original",
+          filePath: "/path/doc.md",
+          isDirty: true,
+          documentId: 2,
+        }),
+        "tab-3": makeDocState({ documentId: 3 }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("writes snapshots for dirty tabs after interval", async () => {
+    renderHook(() => useCrashRecoveryWriter());
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // Should have written snapshots for tab-1 and tab-2 (dirty), not tab-3 (clean)
+    expect(mockWriteRecoverySnapshot).toHaveBeenCalledTimes(2);
+
+    expect(mockWriteRecoverySnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabId: "tab-1",
+        content: "# Dirty untitled",
+        filePath: null,
+        title: "Untitled-1",
+        windowLabel: "main",
+      })
+    );
+
+    expect(mockWriteRecoverySnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabId: "tab-2",
+        content: "# Modified saved doc",
+        filePath: "/path/doc.md",
+        title: "doc.md",
+      })
+    );
+  });
+
+  it("skips unchanged content on subsequent intervals", async () => {
+    renderHook(() => useCrashRecoveryWriter());
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mockWriteRecoverySnapshot).toHaveBeenCalledTimes(2);
+
+    mockWriteRecoverySnapshot.mockClear();
+
+    // Advance again — content hasn't changed
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mockWriteRecoverySnapshot).toHaveBeenCalledTimes(0);
+  });
+
+  it("writes again when content changes", async () => {
+    renderHook(() => useCrashRecoveryWriter());
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    mockWriteRecoverySnapshot.mockClear();
+
+    // Change content for tab-1
+    useDocumentStore.setState({
+      documents: {
+        ...useDocumentStore.getState().documents,
+        "tab-1": {
+          ...useDocumentStore.getState().documents["tab-1"],
+          content: "# Updated content",
+        },
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // Only tab-1 should be re-written
+    expect(mockWriteRecoverySnapshot).toHaveBeenCalledTimes(1);
+    expect(mockWriteRecoverySnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabId: "tab-1",
+        content: "# Updated content",
+      })
+    );
+  });
+
+  it("retries after failed write on next interval", async () => {
+    // First interval: write fails, hash should NOT be cached
+    mockWriteRecoverySnapshot.mockResolvedValue(false);
+    renderHook(() => useCrashRecoveryWriter());
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mockWriteRecoverySnapshot).toHaveBeenCalledTimes(2);
+
+    mockWriteRecoverySnapshot.mockClear();
+
+    // Second interval: write succeeds — should retry same content
+    mockWriteRecoverySnapshot.mockResolvedValue(true);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mockWriteRecoverySnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not throw on write errors", async () => {
+    mockWriteRecoverySnapshot.mockRejectedValue(new Error("disk full"));
+    renderHook(() => useCrashRecoveryWriter());
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // Should not throw — errors are caught internally
+    expect(mockWriteRecoverySnapshot).toHaveBeenCalled();
+  });
+
+  it("cleans up interval on unmount", async () => {
+    const { unmount } = renderHook(() => useCrashRecoveryWriter());
+    unmount();
+
+    mockWriteRecoverySnapshot.mockClear();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mockWriteRecoverySnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useCrashRecoveryCleanup.ts
+++ b/src/hooks/useCrashRecoveryCleanup.ts
@@ -1,0 +1,95 @@
+/**
+ * Crash Recovery Cleanup Hook
+ *
+ * Deletes recovery files when they are no longer needed:
+ * - When a tab is closed (removed from tabStore)
+ * - When a document transitions from dirty to clean (saved)
+ * - When the window unloads normally (deletes only this window's tabs)
+ *
+ * @module hooks/useCrashRecoveryCleanup
+ * @coordinates-with crashRecovery.ts, useCrashRecoveryWriter.ts
+ */
+
+import { useEffect, useRef } from "react";
+import { useWindowLabel } from "@/contexts/WindowContext";
+import { useTabStore } from "@/stores/tabStore";
+import { useDocumentStore } from "@/stores/documentStore";
+import {
+  deleteRecoverySnapshot,
+  deleteRecoveryFilesForTabs,
+} from "@/utils/crashRecovery";
+import { crashRecoveryLog } from "@/utils/debug";
+
+/**
+ * Clean up recovery files when tabs close, documents save, or window exits.
+ * Mount in DocumentWindowHooks (runs per window).
+ */
+export function useCrashRecoveryCleanup(): void {
+  const windowLabel = useWindowLabel();
+  const prevTabIdsRef = useRef<Set<string>>(new Set());
+  const prevDirtyRef = useRef<Map<string, boolean>>(new Map());
+
+  // Tab-close cleanup: detect removed tabs and delete their recovery files
+  useEffect(() => {
+    const currentTabs = useTabStore.getState().getTabsByWindow(windowLabel);
+    prevTabIdsRef.current = new Set(currentTabs.map((t) => t.id));
+
+    const unsub = useTabStore.subscribe((state) => {
+      const currentIds = new Set(
+        state.getTabsByWindow(windowLabel).map((t) => t.id)
+      );
+      const prevIds = prevTabIdsRef.current;
+
+      for (const id of prevIds) {
+        if (!currentIds.has(id)) {
+          crashRecoveryLog("Tab closed, deleting snapshot:", id);
+          void deleteRecoverySnapshot(id);
+        }
+      }
+
+      prevTabIdsRef.current = currentIds;
+    });
+
+    return () => unsub();
+  }, [windowLabel]);
+
+  // Save cleanup: detect dirty → clean transitions
+  useEffect(() => {
+    const docs = useDocumentStore.getState().documents;
+    for (const [tabId, doc] of Object.entries(docs)) {
+      prevDirtyRef.current.set(tabId, doc.isDirty);
+    }
+
+    const unsub = useDocumentStore.subscribe((state) => {
+      const currentDocIds = new Set(Object.keys(state.documents));
+
+      for (const [tabId, doc] of Object.entries(state.documents)) {
+        const wasDirty = prevDirtyRef.current.get(tabId);
+        if (wasDirty === true && !doc.isDirty) {
+          crashRecoveryLog("Document saved, deleting snapshot:", tabId);
+          void deleteRecoverySnapshot(tabId);
+        }
+        prevDirtyRef.current.set(tabId, doc.isDirty);
+      }
+
+      // Prune tracking for removed documents
+      for (const key of prevDirtyRef.current.keys()) {
+        if (!currentDocIds.has(key)) prevDirtyRef.current.delete(key);
+      }
+    });
+
+    return () => unsub();
+  }, []);
+
+  // Normal-exit cleanup: delete only this window's tabs (not all windows)
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      const tabs = useTabStore.getState().getTabsByWindow(windowLabel);
+      const tabIds = tabs.map((t) => t.id);
+      void deleteRecoveryFilesForTabs(tabIds);
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [windowLabel]);
+}

--- a/src/hooks/useCrashRecoveryStartup.ts
+++ b/src/hooks/useCrashRecoveryStartup.ts
@@ -1,0 +1,152 @@
+/**
+ * Crash Recovery Startup Hook
+ *
+ * Runs once on the main window after hot exit restore completes.
+ * Scans for recovery snapshots, restores them as dirty tabs,
+ * and shows a toast notification.
+ *
+ * @module hooks/useCrashRecoveryStartup
+ * @coordinates-with crashRecovery.ts, hotExitCoordination.ts
+ */
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { useWindowLabel } from "@/contexts/WindowContext";
+import { useTabStore } from "@/stores/tabStore";
+import { useDocumentStore } from "@/stores/documentStore";
+import { waitForRestoreComplete } from "@/utils/hotExit/hotExitCoordination";
+import {
+  readRecoverySnapshots,
+  deleteStaleRecoveryFiles,
+  deleteRecoverySnapshot,
+  type RecoverySnapshot,
+} from "@/utils/crashRecovery";
+import { crashRecoveryLog } from "@/utils/debug";
+
+/**
+ * Restore documents from crash recovery snapshots on startup.
+ * Mount in MainWindowHooks (main window only, after useHotExitStartup).
+ */
+export function useCrashRecoveryStartup(): void {
+  const windowLabel = useWindowLabel();
+  const hasRun = useRef(false);
+
+  useEffect(() => {
+    if (hasRun.current) return;
+    hasRun.current = true;
+
+    void runCrashRecovery(windowLabel);
+  }, [windowLabel]);
+}
+
+async function runCrashRecovery(windowLabel: string): Promise<void> {
+  try {
+    // Wait for hot exit to finish first
+    const completed = await waitForRestoreComplete();
+    if (!completed) {
+      crashRecoveryLog("Hot exit restore timed out — proceeding with recovery anyway");
+    }
+
+    // Clean up old snapshots
+    await deleteStaleRecoveryFiles(7);
+
+    // Read remaining snapshots
+    const snapshots = await readRecoverySnapshots();
+    if (snapshots.length === 0) {
+      crashRecoveryLog("No recovery snapshots found");
+      return;
+    }
+
+    // Deduplicate by filePath — keep the newest snapshot for each path
+    const deduped = deduplicateSnapshots(snapshots);
+    crashRecoveryLog(`Found ${deduped.length} recovery snapshot(s)`);
+
+    let restoredCount = 0;
+
+    for (const snapshot of deduped) {
+      try {
+        restoreSnapshot(windowLabel, snapshot);
+        restoredCount++;
+
+        // Delete the recovery file after successful restore
+        await deleteRecoverySnapshot(snapshot.tabId);
+      } catch (error) {
+        crashRecoveryLog(
+          "Failed to restore snapshot:",
+          snapshot.tabId,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    }
+
+    // Delete any snapshots that were dropped as duplicates
+    for (const snapshot of snapshots) {
+      if (!deduped.includes(snapshot)) {
+        await deleteRecoverySnapshot(snapshot.tabId);
+      }
+    }
+
+    if (restoredCount > 0) {
+      toast.info(
+        `Recovered ${restoredCount} document(s) from unexpected exit`
+      );
+      crashRecoveryLog(`Restored ${restoredCount} document(s)`);
+    }
+  } catch (error) {
+    crashRecoveryLog(
+      "Crash recovery failed:",
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+/**
+ * Deduplicate snapshots by filePath, keeping the newest for each path.
+ * Untitled documents (filePath === null) are never deduplicated.
+ */
+function deduplicateSnapshots(
+  snapshots: RecoverySnapshot[]
+): RecoverySnapshot[] {
+  const byPath = new Map<string, RecoverySnapshot>();
+  const untitled: RecoverySnapshot[] = [];
+
+  for (const snap of snapshots) {
+    if (snap.filePath === null) {
+      untitled.push(snap);
+      continue;
+    }
+    const existing = byPath.get(snap.filePath);
+    if (!existing || snap.timestamp > existing.timestamp) {
+      byPath.set(snap.filePath, snap);
+    }
+  }
+
+  return [...untitled, ...byPath.values()];
+}
+
+/**
+ * Restore a single snapshot as a new dirty tab.
+ * Uses createTab (null path) then sets filePath via initDocument
+ * to avoid createTab's path deduplication merging with hot-exit restored tabs.
+ */
+function restoreSnapshot(
+  windowLabel: string,
+  snapshot: RecoverySnapshot
+): void {
+  // Always create as untitled to bypass filePath dedup, then set filePath in doc
+  const tabId = useTabStore.getState().createTab(windowLabel, null);
+
+  // Update tab title to match the original
+  if (snapshot.filePath) {
+    useTabStore.getState().updateTabPath(tabId, snapshot.filePath);
+  }
+
+  // Initialize document with recovered content, marked dirty
+  // savedContent = "" ensures isDirty = true (content !== savedContent)
+  useDocumentStore.getState().initDocument(
+    tabId,
+    snapshot.content,
+    snapshot.filePath,
+    "" // savedContent — makes it dirty
+  );
+}

--- a/src/hooks/useCrashRecoveryWriter.ts
+++ b/src/hooks/useCrashRecoveryWriter.ts
@@ -1,0 +1,105 @@
+/**
+ * Crash Recovery Writer Hook
+ *
+ * Periodically snapshots all dirty documents to the recovery directory.
+ * Runs every 10 seconds, skipping tabs whose content hasn't changed
+ * since the last write (tracked via content hash).
+ *
+ * @module hooks/useCrashRecoveryWriter
+ * @coordinates-with crashRecovery.ts, useCrashRecoveryCleanup.ts
+ */
+
+import { useEffect, useRef } from "react";
+import { useWindowLabel } from "@/contexts/WindowContext";
+import { useTabStore } from "@/stores/tabStore";
+import { useDocumentStore } from "@/stores/documentStore";
+import { writeRecoverySnapshot } from "@/utils/crashRecovery";
+import { crashRecoveryLog } from "@/utils/debug";
+
+const WRITE_INTERVAL_MS = 10_000;
+
+/**
+ * Periodically write recovery snapshots for dirty documents.
+ * Mount in DocumentWindowHooks (runs per window).
+ */
+export function useCrashRecoveryWriter(): void {
+  const windowLabel = useWindowLabel();
+  const lastHashRef = useRef<Map<string, string>>(new Map());
+  const writingRef = useRef(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      void writeDirtySnapshots(
+        windowLabel,
+        lastHashRef.current,
+        writingRef
+      );
+    }, WRITE_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [windowLabel]);
+}
+
+/**
+ * Simple string hash for change detection.
+ * Not cryptographic — just fast deduplication.
+ */
+function simpleHash(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const ch = str.charCodeAt(i);
+    hash = ((hash << 5) - hash + ch) | 0;
+  }
+  return hash.toString(36);
+}
+
+async function writeDirtySnapshots(
+  windowLabel: string,
+  lastHashes: Map<string, string>,
+  writingRef: React.RefObject<boolean>
+): Promise<void> {
+  // In-flight guard — skip if previous write pass is still running
+  if (writingRef.current) return;
+  writingRef.current = true;
+
+  try {
+    const tabs = useTabStore.getState().getTabsByWindow(windowLabel);
+    const docStore = useDocumentStore.getState();
+
+    // Prune hash entries for tabs that no longer exist
+    const currentTabIds = new Set(tabs.map((t) => t.id));
+    for (const key of lastHashes.keys()) {
+      if (!currentTabIds.has(key)) lastHashes.delete(key);
+    }
+
+    for (const tab of tabs) {
+      const doc = docStore.getDocument(tab.id);
+      if (!doc || !doc.isDirty) continue;
+
+      const hash = simpleHash(doc.content);
+      if (lastHashes.get(tab.id) === hash) continue;
+
+      const success = await writeRecoverySnapshot({
+        version: 1,
+        tabId: tab.id,
+        windowLabel,
+        content: doc.content,
+        filePath: tab.filePath,
+        title: tab.title,
+        timestamp: Date.now(),
+      });
+
+      // Only cache hash on success — failed writes will be retried next interval
+      if (success) {
+        lastHashes.set(tab.id, hash);
+      }
+    }
+  } catch (error) {
+    crashRecoveryLog(
+      "Writer error:",
+      error instanceof Error ? error.message : String(error)
+    );
+  } finally {
+    writingRef.current = false;
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -12,6 +12,8 @@ vi.mock("@tauri-apps/plugin-fs", () => ({
   exists: vi.fn(),
   mkdir: vi.fn(),
   readDir: vi.fn(),
+  remove: vi.fn(),
+  rename: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({

--- a/src/utils/crashRecovery.test.ts
+++ b/src/utils/crashRecovery.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  readTextFile,
+  writeTextFile,
+  exists,
+  mkdir,
+  readDir,
+  remove,
+  rename,
+} from "@tauri-apps/plugin-fs";
+import { appDataDir, join } from "@tauri-apps/api/path";
+
+import {
+  getRecoveryDir,
+  ensureRecoveryDir,
+  writeRecoverySnapshot,
+  readRecoverySnapshots,
+  deleteRecoverySnapshot,
+  deleteAllRecoveryFiles,
+  deleteStaleRecoveryFiles,
+  type RecoverySnapshot,
+} from "./crashRecovery";
+
+const mockExists = vi.mocked(exists);
+const mockMkdir = vi.mocked(mkdir);
+const mockWriteTextFile = vi.mocked(writeTextFile);
+const mockReadTextFile = vi.mocked(readTextFile);
+const mockReadDir = vi.mocked(readDir);
+const mockRemove = vi.mocked(remove);
+const mockRename = vi.mocked(rename);
+const mockAppDataDir = vi.mocked(appDataDir);
+const mockJoin = vi.mocked(join);
+
+function makeSnapshot(overrides: Partial<RecoverySnapshot> = {}): RecoverySnapshot {
+  return {
+    version: 1,
+    tabId: "tab-123",
+    windowLabel: "main",
+    content: "# Hello",
+    filePath: null,
+    title: "Untitled-1",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("crashRecovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAppDataDir.mockResolvedValue("/Users/test/.config");
+    mockJoin.mockImplementation((...parts: string[]) =>
+      Promise.resolve(parts.join("/"))
+    );
+    mockExists.mockResolvedValue(false);
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteTextFile.mockResolvedValue(undefined);
+    mockRename.mockResolvedValue(undefined);
+    mockRemove.mockResolvedValue(undefined);
+  });
+
+  describe("getRecoveryDir", () => {
+    it("returns appDataDir/recovery path", async () => {
+      const dir = await getRecoveryDir();
+      expect(dir).toBe("/Users/test/.config/recovery");
+    });
+  });
+
+  describe("ensureRecoveryDir", () => {
+    it("creates recovery dir if it does not exist", async () => {
+      mockExists.mockResolvedValue(false);
+      const dir = await ensureRecoveryDir();
+      expect(dir).toBe("/Users/test/.config/recovery");
+      expect(mockMkdir).toHaveBeenCalledWith("/Users/test/.config/recovery", {
+        recursive: true,
+      });
+    });
+
+    it("skips mkdir if dir already exists", async () => {
+      mockExists.mockResolvedValue(true);
+      await ensureRecoveryDir();
+      expect(mockMkdir).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("writeRecoverySnapshot", () => {
+    it("writes snapshot as JSON via atomic rename", async () => {
+      const snapshot = makeSnapshot();
+      const result = await writeRecoverySnapshot(snapshot);
+
+      expect(result).toBe(true);
+
+      // Should write to tmp file first (includes timestamp suffix)
+      expect(mockWriteTextFile).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/Users\/test\/\.config\/recovery\/\.tmp-tab-123-\d+$/),
+        expect.any(String)
+      );
+
+      // Then rename to final path
+      const tmpPath = mockWriteTextFile.mock.calls[0][0] as string;
+      expect(mockRename).toHaveBeenCalledWith(
+        tmpPath,
+        "/Users/test/.config/recovery/snapshot-tab-123.json"
+      );
+
+      // Verify JSON content
+      const writtenJson = mockWriteTextFile.mock.calls[0][1] as string;
+      const parsed = JSON.parse(writtenJson);
+      expect(parsed.version).toBe(1);
+      expect(parsed.tabId).toBe("tab-123");
+      expect(parsed.content).toBe("# Hello");
+    });
+
+    it("ensures recovery dir exists before writing", async () => {
+      mockExists.mockResolvedValue(false);
+      await writeRecoverySnapshot(makeSnapshot());
+      expect(mockMkdir).toHaveBeenCalled();
+    });
+
+    it("returns false on write error", async () => {
+      mockWriteTextFile.mockRejectedValue(new Error("disk full"));
+      const result = await writeRecoverySnapshot(makeSnapshot());
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("readRecoverySnapshots", () => {
+    it("returns empty array if recovery dir does not exist", async () => {
+      mockExists.mockResolvedValue(false);
+      const result = await readRecoverySnapshots();
+      expect(result).toEqual([]);
+    });
+
+    it("reads and parses valid snapshot files", async () => {
+      mockExists.mockResolvedValue(true);
+      const snapshot = makeSnapshot();
+      mockReadDir.mockResolvedValue([
+        { name: "snapshot-tab-123.json", isDirectory: false, isFile: true, isSymlink: false },
+      ] as never);
+      mockReadTextFile.mockResolvedValue(JSON.stringify(snapshot));
+
+      const result = await readRecoverySnapshots();
+      expect(result).toHaveLength(1);
+      expect(result[0].tabId).toBe("tab-123");
+    });
+
+    it("skips corrupted JSON files", async () => {
+      mockExists.mockResolvedValue(true);
+      mockReadDir.mockResolvedValue([
+        { name: "snapshot-tab-1.json", isDirectory: false, isFile: true, isSymlink: false },
+        { name: "snapshot-tab-2.json", isDirectory: false, isFile: true, isSymlink: false },
+      ] as never);
+
+      mockReadTextFile
+        .mockResolvedValueOnce("not valid json")
+        .mockResolvedValueOnce(JSON.stringify(makeSnapshot({ tabId: "tab-2" })));
+
+      const result = await readRecoverySnapshots();
+      expect(result).toHaveLength(1);
+      expect(result[0].tabId).toBe("tab-2");
+    });
+
+    it("skips non-snapshot files", async () => {
+      mockExists.mockResolvedValue(true);
+      mockReadDir.mockResolvedValue([
+        { name: ".tmp-tab-1", isDirectory: false, isFile: true, isSymlink: false },
+        { name: "random.txt", isDirectory: false, isFile: true, isSymlink: false },
+        { name: "snapshot-tab-2.json", isDirectory: false, isFile: true, isSymlink: false },
+      ] as never);
+      mockReadTextFile.mockResolvedValue(JSON.stringify(makeSnapshot({ tabId: "tab-2" })));
+
+      const result = await readRecoverySnapshots();
+      expect(result).toHaveLength(1);
+    });
+
+    it("skips files missing required fields", async () => {
+      mockExists.mockResolvedValue(true);
+      mockReadDir.mockResolvedValue([
+        { name: "snapshot-tab-1.json", isDirectory: false, isFile: true, isSymlink: false },
+      ] as never);
+      mockReadTextFile.mockResolvedValue(JSON.stringify({ version: 1 }));
+
+      const result = await readRecoverySnapshots();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("deleteRecoverySnapshot", () => {
+    it("deletes the snapshot file for a tab", async () => {
+      mockExists.mockResolvedValue(true);
+      await deleteRecoverySnapshot("tab-123");
+      expect(mockRemove).toHaveBeenCalledWith(
+        "/Users/test/.config/recovery/snapshot-tab-123.json"
+      );
+    });
+
+    it("does not throw if file is missing", async () => {
+      mockExists.mockResolvedValue(false);
+      await expect(deleteRecoverySnapshot("tab-123")).resolves.toBeUndefined();
+      expect(mockRemove).not.toHaveBeenCalled();
+    });
+
+    it("does not throw on remove error", async () => {
+      mockExists.mockResolvedValue(true);
+      mockRemove.mockRejectedValue(new Error("permission denied"));
+      await expect(deleteRecoverySnapshot("tab-123")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("deleteAllRecoveryFiles", () => {
+    it("removes all snapshot files in recovery dir", async () => {
+      mockExists.mockResolvedValue(true);
+      mockReadDir.mockResolvedValue([
+        { name: "snapshot-tab-1.json", isDirectory: false, isFile: true, isSymlink: false },
+        { name: "snapshot-tab-2.json", isDirectory: false, isFile: true, isSymlink: false },
+        { name: ".tmp-tab-3", isDirectory: false, isFile: true, isSymlink: false },
+      ] as never);
+
+      await deleteAllRecoveryFiles();
+      // Should remove snapshot files and tmp files
+      expect(mockRemove).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not throw if dir does not exist", async () => {
+      mockExists.mockResolvedValue(false);
+      await expect(deleteAllRecoveryFiles()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("deleteStaleRecoveryFiles", () => {
+    it("deletes files older than maxAgeDays", async () => {
+      mockExists.mockResolvedValue(true);
+      const oldTimestamp = Date.now() - 8 * 24 * 60 * 60 * 1000; // 8 days ago
+      const recentTimestamp = Date.now() - 1 * 24 * 60 * 60 * 1000; // 1 day ago
+
+      const oldSnapshot = makeSnapshot({ tabId: "old-tab", timestamp: oldTimestamp });
+      const recentSnapshot = makeSnapshot({ tabId: "recent-tab", timestamp: recentTimestamp });
+
+      mockReadDir.mockResolvedValue([
+        { name: "snapshot-old-tab.json", isDirectory: false, isFile: true, isSymlink: false },
+        { name: "snapshot-recent-tab.json", isDirectory: false, isFile: true, isSymlink: false },
+      ] as never);
+
+      mockReadTextFile
+        .mockResolvedValueOnce(JSON.stringify(oldSnapshot))
+        .mockResolvedValueOnce(JSON.stringify(recentSnapshot));
+
+      await deleteStaleRecoveryFiles(7);
+
+      // Should only delete the old one
+      expect(mockRemove).toHaveBeenCalledTimes(1);
+      expect(mockRemove).toHaveBeenCalledWith(
+        "/Users/test/.config/recovery/snapshot-old-tab.json"
+      );
+    });
+
+    it("does not throw if dir does not exist", async () => {
+      mockExists.mockResolvedValue(false);
+      await expect(deleteStaleRecoveryFiles(7)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/utils/crashRecovery.ts
+++ b/src/utils/crashRecovery.ts
@@ -1,0 +1,259 @@
+/**
+ * Crash Recovery Utilities
+ *
+ * Core read/write/delete operations for recovery snapshots.
+ * Periodically writes dirty document content to {appDataDir}/recovery/
+ * so it can be restored after unexpected crashes.
+ *
+ * @module utils/crashRecovery
+ * @coordinates-with useCrashRecoveryWriter, useCrashRecoveryStartup, useCrashRecoveryCleanup
+ */
+
+import {
+  writeTextFile,
+  readTextFile,
+  readDir,
+  exists,
+  mkdir,
+  remove,
+  rename,
+} from "@tauri-apps/plugin-fs";
+import { appDataDir, join } from "@tauri-apps/api/path";
+import { crashRecoveryLog } from "./debug";
+
+export interface RecoverySnapshot {
+  version: 1;
+  tabId: string;
+  windowLabel: string;
+  content: string;
+  filePath: string | null;
+  title: string;
+  timestamp: number;
+}
+
+const RECOVERY_DIR_NAME = "recovery";
+const SNAPSHOT_PREFIX = "snapshot-";
+const SNAPSHOT_SUFFIX = ".json";
+const TMP_PREFIX = ".tmp-";
+
+// --- Path helpers (shared naming logic) ---
+
+/** Build the final snapshot file path for a tab. */
+async function snapshotPath(dir: string, tabId: string): Promise<string> {
+  return join(dir, `${SNAPSHOT_PREFIX}${tabId}${SNAPSHOT_SUFFIX}`);
+}
+
+/** Build a unique temp file path for atomic writes. */
+async function tmpPath(dir: string, tabId: string): Promise<string> {
+  return join(dir, `${TMP_PREFIX}${tabId}-${Date.now()}`);
+}
+
+/** Check whether a filename matches the snapshot naming convention. */
+function isSnapshotFilename(name: string): boolean {
+  return name.startsWith(SNAPSHOT_PREFIX) && name.endsWith(SNAPSHOT_SUFFIX);
+}
+
+// --- Public API ---
+
+/**
+ * Get the recovery directory path.
+ */
+export async function getRecoveryDir(): Promise<string> {
+  const base = await appDataDir();
+  return join(base, RECOVERY_DIR_NAME);
+}
+
+/**
+ * Ensure the recovery directory exists, creating it if needed.
+ */
+export async function ensureRecoveryDir(): Promise<string> {
+  const dir = await getRecoveryDir();
+  if (!(await exists(dir))) {
+    await mkdir(dir, { recursive: true });
+  }
+  return dir;
+}
+
+/**
+ * Write a recovery snapshot atomically (write to tmp, then rename).
+ * Returns true on success, false on failure (logged, never throws).
+ */
+export async function writeRecoverySnapshot(
+  snapshot: RecoverySnapshot
+): Promise<boolean> {
+  try {
+    const dir = await ensureRecoveryDir();
+    const tmp = await tmpPath(dir, snapshot.tabId);
+    const final = await snapshotPath(dir, snapshot.tabId);
+
+    await writeTextFile(tmp, JSON.stringify(snapshot));
+    await rename(tmp, final);
+    crashRecoveryLog("Wrote snapshot for", snapshot.tabId);
+    return true;
+  } catch (error) {
+    crashRecoveryLog(
+      "Failed to write snapshot:",
+      error instanceof Error ? error.message : String(error)
+    );
+    return false;
+  }
+}
+
+/**
+ * Read all valid recovery snapshots from the recovery directory.
+ * Skips corrupted files and files missing required fields.
+ * Returns empty array if directory doesn't exist.
+ */
+export async function readRecoverySnapshots(): Promise<RecoverySnapshot[]> {
+  try {
+    const dir = await getRecoveryDir();
+    if (!(await exists(dir))) return [];
+
+    const entries = await readDir(dir);
+    const snapshots: RecoverySnapshot[] = [];
+
+    for (const entry of entries) {
+      if (!entry.name || !isSnapshotFilename(entry.name)) continue;
+
+      try {
+        const filePath = await join(dir, entry.name);
+        const content = await readTextFile(filePath);
+        const parsed = JSON.parse(content);
+
+        if (isValidSnapshot(parsed)) {
+          snapshots.push(parsed);
+        }
+      } catch {
+        crashRecoveryLog("Skipping corrupted snapshot:", entry.name);
+      }
+    }
+
+    return snapshots;
+  } catch (error) {
+    crashRecoveryLog(
+      "Failed to read snapshots:",
+      error instanceof Error ? error.message : String(error)
+    );
+    return [];
+  }
+}
+
+/**
+ * Delete the recovery snapshot for a specific tab.
+ * Fire-and-forget safe — logs errors, never throws.
+ */
+export async function deleteRecoverySnapshot(tabId: string): Promise<void> {
+  try {
+    const dir = await getRecoveryDir();
+    const path = await snapshotPath(dir, tabId);
+
+    if (await exists(path)) {
+      await remove(path);
+      crashRecoveryLog("Deleted snapshot for", tabId);
+    }
+  } catch (error) {
+    crashRecoveryLog(
+      "Failed to delete snapshot:",
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+/**
+ * Delete all recovery files (snapshots and tmp files).
+ * Called on normal exit.
+ */
+export async function deleteAllRecoveryFiles(): Promise<void> {
+  try {
+    const dir = await getRecoveryDir();
+    if (!(await exists(dir))) return;
+
+    const entries = await readDir(dir);
+    for (const entry of entries) {
+      if (!entry.name) continue;
+      try {
+        const filePath = await join(dir, entry.name);
+        await remove(filePath);
+      } catch {
+        // Best-effort deletion
+      }
+    }
+    crashRecoveryLog("Deleted all recovery files");
+  } catch (error) {
+    crashRecoveryLog(
+      "Failed to delete all recovery files:",
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+/**
+ * Delete recovery files for specific tabs only.
+ * Used for per-window cleanup on normal exit.
+ */
+export async function deleteRecoveryFilesForTabs(
+  tabIds: string[]
+): Promise<void> {
+  for (const tabId of tabIds) {
+    await deleteRecoverySnapshot(tabId);
+  }
+}
+
+/**
+ * Delete recovery files older than maxAgeDays.
+ * Reads each snapshot to check its timestamp.
+ */
+export async function deleteStaleRecoveryFiles(
+  maxAgeDays = 7
+): Promise<void> {
+  try {
+    const dir = await getRecoveryDir();
+    if (!(await exists(dir))) return;
+
+    const entries = await readDir(dir);
+    const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+
+    for (const entry of entries) {
+      if (!entry.name || !isSnapshotFilename(entry.name)) continue;
+
+      try {
+        const filePath = await join(dir, entry.name);
+        const content = await readTextFile(filePath);
+        const parsed = JSON.parse(content);
+
+        if (
+          Number.isFinite(parsed.timestamp) &&
+          parsed.timestamp < cutoff
+        ) {
+          await remove(filePath);
+          crashRecoveryLog("Deleted stale snapshot:", entry.name);
+        }
+      } catch {
+        // Skip unreadable files
+      }
+    }
+  } catch (error) {
+    crashRecoveryLog(
+      "Failed to delete stale files:",
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+/**
+ * Validate that a parsed JSON object has the required RecoverySnapshot fields.
+ */
+function isValidSnapshot(obj: unknown): obj is RecoverySnapshot {
+  if (typeof obj !== "object" || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return (
+    o.version === 1 &&
+    typeof o.tabId === "string" &&
+    typeof o.windowLabel === "string" &&
+    typeof o.content === "string" &&
+    (o.filePath === null || typeof o.filePath === "string") &&
+    typeof o.title === "string" &&
+    typeof o.timestamp === "number" &&
+    Number.isFinite(o.timestamp)
+  );
+}

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -30,3 +30,11 @@ export const autoSaveLog = isDev
 export const terminalLog = isDev
   ? (...args: unknown[]) => console.log("[Terminal]", ...args)
   : () => {};
+
+/**
+ * Debug logger for Crash Recovery operations.
+ * Only logs in development mode.
+ */
+export const crashRecoveryLog = isDev
+  ? (...args: unknown[]) => console.log("[CrashRecovery]", ...args)
+  : () => {};


### PR DESCRIPTION
## Summary

Closes #71.

- **Periodic snapshots**: Every 10s, all dirty documents (including untitled) are written to `{appDataDir}/recovery/` as JSON files via atomic write (tmp + rename)
- **Startup restore**: On launch, after hot exit completes, scans for recovery snapshots, deduplicates by filePath (keeps newest), restores as dirty tabs, and shows a toast notification
- **Automatic cleanup**: Recovery files are deleted when a tab is closed, a document is saved (dirty -> clean transition), or the window exits normally (per-window only, not global)
- **Robustness**: Content hash dedup skips unchanged docs, in-flight write guard prevents concurrent writes, failed writes are retried next interval, all errors are caught and logged

### New files

| File | Purpose |
|------|---------|
| `src/utils/crashRecovery.ts` | Core CRUD for recovery snapshots (read/write/delete/stale cleanup) |
| `src/hooks/useCrashRecoveryWriter.ts` | Periodic writer hook (10s interval, hash dedup, in-flight guard) |
| `src/hooks/useCrashRecoveryCleanup.ts` | Cleanup hook (tab close, save, beforeunload) |
| `src/hooks/useCrashRecoveryStartup.ts` | Startup restore hook (waits for hot exit, dedup, toast) |

### Modified files

| File | Change |
|------|--------|
| `src/App.tsx` | Mount hooks in `DocumentWindowHooks` and `MainWindowHooks` |
| `src/utils/debug.ts` | Add `crashRecoveryLog` debug logger |
| `src/test/setup.ts` | Add `remove` and `rename` to fs mock |

### Test coverage

- 38 new tests across 4 test files (18 unit + 6 writer + 5 cleanup + 9 startup)
- Full gate passes: 265 test files, 4462 tests

## Test plan

- [x] `pnpm check:all` passes (lint + coverage + build)
- [x] All 38 crash recovery tests pass
- [x] Codex independent verification: 18/18 audit findings confirmed FIXED
- [ ] Manual QA: create untitled doc with content, force-quit VMark, reopen — content restored with toast
- [ ] Manual QA: create saved doc, edit without saving, force-quit, reopen — modified content restored
- [ ] Manual QA: normal quit and reopen — no recovery toast (files cleaned up on exit)