### PR TITLE
fix: replace bare console.* with debug loggers (#90)

### DIFF
--- a/src/hooks/useFileOperations.ts
+++ b/src/hooks/useFileOperations.ts
@@ -53,6 +53,7 @@ import { detectLinebreaks } from "@/utils/linebreakDetection";
 import { isWithinRoot, getParentDir } from "@/utils/paths";
 import { saveAllDocuments, type CloseSaveContext } from "@/hooks/closeSave";
 import { safeUnlistenAll } from "@/utils/safeUnlisten";
+import { fileOpsLog, fileOpsWarn } from "@/utils/debug";
 
 /**
  * Save dialog with timeout and filter fallback for macOS Tahoe compatibility.
@@ -89,7 +90,7 @@ async function saveDialogWithFallback(
 
   // Attempt 1: with filters (normal)
   try {
-    console.log("[FileOps] Save dialog attempt 1: with filters");
+    fileOpsLog("Save dialog attempt 1: with filters");
     const path = await withTimeout(
       save({
         defaultPath,
@@ -99,11 +100,11 @@ async function saveDialogWithFallback(
     );
     return path;
   } catch (firstError) {
-    console.warn("[FileOps] Save dialog attempt 1 failed:", firstError);
+    fileOpsWarn("Save dialog attempt 1 failed:", firstError);
 
     // If it timed out, retry without filters to bypass deprecated setAllowedFileTypes
     if (firstError instanceof Error && firstError.message.includes("timed out")) {
-      console.log("[FileOps] Save dialog attempt 2: without filters (Tahoe workaround)");
+      fileOpsLog("Save dialog attempt 2: without filters (Tahoe workaround)");
       try {
         const path = await withTimeout(
           save({ defaultPath }),
@@ -111,7 +112,7 @@ async function saveDialogWithFallback(
         );
         return path;
       } catch (secondError) {
-        console.error("[FileOps] Save dialog attempt 2 also failed:", secondError);
+        fileOpsLog("Save dialog attempt 2 also failed:", secondError);
         throw secondError;
       }
     }
@@ -184,7 +185,7 @@ export async function openFileInNewTabCore(
     useRecentFilesStore.getState().addFile(path);
     perfMark("openFileInNewTab:complete");
   } catch (error) {
-    console.error("[FileOps] Failed to open file:", path, error);
+    console.error("[FileOps] Failed to open file:", path, error); // intentional: user-facing error with toast
     // Clean up the orphaned tab — without initDocument, it renders blank.
     // Use detachTab (not closeTab) to avoid polluting the "reopen closed tab" history.
     useTabStore.getState().detachTab(windowLabel, tabId);
@@ -289,7 +290,7 @@ export function useFileOperations() {
             useRecentFilesStore.getState().addFile(path);
             perfMark("handleOpen:replacedTab");
           } catch (error) {
-            console.error("[FileOps] Failed to replace tab with file:", error);
+            fileOpsLog("Failed to replace tab with file:", error);
           }
           break;
         case "open_workspace_in_new_window":
@@ -299,7 +300,7 @@ export function useFileOperations() {
               filePath: decision.filePath,
             });
           } catch (error) {
-            console.error("[FileOps] Failed to open workspace in new window:", error);
+            fileOpsLog("Failed to open workspace in new window:", error);
           }
           break;
         case "no_op":
@@ -310,23 +311,23 @@ export function useFileOperations() {
   }, [windowLabel, openFileInNewTab]);
 
   const handleSave = useCallback(async () => {
-    console.log("[FileOps] handleSave called for window:", windowLabel);
+    fileOpsLog("handleSave called for window:", windowLabel);
     flushActiveWysiwygNow();
 
     const guardResult = await withReentryGuard(windowLabel, "save", async () => {
       const tabId = useTabStore.getState().activeTabId[windowLabel];
       if (!tabId) {
-        console.warn("[FileOps] No active tab for save in window:", windowLabel);
+        fileOpsWarn("No active tab for save in window:", windowLabel);
         return;
       }
 
       const doc = useDocumentStore.getState().getDocument(tabId);
       if (!doc) {
-        console.warn("[FileOps] No document found for tab:", tabId);
+        fileOpsWarn("No document found for tab:", tabId);
         return;
       }
 
-      console.log("[FileOps] Save target:", {
+      fileOpsLog("Save target:", {
         tabId,
         filePath: doc.filePath ?? "(untitled)",
         isMissing: doc.isMissing,
@@ -345,21 +346,21 @@ export function useFileOperations() {
 
       // If file is missing, force Save As flow instead of normal save
       if (saveAction === "save_as_required" || !doc.filePath) {
-        console.log("[FileOps] Entering Save As flow (untitled or missing file)");
+        fileOpsLog("Entering Save As flow (untitled or missing file)");
         // Build default path with suggested filename from H1 or tab title
         const tab = useTabStore.getState().tabs[windowLabel]?.find(t => t.id === tabId);
         const suggestedName = getSaveFileName(doc.content, tab?.title ?? "");
         const filename = `${suggestedName}.md`;
         const folder = await getDefaultSaveFolderWithFallback(windowLabel);
         const defaultPath = joinPath(folder, filename);
-        console.log("[FileOps] Opening save dialog with defaultPath:", defaultPath);
+        fileOpsLog("Opening save dialog with defaultPath:", defaultPath);
 
         let path: string | null;
         try {
           path = await saveDialogWithFallback(defaultPath);
-          console.log("[FileOps] Save dialog returned:", path ?? "(cancelled)");
+          fileOpsLog("Save dialog returned:", path ?? "(cancelled)");
         } catch (error) {
-          console.error("[FileOps] Save dialog threw:", error);
+          console.error("[FileOps] Save dialog threw:", error); // intentional: user-facing error with toast
           toast.error(
             `Save dialog failed: ${error instanceof Error ? error.message : String(error)}`
           );
@@ -395,13 +396,13 @@ export function useFileOperations() {
           try {
             await openWorkspaceWithConfig(postSaveAction.workspaceRoot);
           } catch (error) {
-            console.error("[FileOps] Failed to open workspace after save:", error);
+            fileOpsLog("Failed to open workspace after save:", error);
           }
         }
       }
     });
     if (guardResult === undefined) {
-      console.warn("[FileOps] Save blocked by re-entry guard (another save in progress)");
+      fileOpsWarn("Save blocked by re-entry guard (another save in progress)");
     }
   }, [windowLabel]);
 
@@ -434,7 +435,7 @@ export function useFileOperations() {
       try {
         path = await saveDialogWithFallback(defaultPath);
       } catch (error) {
-        console.error("[FileOps] Save As dialog threw:", error);
+        console.error("[FileOps] Save As dialog threw:", error); // intentional: user-facing error with toast
         toast.error(
           `Save dialog failed: ${error instanceof Error ? error.message : String(error)}`
         );
@@ -479,7 +480,7 @@ export function useFileOperations() {
       try {
         newPath = await saveDialogWithFallback(defaultPath);
       } catch (error) {
-        console.error("[FileOps] Move To dialog threw:", error);
+        console.error("[FileOps] Move To dialog threw:", error); // intentional: user-facing error with toast
         toast.error(
           `Save dialog failed: ${error instanceof Error ? error.message : String(error)}`
         );
@@ -497,7 +498,7 @@ export function useFileOperations() {
         try {
           await remove(oldPath);
         } catch (error) {
-          console.error("[FileOps] Failed to delete old file during move:", error);
+          console.error("[FileOps] Failed to delete old file during move:", error); // intentional: user-facing error with toast
           // File was saved to new location, but old file couldn't be deleted
           toast.warning("File saved to new location, but couldn't delete original file");
         }
@@ -560,7 +561,7 @@ export function useFileOperations() {
       unlistenRefs.current.push(unlistenOpen);
 
       const unlistenSave = await currentWindow.listen<string>("menu:save", async (event) => {
-        console.log("[FileOps] menu:save event received, payload:", event.payload);
+        fileOpsLog("menu:save event received, payload:", event.payload);
         if (event.payload !== windowLabel) return;
         await handleSave();
       });
@@ -640,7 +641,7 @@ export function useFileOperations() {
               }
               // If cancelled, do nothing (stay in app)
             } catch (error) {
-              console.error("[SaveAllQuit] Failed:", error);
+              console.error("[SaveAllQuit] Failed:", error); // intentional: user-facing error with toast
               toast.error("Failed to save documents");
             }
           });
@@ -683,7 +684,7 @@ export function useFileOperations() {
       // Save (Cmd+S)
       const saveKey = shortcuts.getShortcut("save");
       if (matchesShortcutEvent(e, saveKey)) {
-        console.log("[FileOps] Cmd+S keyboard shortcut matched");
+        fileOpsLog("Cmd+S keyboard shortcut matched");
         e.preventDefault();
         handleSave();
         return;

--- a/src/hooks/useMcpAutoStart.ts
+++ b/src/hooks/useMcpAutoStart.ts
@@ -11,6 +11,7 @@
 import { useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { mcpAutoStartLog } from "@/utils/debug";
 
 /**
  * Auto-start the MCP server if enabled in settings.
@@ -37,10 +38,10 @@ export function useMcpAutoStart() {
     // We don't start a local sidecar - that would conflict with the AI client's sidecar.
     invoke("mcp_bridge_start", { port: mcpServer.port })
       .then(() => {
-        console.log("[MCP] Auto-started MCP bridge on port", mcpServer.port);
+        mcpAutoStartLog("Auto-started MCP bridge on port", mcpServer.port);
       })
       .catch((error) => {
-        console.error("[MCP] Failed to auto-start MCP bridge:", error);
+        mcpAutoStartLog("Failed to auto-start MCP bridge:", error);
       });
   }, []);
 }

--- a/src/hooks/useUpdateChecker.ts
+++ b/src/hooks/useUpdateChecker.ts
@@ -30,6 +30,7 @@ import { useUpdateStore, type UpdateStatus } from "@/stores/updateStore";
 import { useDocumentStore } from "@/stores/documentStore";
 import { useUpdateOperationHandler, clearPendingUpdate } from "./useUpdateOperations";
 import { restartWithHotExit } from "@/utils/hotExit/restartWithHotExit";
+import { updateCheckerLog } from "@/utils/debug";
 
 // Time constants in milliseconds
 const ONE_DAY = 24 * 60 * 60 * 1000;
@@ -101,7 +102,7 @@ export function useUpdateChecker() {
 
       const timer = setTimeout(() => {
         doCheckForUpdates().catch((error) => {
-          console.error("[UpdateChecker] Auto-check failed on startup:", error);
+          updateCheckerLog("Auto-check failed on startup:", error);
         });
       }, STARTUP_CHECK_DELAY_MS);
 
@@ -156,17 +157,17 @@ export function useUpdateChecker() {
         const delay = BASE_RETRY_DELAY_MS * Math.pow(2, retryCount.current);
         retryCount.current += 1;
 
-        console.log(
-          `[UpdateChecker] Retry ${retryCount.current}/${MAX_RETRIES} in ${delay / 1000}s`
+        updateCheckerLog(
+          `Retry ${retryCount.current}/${MAX_RETRIES} in ${delay / 1000}s`
         );
 
         retryTimerRef.current = setTimeout(() => {
           doCheckForUpdates().catch((err) => {
-            console.error("[UpdateChecker] Retry failed:", err);
+            updateCheckerLog("Retry failed:", err);
           });
         }, delay);
       } else {
-        console.log("[UpdateChecker] Max retries reached, giving up");
+        updateCheckerLog("Max retries reached, giving up");
       }
     }
 
@@ -205,7 +206,7 @@ export function useUpdateChecker() {
     ) {
       hasAutoDownloaded.current = true;
       doDownloadAndInstall().catch((error) => {
-        console.error("[UpdateChecker] Auto-download failed:", error);
+        updateCheckerLog("Auto-download failed:", error);
       });
     }
   }, [status, autoDownload, updateInfo, skipVersion, doDownloadAndInstall]);
@@ -222,7 +223,7 @@ export function useUpdateChecker() {
     const unlistenPromise = listen(EVENTS.REQUEST_CHECK, () => {
       isManualCheck.current = true;
       doCheckForUpdates().catch((error) => {
-        console.error("[UpdateChecker] Check request failed:", error);
+        updateCheckerLog("Check request failed:", error);
       });
     });
 
@@ -237,7 +238,7 @@ export function useUpdateChecker() {
   useEffect(() => {
     const unlistenPromise = listen(EVENTS.REQUEST_DOWNLOAD, () => {
       doDownloadAndInstall().catch((error) => {
-        console.error("[UpdateChecker] Download request failed:", error);
+        updateCheckerLog("Download request failed:", error);
       });
     });
 
@@ -262,7 +263,7 @@ export function useUpdateChecker() {
         downloadProgress: currentState.downloadProgress,
         error: currentState.error,
       }).catch((error) => {
-        console.error("[UpdateChecker] Failed to emit state:", error);
+        updateCheckerLog("Failed to emit state:", error);
       });
     });
 
@@ -305,10 +306,10 @@ export function useUpdateChecker() {
             await emit("update:restart-cancelled");
           }
         } catch (error) {
-          console.error("[UpdateChecker] Restart request failed:", error);
+          updateCheckerLog("Restart request failed:", error);
           // Emit cancel event on error so UI can reset
           emit("update:restart-cancelled").catch((e) => {
-            console.error("[UpdateChecker] Failed to emit restart-cancelled:", e);
+            updateCheckerLog("Failed to emit restart-cancelled:", e);
           });
         }
       })();

--- a/src/stores/aiProviderStore.ts
+++ b/src/stores/aiProviderStore.ts
@@ -25,6 +25,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { invoke } from "@tauri-apps/api/core";
+import { aiProviderLog, aiProviderWarn } from "@/utils/debug";
 import type {
   CliProviderInfo,
   RestProviderConfig,
@@ -160,7 +161,7 @@ export const useAiProviderStore = create<AiProviderState & AiProviderActions>()(
             }
           }
         } catch (e) {
-          console.error("Failed to detect providers:", e);
+          aiProviderLog("Failed to detect providers:", e);
           if (thisDetectId === _detectId) {
             set({ detecting: false });
           }
@@ -214,7 +215,7 @@ export const useAiProviderStore = create<AiProviderState & AiProviderActions>()(
           }));
         } catch (e) {
           // Non-critical — user can still type keys manually
-          console.warn("Failed to read env API keys:", e);
+          aiProviderWarn("Failed to read env API keys:", e);
         }
       },
 

--- a/src/stores/geniesStore.ts
+++ b/src/stores/geniesStore.ts
@@ -26,6 +26,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { invoke } from "@tauri-apps/api/core";
 import type { GenieDefinition, GenieMetadata, GenieScope } from "@/types/aiGenies";
+import { geniesWarn, geniesLog } from "@/utils/debug";
 
 // ============================================================================
 // Types
@@ -103,7 +104,7 @@ export const useGeniesStore = create<GeniesState & GeniesActions>()(
                 source: "global",
               });
             } catch (e) {
-              console.warn(`Failed to read genie ${entry.path}:`, e);
+              geniesWarn(`Failed to read genie ${entry.path}:`, e);
             }
           }
 
@@ -123,7 +124,7 @@ export const useGeniesStore = create<GeniesState & GeniesActions>()(
             favoriteGenieNames: prunedFavorites,
           });
         } catch (e) {
-          console.error("Failed to load genies:", e);
+          geniesLog("Failed to load genies:", e);
           if (thisLoadId === _loadId) {
             set({ loading: false });
           }

--- a/src/stores/recentFilesStore.ts
+++ b/src/stores/recentFilesStore.ts
@@ -18,6 +18,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { invoke } from "@tauri-apps/api/core";
 import { getFileName } from "@/utils/pathUtils";
+import { recentWarn } from "@/utils/debug";
 
 export interface RecentFile {
   path: string;
@@ -39,7 +40,7 @@ async function updateNativeMenu(files: RecentFile[]) {
   try {
     await invoke("update_recent_files", { files: files.map((f) => f.path) });
   } catch (error) {
-    console.warn("[RecentFiles] Failed to update native menu:", error);
+    recentWarn("Failed to update recent files native menu:", error);
   }
 }
 

--- a/src/stores/recentWorkspacesStore.ts
+++ b/src/stores/recentWorkspacesStore.ts
@@ -16,6 +16,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { invoke } from "@tauri-apps/api/core";
 import { getFileName } from "@/utils/pathUtils";
+import { recentWarn } from "@/utils/debug";
 
 export interface RecentWorkspace {
   path: string;       // Absolute path to workspace folder
@@ -37,7 +38,7 @@ async function updateNativeMenu(workspaces: RecentWorkspace[]) {
   try {
     await invoke("update_recent_workspaces", { workspaces: workspaces.map((w) => w.path) });
   } catch (error) {
-    console.warn("[RecentWorkspaces] Failed to update native menu:", error);
+    recentWarn("Failed to update recent workspaces native menu:", error);
   }
 }
 

--- a/src/stores/shortcutsStore.ts
+++ b/src/stores/shortcutsStore.ts
@@ -28,6 +28,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { invoke } from "@tauri-apps/api/core";
 import { isMacPlatform } from "@/utils/shortcutMatch";
+import { shortcutsWarn } from "@/utils/debug";
 
 // ============================================================================
 // Types
@@ -397,7 +398,7 @@ async function syncMenuShortcuts(shortcuts: Record<string, string>) {
     await invoke("refresh_genies_menu");
   } catch (e) {
     // Menu rebuild may fail if command not yet implemented
-    console.warn("Failed to sync menu shortcuts:", e);
+    shortcutsWarn("Failed to sync menu shortcuts:", e);
   }
 }
 

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -38,3 +38,99 @@ export const terminalLog = isDev
 export const crashRecoveryLog = isDev
   ? (...args: unknown[]) => console.log("[CrashRecovery]", ...args)
   : () => {};
+
+/**
+ * Debug logger for Hot Exit operations (capture, restore, restart).
+ * Only logs in development mode.
+ */
+export const hotExitLog = isDev
+  ? (...args: unknown[]) => console.log("[HotExit]", ...args)
+  : () => {};
+
+/**
+ * Debug logger for Hot Exit warnings.
+ * Only logs in development mode.
+ */
+export const hotExitWarn = isDev
+  ? (...args: unknown[]) => console.warn("[HotExit]", ...args)
+  : () => {};
+
+/**
+ * Debug logger for File Operations (open, save, save-as, move).
+ * Only logs in development mode.
+ */
+export const fileOpsLog = isDev
+  ? (...args: unknown[]) => console.log("[FileOps]", ...args)
+  : () => {};
+
+/**
+ * Debug logger for File Operations warnings.
+ * Only logs in development mode.
+ */
+export const fileOpsWarn = isDev
+  ? (...args: unknown[]) => console.warn("[FileOps]", ...args)
+  : () => {};
+
+/**
+ * Debug logger for MCP Auto-Start operations.
+ * Only logs in development mode.
+ */
+export const mcpAutoStartLog = isDev
+  ? (...args: unknown[]) => console.log("[MCP]", ...args)
+  : () => {};
+
+/**
+ * Debug logger for Update Checker operations.
+ * Only logs in development mode.
+ */
+export const updateCheckerLog = isDev
+  ? (...args: unknown[]) => console.log("[UpdateChecker]", ...args)
+  : () => {};
+
+/**
+ * Debug logger for AI Provider operations.
+ * Only logs in development mode.
+ */
+export const aiProviderLog = isDev
+  ? (...args: unknown[]) => console.log("[AIProvider]", ...args)
+  : () => {};
+
+/**
+ * Debug logger for AI Provider warnings.
+ * Only logs in development mode.
+ */
+export const aiProviderWarn = isDev
+  ? (...args: unknown[]) => console.warn("[AIProvider]", ...args)
+  : () => {};
+
+/**
+ * Debug logger for Genies store operations.
+ * Only logs in development mode.
+ */
+export const geniesLog = isDev
+  ? (...args: unknown[]) => console.log("[Genies]", ...args)
+  : () => {};
+
+/**
+ * Debug logger for Genies warnings.
+ * Only logs in development mode.
+ */
+export const geniesWarn = isDev
+  ? (...args: unknown[]) => console.warn("[Genies]", ...args)
+  : () => {};
+
+/**
+ * Debug logger for Recent Files/Workspaces warnings.
+ * Only logs in development mode.
+ */
+export const recentWarn = isDev
+  ? (...args: unknown[]) => console.warn("[Recent]", ...args)
+  : () => {};
+
+/**
+ * Debug logger for Shortcuts store warnings.
+ * Only logs in development mode.
+ */
+export const shortcutsWarn = isDev
+  ? (...args: unknown[]) => console.warn("[Shortcuts]", ...args)
+  : () => {};

--- a/src/utils/hotExit/restartWithHotExit.ts
+++ b/src/utils/hotExit/restartWithHotExit.ts
@@ -17,6 +17,7 @@ import type { SessionData } from './types';
 import { HOT_EXIT_EVENTS } from './types';
 import { migrateSession, canMigrate, needsMigration, SCHEMA_VERSION } from './schemaMigration';
 import { restoreMainWindowState } from './useHotExitRestore';
+import { hotExitLog, hotExitWarn } from '@/utils/debug';
 
 /** Default timeout for restore operation in milliseconds */
 const DEFAULT_RESTORE_TIMEOUT_MS = 15000;
@@ -50,9 +51,9 @@ function formatTimestamp(timestamp: number): string {
 async function clearSessionFile(context: string): Promise<void> {
   try {
     await invoke<void>(HOT_EXIT_COMMANDS.CLEAR);
-    console.log(`[HotExit] Cleared session file (${context})`);
+    hotExitLog(`Cleared session file (${context})`);
   } catch (clearError) {
-    console.warn(`[HotExit] Failed to clear session file (${context}):`, clearError);
+    hotExitWarn(`Failed to clear session file (${context}):`, clearError);
   }
 }
 
@@ -66,13 +67,13 @@ export async function restartWithHotExit(): Promise<void> {
     // This command waits for all windows to respond with 5s timeout
     const session = await invoke<SessionData>(HOT_EXIT_COMMANDS.CAPTURE);
 
-    console.log('[HotExit] Session captured and persisted:', {
+    hotExitLog('Session captured and persisted:', {
       windows: session.windows.length,
       version: session.vmark_version,
     });
   } catch (error) {
     const captureError = error instanceof Error ? error : new Error(String(error));
-    console.error('[HotExit] Failed to capture session before restart:', captureError);
+    console.error('[HotExit] Failed to capture session before restart:', captureError); // intentional: critical error before relaunch
     // Continue to relaunch - user already confirmed restart
   }
 
@@ -80,7 +81,7 @@ export async function restartWithHotExit(): Promise<void> {
   try {
     await relaunch();
   } catch (error) {
-    console.error('[HotExit] Failed to relaunch:', error);
+    console.error('[HotExit] Failed to relaunch:', error); // intentional: critical relaunch failure
     throw error;
   }
 }
@@ -102,7 +103,7 @@ export async function checkAndRestoreSession(
   // Runtime guard: only main window should trigger restore
   const windowLabel = getCurrentWebviewWindow().label;
   if (windowLabel !== 'main') {
-    console.warn(`[HotExit] checkAndRestoreSession called from non-main window: ${windowLabel}`);
+    hotExitWarn(`checkAndRestoreSession called from non-main window: ${windowLabel}`);
     return false;
   }
 
@@ -115,13 +116,13 @@ export async function checkAndRestoreSession(
     const session = await invoke<SessionData | null>(HOT_EXIT_COMMANDS.INSPECT);
 
     if (!session) {
-      console.log('[HotExit] No saved session found');
+      hotExitLog('No saved session found');
       return false;
     }
 
     // Check if session can be migrated
     if (!canMigrate(session.version)) {
-      console.error(`[HotExit] Cannot restore session: incompatible version ${session.version} (current: ${SCHEMA_VERSION})`);
+      hotExitLog(`Cannot restore session: incompatible version ${session.version} (current: ${SCHEMA_VERSION})`);
       await clearSessionFile('incompatible version');
       return false;
     }
@@ -129,13 +130,13 @@ export async function checkAndRestoreSession(
     // Migrate session if needed (frontend applies migration before sending to Rust)
     let migratedSession = session;
     if (needsMigration(session)) {
-      console.log(`[HotExit] Migrating session from v${session.version} to v${SCHEMA_VERSION}`);
+      hotExitLog(`Migrating session from v${session.version} to v${SCHEMA_VERSION}`);
       migratedSession = migrateSession(session);
     }
 
     const hasSecondaryWindows = migratedSession.windows.some(w => !w.is_main_window);
 
-    console.log('[HotExit] Found saved session:', {
+    hotExitLog('Found saved session:', {
       windows: migratedSession.windows.length,
       hasSecondaryWindows,
       timestamp: formatTimestamp(migratedSession.timestamp),
@@ -155,7 +156,7 @@ export async function checkAndRestoreSession(
           HOT_EXIT_COMMANDS.RESTORE_MULTI,
           { session: migratedSession }
         );
-        console.log('[HotExit] Multi-window restore initiated:', {
+        hotExitLog('Multi-window restore initiated:', {
           windowsCreated: result.windows_created,
         });
       } else {
@@ -167,7 +168,7 @@ export async function checkAndRestoreSession(
       // This bypasses the RESTORE_START event listener race condition where
       // useHotExitRestore's listener may not be registered when Rust emits the event.
       // By the time invoke returns, Rust has already stored state in PendingRestoreState.
-      console.log('[HotExit] Invoking main window restore directly (bypassing event)');
+      hotExitLog('Invoking main window restore directly (bypassing event)');
       await restoreMainWindowState();
     } catch (invokeError) {
       // Invoke failed - clean up listeners and rethrow
@@ -184,12 +185,12 @@ export async function checkAndRestoreSession(
       return true;
     } else {
       // Restore failed or timed out - keep session file for retry
-      console.error('[HotExit] Restore failed:', restoreResult.error);
-      console.log('[HotExit] Session file preserved for retry on next launch');
+      hotExitLog('Restore failed:', restoreResult.error);
+      hotExitLog('Session file preserved for retry on next launch');
       return false;
     }
   } catch (error) {
-    console.error('[HotExit] Failed to restore session:', error);
+    hotExitLog('Failed to restore session:', error);
     return false;
   }
 }

--- a/src/utils/hotExit/useHotExitCapture.ts
+++ b/src/utils/hotExit/useHotExitCapture.ts
@@ -15,6 +15,7 @@ import { useEditorStore } from '@/stores/editorStore';
 import { useUnifiedHistoryStore } from '@/stores/unifiedHistoryStore';
 import type { WindowState, TabState, CaptureRequest, CaptureResponse, CursorInfo } from './types';
 import { HOT_EXIT_EVENTS, MAIN_WINDOW_LABEL } from './types';
+import { hotExitWarn } from '@/utils/debug';
 import type { LineEnding as StoreLineEnding } from '@/utils/linebreakDetection';
 import type { HistoryCheckpoint as StoreHistoryCheckpoint } from '@/stores/unifiedHistoryStore';
 import type { CursorInfo as StoreCursorInfo } from '@/stores/documentStore';
@@ -226,7 +227,7 @@ export function useHotExitCapture() {
         const windowState = captureWindowState(windowLabel, isMainWindow);
         response = buildCaptureResponse(captureId, windowLabel, windowState);
       } catch (error) {
-        console.error('[HotExit] Failed to capture window state:', error);
+        console.error('[HotExit] Failed to capture window state:', error); // intentional: critical capture failure
 
         // Build fallback state - getUiStateSafe won't throw
         const fallbackState: WindowState = {
@@ -247,7 +248,7 @@ export function useHotExitCapture() {
         await currentWindow.emit(HOT_EXIT_EVENTS.CAPTURE_RESPONSE, response);
       } catch (emitError) {
         // This is critical - log prominently
-        console.error('[HotExit] CRITICAL: Failed to emit capture response:', emitError);
+        console.error('[HotExit] CRITICAL: Failed to emit capture response:', emitError); // intentional: critical emit failure
         // No fallback possible - coordinator will timeout
       }
     });
@@ -255,7 +256,7 @@ export function useHotExitCapture() {
     return () => {
       void unlistenPromise.then((unlisten) => unlisten()).catch((e) => {
         // Log cleanup errors for debugging listener leaks (always log, useful for production debugging)
-        console.warn('[HotExit] Cleanup error (may indicate listener leak):', e);
+        hotExitWarn('Cleanup error (may indicate listener leak):', e);
       });
     };
   }, []);

--- a/src/utils/hotExit/useHotExitRestore.ts
+++ b/src/utils/hotExit/useHotExitRestore.ts
@@ -27,6 +27,7 @@ import { HOT_EXIT_EVENTS } from './types';
 import type { LineEnding } from '@/utils/linebreakDetection';
 import type { HistoryCheckpoint as StoreHistoryCheckpoint } from '@/stores/unifiedHistoryStore';
 import type { CursorInfo as StoreCursorInfo } from '@/types/cursorSync';
+import { hotExitLog, hotExitWarn } from '@/utils/debug';
 
 /** Maximum retries when pulling state (handles timing issues) */
 const MAX_STATE_RETRIES = 5;
@@ -72,7 +73,7 @@ function toStoreCursorInfo(cursorInfo: CursorInfo | null | undefined): StoreCurs
     !Number.isFinite(cursorInfo.offset_in_word) ||
     !Number.isFinite(cursorInfo.percent_in_line)
   ) {
-    console.warn('[HotExit] Invalid cursor info, skipping restore');
+    hotExitWarn('Invalid cursor info, skipping restore');
     return null;
   }
 
@@ -113,13 +114,13 @@ function fromHotExitCheckpoint(checkpoint: HistoryCheckpoint): StoreHistoryCheck
 export async function restoreMainWindowState(): Promise<void> {
   const windowLabel = getCurrentWebviewWindow().label;
   if (windowLabel !== 'main') {
-    console.warn('[HotExit] restoreMainWindowState called from non-main window');
+    hotExitWarn('restoreMainWindowState called from non-main window');
     return;
   }
 
   // Guard against double-restore
   if (mainWindowRestoreStarted) {
-    console.log('[HotExit] Main window restore already in progress or completed, skipping');
+    hotExitLog('Main window restore already in progress or completed, skipping');
     return;
   }
   mainWindowRestoreStarted = true;
@@ -128,29 +129,29 @@ export async function restoreMainWindowState(): Promise<void> {
     const windowState = await pullWindowStateWithRetry(windowLabel);
 
     if (!windowState) {
-      console.error('[HotExit] No state found for main window after retries');
+      hotExitLog('No state found for main window after retries');
       void emit(HOT_EXIT_EVENTS.RESTORE_FAILED, {
         error: `No restore state found for window '${windowLabel}'`,
-      }).catch((e) => console.error('[HotExit] Failed to emit restore failed:', e));
+      }).catch((e) => hotExitWarn('Failed to emit restore failed:', e));
       return;
     }
 
-    console.log('[HotExit] Main window found pending state, restoring...');
+    hotExitLog('Main window found pending state, restoring...');
     await restoreWindowState(windowLabel, windowState);
 
     // Signal completion for this window and check if all windows done
     const allDone = await invoke<boolean>('hot_exit_window_restore_complete', { windowLabel });
-    console.log(`[HotExit] Main window restored successfully (allDone: ${allDone})`);
+    hotExitLog(`Main window restored successfully (allDone: ${allDone})`);
 
     // Only emit RESTORE_COMPLETE when ALL windows have completed
     if (allDone) {
       await emit(HOT_EXIT_EVENTS.RESTORE_COMPLETE, {});
     }
   } catch (error) {
-    console.error('[HotExit] Main window restore failed:', error);
+    hotExitLog('Main window restore failed:', error);
     void emit(HOT_EXIT_EVENTS.RESTORE_FAILED, {
       error: error instanceof Error ? error.message : String(error),
-    }).catch((e) => console.error('[HotExit] Failed to emit restore failed:', e));
+    }).catch((e) => hotExitWarn('Failed to emit restore failed:', e));
   }
 }
 
@@ -171,11 +172,11 @@ async function pullWindowStateWithRetry(windowLabel: string, retries = MAX_STATE
 
       // State not found - wait and retry (might not be stored yet)
       if (attempt < retries) {
-        console.log(`[HotExit] Window '${windowLabel}' state not ready, retry ${attempt}/${retries}`);
+        hotExitLog(`Window '${windowLabel}' state not ready, retry ${attempt}/${retries}`);
         await sleep(RETRY_DELAY_MS);
       }
     } catch (error) {
-      console.error(`[HotExit] Failed to pull state for '${windowLabel}' (attempt ${attempt}):`, error);
+      hotExitLog(`Failed to pull state for '${windowLabel}' (attempt ${attempt}):`, error);
       if (attempt < retries) {
         await sleep(RETRY_DELAY_MS);
       }
@@ -203,7 +204,7 @@ export function useHotExitRestore() {
      */
     const restoreFromPulledState = async (isRequestedRestore: boolean) => {
       if (isRestoring.current) {
-        console.warn(`[HotExit] Window '${windowLabel}' ignoring concurrent restore`);
+        hotExitWarn(`Window '${windowLabel}' ignoring concurrent restore`);
         return;
       }
 
@@ -213,35 +214,35 @@ export function useHotExitRestore() {
         const windowState = await pullWindowStateWithRetry(windowLabel);
 
         if (!windowState) {
-          console.warn(`[HotExit] No state found for window '${windowLabel}' after ${MAX_STATE_RETRIES} retries`);
+          hotExitWarn(`No state found for window '${windowLabel}' after ${MAX_STATE_RETRIES} retries`);
 
           // If restore was explicitly requested but no state found, emit failure
           // (This prevents checkAndRestoreSession from waiting until timeout)
           if (isRequestedRestore && isMainWindow) {
-            console.error('[HotExit] Restore was requested but no state available');
+            hotExitLog('Restore was requested but no state available');
             void emit(HOT_EXIT_EVENTS.RESTORE_FAILED, {
               error: `No restore state found for window '${windowLabel}'`,
-            }).catch((e) => console.error('[HotExit] Failed to emit restore failed:', e));
+            }).catch((e) => hotExitWarn('Failed to emit restore failed:', e));
           }
           return;
         }
 
-        console.log(`[HotExit] Window '${windowLabel}' found pending state, restoring...`);
+        hotExitLog(`Window '${windowLabel}' found pending state, restoring...`);
         await restoreWindowState(windowLabel, windowState);
 
         // Signal completion for this window and check if all windows done
         const allDone = await invoke<boolean>('hot_exit_window_restore_complete', { windowLabel });
-        console.log(`[HotExit] Window '${windowLabel}' restored successfully (allDone: ${allDone})`);
+        hotExitLog(`Window '${windowLabel}' restored successfully (allDone: ${allDone})`);
 
         // Only emit RESTORE_COMPLETE when ALL windows have completed
         if (allDone) {
           await emit(HOT_EXIT_EVENTS.RESTORE_COMPLETE, {});
         }
       } catch (error) {
-        console.error(`[HotExit] Window '${windowLabel}' restore failed:`, error);
+        hotExitLog(`Window '${windowLabel}' restore failed:`, error);
         void emit(HOT_EXIT_EVENTS.RESTORE_FAILED, {
           error: error instanceof Error ? error.message : String(error),
-        }).catch((e) => console.error('[HotExit] Failed to emit restore failed:', e));
+        }).catch((e) => hotExitWarn('Failed to emit restore failed:', e));
       } finally {
         isRestoring.current = false;
       }
@@ -272,7 +273,7 @@ export function useHotExitRestore() {
         // Main window: check if already restored via direct call
         if (isMainWindow) {
           if (mainWindowRestoreStarted) {
-            console.log('[HotExit] RESTORE_START received but restore already started, ignoring');
+            hotExitLog('RESTORE_START received but restore already started, ignoring');
             return;
           }
           // Set flag to prevent double-restore via direct call
@@ -286,7 +287,7 @@ export function useHotExitRestore() {
 
     return () => {
       void unlistenPromise.then((unlisten) => unlisten()).catch((e) => {
-        console.debug('[HotExit] Cleanup error (expected during unmount):', e);
+        hotExitLog('Cleanup error (expected during unmount):', e);
       });
     };
   }, []);
@@ -490,7 +491,7 @@ function restoreUnifiedHistory(
     },
   }));
 
-  console.log(
-    `[HotExit] Restored unified history for tab '${tabId}': ${undoStack.length} undo, ${redoStack.length} redo checkpoints`
+  hotExitLog(
+    `Restored unified history for tab '${tabId}': ${undoStack.length} undo, ${redoStack.length} redo checkpoints`
   );
 }

--- a/src/utils/hotExit/useHotExitStartup.ts
+++ b/src/utils/hotExit/useHotExitStartup.ts
@@ -15,6 +15,7 @@ import {
   setRestoreInProgress,
   notifyRestoreComplete,
 } from './hotExitCoordination';
+import { hotExitLog } from '@/utils/debug';
 
 export function useHotExitStartup() {
   const hasChecked = useRef(false);
@@ -33,7 +34,7 @@ export function useHotExitStartup() {
       try {
         const restored = await checkAndRestoreSession();
         if (restored) {
-          console.log('[HotExit] Startup: session restored successfully');
+          hotExitLog('Startup: session restored successfully');
         }
       } finally {
         // Always notify completion, even if restore failed or no session existed


### PR DESCRIPTION
## Summary

- Add 13 new debug loggers to `src/utils/debug.ts` (hotExitLog/Warn, fileOpsLog/Warn, mcpAutoStartLog, updateCheckerLog, aiProviderLog/Warn, geniesLog/Warn, recentWarn, shortcutsWarn)
- Replace ~60 bare `console.log/warn/error` calls with conditional debug loggers across hotExit (4 files), hooks (3 files), and stores (5 files)
- Critical error paths (file save failures with user-facing toasts, capture/emit failures) retain `console.error` with `// intentional:` comments

## Test plan
- [ ] Verify `pnpm check:all` passes
- [ ] Open app in dev mode — confirm `[HotExit]`, `[FileOps]`, `[MCP]`, `[UpdateChecker]` prefixed logs appear in console
- [ ] Build production — confirm no debug logs leak to console (all gated by `import.meta.env.DEV`)

Closes #90