### PR TITLE
fix: replace dead type guards with proper validation helpers in MCP tools

### DIFF
--- a/vmark-mcp-server/src/tools/document.ts
+++ b/vmark-mcp-server/src/tools/document.ts
@@ -2,7 +2,15 @@
  * Document tools - Read and write document content.
  */
 
-import { VMarkMcpServer, resolveWindowId, validateNonNegativeInteger } from '../server.js';
+import {
+  VMarkMcpServer,
+  validateNonNegativeInteger,
+  requireStringArg,
+  requireStringArgAllowEmpty,
+  getWindowIdArg,
+  requireNumberArg,
+  getBooleanArg,
+} from '../server.js';
 import type { SearchResult, ReplaceResult, EditResult } from '../bridge/types.js';
 
 /**
@@ -30,7 +38,7 @@ export function registerDocumentTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const windowId = resolveWindowId(args.windowId as string | undefined);
+      const windowId = getWindowIdArg(args);
 
       try {
         const content = await server.sendBridgeRequest<string>({
@@ -72,14 +80,10 @@ export function registerDocumentTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const content = args.content as string;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof content !== 'string') {
-        return VMarkMcpServer.errorResult('content must be a string');
-      }
-
       try {
+        const content = requireStringArgAllowEmpty(args, 'content');
+        const windowId = getWindowIdArg(args);
+
         const result = await server.sendBridgeRequest<{ message: string }>({
           type: 'document.setContent',
           content,
@@ -119,14 +123,9 @@ export function registerDocumentTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const text = args.text as string;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof text !== 'string') {
-        return VMarkMcpServer.errorResult('text must be a string');
-      }
-
       try {
+        const text = requireStringArgAllowEmpty(args, 'text');
+        const windowId = getWindowIdArg(args);
         const result = await server.sendBridgeRequest<EditResult>({
           type: 'document.insertAtCursor',
           text,
@@ -175,19 +174,14 @@ export function registerDocumentTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const text = args.text as string;
-      const position = args.position as number;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof text !== 'string') {
-        return VMarkMcpServer.errorResult('text must be a string');
-      }
-      const positionError = validateNonNegativeInteger(position, 'position');
-      if (positionError) {
-        return VMarkMcpServer.errorResult(positionError);
-      }
-
       try {
+        const text = requireStringArgAllowEmpty(args, 'text');
+        const position = requireNumberArg(args, 'position');
+        const windowId = getWindowIdArg(args);
+        const positionError = validateNonNegativeInteger(position, 'position');
+        if (positionError) {
+          return VMarkMcpServer.errorResult(positionError);
+        }
         const result = await server.sendBridgeRequest<EditResult>({
           type: 'document.insertAtPosition',
           text,
@@ -237,15 +231,10 @@ export function registerDocumentTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const query = args.query as string;
-      const caseSensitive = (args.caseSensitive as boolean) ?? false;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof query !== 'string' || query.length === 0) {
-        return VMarkMcpServer.errorResult('query must be a non-empty string');
-      }
-
       try {
+        const query = requireStringArg(args, 'query');
+        const caseSensitive = getBooleanArg(args, 'caseSensitive') ?? false;
+        const windowId = getWindowIdArg(args);
         const result = await server.sendBridgeRequest<SearchResult>({
           type: 'document.search',
           query,
@@ -298,19 +287,11 @@ export function registerDocumentTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const search = args.search as string;
-      const replace = args.replace as string;
-      const all = (args.all as boolean) ?? false;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof search !== 'string' || search.length === 0) {
-        return VMarkMcpServer.errorResult('search must be a non-empty string');
-      }
-      if (typeof replace !== 'string') {
-        return VMarkMcpServer.errorResult('replace must be a string');
-      }
-
       try {
+        const search = requireStringArg(args, 'search');
+        const replace = requireStringArgAllowEmpty(args, 'replace');
+        const all = getBooleanArg(args, 'all') ?? false;
+        const windowId = getWindowIdArg(args);
         const result = await server.sendBridgeRequest<ReplaceResult>({
           type: 'document.replaceInSource',
           search,

--- a/vmark-mcp-server/src/tools/selection.ts
+++ b/vmark-mcp-server/src/tools/selection.ts
@@ -2,7 +2,14 @@
  * Selection tools - Read and manipulate text selection.
  */
 
-import { VMarkMcpServer, resolveWindowId, validateNonNegativeInteger } from '../server.js';
+import {
+  VMarkMcpServer,
+  validateNonNegativeInteger,
+  requireStringArgAllowEmpty,
+  requireNumberArg,
+  getNumberArg,
+  getWindowIdArg,
+} from '../server.js';
 import type { Selection, CursorContext, EditResult } from '../bridge/types.js';
 
 /**
@@ -27,7 +34,7 @@ export function registerSelectionTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const windowId = resolveWindowId(args.windowId as string | undefined);
+      const windowId = getWindowIdArg(args);
 
       try {
         const selection = await server.sendBridgeRequest<Selection>({
@@ -71,23 +78,23 @@ export function registerSelectionTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const from = args.from as number;
-      const to = args.to as number;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      const fromError = validateNonNegativeInteger(from, 'from');
-      if (fromError) {
-        return VMarkMcpServer.errorResult(fromError);
-      }
-      const toError = validateNonNegativeInteger(to, 'to');
-      if (toError) {
-        return VMarkMcpServer.errorResult(toError);
-      }
-      if (from > to) {
-        return VMarkMcpServer.errorResult('from cannot be greater than to');
-      }
-
       try {
+        const from = requireNumberArg(args, 'from');
+        const to = requireNumberArg(args, 'to');
+        const windowId = getWindowIdArg(args);
+
+        const fromError = validateNonNegativeInteger(from, 'from');
+        if (fromError) {
+          return VMarkMcpServer.errorResult(fromError);
+        }
+        const toError = validateNonNegativeInteger(to, 'to');
+        if (toError) {
+          return VMarkMcpServer.errorResult(toError);
+        }
+        if (from > to) {
+          return VMarkMcpServer.errorResult('from cannot be greater than to');
+        }
+
         await server.sendBridgeRequest<null>({
           type: 'selection.set',
           from,
@@ -133,14 +140,9 @@ export function registerSelectionTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const text = args.text as string;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof text !== 'string') {
-        return VMarkMcpServer.errorResult('text must be a string');
-      }
-
       try {
+        const text = requireStringArgAllowEmpty(args, 'text');
+        const windowId = getWindowIdArg(args);
         const result = await server.sendBridgeRequest<EditResult>({
           type: 'selection.replace',
           text,
@@ -190,9 +192,9 @@ export function registerSelectionTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const linesBefore = (args.linesBefore as number) ?? 3;
-      const linesAfter = (args.linesAfter as number) ?? 3;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
+      const linesBefore = getNumberArg(args, 'linesBefore') ?? 3;
+      const linesAfter = getNumberArg(args, 'linesAfter') ?? 3;
+      const windowId = getWindowIdArg(args);
 
       const linesBeforeError = validateNonNegativeInteger(linesBefore, 'linesBefore');
       if (linesBeforeError) {
@@ -243,15 +245,14 @@ export function registerSelectionTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const position = args.position as number;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      const positionError = validateNonNegativeInteger(position, 'position');
-      if (positionError) {
-        return VMarkMcpServer.errorResult(positionError);
-      }
-
       try {
+        const position = requireNumberArg(args, 'position');
+        const windowId = getWindowIdArg(args);
+
+        const positionError = validateNonNegativeInteger(position, 'position');
+        if (positionError) {
+          return VMarkMcpServer.errorResult(positionError);
+        }
         await server.sendBridgeRequest<null>({
           type: 'cursor.setPosition',
           position,

--- a/vmark-mcp-server/src/tools/vmark.ts
+++ b/vmark-mcp-server/src/tools/vmark.ts
@@ -2,7 +2,12 @@
  * VMark-specific tools - Math, Mermaid, SVG, Wiki links, CJK formatting.
  */
 
-import { VMarkMcpServer, resolveWindowId } from '../server.js';
+import {
+  VMarkMcpServer,
+  requireStringArg,
+  getStringArg,
+  getWindowIdArg,
+} from '../server.js';
 
 /**
  * Register all VMark-specific tools on the server.
@@ -32,14 +37,10 @@ export function registerVMarkTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const latex = args.latex as string;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof latex !== 'string' || latex.length === 0) {
-        return VMarkMcpServer.errorResult('latex must be a non-empty string');
-      }
-
       try {
+        const latex = requireStringArg(args, 'latex');
+        const windowId = getWindowIdArg(args);
+
         await server.sendBridgeRequest<null>({
           type: 'vmark.insertMathInline',
           latex,
@@ -79,14 +80,9 @@ export function registerVMarkTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const latex = args.latex as string;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof latex !== 'string' || latex.length === 0) {
-        return VMarkMcpServer.errorResult('latex must be a non-empty string');
-      }
-
       try {
+        const latex = requireStringArg(args, 'latex');
+        const windowId = getWindowIdArg(args);
         await server.sendBridgeRequest<null>({
           type: 'vmark.insertMathBlock',
           latex,
@@ -126,14 +122,10 @@ export function registerVMarkTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const code = args.code as string;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof code !== 'string' || code.length === 0) {
-        return VMarkMcpServer.errorResult('code must be a non-empty string');
-      }
-
       try {
+        const code = requireStringArg(args, 'code');
+        const windowId = getWindowIdArg(args);
+
         await server.sendBridgeRequest<null>({
           type: 'vmark.insertMermaid',
           code,
@@ -173,14 +165,10 @@ export function registerVMarkTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const code = args.code as string;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof code !== 'string' || code.length === 0) {
-        return VMarkMcpServer.errorResult('code must be a non-empty string');
-      }
-
       try {
+        const code = requireStringArg(args, 'code');
+        const windowId = getWindowIdArg(args);
+
         await server.sendBridgeRequest<null>({
           type: 'vmark.insertMarkmap',
           code,
@@ -220,14 +208,10 @@ export function registerVMarkTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const code = args.code as string;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof code !== 'string' || code.length === 0) {
-        return VMarkMcpServer.errorResult('code must be a non-empty string');
-      }
-
       try {
+        const code = requireStringArg(args, 'code');
+        const windowId = getWindowIdArg(args);
+
         await server.sendBridgeRequest<null>({
           type: 'vmark.insertSvg',
           code,
@@ -270,15 +254,10 @@ export function registerVMarkTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const target = args.target as string;
-      const displayText = args.displayText as string | undefined;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
-
-      if (typeof target !== 'string' || target.length === 0) {
-        return VMarkMcpServer.errorResult('target must be a non-empty string');
-      }
-
       try {
+        const target = requireStringArg(args, 'target');
+        const displayText = getStringArg(args, 'displayText');
+        const windowId = getWindowIdArg(args);
         await server.sendBridgeRequest<null>({
           type: 'vmark.insertWikiLink',
           target,
@@ -320,8 +299,8 @@ export function registerVMarkTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const direction = args.direction as string;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
+      const direction = requireStringArg(args, 'direction');
+      const windowId = getWindowIdArg(args);
 
       if (direction !== 'to-fullwidth' && direction !== 'to-halfwidth') {
         return VMarkMcpServer.errorResult(
@@ -369,8 +348,8 @@ export function registerVMarkTools(server: VMarkMcpServer): void {
       },
     },
     async (args) => {
-      const action = args.action as string;
-      const windowId = resolveWindowId(args.windowId as string | undefined);
+      const action = requireStringArg(args, 'action');
+      const windowId = getWindowIdArg(args);
 
       if (action !== 'add' && action !== 'remove') {
         return VMarkMcpServer.errorResult('action must be "add" or "remove"');


### PR DESCRIPTION
## Summary

Closes #87

- Replaced `as string` / `as number` casts followed by dead `typeof` guards with the existing typed arg helper functions (`requireStringArg`, `requireStringArgAllowEmpty`, `requireNumberArg`, `getNumberArg`, `getWindowIdArg`, `getBooleanArg`)
- Affected files: `document.ts` (5 handlers), `vmark.ts` (8 handlers), `selection.ts` (5 handlers)
- Net reduction of 39 lines by removing redundant validation code

## Test plan

- [ ] Verify MCP tools still reject invalid args (non-string where string expected, missing required args)
- [ ] Verify MCP tools accept valid args and execute normally
- [ ] Run existing MCP server tests if available