### PR TITLE
fix: resolve audit findings — dead code and unhandled promise rejections

### DIFF
--- a/src/components/Sidebar/FileExplorer/useFileTree.ts
+++ b/src/components/Sidebar/FileExplorer/useFileTree.ts
@@ -168,6 +168,9 @@ export function useFileTree(
       } else {
         unlistenRef.current = unlisten;
       }
+    }).catch((error: unknown) => {
+      console.error("[FileTree] Failed to listen for fs changes:",
+        error instanceof Error ? error.message : String(error));
     });
 
     return () => {

--- a/src/components/StatusBar/useQuitFeedback.ts
+++ b/src/components/StatusBar/useQuitFeedback.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { safeUnlistenAsync } from "@/utils/safeUnlisten";
 
 /** Duration to show the quit feedback message (matches Rust CONFIRM_QUIT_WINDOW). */
 const FEEDBACK_DURATION_MS = 2000;
@@ -19,7 +20,7 @@ export function useQuitFeedback(): boolean {
     const unlisten = currentWindow.listen("app:quit-first-press", () => {
       setVisible(true);
     });
-    return () => { unlisten.then((fn) => fn()); };
+    return () => { safeUnlistenAsync(unlisten); };
   }, []);
 
   // Auto-hide after timeout

--- a/src/pages/settings/AboutSettings.tsx
+++ b/src/pages/settings/AboutSettings.tsx
@@ -32,7 +32,7 @@ function VersionInfo() {
   const [version, setVersion] = useState<string>("");
 
   useEffect(() => {
-    getVersion().then(setVersion);
+    getVersion().then(setVersion).catch(() => setVersion("Unknown"));
   }, []);
 
   return (

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -72,7 +72,7 @@ interface DocumentStore {
   markMissing: (tabId: string) => void;
   clearMissing: (tabId: string) => void;
   markDivergent: (tabId: string) => void;
-  clearDivergent: (tabId: string) => void;
+
   markSaved: (tabId: string, lastDiskContent?: string) => void;
   markAutoSaved: (tabId: string, lastDiskContent?: string) => void;
   setCursorInfo: (tabId: string, info: CursorInfo | null) => void;
@@ -169,9 +169,6 @@ export const useDocumentStore = create<DocumentStore>((set, get) => ({
 
   markDivergent: (tabId) =>
     set((state) => updateDoc(state, tabId, () => ({ isDivergent: true }))),
-
-  clearDivergent: (tabId) =>
-    set((state) => updateDoc(state, tabId, () => ({ isDivergent: false }))),
 
   markSaved: (tabId, lastDiskContent) =>
     set((state) =>


### PR DESCRIPTION
## Summary

- Remove unused `clearDivergent()` from documentStore — dead code with zero call sites
- Add `.catch()` to `getVersion()` in AboutSettings — shows "Unknown" on failure
- Add `.catch()` to `listen()` in useFileTree — logs error instead of silent rejection
- Use `safeUnlistenAsync` in useQuitFeedback cleanup — consistent with existing patterns

Closes #188, closes #189, closes #190, closes #191

## What Changed

| File | Change |
|------|--------|
| `src/stores/documentStore.ts` | Remove `clearDivergent` type + implementation |
| `src/pages/settings/AboutSettings.tsx` | `.catch(() => setVersion("Unknown"))` |
| `src/components/Sidebar/FileExplorer/useFileTree.ts` | `.catch()` with `console.error` |
| `src/components/StatusBar/useQuitFeedback.ts` | Replace raw `.then(fn => fn())` with `safeUnlistenAsync` |

## Validation

- [x] `pnpm check:all` passes (lint + coverage + build)
- [x] All changes are minimal and focused
- [x] Uses existing `safeUnlistenAsync` utility for consistency