### PR TITLE
fix: mcp-bridge: Queued requests not drained when reconnection exhausted

### DIFF
--- a/vmark-mcp-server/src/bridge/websocket.ts
+++ b/vmark-mcp-server/src/bridge/websocket.ts
@@ -663,6 +663,13 @@ export class WebSocketBridge implements Bridge {
       this.reconnectAttempts < this.maxReconnectAttempts
     ) {
       this.scheduleReconnect();
+    } else {
+      // Reconnection won't be attempted — drain queued requests immediately
+      // instead of letting them hang until their individual timeouts.
+      for (const queued of this.requestQueue) {
+        queued.reject(new Error('Connection lost and reconnection not available'));
+      }
+      this.requestQueue = [];
     }
   }
 


### PR DESCRIPTION
Closes #664