### PR TITLE
fix: use execFileSync and add timeout in MCP server startup

### DIFF
--- a/vmark-mcp-server/src/cli.ts
+++ b/vmark-mcp-server/src/cli.ts
@@ -104,7 +104,7 @@ import { WebSocketBridge, ClientIdentity } from './bridge/websocket.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z, ZodTypeAny } from 'zod';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir, platform } from 'os';
@@ -228,16 +228,18 @@ function getParentProcessName(): string | undefined {
     if (!ppid) return undefined;
 
     if (process.platform === 'darwin' || process.platform === 'linux') {
-      const result = execSync(`ps -p ${ppid} -o comm=`, { encoding: 'utf8' }).trim();
+      const result = execFileSync('ps', ['-p', String(ppid), '-o', 'comm='], {
+        encoding: 'utf8',
+        timeout: 500,
+      }).trim();
       return result || undefined;
     } else if (process.platform === 'win32') {
       // Use PowerShell — wmic is deprecated on Windows 11+
-      const result = execSync(
-        `powershell -NoProfile -Command "(Get-Process -Id ${ppid}).ProcessName"`,
-        { encoding: 'utf8' }
-      );
-      const name = result.trim();
-      return name || undefined;
+      const result = execFileSync('powershell', [
+        '-NoProfile', '-Command',
+        `(Get-Process -Id ${ppid}).ProcessName`,
+      ], { encoding: 'utf8', timeout: 500 }).trim();
+      return result || undefined;
     }
   } catch {
     // Ignore errors — parent process detection is best-effort

--- a/vmark-mcp-server/src/server.ts
+++ b/vmark-mcp-server/src/server.ts
@@ -56,6 +56,7 @@ export class VMarkMcpServer implements McpServerInterface {
   constructor(config: VMarkMcpServerConfig) {
     this.bridge = config.bridge;
     this.serverName = config.name ?? 'vmark';
+    // MCP protocol version (distinct from app version in cli.ts)
     this.serverVersion = config.version ?? '0.1.0';
   }
 


### PR DESCRIPTION
## Summary
- Replace `execSync` with `execFileSync` in `getParentProcessName()` to avoid shell injection via template strings
- Add `timeout: 500` to both macOS/Linux and Windows code paths to prevent blocking startup
- Document the `0.1.0` version string in `server.ts` as MCP protocol version (distinct from app version)

Closes #102

## Test plan
- [ ] Verify MCP server starts normally (`vmark-mcp-server --health-check`)
- [ ] Verify parent process detection still works (client identity in bridge logs)
- [ ] Verify timeout does not fire under normal conditions (ps completes well under 500ms)