### PR TITLE
fix: add cleanup-images menu item to default_menu.rs

### DIFF
--- a/src-tauri/src/menu/default_menu.rs
+++ b/src-tauri/src/menu/default_menu.rs
@@ -311,6 +311,8 @@ pub fn create_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         &[
             &MenuItem::with_id(app, "remove-trailing-spaces", "Remove Trailing Spaces", true, None::<&str>)?,
             &MenuItem::with_id(app, "collapse-blank-lines", "Collapse Blank Lines", true, None::<&str>)?,
+            &PredefinedMenuItem::separator(app)?,
+            &MenuItem::with_id(app, "cleanup-images", "Clean Up Unused Images...", true, None::<&str>)?,
         ],
     )?;
 


### PR DESCRIPTION
## Summary
- Adds the missing "Clean Up Unused Images..." menu item to `default_menu.rs`, matching the existing entry in `custom_menu.rs`
- The item is placed in the "Text Cleanup" submenu after a separator, identical to the custom menu structure
- The SF Symbol icon mapping (`photo.badge.minus`) already exists in `macos_menu.rs`

Closes #84

## Test plan
- [ ] Launch VMark and verify Format > Text Cleanup submenu shows "Clean Up Unused Images..." item
- [ ] Verify the item triggers the cleanup-images menu event
- [ ] Verify custom shortcuts menu still works identically