### PR TITLE
fix: improve MCP server input validation

### DIFF
--- a/vmark-mcp-server/src/index.ts
+++ b/vmark-mcp-server/src/index.ts
@@ -383,7 +383,10 @@ export const TOOL_CATEGORIES = [
  * Expected tool count — used by --health-check to catch stale builds.
  * Update this number whenever tools are added or removed.
  */
-export const EXPECTED_TOOL_COUNT = 80;
+export const EXPECTED_TOOL_COUNT = TOOL_CATEGORIES.reduce(
+  (sum, cat) => sum + cat.tools.length,
+  0
+);
 
 /**
  * List of all resources for documentation.

--- a/vmark-mcp-server/src/tools/genies.ts
+++ b/vmark-mcp-server/src/tools/genies.ts
@@ -95,6 +95,9 @@ export function registerGenieTools(server: VMarkMcpServer): void {
     },
     async (args) => {
       const path = requireStringArg(args, 'path');
+      if (path.includes('..')) {
+        return VMarkMcpServer.errorResult('Invalid genie path: must not contain ".."');
+      }
       const windowId = resolveWindowId(args.windowId as string | undefined);
 
       try {

--- a/vmark-mcp-server/src/tools/sections.ts
+++ b/vmark-mcp-server/src/tools/sections.ts
@@ -7,7 +7,7 @@
  * - move_section: Reorder sections
  */
 
-import { VMarkMcpServer, resolveWindowId, requireStringArg, getStringArg, validateByIndex } from '../server.js';
+import { VMarkMcpServer, resolveWindowId, requireStringArg, requireStringArgAllowEmpty, getStringArg, validateByIndex } from '../server.js';
 import type {
   BatchEditResult,
   OperationMode,
@@ -77,7 +77,7 @@ export function registerSectionTools(server: VMarkMcpServer): void {
       const windowId = resolveWindowId(args.windowId as string | undefined);
       const baseRevision = requireStringArg(args, 'baseRevision');
       const target = args.target as SectionTarget;
-      const newContent = requireStringArg(args, 'newContent');
+      const newContent = requireStringArgAllowEmpty(args, 'newContent');
       const mode = (args.mode as OperationMode) ?? 'apply';
 
       if (!target || (!target.heading && !target.byIndex && !target.sectionId)) {

--- a/vmark-mcp-server/src/tools/selection.ts
+++ b/vmark-mcp-server/src/tools/selection.ts
@@ -2,7 +2,7 @@
  * Selection tools - Read and manipulate text selection.
  */
 
-import { VMarkMcpServer, resolveWindowId, validateNonNegativeInteger } from '../server.js';
+import { VMarkMcpServer, resolveWindowId, validateNonNegativeInteger, getNumberArg } from '../server.js';
 import type { Selection, CursorContext, EditResult } from '../bridge/types.js';
 
 /**
@@ -190,8 +190,8 @@ export function registerSelectionTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const linesBefore = (args.linesBefore as number) ?? 3;
-      const linesAfter = (args.linesAfter as number) ?? 3;
+      const linesBefore = getNumberArg(args, 'linesBefore') ?? 3;
+      const linesAfter = getNumberArg(args, 'linesAfter') ?? 3;
       const windowId = resolveWindowId(args.windowId as string | undefined);
 
       const linesBeforeError = validateNonNegativeInteger(linesBefore, 'linesBefore');


### PR DESCRIPTION
## Summary
- **Path traversal guard**: `read_genie` now rejects paths containing `..` to prevent directory traversal
- **Empty content support**: `update_section` accepts empty string for `newContent` (uses `requireStringArgAllowEmpty` instead of `requireStringArg`)
- **Safe number casting**: `cursor_get_context` uses `getNumberArg()` instead of unsafe `as number` cast for `linesBefore`/`linesAfter`
- **Dynamic tool count**: `EXPECTED_TOOL_COUNT` is now computed from `TOOL_CATEGORIES` instead of a hardcoded magic number

Closes #99

## Test plan
- [ ] Verify `read_genie` returns error for paths with `..`
- [ ] Verify `update_section` accepts empty string `newContent`
- [ ] Verify `cursor_get_context` handles non-numeric `linesBefore`/`linesAfter` gracefully
- [ ] Verify `EXPECTED_TOOL_COUNT` matches actual tool count after adding/removing tools