### PR TITLE
fix: correct shortcut lookup key for Save All and Quit on macOS

### DIFF
--- a/src-tauri/src/menu/custom_menu.rs
+++ b/src-tauri/src/menu/custom_menu.rs
@@ -46,7 +46,7 @@ pub(crate) fn create_menu_with_shortcuts(
             &PredefinedMenuItem::hide_others(app, Some("Hide Others"))?,
             &PredefinedMenuItem::show_all(app, Some("Show All"))?,
             &PredefinedMenuItem::separator(app)?,
-            &MenuItem::with_id(app, "save-all-quit", "Save All and Quit", true, get_accel("saveAllQuit", "Alt+Shift+CmdOrCtrl+Q"))?,
+            &MenuItem::with_id(app, "save-all-quit", "Save All and Quit", true, get_accel("save-all-quit", "Alt+Shift+CmdOrCtrl+Q"))?,
             &MenuItem::with_id(app, "quit", "Quit VMark", true, get_accel("quit", "CmdOrCtrl+Q"))?,
         ],
     )?;


### PR DESCRIPTION
## Summary
- Fix `get_accel` lookup key for "Save All and Quit" on macOS from `"saveAllQuit"` (camelCase) to `"save-all-quit"` (kebab-case), matching the frontend shortcut store IDs.
- The non-macOS code path already used the correct kebab-case key; only the macOS path was wrong.

Closes #85

## Test plan
- [ ] On macOS, verify that a custom shortcut assigned to "Save All and Quit" in the shortcut settings is picked up by the menu item.
- [ ] Verify default shortcut (Alt+Shift+Cmd+Q) still works when no custom shortcut is set.