### PR TITLE
fix: chunked base64 encoding prevents stack overflow in HTML export

### DIFF
--- a/src/export/fontEmbedder.ts
+++ b/src/export/fontEmbedder.ts
@@ -135,10 +135,24 @@ export function generateEmbeddedFontCSS(fonts: EmbeddedFont[]): string {
 }
 
 /**
+ * Convert Uint8Array to base64 without hitting V8's argument-count limit.
+ * String.fromCharCode(...data) crashes for arrays > ~65 KB because the
+ * spread exceeds the maximum number of function arguments.
+ */
+export function uint8ArrayToBase64(data: Uint8Array): string {
+  let binary = "";
+  const CHUNK = 8192;
+  for (let i = 0; i < data.length; i += CHUNK) {
+    binary += String.fromCharCode(...data.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
+/**
  * Convert font binary data to base64 data URI.
  */
 export function fontDataToDataUri(data: Uint8Array): string {
-  const base64 = btoa(String.fromCharCode(...data));
+  const base64 = uint8ArrayToBase64(data);
   return `data:font/woff2;base64,${base64}`;
 }
 
@@ -213,7 +227,7 @@ async function fetchFontAsDataUri(url: string): Promise<string | null> {
 
     const buffer = await response.arrayBuffer();
     const bytes = new Uint8Array(buffer);
-    const base64 = btoa(String.fromCharCode(...bytes));
+    const base64 = uint8ArrayToBase64(bytes);
 
     // Determine format from URL
     const format = url.includes(".woff2")

--- a/src/export/resourceResolver.ts
+++ b/src/export/resourceResolver.ts
@@ -7,6 +7,7 @@
 
 import { readFile, copyFile, exists, mkdir } from "@tauri-apps/plugin-fs";
 import { join, dirname, basename } from "@tauri-apps/api/path";
+import { uint8ArrayToBase64 } from "./fontEmbedder";
 
 export interface ResourceInfo {
   /** Original src value from HTML */
@@ -127,7 +128,7 @@ export async function fileToDataUri(filePath: string): Promise<string | null> {
     const data = await readFile(filePath);
     const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
     const mimeType = getMimeType(ext);
-    const base64 = btoa(String.fromCharCode(...data));
+    const base64 = uint8ArrayToBase64(data);
     return `data:${mimeType};base64,${base64}`;
   } catch (error) {
     console.warn("[ResourceResolver] Failed to read file for data URI:", filePath, error);


### PR DESCRIPTION
## Summary

- `btoa(String.fromCharCode(...data))` crashes when fonts or images exceed ~65 KB because the spread exceeds V8's max argument count (~65,536).
- Added `uint8ArrayToBase64()` helper that processes data in 8 KB chunks, replacing all three unsafe call sites in `fontEmbedder.ts` and `resourceResolver.ts`.

Closes #82

## Test plan

- [ ] Export a document with an embedded image larger than 65 KB — should succeed without stack overflow
- [ ] Export a document with embedded fonts (e.g., KaTeX) — verify fonts render correctly in the exported HTML
- [ ] Export a small document — verify no regression in base64 encoding