### PR TITLE
fix: relax split-block IME detection for heading composition

### DIFF
--- a/src/plugins/compositionGuard/__tests__/splitBlockFix.test.ts
+++ b/src/plugins/compositionGuard/__tests__/splitBlockFix.test.ts
@@ -27,10 +27,8 @@ function createSplitState(
     schema.node("paragraph", null, paragraphText ? [schema.text(paragraphText)] : []),
   ]);
 
-  // Position cursor at end of paragraph text if cursorInParagraph,
-  // otherwise at end of heading text
-  const headingEnd = 1 + headingText.length; // end of heading content
-  const paragraphContentStart = headingEnd + 2; // +1 heading close, +1 paragraph open
+  const headingEnd = 1 + headingText.length;
+  const paragraphContentStart = headingEnd + 2;
   const paragraphContentEnd = paragraphContentStart + paragraphText.length;
 
   const cursorPos = cursorInParagraph ? paragraphContentEnd : headingEnd;
@@ -48,19 +46,39 @@ describe("fixCompositionSplitBlock", () => {
     expect(tr).not.toBeNull();
     const result = tr!.doc;
 
-    // Should have a single heading with composed text, no paragraph
     expect(result.childCount).toBe(1);
     expect(result.child(0).type.name).toBe("heading");
     expect(result.child(0).textContent).toBe("\u6211\u770B\u770B");
-
-    // Cursor should be at end of composed text
     expect(tr!.selection.from).toBe(1 + "\u6211\u770B\u770B".length);
   });
 
+  it("fixes split even when pinyin in heading doesn't match compositionPinyin exactly", () => {
+    // Abbreviated pinyin: user typed "ch qi" but heading shows different preedit
+    const state = createSplitState("ch qi", "\u957F\u671F");
+    const tr = fixCompositionSplitBlock(state, 1, "\u957F\u671F", "chang qi");
+
+    expect(tr).not.toBeNull();
+    const result = tr!.doc;
+    expect(result.childCount).toBe(1);
+    expect(result.child(0).type.name).toBe("heading");
+    expect(result.child(0).textContent).toBe("\u957F\u671F");
+  });
+
+  it("fixes split when browser already cleared heading preedit", () => {
+    // Browser removed pinyin from heading, leaving it empty
+    const state = createSplitState("", "\u6211\u770B\u770B");
+    const tr = fixCompositionSplitBlock(state, 1, "\u6211\u770B\u770B", "wo kj kj");
+
+    expect(tr).not.toBeNull();
+    const result = tr!.doc;
+    expect(result.childCount).toBe(1);
+    expect(result.child(0).type.name).toBe("heading");
+    expect(result.child(0).textContent).toBe("\u6211\u770B\u770B");
+  });
+
   it("preserves heading text before composition start", () => {
-    // "Chapter 1: wo kj kj" — composition started after "Chapter 1: "
     const state = createSplitState("Chapter 1: wo kj kj", "\u6211\u770B\u770B");
-    const compositionStartPos = 1 + "Chapter 1: ".length; // after prefix
+    const compositionStartPos = 1 + "Chapter 1: ".length;
     const tr = fixCompositionSplitBlock(state, compositionStartPos, "\u6211\u770B\u770B", "wo kj kj");
 
     expect(tr).not.toBeNull();
@@ -70,8 +88,30 @@ describe("fixCompositionSplitBlock", () => {
     expect(tr!.selection.from).toBe(compositionStartPos + "\u6211\u770B\u770B".length);
   });
 
+  it("preserves CJK suffix after preedit in heading", () => {
+    // Heading: "wo kj kj已有内容" — "已有内容" existed before composition
+    const state = createSplitState("wo kj kj\u5DF2\u6709\u5185\u5BB9", "\u6211\u770B\u770B");
+    const tr = fixCompositionSplitBlock(state, 1, "\u6211\u770B\u770B", "wo kj kj");
+
+    expect(tr).not.toBeNull();
+    const result = tr!.doc;
+    expect(result.childCount).toBe(1);
+    expect(result.child(0).textContent).toBe("\u6211\u770B\u770B\u5DF2\u6709\u5185\u5BB9");
+  });
+
+  it("preserves suffix when pinyin doesn't match (scan mode)", () => {
+    // Abbreviated pinyin "ch qi" but compositionPinyin was "chang qi"
+    const state = createSplitState("ch qi\u5DF2\u6709", "\u957F\u671F");
+    const tr = fixCompositionSplitBlock(state, 1, "\u957F\u671F", "chang qi");
+
+    expect(tr).not.toBeNull();
+    const result = tr!.doc;
+    expect(result.childCount).toBe(1);
+    // "ch qi" is ASCII pinyin → scanned and deleted, "已有" preserved
+    expect(result.child(0).textContent).toBe("\u957F\u671F\u5DF2\u6709");
+  });
+
   it("returns null when cursor is in the same block (no split)", () => {
-    // Heading-only doc, cursor in heading — no fix needed
     const doc = schema.node("doc", null, [
       schema.node("heading", { level: 1 }, [schema.text("\u6211\u770B\u770B")]),
       schema.node("paragraph", null, [schema.text("other")]),
@@ -84,15 +124,23 @@ describe("fixCompositionSplitBlock", () => {
     expect(tr).toBeNull();
   });
 
-  it("returns null when cursor block text does not match composed text", () => {
-    const state = createSplitState("wo kj kj", "something else");
+  it("returns null when original block is not a heading", () => {
+    // Paragraph split — not a heading, should not fix
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("wo kj kj")]),
+      schema.node("paragraph", null, [schema.text("\u6211\u770B\u770B")]),
+    ]);
+    const cursorPos = 1 + "wo kj kj".length + 2 + "\u6211\u770B\u770B".length;
+    const state = EditorState.create({
+      doc,
+      selection: TextSelection.create(doc, cursorPos),
+    });
     const tr = fixCompositionSplitBlock(state, 1, "\u6211\u770B\u770B", "wo kj kj");
     expect(tr).toBeNull();
   });
 
-  it("returns null when pinyin does not match at expected position", () => {
-    // Heading has different text than expected pinyin
-    const state = createSplitState("different text", "\u6211\u770B\u770B");
+  it("returns null when cursor block text does not match composed text", () => {
+    const state = createSplitState("wo kj kj", "something else");
     const tr = fixCompositionSplitBlock(state, 1, "\u6211\u770B\u770B", "wo kj kj");
     expect(tr).toBeNull();
   });
@@ -103,14 +151,7 @@ describe("fixCompositionSplitBlock", () => {
     expect(tr).toBeNull();
   });
 
-  it("returns null for empty compositionPinyin", () => {
-    const state = createSplitState("wo kj kj", "\u6211\u770B\u770B");
-    const tr = fixCompositionSplitBlock(state, 1, "\u6211\u770B\u770B", "");
-    expect(tr).toBeNull();
-  });
-
   it("returns null when cursor block is not a paragraph", () => {
-    // Two headings — cursor in second heading, not a paragraph
     const doc = schema.node("doc", null, [
       schema.node("heading", { level: 1 }, [schema.text("wo kj kj")]),
       schema.node("heading", { level: 2 }, [schema.text("\u6211\u770B\u770B")]),
@@ -125,13 +166,11 @@ describe("fixCompositionSplitBlock", () => {
   });
 
   it("returns null when cursor block is not the immediate next sibling", () => {
-    // Heading, paragraph (unrelated), paragraph (composed text)
     const doc = schema.node("doc", null, [
       schema.node("heading", { level: 1 }, [schema.text("wo kj kj")]),
       schema.node("paragraph", null, [schema.text("unrelated")]),
       schema.node("paragraph", null, [schema.text("\u6211\u770B\u770B")]),
     ]);
-    // Cursor at end of third block
     const pos = 1 + "wo kj kj".length + 2 + "unrelated".length + 2 + "\u6211\u770B\u770B".length;
     const state = EditorState.create({
       doc,
@@ -152,29 +191,5 @@ describe("fixCompositionSplitBlock", () => {
     const tr = fixCompositionSplitBlock(state, 1, "\u6211\u770B\u770B", "wo kj kj");
     expect(tr).not.toBeNull();
     expect(tr!.getMeta("uiEvent")).toBe("composition-cleanup");
-  });
-
-  it("returns null when pinyin extends beyond heading end", () => {
-    // Heading has "wo" (2 chars), but pinyin is "wo kj kj" (8 chars)
-    // pinyinEnd = 1 + 8 = 9, but heading content ends at 1 + 2 = 3
-    const state = createSplitState("wo", "\u6211\u770B\u770B");
-    const tr = fixCompositionSplitBlock(state, 1, "\u6211\u770B\u770B", "wo kj kj");
-    expect(tr).toBeNull();
-  });
-
-  it("returns null when textBetween throws for invalid range", () => {
-    // Create a state where startPos is valid but pinyin range overlaps block boundary
-    const doc = schema.node("doc", null, [
-      schema.node("heading", { level: 1 }, [schema.text("ab")]),
-      schema.node("paragraph", null, [schema.text("\u6211\u770B\u770B")]),
-    ]);
-    const paragraphStart = 1 + 2 + 2; // heading content + boundaries
-    const state = EditorState.create({
-      doc,
-      selection: TextSelection.create(doc, paragraphStart + "\u6211\u770B\u770B".length),
-    });
-    // pinyin "abcdef" is longer than heading content "ab" (2 chars)
-    const tr = fixCompositionSplitBlock(state, 1, "\u6211\u770B\u770B", "abcdef");
-    expect(tr).toBeNull();
   });
 });

--- a/src/plugins/compositionGuard/splitBlockFix.ts
+++ b/src/plugins/compositionGuard/splitBlockFix.ts
@@ -25,13 +25,16 @@ import { type EditorState, TextSelection, type Transaction } from "@tiptap/pm/st
  * @param pinyin     The pinyin that was typed during composition (e.g., "wo kj kj")
  * @returns          A corrective Transaction, or null if no fix is needed
  */
+/** Match ASCII pinyin residue: letters, digits, spaces, apostrophes, semicolons */
+const PINYIN_CHAR_RE = /^[A-Za-z0-9;' ]+$/;
+
 export function fixCompositionSplitBlock(
   state: EditorState,
   startPos: number,
   composed: string,
   pinyin: string,
 ): Transaction | null {
-  if (!composed || !pinyin) return null;
+  if (!composed) return null;
 
   let $start;
   try {
@@ -46,6 +49,9 @@ export function fixCompositionSplitBlock(
   // No fix needed if cursor is in the same block
   if ($cursor.parent === parentNode) return null;
 
+  // The original block must be a heading (this bug only affects headings)
+  if (parentNode.type.name !== "heading") return null;
+
   // The spurious block must be a paragraph with exactly the composed text
   if ($cursor.parent.type.name !== "paragraph") return null;
   if ($cursor.parent.textContent !== composed) return null;
@@ -55,19 +61,6 @@ export function fixCompositionSplitBlock(
   const expectedSiblingStart = $start.after($start.depth);
   if (blockStart !== expectedSiblingStart) return null;
 
-  // Verify pinyin is at the expected position in the original block
-  const pinyinEnd = startPos + pinyin.length;
-  if (pinyinEnd > $start.end()) return null;
-
-  let textAtPos: string;
-  try {
-    textAtPos = state.doc.textBetween(startPos, pinyinEnd);
-  } catch {
-    /* v8 ignore next -- @preserve textBetween only throws for out-of-range positions; guarded by pinyinEnd check above */
-    return null;
-  }
-  if (textAtPos !== pinyin) return null;
-
   const tr = state.tr;
 
   // Delete the spurious paragraph (immediately after original block).
@@ -75,9 +68,35 @@ export function fixCompositionSplitBlock(
   const blockEnd = $cursor.after($cursor.depth);
   tr.delete(blockStart, blockEnd);
 
-  // Replace pinyin in original block with composed text.
-  // After deleting the later block, heading positions are unchanged.
-  tr.insertText(composed, startPos, pinyinEnd);
+  // Remove leftover preedit text from the heading. Strategy:
+  // 1. If pinyin matches exactly at startPos, delete that exact range
+  // 2. Otherwise, scan forward from startPos and delete only ASCII
+  //    pinyin-looking characters (preserves any user content after preedit)
+  const headingEnd = $start.end();
+  if (startPos < headingEnd) {
+    const tailText = state.doc.textBetween(startPos, headingEnd);
+
+    if (pinyin && tailText.startsWith(pinyin)) {
+      // Exact pinyin match — delete precisely
+      tr.delete(startPos, startPos + pinyin.length);
+    } else if (tailText.length > 0) {
+      // Scan forward: delete only contiguous ASCII pinyin chars
+      let pinyinLen = 0;
+      for (const ch of tailText) {
+        if (PINYIN_CHAR_RE.test(ch)) {
+          pinyinLen += ch.length;
+        } else {
+          break;
+        }
+      }
+      if (pinyinLen > 0) {
+        tr.delete(startPos, startPos + pinyinLen);
+      }
+    }
+  }
+
+  // Insert composed text at the composition start position
+  tr.insertText(composed, startPos);
 
   // Place cursor at end of composed text
   const newCursorPos = startPos + composed.length;

--- a/src/plugins/compositionGuard/tiptap.ts
+++ b/src/plugins/compositionGuard/tiptap.ts
@@ -77,14 +77,12 @@ export const compositionGuardExtension = Extension.create({
       // Detect split-block bug: composed text landed in a different block
       // (e.g., heading splits into heading + paragraph on macOS WebKit
       // when Space accepts IME composition)
-      if (compositionPinyin) {
-        const splitFix = fixCompositionSplitBlock(
-          state, compositionStartPos, compositionData, compositionPinyin,
-        );
-        if (splitFix) {
-          view.dispatch(splitFix);
-          return;
-        }
+      const splitFix = fixCompositionSplitBlock(
+        state, compositionStartPos, compositionData, compositionPinyin,
+      );
+      if (splitFix) {
+        view.dispatch(splitFix);
+        return;
       }
 
       let cleanupEnd = $start.end();


### PR DESCRIPTION
## Summary

- Replace brittle pinyin text matching with structural heading detection in `splitBlockFix`
- Scan for ASCII pinyin residue instead of deleting everything to heading end (prevents data loss of user content after preedit)
- Remove `compositionPinyin` emptiness guard so the fix triggers for abbreviated pinyin and browser-cleared preedit
- Add heading type check (the split-block bug only affects headings)

**Root cause**: The previous fix required exact pinyin text at the original position, but by the time `requestAnimationFrame` fired after `compositionend`, the browser had already modified or cleared the heading content. The match always failed → fix never triggered.

Closes #66

## Test plan

- [x] Unit tests: suffix preservation, abbreviated pinyin, empty heading, scan mode
- [x] Manual: Chinese IME in H1 heading — composed text stays in heading
- [x] `pnpm check:all` passes