### PR TITLE
fix: correct Zustand anti-patterns (closes #98)

### DIFF
--- a/src/components/Editor/ImageContextMenu.tsx
+++ b/src/components/Editor/ImageContextMenu.tsx
@@ -43,7 +43,9 @@ interface ImageContextMenuProps {
 
 export function ImageContextMenu({ onAction }: ImageContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
-  const { isOpen, position, closeMenu } = useImageContextMenuStore();
+  const isOpen = useImageContextMenuStore((s) => s.isOpen);
+  const position = useImageContextMenuStore((s) => s.position);
+  const closeMenu = useImageContextMenuStore((s) => s.closeMenu);
   // Get platform-appropriate label once (stable across renders)
   const revealLabel = useMemo(() => getRevealInFileManagerLabel(), []);
   const menuItems = useMemo(() => buildMenuItems(revealLabel), [revealLabel]);

--- a/src/components/GeniePicker/GeniePicker.tsx
+++ b/src/components/GeniePicker/GeniePicker.tsx
@@ -49,6 +49,14 @@ export function GeniePicker() {
 
   const { invokeGenie, invokeFreeform, isRunning } = useGenieInvocation();
   const activeProvider = useAiProviderStore((s) => s.activeProvider);
+  const activeProviderName = useAiProviderStore((s) => {
+    if (!s.activeProvider) return null;
+    return (
+      s.cliProviders.find((p) => p.type === s.activeProvider)?.name ??
+      s.restProviders.find((p) => p.type === s.activeProvider)?.name ??
+      s.activeProvider
+    );
+  });
   const ime = useImeComposition();
 
   // Prompt history hook (pass grace-period guard for freeform keyDown)
@@ -376,7 +384,7 @@ export function GeniePicker() {
                 className="provider-switcher-trigger"
                 onClick={() => setShowProviderSwitcher((v) => !v)}
               >
-                via {useAiProviderStore.getState().getActiveProviderName()}
+                via {activeProviderName}
               </button>
               {showProviderSwitcher && (
                 <ProviderSwitcher

--- a/src/hooks/useUpdateSync.ts
+++ b/src/hooks/useUpdateSync.ts
@@ -67,16 +67,13 @@ export function useUpdateBroadcast() {
  * Should be used in non-main windows (e.g., Settings).
  */
 export function useUpdateListener() {
-  const setStatus = useUpdateStore((state) => state.setStatus);
-  const setUpdateInfo = useUpdateStore((state) => state.setUpdateInfo);
-  const setDownloadProgress = useUpdateStore((state) => state.setDownloadProgress);
-  const setError = useUpdateStore((state) => state.setError);
   const hasRequestedState = useRef(false);
 
   // Listen for state broadcasts
   useEffect(() => {
     const unlistenPromise = listen<UpdateStatePayload>(UPDATE_STATE_EVENT, (event) => {
       const { status, updateInfo, downloadProgress, error } = event.payload;
+      const { setStatus, setUpdateInfo, setDownloadProgress, setError } = useUpdateStore.getState();
 
       // Update store with received state
       // Order matters: set info/progress first, then status (which may clear error)
@@ -93,7 +90,7 @@ export function useUpdateListener() {
     return () => {
       safeUnlistenAsync(unlistenPromise);
     };
-  }, [setStatus, setUpdateInfo, setDownloadProgress, setError]);
+  }, []);
 
   // Request initial state from main window on mount
   useEffect(() => {

--- a/src/stores/aiProviderStore.ts
+++ b/src/stores/aiProviderStore.ts
@@ -231,7 +231,13 @@ export const useAiProviderStore = create<AiProviderState & AiProviderActions>()(
     {
       name: "vmark-ai-providers",
       version: 2,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() =>
+        typeof window !== "undefined" ? localStorage : {
+          getItem: () => null,
+          setItem: () => {},
+          removeItem: () => {},
+        }
+      ),
       partialize: (state) => ({
         activeProvider: state.activeProvider,
         restProviders: state.restProviders,

--- a/src/stores/geniesStore.ts
+++ b/src/stores/geniesStore.ts
@@ -189,7 +189,13 @@ export const useGeniesStore = create<GeniesState & GeniesActions>()(
     }),
     {
       name: "vmark-genies",
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() =>
+        typeof window !== "undefined" ? localStorage : {
+          getItem: () => null,
+          setItem: () => {},
+          removeItem: () => {},
+        }
+      ),
       partialize: (state) => ({
         recentGenieNames: state.recentGenieNames,
         favoriteGenieNames: state.favoriteGenieNames,

--- a/src/stores/imagePasteToastStore.ts
+++ b/src/stores/imagePasteToastStore.ts
@@ -16,13 +16,7 @@
 
 import { create } from "zustand";
 import type { ImagePathResult } from "@/utils/imagePathDetection";
-
-interface AnchorRect {
-  top: number;
-  left: number;
-  bottom: number;
-  right: number;
-}
+import type { AnchorRect } from "@/utils/popupPosition";
 
 interface ImagePasteToastState {
   isOpen: boolean;

--- a/src/stores/linkPopupStore.ts
+++ b/src/stores/linkPopupStore.ts
@@ -9,13 +9,7 @@
  */
 
 import { create } from "zustand";
-
-interface AnchorRect {
-  top: number;
-  left: number;
-  bottom: number;
-  right: number;
-}
+import type { AnchorRect } from "@/utils/popupPosition";
 
 interface LinkPopupState {
   isOpen: boolean;

--- a/src/stores/promptHistoryStore.ts
+++ b/src/stores/promptHistoryStore.ts
@@ -55,7 +55,13 @@ export const usePromptHistoryStore = create<
     }),
     {
       name: "vmark-prompt-history",
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() =>
+        typeof window !== "undefined" ? localStorage : {
+          getItem: () => null,
+          setItem: () => {},
+          removeItem: () => {},
+        }
+      ),
       partialize: (state) => ({
         entries: state.entries,
       }),


### PR DESCRIPTION
## Summary

- **ImageContextMenu**: Replace store destructuring with individual selectors to avoid unnecessary re-renders
- **GeniePicker**: Replace `getState()` call in JSX render with a proper reactive selector for `activeProviderName`
- **useUpdateSync**: Move action selectors (`setStatus`, `setUpdateInfo`, etc.) from hook top-level into `useUpdateStore.getState()` inside the event listener callback
- **aiProviderStore, geniesStore, promptHistoryStore**: Add SSR-safe `localStorage` guard in `createJSONStorage`
- **linkPopupStore, imagePasteToastStore**: Remove local `AnchorRect` interface duplication, import from `@/utils/popupPosition`

## Test plan

- [x] `pnpm check:all` passes (lint + coverage + build)
- [ ] Verify GeniePicker footer shows correct provider name
- [ ] Verify ImageContextMenu opens/closes correctly on right-click
- [ ] Verify update state syncs between windows