### PR TITLE
fix: add missing focus-visible indicators for accessibility

### DIFF
--- a/src/components/FindBar/FindBar.css
+++ b/src/components/FindBar/FindBar.css
@@ -118,6 +118,7 @@
 }
 
 .find-bar-nav-btn {
+  position: relative;
   width: 24px;
   height: 24px;
   padding: 0;
@@ -155,6 +156,7 @@
 }
 
 .find-bar-close {
+  position: relative;
   width: 24px;
   height: 24px;
   padding: 0;
@@ -186,6 +188,7 @@
 }
 
 .find-bar-icon-btn {
+  position: relative;
   width: 26px;
   height: 26px;
   padding: 0;
@@ -207,4 +210,26 @@
 .find-bar-icon-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+/* Focus indicators for FindBar buttons */
+.find-bar-nav-btn:focus-visible,
+.find-bar-toggle:focus-visible,
+.find-bar-close:focus-visible,
+.find-bar-icon-btn:focus-visible {
+  outline: none;
+}
+
+.find-bar-nav-btn:focus-visible::after,
+.find-bar-toggle:focus-visible::after,
+.find-bar-close:focus-visible::after,
+.find-bar-icon-btn:focus-visible::after {
+  content: '';
+  position: absolute;
+  bottom: 2px;
+  left: 4px;
+  right: 4px;
+  height: 2px;
+  background: var(--primary-color);
+  border-radius: 1px;
 }

--- a/src/components/Sidebar/FileExplorer/FileExplorer.css
+++ b/src/components/Sidebar/FileExplorer/FileExplorer.css
@@ -32,6 +32,7 @@
 }
 
 .file-explorer-btn {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -47,6 +48,21 @@
 .file-explorer-btn:hover {
   background-color: var(--selection-color);
   color: var(--text-color);
+}
+
+.file-explorer-btn:focus-visible {
+  outline: none;
+}
+
+.file-explorer-btn:focus-visible::after {
+  content: '';
+  position: absolute;
+  bottom: 2px;
+  left: 4px;
+  right: 4px;
+  height: 2px;
+  background: var(--primary-color);
+  border-radius: 1px;
 }
 
 .file-explorer-tree {

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -37,6 +37,7 @@
 }
 
 .sidebar-btn {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -52,6 +53,21 @@
 .sidebar-btn:hover {
   background-color: var(--selection-color);
   color: var(--text-color);
+}
+
+.sidebar-btn:focus-visible {
+  outline: none;
+}
+
+.sidebar-btn:focus-visible::after {
+  content: '';
+  position: absolute;
+  bottom: 2px;
+  left: 4px;
+  right: 4px;
+  height: 2px;
+  background: var(--primary-color);
+  border-radius: 1px;
 }
 
 .sidebar-title {

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -53,6 +53,7 @@
 
 .status-toggle,
 .status-mode {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -309,6 +310,7 @@
 
 /* New tab button */
 .status-new-tab {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -411,6 +413,7 @@
    ======================================== */
 
 .status-mcp {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 4px;
@@ -466,6 +469,7 @@
    ======================================== */
 
 .status-terminal {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -489,6 +493,30 @@
 
 .status-terminal.active {
   color: var(--accent-primary);
+}
+
+/* Focus indicators for StatusBar buttons */
+.status-new-tab:focus-visible,
+.status-toggle:focus-visible,
+.status-mode:focus-visible,
+.status-mcp:focus-visible,
+.status-terminal:focus-visible {
+  outline: none;
+}
+
+.status-new-tab:focus-visible::after,
+.status-toggle:focus-visible::after,
+.status-mode:focus-visible::after,
+.status-mcp:focus-visible::after,
+.status-terminal:focus-visible::after {
+  content: '';
+  position: absolute;
+  bottom: 2px;
+  left: 4px;
+  right: 4px;
+  height: 2px;
+  background: var(--primary-color);
+  border-radius: 1px;
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary
- Add U-shaped underline `:focus-visible` indicators to buttons in Sidebar, FileExplorer, FindBar, and StatusBar that previously only had `:hover` styles
- Add `position: relative` to each affected selector so the `::after` pseudo-element positions correctly
- Closes #89

## Affected selectors
- **Sidebar.css**: `.sidebar-btn`
- **FileExplorer.css**: `.file-explorer-btn`
- **FindBar.css**: `.find-bar-nav-btn`, `.find-bar-toggle`, `.find-bar-close`, `.find-bar-icon-btn`
- **StatusBar.css**: `.status-new-tab`, `.status-toggle`, `.status-mode`, `.status-mcp`, `.status-terminal`

## Test plan
- [ ] Tab through Sidebar buttons and verify U-shaped underline appears on focus
- [ ] Tab through FileExplorer toolbar buttons and verify focus indicator
- [ ] Open FindBar (Cmd+F), tab through nav/toggle/close/replace buttons and verify focus indicator
- [ ] Tab through StatusBar buttons and verify focus indicator
- [ ] Verify in both light and dark themes
- [ ] Verify hover styles are unchanged