### PR TITLE
docs: add missing marketplace prerequisite step

### DIFF
--- a/website/de/guide/users-as-developers/cross-model-verification.md
+++ b/website/de/guide/users-as-developers/cross-model-verification.md
@@ -43,13 +43,19 @@ npm install -g @openai/codex
 codex login                   # Mit ChatGPT-Abonnement anmelden (empfohlen)
 ```
 
-2. Das codex-toolkit-Plugin in Claude Code installieren und aktivieren:
+2. Den xiaolai Plugin-Marktplatz hinzufügen (nur beim ersten Mal):
+
+```bash
+claude plugin marketplace add xiaolai/claude-plugin-marketplace
+```
+
+3. Das codex-toolkit-Plugin in Claude Code installieren und aktivieren:
 
 ```bash
 claude plugin install codex-toolkit@xiaolai --scope project
 ```
 
-3. Überprüfen, ob Codex verfügbar ist:
+4. Überprüfen, ob Codex verfügbar ist:
 
 ```bash
 codex --version

--- a/website/es/guide/users-as-developers/cross-model-verification.md
+++ b/website/es/guide/users-as-developers/cross-model-verification.md
@@ -43,13 +43,19 @@ npm install -g @openai/codex
 codex login                   # Iniciar sesión con suscripción ChatGPT (recomendado)
 ```
 
-2. Instala y habilita el plugin codex-toolkit en Claude Code:
+2. Añade el marketplace de plugins xiaolai (solo la primera vez):
+
+```bash
+claude plugin marketplace add xiaolai/claude-plugin-marketplace
+```
+
+3. Instala y habilita el plugin codex-toolkit en Claude Code:
 
 ```bash
 claude plugin install codex-toolkit@xiaolai --scope project
 ```
 
-3. Verifica que Codex está disponible:
+4. Verifica que Codex está disponible:
 
 ```bash
 codex --version

--- a/website/fr/guide/users-as-developers/cross-model-verification.md
+++ b/website/fr/guide/users-as-developers/cross-model-verification.md
@@ -43,13 +43,19 @@ npm install -g @openai/codex
 codex login                   # Connexion avec abonnement ChatGPT (recommandé)
 ```
 
-2. Installez et activez le plugin codex-toolkit dans Claude Code :
+2. Ajoutez le marketplace de plugins xiaolai (première fois uniquement) :
+
+```bash
+claude plugin marketplace add xiaolai/claude-plugin-marketplace
+```
+
+3. Installez et activez le plugin codex-toolkit dans Claude Code :
 
 ```bash
 claude plugin install codex-toolkit@xiaolai --scope project
 ```
 
-3. Vérifiez que Codex est disponible :
+4. Vérifiez que Codex est disponible :
 
 ```bash
 codex --version

--- a/website/guide/users-as-developers/cross-model-verification.md
+++ b/website/guide/users-as-developers/cross-model-verification.md
@@ -43,13 +43,19 @@ npm install -g @openai/codex
 codex login                   # Log in with ChatGPT subscription (recommended)
 ```
 
-2. Install and enable the codex-toolkit plugin in Claude Code:
+2. Add the xiaolai plugin marketplace (first time only):
+
+```bash
+claude plugin marketplace add xiaolai/claude-plugin-marketplace
+```
+
+3. Install and enable the codex-toolkit plugin in Claude Code:
 
 ```bash
 claude plugin install codex-toolkit@xiaolai --scope project
 ```
 
-3. Verify Codex is available:
+4. Verify Codex is available:
 
 ```bash
 codex --version

--- a/website/it/guide/users-as-developers/cross-model-verification.md
+++ b/website/it/guide/users-as-developers/cross-model-verification.md
@@ -43,13 +43,19 @@ npm install -g @openai/codex
 codex login                   # Accedi con abbonamento ChatGPT (raccomandato)
 ```
 
-2. Installa e abilita il plugin codex-toolkit in Claude Code:
+2. Aggiungi il marketplace di plugin xiaolai (solo la prima volta):
+
+```bash
+claude plugin marketplace add xiaolai/claude-plugin-marketplace
+```
+
+3. Installa e abilita il plugin codex-toolkit in Claude Code:
 
 ```bash
 claude plugin install codex-toolkit@xiaolai --scope project
 ```
 
-3. Verifica che Codex sia disponibile:
+4. Verifica che Codex sia disponibile:
 
 ```bash
 codex --version

--- a/website/ja/guide/users-as-developers/cross-model-verification.md
+++ b/website/ja/guide/users-as-developers/cross-model-verification.md
@@ -43,13 +43,19 @@ npm install -g @openai/codex
 codex login                   # ChatGPTサブスクリプションでログイン（推奨）
 ```
 
-2. Claude Code に codex-toolkit プラグインをインストールして有効化:
+2. xiaolai プラグインマーケットプレイスを追加（初回のみ）:
+
+```bash
+claude plugin marketplace add xiaolai/claude-plugin-marketplace
+```
+
+3. Claude Code に codex-toolkit プラグインをインストールして有効化:
 
 ```bash
 claude plugin install codex-toolkit@xiaolai --scope project
 ```
 
-3. Codex が利用可能か確認:
+4. Codex が利用可能か確認:
 
 ```bash
 codex --version

--- a/website/ko/guide/users-as-developers/cross-model-verification.md
+++ b/website/ko/guide/users-as-developers/cross-model-verification.md
@@ -43,13 +43,19 @@ npm install -g @openai/codex
 codex login                   # ChatGPT 구독으로 로그인 (권장)
 ```
 
-2. Claude Code에 codex-toolkit 플러그인 설치 및 활성화:
+2. xiaolai 플러그인 마켓플레이스 추가 (처음 한 번만):
+
+```bash
+claude plugin marketplace add xiaolai/claude-plugin-marketplace
+```
+
+3. Claude Code에 codex-toolkit 플러그인 설치 및 활성화:
 
 ```bash
 claude plugin install codex-toolkit@xiaolai --scope project
 ```
 
-3. Codex가 사용 가능한지 확인:
+4. Codex가 사용 가능한지 확인:
 
 ```bash
 codex --version

--- a/website/pt-BR/guide/users-as-developers/cross-model-verification.md
+++ b/website/pt-BR/guide/users-as-developers/cross-model-verification.md
@@ -43,13 +43,19 @@ npm install -g @openai/codex
 codex login                   # Login com assinatura ChatGPT (recomendado)
 ```
 
-2. Instale e habilite o plugin codex-toolkit no Claude Code:
+2. Adicione o marketplace de plugins xiaolai (apenas na primeira vez):
+
+```bash
+claude plugin marketplace add xiaolai/claude-plugin-marketplace
+```
+
+3. Instale e habilite o plugin codex-toolkit no Claude Code:
 
 ```bash
 claude plugin install codex-toolkit@xiaolai --scope project
 ```
 
-3. Verifique se o Codex está disponível:
+4. Verifique se o Codex está disponível:
 
 ```bash
 codex --version

--- a/website/zh-CN/guide/users-as-developers/cross-model-verification.md
+++ b/website/zh-CN/guide/users-as-developers/cross-model-verification.md
@@ -43,13 +43,19 @@ npm install -g @openai/codex
 codex login                   # 使用 ChatGPT 订阅登录（推荐）
 ```
 
-2. 在 Claude Code 中安装并启用 codex-toolkit 插件：
+2. 添加 xiaolai 插件市场（仅首次需要）：
+
+```bash
+claude plugin marketplace add xiaolai/claude-plugin-marketplace
+```
+
+3. 在 Claude Code 中安装并启用 codex-toolkit 插件：
 
 ```bash
 claude plugin install codex-toolkit@xiaolai --scope project
 ```
 
-3. 验证 Codex 可用：
+4. 验证 Codex 可用：
 
 ```bash
 codex --version

--- a/website/zh-TW/guide/users-as-developers/cross-model-verification.md
+++ b/website/zh-TW/guide/users-as-developers/cross-model-verification.md
@@ -43,13 +43,19 @@ npm install -g @openai/codex
 codex login                   # 使用 ChatGPT 訂閱登入（推薦）
 ```
 
-2. 在 Claude Code 中安裝並啟用 codex-toolkit 插件：
+2. 新增 xiaolai 插件市集（僅首次需要）：
+
+```bash
+claude plugin marketplace add xiaolai/claude-plugin-marketplace
+```
+
+3. 在 Claude Code 中安裝並啟用 codex-toolkit 插件：
 
 ```bash
 claude plugin install codex-toolkit@xiaolai --scope project
 ```
 
-3. 確認 Codex 可用：
+4. 確認 Codex 可用：
 
 ```bash
 codex --version


### PR DESCRIPTION
## Summary

- Adds a missing prerequisite step to the cross-model verification setup guide: users must run `claude plugin marketplace add xiaolai/claude-plugin-marketplace` **before** installing the codex-toolkit plugin
- Updated all 10 locale versions (en, de, es, fr, it, ja, ko, pt-BR, zh-CN, zh-TW) with the new step in each locale's language
- Renumbered subsequent steps (old step 2 becomes step 3, old step 3 becomes step 4)

Closes #504

## Test plan

- [ ] Verify the English guide at `website/guide/users-as-developers/cross-model-verification.md` shows 4 setup steps in correct order
- [ ] Spot-check at least 2 locale translations for correct step numbering and native-language labels
- [ ] Run `cd website && pnpm build` to confirm no broken links or build errors