### PR TITLE
fix: replace hardcoded CSS values with design tokens

### DIFF
--- a/src/components/Editor/UniversalToolbar/universal-toolbar.css
+++ b/src/components/Editor/UniversalToolbar/universal-toolbar.css
@@ -171,8 +171,12 @@
   background-color: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--popup-shadow);
   z-index: 103;
+}
+
+.dark-theme .universal-toolbar-dropdown {
+  box-shadow: var(--popup-shadow-dark);
 }
 
 .universal-toolbar-dropdown-item {

--- a/src/components/Editor/heading-picker.css
+++ b/src/components/Editor/heading-picker.css
@@ -115,5 +115,5 @@
 
 /* Dark theme */
 .dark-theme .heading-picker-item:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--hover-bg-dark);
 }

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -129,7 +129,7 @@
 }
 
 .dark-theme .status-divergent {
-  border-color: rgba(0, 136, 255, 0.25);
+  border-color: var(--divergent-border-dark);
 }
 
 /* ========================================
@@ -260,7 +260,7 @@
 }
 
 .dark-theme .tab-pill.tab-divergent {
-  border-color: rgba(0, 136, 255, 0.25);
+  border-color: var(--divergent-border-dark);
 }
 
 /* Tab being dragged out of the bar */

--- a/src/plugins/mermaid/index.ts
+++ b/src/plugins/mermaid/index.ts
@@ -19,7 +19,8 @@ let currentFontSize: number = 14; // Default fallback
  * Detect if dark mode is active by checking document class
  */
 function isDarkMode(): boolean {
-  return document.documentElement.classList.contains("dark");
+  const cl = document.documentElement.classList;
+  return cl.contains("dark-theme") || cl.contains("dark");
 }
 
 /**

--- a/src/plugins/search/search.css
+++ b/src/plugins/search/search.css
@@ -7,7 +7,7 @@
 /* All matches - underline style */
 .search-match {
   text-decoration: underline;
-  text-decoration-color: rgba(255, 180, 0, 0.8);
+  text-decoration-color: var(--search-match-color);
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 }
@@ -15,16 +15,7 @@
 /* Current match - stronger underline */
 .search-match-active {
   text-decoration: underline;
-  text-decoration-color: var(--accent-primary, #007aff);
+  text-decoration-color: var(--search-match-active-color);
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
-}
-
-/* Dark mode adjustments */
-.dark-theme .search-match {
-  text-decoration-color: rgba(255, 200, 0, 0.7);
-}
-
-.dark-theme .search-match-active {
-  text-decoration-color: var(--primary-color, #58a6ff);
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -141,12 +141,23 @@
   --cjk-letter-spacing: 0.05em;        /* Default CJK spacing */
   --editor-width: 50em;                /* Default editor width */
 
+  /* Search match colors */
+  --search-match-color: rgba(255, 180, 0, 0.8);
+  --search-match-active-color: rgba(255, 200, 0, 0.7);
+
   /* Alert tokens for dark mode (centralized) */
   --alert-note-dark: #58a6ff;
   --alert-tip-dark: #3fb950;
   --alert-important-dark: #a371f7;
   --alert-warning-dark: #d29922;
   --alert-caution-dark: #f85149;
+}
+
+/* Dark theme token overrides */
+.dark-theme {
+  --search-match-color: rgba(255, 200, 0, 0.7);
+  --search-match-active-color: rgba(255, 200, 0, 0.5);
+  --divergent-border-dark: rgba(0, 136, 255, 0.25);
 }
 
 html,


### PR DESCRIPTION
## Summary
- Replace hardcoded `rgba()` colors and shadows with CSS design tokens across 5 files
- Add `--search-match-color`, `--search-match-active-color`, and `--divergent-border-dark` tokens to `index.css`
- Fix Mermaid dark mode detection to check `.dark-theme` class (not just `.dark`)

Closes #92

## Test plan
- [ ] Verify heading picker hover in dark theme uses correct highlight
- [ ] Verify toolbar dropdown shadow in both light and dark themes
- [ ] Verify search match underline colors in both themes
- [ ] Verify divergent file border color in dark theme (StatusBar + tab pill)
- [ ] Verify Mermaid diagrams render with correct theme when using `.dark-theme`