### PR TITLE
fix: sanitize mermaid SVG output to prevent XSS

### DIFF
--- a/src/plugins/mermaidPreview/MermaidPreviewView.ts
+++ b/src/plugins/mermaidPreview/MermaidPreviewView.ts
@@ -471,7 +471,7 @@ export class MermaidPreviewView {
         if (currentToken !== this.renderToken) return;
 
         if (svg) {
-          this.preview.innerHTML = svg;
+          this.preview.innerHTML = sanitizeSvg(svg);
           this.error.textContent = "";
           this.applyZoom();
         } else {


### PR DESCRIPTION
## Summary
- Applies `sanitizeSvg()` to mermaid preview rendering output, matching the existing pattern used for SVG blocks (line 421)
- `sanitizeSvg` was already imported but not used in the async mermaid render path

Closes #81