### PR TITLE
fix: use poison-recovery for mutex locks in production paths

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,7 +60,7 @@ static FRONTEND_READY: AtomicBool = AtomicBool::new(false);
 #[tauri::command]
 fn get_pending_file_opens() -> Vec<PendingFileOpen> {
     FRONTEND_READY.store(true, Ordering::SeqCst);
-    let mut pending = PENDING_FILE_OPENS.lock().unwrap();
+    let mut pending = PENDING_FILE_OPENS.lock().unwrap_or_else(|p| p.into_inner());
     pending.drain(..).collect()
 }
 

--- a/src-tauri/src/tab_transfer.rs
+++ b/src-tauri/src/tab_transfer.rs
@@ -40,7 +40,7 @@ pub struct TabTransferData {
 static TRANSFER_REGISTRY: Mutex<Option<HashMap<String, TabTransferData>>> = Mutex::new(None);
 
 fn registry() -> std::sync::MutexGuard<'static, Option<HashMap<String, TabTransferData>>> {
-    TRANSFER_REGISTRY.lock().unwrap()
+    TRANSFER_REGISTRY.lock().unwrap_or_else(|p| p.into_inner())
 }
 
 /// Create a new window and store transfer data for it.

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -115,7 +115,7 @@ fn handle_event(app: &AppHandle, watch_id: &str, root_path: &str, event: Event) 
     let now = Instant::now();
 
     // Collect paths, filtering ignored dirs and those within the debounce window
-    let mut guard = LAST_EMITTED.lock().unwrap();
+    let mut guard = LAST_EMITTED.lock().unwrap_or_else(|p| p.into_inner());
     let map = guard.get_or_insert_with(HashMap::new);
 
     let paths: Vec<String> = event


### PR DESCRIPTION
## Summary

- Replace `.lock().unwrap()` with `.lock().unwrap_or_else(|p| p.into_inner())` in three production-path mutex locks to prevent panics if a mutex is poisoned:
  - `LAST_EMITTED` in `src-tauri/src/watcher.rs`
  - `TRANSFER_REGISTRY` in `src-tauri/src/tab_transfer.rs`
  - `PENDING_FILE_OPENS` in `src-tauri/src/lib.rs`

Closes #91

## Test plan

- [x] `cargo check` passes
- [ ] Verify file watcher still works (open workspace, modify file externally)
- [ ] Verify tab transfer works (drag tab to new window)
- [ ] Verify Finder file open works (double-click .md file)