### PR TITLE
fix: add SF Symbol icon for Mindmap menu item

### DIFF
--- a/src-tauri/src/macos_menu.rs
+++ b/src-tauri/src/macos_menu.rs
@@ -199,6 +199,7 @@ const MENU_ICONS: &[(&str, &str)] = &[
     ("Horizontal Line", "minus"),
     ("Footnote", "note.text"),
     ("Collapsible Block", "chevron.down.square"),
+    ("Mindmap", "brain"),
     // Table
     ("Add Row Above", "arrow.up.to.line"),
     ("Add Row Below", "arrow.down.to.line"),


### PR DESCRIPTION
## Summary
- Add missing `("Mindmap", "brain")` entry to the `MENU_ICONS` array in `macos_menu.rs`
- The Mindmap menu item existed in both `default_menu.rs` and `custom_menu.rs` but had no SF Symbol icon mapped

Closes #101

## Test plan
- [ ] Open VMark on macOS, check Insert menu — Mindmap item should display the `brain` SF Symbol icon