### PR TITLE
fix: terminal IME duplication in CLI apps like Claude Code

### DIFF
--- a/src/components/Terminal/createTerminalInstance.ts
+++ b/src/components/Terminal/createTerminalInstance.ts
@@ -83,6 +83,8 @@ export interface TerminalInstance {
    * onData which may inject spaces (macOS Chinese IME: "claude" → "cl au de").
    */
   onCompositionCommit: ((text: string) => void) | null;
+  /** Text pending commit during grace period — used to block xterm re-emission (#608). */
+  pendingCommitText: string | null;
   /** Last text committed via onCompositionCommit — used for dedup against late onData (#525). */
   lastCommittedText: string | null;
   /** Timestamp (Date.now()) of the last onCompositionCommit — dedup window check (#525). */
@@ -345,6 +347,7 @@ export function createTerminalInstance(options: CreateOptions): TerminalInstance
     get inGracePeriod() { return inGracePeriod; },
     get onCompositionCommit() { return onCompositionCommit; },
     set onCompositionCommit(cb: ((text: string) => void) | null) { onCompositionCommit = cb; },
+    get pendingCommitText() { return pendingCommitText; },
     get lastCommittedText() { return lastCommittedText; },
     get lastCommitTime() { return lastCommitTime; },
   };

--- a/src/components/Terminal/useTerminalSessions.ts
+++ b/src/components/Terminal/useTerminalSessions.ts
@@ -292,6 +292,10 @@ export function useTerminalSessions(
         // let non-ASCII through so CJK punctuation isn't silently dropped (#454).
         if (instance.composing) {
           if (!instance.inGracePeriod) return; // active composition — block all
+          // Grace period: block the committed text xterm re-emits (#608).
+          // Without this, CJK text (e.g., "你好") passes the ASCII-only check below,
+          // gets written to PTY, and then onCompositionCommit writes it again → duplication.
+          if (instance.pendingCommitText && data === instance.pendingCommitText) return;
           // eslint-disable-next-line no-control-regex
           if (/^[\x00-\x7F]+$/.test(data)) return; // grace period — block ASCII only
         }


### PR DESCRIPTION
## Summary

- Fixes Chinese IME text duplication when using Claude Code CLI (or other ink-based apps) inside VMark's built-in terminal
- Root cause: during the post-composition grace period, xterm re-emits committed CJK text via `onData`. The guard only blocked ASCII but let non-ASCII through — causing the text to be written to PTY twice
- Fix: block `onData` that matches `pendingCommitText` during the grace period

Closes #608

## Test plan

- [ ] Open VMark terminal, run `claude`, type Chinese with pinyin IME — no duplication
- [ ] Type CJK punctuation (brackets, commas) in terminal — still works correctly
- [ ] Regular shell commands with Chinese input — still works correctly
- [ ] 17564 unit tests pass