### PR TITLE
fix: prevent unwanted horizontal scroll jumps in tables

### DIFF
--- a/src/components/Editor/editor.css
+++ b/src/components/Editor/editor.css
@@ -15,7 +15,7 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  overflow-x: hidden; /* Prevent horizontal overflow */
+  overflow-x: clip; /* Prevent horizontal overflow — clip (not hidden) avoids creating a scroll container, so ProseMirror's scrollIntoView cannot set scrollLeft on this element */
   padding-bottom: 40px; /* statusbar/findbar height */
   /* No horizontal padding - applied per-element so tables can span full width */
   transition: padding-bottom 0.15s ease-out;
@@ -479,6 +479,7 @@
    Horizontal scrollbar appears when table is wider than container. */
 .tiptap-editor .table-scroll-wrapper {
   overflow-x: auto;
+  overscroll-behavior-x: contain; /* Prevent horizontal scroll chaining to parent */
   margin: 0 calc(-1 * var(--editor-content-padding)) var(--editor-block-spacing, 1em) calc(-1 * var(--editor-content-padding));
   padding: 0 var(--editor-content-padding); /* Restore visual alignment for table content */
 }

--- a/src/plugins/tableScroll/scrollControl.test.ts
+++ b/src/plugins/tableScroll/scrollControl.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { isSelectionInTable, scrollEditorToSelection } from "./scrollControl";
+import { Schema } from "@tiptap/pm/model";
+import { EditorState, TextSelection } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
+
+// Minimal schema with table nodes
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { content: "text*", group: "block" },
+    table: { content: "table_row+", group: "block", attrs: { sourceLine: { default: null } } },
+    table_row: { content: "table_cell+" },
+    table_cell: { content: "paragraph+", attrs: { colspan: { default: 1 }, rowspan: { default: 1 } } },
+    text: { inline: true },
+  },
+});
+
+function createDocWithTable() {
+  return schema.node("doc", null, [
+    schema.node("paragraph", null, [schema.text("before table")]),
+    schema.node("table", null, [
+      schema.node("table_row", null, [
+        schema.node("table_cell", null, [
+          schema.node("paragraph", null, [schema.text("cell A")]),
+        ]),
+        schema.node("table_cell", null, [
+          schema.node("paragraph", null, [schema.text("cell B")]),
+        ]),
+      ]),
+    ]),
+    schema.node("paragraph", null, [schema.text("after table")]),
+  ]);
+}
+
+function createDocWithoutTable() {
+  return schema.node("doc", null, [
+    schema.node("paragraph", null, [schema.text("hello world")]),
+    schema.node("paragraph", null, [schema.text("second paragraph")]),
+  ]);
+}
+
+function createState(doc: ReturnType<typeof schema.node>, pos: number): EditorState {
+  const state = EditorState.create({ doc, schema });
+  return state.apply(
+    state.tr.setSelection(TextSelection.create(state.doc, pos))
+  );
+}
+
+function mockView(state: EditorState, overrides: Partial<EditorView> = {}): EditorView {
+  return {
+    state,
+    dom: document.createElement("div"),
+    ...overrides,
+  } as unknown as EditorView;
+}
+
+describe("isSelectionInTable", () => {
+  it("returns true when cursor is inside a table cell", () => {
+    const doc = createDocWithTable();
+    // Position inside first table cell paragraph: doc(1) -> paragraph(+1) -> table(+1) -> row(+1) -> cell(+1) -> paragraph(+1)
+    // "before table" is 12 chars, paragraph node size = 14 (12 + 2 boundary), so table starts at pos 15
+    // table(+1) -> row(+1) -> cell(+1) -> paragraph(+1) = 15+1+1+1+1 = 19
+    // Let's find the pos by walking the doc
+    let cellTextPos = -1;
+    doc.descendants((node, pos) => {
+      if (node.isText && node.text === "cell A" && cellTextPos === -1) {
+        cellTextPos = pos;
+      }
+    });
+    expect(cellTextPos).toBeGreaterThan(0);
+    const state = createState(doc, cellTextPos);
+    const view = mockView(state);
+    expect(isSelectionInTable(view)).toBe(true);
+  });
+
+  it("returns false when cursor is in a regular paragraph", () => {
+    const doc = createDocWithTable();
+    // Position 1 is inside the first paragraph
+    const state = createState(doc, 1);
+    const view = mockView(state);
+    expect(isSelectionInTable(view)).toBe(false);
+  });
+
+  it("returns false when document has no tables", () => {
+    const doc = createDocWithoutTable();
+    const state = createState(doc, 1);
+    const view = mockView(state);
+    expect(isSelectionInTable(view)).toBe(false);
+  });
+});
+
+describe("scrollEditorToSelection", () => {
+  let container: HTMLElement;
+  let editorDom: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    container.className = "editor-content";
+    editorDom = document.createElement("div");
+    container.appendChild(editorDom);
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  /** Set up container bounding rect and a writable scrollTop. Returns a getter for scrollTop. */
+  function mockContainer(
+    rect: { top: number; bottom: number },
+    initialScrollTop: number,
+  ): { getScrollTop: () => number } {
+    Object.defineProperty(container, "getBoundingClientRect", {
+      value: () => ({ top: rect.top, bottom: rect.bottom, left: 0, right: 800, width: 800, height: rect.bottom - rect.top }),
+      configurable: true,
+    });
+    let scrollTopValue = initialScrollTop;
+    Object.defineProperty(container, "scrollTop", {
+      get: () => scrollTopValue,
+      set: (v: number) => { scrollTopValue = v; },
+      configurable: true,
+    });
+    return { getScrollTop: () => scrollTopValue };
+  }
+
+  it("returns true even when .editor-content is not found", () => {
+    const doc = createDocWithoutTable();
+    const state = createState(doc, 1);
+    // View with dom that has no .editor-content ancestor
+    const orphanDom = document.createElement("div");
+    const view = mockView(state, {
+      dom: orphanDom,
+      coordsAtPos: () => ({ top: 50, bottom: 70, left: 0, right: 0 }),
+    });
+    // Always returns true to suppress ProseMirror's default scroll
+    expect(scrollEditorToSelection(view)).toBe(true);
+  });
+
+  it("returns true and scrolls down when cursor is below viewport", () => {
+    const doc = createDocWithoutTable();
+    const state = createState(doc, 1);
+    const { getScrollTop } = mockContainer({ top: 0, bottom: 400 }, 0);
+
+    const view = mockView(state, {
+      dom: editorDom,
+      coordsAtPos: () => ({ top: 450, bottom: 470, left: 0, right: 0 }),
+    });
+
+    const result = scrollEditorToSelection(view);
+    expect(result).toBe(true);
+    // Cursor bottom (470) > container bottom (400) - margin (20) = 380
+    // scrollTop should increase by 470 - 400 + 20 = 90
+    expect(getScrollTop()).toBe(90);
+  });
+
+  it("returns true and scrolls up when cursor is above viewport", () => {
+    const doc = createDocWithoutTable();
+    const state = createState(doc, 1);
+    const { getScrollTop } = mockContainer({ top: 100, bottom: 500 }, 200);
+
+    const view = mockView(state, {
+      dom: editorDom,
+      coordsAtPos: () => ({ top: 50, bottom: 70, left: 0, right: 0 }),
+    });
+
+    const result = scrollEditorToSelection(view);
+    expect(result).toBe(true);
+    // Cursor top (50) < container top (100) + margin (20) = 120
+    // scrollTop should decrease by 120 - 50 = 70
+    expect(getScrollTop()).toBe(200 - 70);
+  });
+
+  it("does not scroll when cursor is already visible", () => {
+    const doc = createDocWithoutTable();
+    const state = createState(doc, 1);
+    const { getScrollTop } = mockContainer({ top: 0, bottom: 400 }, 100);
+
+    const view = mockView(state, {
+      dom: editorDom,
+      coordsAtPos: () => ({ top: 200, bottom: 220, left: 0, right: 0 }),
+    });
+
+    const result = scrollEditorToSelection(view);
+    expect(result).toBe(true);
+    // Cursor is well within bounds, scrollTop should not change
+    expect(getScrollTop()).toBe(100);
+  });
+
+  it("returns true even when coordsAtPos throws", () => {
+    const doc = createDocWithoutTable();
+    const state = createState(doc, 1);
+
+    const view = mockView(state, {
+      dom: editorDom,
+      coordsAtPos: () => { throw new Error("Invalid pos"); },
+    });
+
+    // Always returns true to suppress ProseMirror's default scroll
+    expect(scrollEditorToSelection(view)).toBe(true);
+  });
+});

--- a/src/plugins/tableScroll/scrollControl.ts
+++ b/src/plugins/tableScroll/scrollControl.ts
@@ -1,0 +1,104 @@
+/**
+ * Table Scroll Control
+ *
+ * Purpose: Overrides ProseMirror's default scrollIntoView behavior when the
+ * cursor is inside a table. ProseMirror's built-in scrollRectIntoView walks
+ * every scrollable ancestor and adjusts scrollTop/scrollLeft on each —
+ * including `.table-scroll-wrapper` (overflow-x: auto), which causes unwanted
+ * horizontal scroll jumps. This plugin uses the `handleScrollToSelection` prop
+ * to perform controlled scrolling: only `.editor-content` is scrolled vertically,
+ * and table wrappers are left untouched.
+ *
+ * Key decisions:
+ *   - Uses handleScrollToSelection (official ProseMirror escape hatch)
+ *   - Only intercepts when cursor is inside a table node — all other scroll
+ *     behavior falls through to ProseMirror's default
+ *   - Scroll margin (20px) ensures cursor isn't flush against container edge
+ *   - Always returns true when in a table to suppress ProseMirror's default
+ *     scroll algorithm, even if our custom scroll encounters an error
+ *
+ * @coordinates-with tableScroll/index.ts — the NodeView that creates the scroll wrapper
+ * @coordinates-with editor.css — .editor-content (overflow-y: auto) and .table-scroll-wrapper
+ * @module plugins/tableScroll/scrollControl
+ */
+
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
+
+const SCROLL_MARGIN = 20;
+
+const tableScrollControlKey = new PluginKey("tableScrollControl");
+
+/**
+ * Check whether the current selection head is inside a table node.
+ */
+export function isSelectionInTable(view: EditorView): boolean {
+  const { $head } = view.state.selection;
+  for (let d = $head.depth; d > 0; d--) {
+    if ($head.node(d).type.name === "table") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Scroll only the editor's main scroll container (.editor-content) to make
+ * the cursor visible. Does NOT touch any inner scroll wrappers.
+ *
+ * Always returns true so that ProseMirror's default scroll algorithm is
+ * suppressed when the cursor is inside a table — even if the scroll container
+ * is missing or coordsAtPos fails. Letting the default through would
+ * reintroduce the horizontal scroll jumps this plugin exists to prevent.
+ */
+export function scrollEditorToSelection(view: EditorView): true {
+  const scrollContainer = view.dom.closest(".editor-content") as HTMLElement | null;
+  if (!scrollContainer) return true;
+
+  let coords: { top: number; bottom: number; left: number; right: number };
+  try {
+    coords = view.coordsAtPos(view.state.selection.head, 1);
+  } catch {
+    return true;
+  }
+
+  const rect = scrollContainer.getBoundingClientRect();
+
+  // Vertical scroll: bring cursor into view within the editor container
+  if (coords.top < rect.top + SCROLL_MARGIN) {
+    scrollContainer.scrollTop -= rect.top + SCROLL_MARGIN - coords.top;
+  } else if (coords.bottom > rect.bottom - SCROLL_MARGIN) {
+    scrollContainer.scrollTop += coords.bottom - rect.bottom + SCROLL_MARGIN;
+  }
+
+  return true;
+}
+
+/**
+ * Extension that overrides scroll-to-selection for table cells.
+ *
+ * When the cursor is in a table, performs vertical-only scrolling on
+ * .editor-content and prevents ProseMirror from adjusting horizontal
+ * scroll on .table-scroll-wrapper.
+ *
+ * For all other positions, falls through to ProseMirror's default behavior.
+ */
+export const tableScrollControlExtension = Extension.create({
+  name: "tableScrollControl",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: tableScrollControlKey,
+        props: {
+          handleScrollToSelection(view) {
+            if (!isSelectionInTable(view)) {
+              return false; // Not in table — use ProseMirror default
+            }
+            return scrollEditorToSelection(view);
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/src/utils/tiptapExtensions.ts
+++ b/src/utils/tiptapExtensions.ts
@@ -33,6 +33,7 @@ import {
   TableRowWithSourceLine,
 } from "@/plugins/shared/sourceLineNodes";
 import { TableWithScrollWrapper } from "@/plugins/tableScroll";
+import { tableScrollControlExtension } from "@/plugins/tableScroll/scrollControl";
 import { smartPasteExtension } from "@/plugins/smartPaste/tiptap";
 import { markdownPasteExtension } from "@/plugins/markdownPaste/tiptap";
 import { htmlPasteExtension } from "@/plugins/htmlPaste/tiptap";
@@ -159,6 +160,7 @@ export function createTiptapExtensions(): Extensions {
     AlignedTableHeader,
     AlignedTableCell,
     tableUIExtension,
+    tableScrollControlExtension,
     blockEscapeExtension,
     compositionGuardExtension,
     blockImageExtension,


### PR DESCRIPTION
## Summary

- **Root cause**: ProseMirror's `scrollRectIntoView` walks all scrollable ancestors — including `.table-scroll-wrapper` (overflow-x: auto) — and adjusts `scrollLeft` on each, causing unwanted horizontal jumps when the cursor moves inside a table.
- **Fix**: Three-layer approach:
  1. New `tableScrollControl` plugin using `handleScrollToSelection` (ProseMirror's official escape hatch) — intercepts scroll when cursor is in a table, performs vertical-only scrolling on `.editor-content`, leaves table wrappers untouched
  2. Changed `overflow-x: hidden` to `overflow-x: clip` on `.editor-content` — `clip` doesn't create a scroll container, so ProseMirror can't programmatically set `scrollLeft`
  3. Added `overscroll-behavior-x: contain` on `.table-scroll-wrapper` to prevent scroll chaining

## Files changed

| File | Change |
|------|--------|
| `src/plugins/tableScroll/scrollControl.ts` | New plugin (104 lines) |
| `src/plugins/tableScroll/scrollControl.test.ts` | 8 tests covering all branches |
| `src/components/Editor/editor.css` | `overflow-x: clip` + `overscroll-behavior-x: contain` |
| `src/utils/tiptapExtensions.ts` | Register new extension |

## Test plan

- [ ] Open a document with a wide table (more columns than viewport)
- [ ] Click into different cells — no horizontal jump on the editor
- [ ] Arrow key through cells — table wrapper scrolls only when user explicitly scrolls horizontally
- [ ] Switch between WYSIWYG and Source mode with cursor in table — no horizontal jump
- [ ] Verify non-table content scrolls normally (paragraph, headings, lists)
- [ ] Run `pnpm check:all` — all gates pass