### PR TITLE
fix: plugin lifecycle — null guards, stale state, and test helpers

### DIFF
--- a/src/hooks/useGenieShortcuts.ts
+++ b/src/hooks/useGenieShortcuts.ts
@@ -13,6 +13,7 @@
 import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
+import { safeUnlistenAsync } from "@/utils/safeUnlisten";
 import { useShortcutsStore } from "@/stores/shortcutsStore";
 import { useGeniePickerStore } from "@/stores/geniePickerStore";
 import { useGeniesStore } from "@/stores/geniesStore";
@@ -99,9 +100,7 @@ export function useGenieShortcuts() {
       }
     );
 
-    return () => {
-      unlisten.then((fn) => fn()).catch(() => {});
-    };
+    return () => safeUnlistenAsync(unlisten);
   }, [invokeGenie]);
 
   // "Search Genies…" menu item opens the picker (same as Cmd+Y)
@@ -109,9 +108,7 @@ export function useGenieShortcuts() {
     const unlisten = listen("menu:search-genies", () => {
       useGeniePickerStore.getState().openPicker({ filterScope: detectScope() });
     });
-    return () => {
-      unlisten.then((fn) => fn()).catch(() => {});
-    };
+    return () => safeUnlistenAsync(unlisten);
   }, []);
 
   // "Reload Genies" menu item re-scans the genies folder
@@ -121,8 +118,6 @@ export function useGenieShortcuts() {
         console.error("[useGenieShortcuts] Failed to reload genies:", e)
       );
     });
-    return () => {
-      unlisten.then((fn) => fn()).catch(() => {});
-    };
+    return () => safeUnlistenAsync(unlisten);
   }, []);
 }

--- a/src/plugins/aiSuggestion/tiptap.ts
+++ b/src/plugins/aiSuggestion/tiptap.ts
@@ -76,7 +76,7 @@ function applySuggestionToTr(
   tr: Transaction,
   suggestion: AiSuggestion,
 ): Transaction {
-  const docSize = state.doc.content.size;
+  const docSize = tr.doc.content.size;
 
   // Whole-document replace (from=0): clamp `to` to current doc size.
   // The doc may have changed since the suggestion was created, but the

--- a/src/plugins/codemirror/smartPaste.ts
+++ b/src/plugins/codemirror/smartPaste.ts
@@ -38,7 +38,8 @@ import { cleanPastedMarkdown } from "@/utils/cleanPastedMarkdown";
 /**
  * Check if a CodeMirror view is still connected and valid.
  */
-function isViewConnected(view: EditorView): boolean {
+function isViewConnected(view: EditorView | null | undefined): boolean {
+  if (!view) return false;
   try {
     return view.dom?.isConnected ?? false;
   } catch {

--- a/src/stores/aiSuggestionStore.ts
+++ b/src/stores/aiSuggestionStore.ts
@@ -295,6 +295,17 @@ export const useAiSuggestionStore = create<AiSuggestionState & AiSuggestionActio
 let _tabWatcherInitialized = false;
 let _prevActiveTabIds: Record<string, string | null> = {};
 
+/**
+ * Reset module-level singletons and store state.
+ * For use in tests only — ensures a clean slate between test runs.
+ */
+export function resetAiSuggestionStore(): void {
+  suggestionCounter = 0;
+  _tabWatcherInitialized = false;
+  _prevActiveTabIds = {};
+  useAiSuggestionStore.setState({ suggestions: new Map(), focusedSuggestionId: null });
+}
+
 /** Start watching for tab changes. Call once at app startup. */
 export function initSuggestionTabWatcher(
   tabStoreSubscribe: (cb: (state: { activeTabId: Record<string, string | null> }) => void) => () => void


### PR DESCRIPTION
## Summary
- **`isViewConnected` null guard** (`smartPaste.ts`): Accept `null | undefined` view parameter to prevent runtime errors when CodeMirror view is destroyed before async callbacks complete.
- **`applySuggestionToTr` stale doc size** (`aiSuggestion/tiptap.ts`): Read `docSize` from `tr.doc` instead of `state.doc` so position clamping uses the correct size after prior mutations in a batched transaction.
- **Consistent async listener cleanup** (`useGenieShortcuts.ts`): Replace 3 inline `.then(fn => fn()).catch(() => {})` patterns with the existing `safeUnlistenAsync` utility for consistent, safe cleanup.
- **Module-level singletons test helper** (`aiSuggestionStore.ts`): Add `resetAiSuggestionStore()` to reset `suggestionCounter`, `_tabWatcherInitialized`, and `_prevActiveTabIds` — enables reliable test isolation.

Closes #100

## Test plan
- [ ] Verify AI suggestion accept/reject still works in WYSIWYG mode
- [ ] Verify paste behavior in Source mode (URL paste over selection, image paste)
- [ ] Verify Genie menu shortcuts (Cmd+Y, menu items) work without leaked listeners
- [ ] Run `pnpm test` to confirm no regressions