### PR TITLE
fix: validate URL scheme in MCP insert_video/insert_audio

### DIFF
--- a/vmark-mcp-server/src/tools/media.ts
+++ b/vmark-mcp-server/src/tools/media.ts
@@ -59,6 +59,9 @@ const PROVIDER_EMBEDS: Record<VideoProvider, ProviderEmbed> = {
 
 const VALID_PROVIDERS = Object.keys(PROVIDER_EMBEDS);
 
+/** Only allow safe URL schemes for media src attributes. */
+const ALLOWED_SCHEMES = /^(https?|file):\/\//i;
+
 export function registerMediaTools(server: VMarkMcpServer): void {
   // insert_video tool
   server.registerTool(
@@ -97,6 +100,9 @@ export function registerMediaTools(server: VMarkMcpServer): void {
     async (args) => {
       const windowId = resolveWindowId(args.windowId as string | undefined);
       const src = requireStringArg(args, 'src');
+      if (!ALLOWED_SCHEMES.test(src)) {
+        return VMarkMcpServer.errorResult('src must use http, https, or file protocol');
+      }
       const baseRevision = requireStringArg(args, 'baseRevision');
       const title = getStringArg(args, 'title');
       const poster = getStringArg(args, 'poster');
@@ -157,6 +163,9 @@ export function registerMediaTools(server: VMarkMcpServer): void {
     async (args) => {
       const windowId = resolveWindowId(args.windowId as string | undefined);
       const src = requireStringArg(args, 'src');
+      if (!ALLOWED_SCHEMES.test(src)) {
+        return VMarkMcpServer.errorResult('src must use http, https, or file protocol');
+      }
       const baseRevision = requireStringArg(args, 'baseRevision');
       const title = getStringArg(args, 'title');
 


### PR DESCRIPTION
## Summary
- Adds a URL scheme allowlist (`http`, `https`, `file`) to `insert_video` and `insert_audio` MCP tool handlers
- Rejects `javascript:`, `data:`, and other unsafe schemes that `escapeAttr()` does not block

Closes #83

## Test plan
- [ ] Call `insert_video` with `javascript:alert(1)` as src — should return error
- [ ] Call `insert_audio` with `data:text/html,...` as src — should return error
- [ ] Call `insert_video` with `https://example.com/video.mp4` — should succeed
- [ ] Call `insert_audio` with `file:///path/to/audio.mp3` — should succeed