### PR TITLE
fix: error handling, KaTeX duplication, and stale comments

### DIFF
--- a/.claude/rules/31-design-tokens.md
+++ b/.claude/rules/31-design-tokens.md
@@ -121,6 +121,7 @@ Reference for CSS custom properties. Always use tokens over hardcoded values.
 **Acceptable hardcoded values:**
 - `1px` or `2px` for inline elements (code spans, cursor indicators)
 - Focus indicator corners (e.g., `0 0 4px 4px` for U-shape)
+- @media print blocks (color-mix() may not render in all print pipelines)
 
 ### Shadows
 

--- a/src/export/fontEmbedder.ts
+++ b/src/export/fontEmbedder.ts
@@ -147,60 +147,7 @@ export function fontDataToDataUri(data: Uint8Array): string {
  * KaTeX fonts are loaded from CDN in exports since they're not bundled.
  */
 export function getKaTeXFontCSS(): string {
-  // Use jsDelivr CDN for KaTeX fonts
-  const cdnBase = "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/fonts";
-
-  return `
-/* KaTeX Fonts */
-@font-face {
-  font-family: 'KaTeX_Main';
-  src: url('${cdnBase}/KaTeX_Main-Regular.woff2') format('woff2');
-  font-weight: normal;
-  font-style: normal;
-}
-@font-face {
-  font-family: 'KaTeX_Main';
-  src: url('${cdnBase}/KaTeX_Main-Bold.woff2') format('woff2');
-  font-weight: bold;
-  font-style: normal;
-}
-@font-face {
-  font-family: 'KaTeX_Main';
-  src: url('${cdnBase}/KaTeX_Main-Italic.woff2') format('woff2');
-  font-weight: normal;
-  font-style: italic;
-}
-@font-face {
-  font-family: 'KaTeX_Math';
-  src: url('${cdnBase}/KaTeX_Math-Italic.woff2') format('woff2');
-  font-weight: normal;
-  font-style: italic;
-}
-@font-face {
-  font-family: 'KaTeX_Size1';
-  src: url('${cdnBase}/KaTeX_Size1-Regular.woff2') format('woff2');
-  font-weight: normal;
-  font-style: normal;
-}
-@font-face {
-  font-family: 'KaTeX_Size2';
-  src: url('${cdnBase}/KaTeX_Size2-Regular.woff2') format('woff2');
-  font-weight: normal;
-  font-style: normal;
-}
-@font-face {
-  font-family: 'KaTeX_Size3';
-  src: url('${cdnBase}/KaTeX_Size3-Regular.woff2') format('woff2');
-  font-weight: normal;
-  font-style: normal;
-}
-@font-face {
-  font-family: 'KaTeX_Size4';
-  src: url('${cdnBase}/KaTeX_Size4-Regular.woff2') format('woff2');
-  font-weight: normal;
-  font-style: normal;
-}
-`.trim();
+  return generateLocalFontCSS(getKaTeXFontFiles(), KATEX_CDN_BASE);
 }
 
 /**

--- a/src/stores/featureFlagsStore.ts
+++ b/src/stores/featureFlagsStore.ts
@@ -20,8 +20,7 @@ export const FEATURE_FLAGS = {
    * When enabled, uses the unified menu dispatcher instead of legacy per-hook handlers.
    * This routes all menu events through a single dispatcher with proper mode routing.
    *
-   * Phase 4: Enable in dev only for testing
-   * Phase 5: Enable in production after testing
+   * Phase 5: Enabled in production (current)
    * Phase 6: Remove flag entirely after stable period
    */
   UNIFIED_MENU_DISPATCHER: true,

--- a/src/stores/shortcutsStore.ts
+++ b/src/stores/shortcutsStore.ts
@@ -340,7 +340,7 @@ export const useShortcutsStore = create<ShortcutsState & ShortcutsActions>()(
 
           return { success: errors.length === 0, errors: errors.length > 0 ? errors : undefined };
         } catch (e) {
-          return { success: false, errors: [`Parse error: ${e}`] };
+          return { success: false, errors: [`Parse error: ${e instanceof Error ? e.message : String(e)}`] };
         }
       },
 


### PR DESCRIPTION
## Summary
- **shortcutsStore.ts**: Properly narrow `unknown` error with `instanceof Error` check instead of raw template literal interpolation
- **fontEmbedder.ts**: Replace duplicated KaTeX font CSS in `getKaTeXFontCSS()` with a call to existing `generateLocalFontCSS(getKaTeXFontFiles(), KATEX_CDN_BASE)` (-53 lines)
- **featureFlagsStore.ts**: Update stale phase comment — unified menu dispatcher is now Phase 5 (enabled in production)
- **31-design-tokens.md**: Document `@media print` as an acceptable hardcoded-value exception

Closes #103

## Test plan
- [ ] `pnpm check:all` passes
- [ ] Verify KaTeX math renders correctly in HTML export (the generated CSS should be identical)
- [ ] Verify shortcut import error messages display cleanly on parse failure