### PR TITLE
fix: scope open-file event to current window (#661)

### DIFF
--- a/src/components/Sidebar/FileExplorer/useExplorerOperations.ts
+++ b/src/components/Sidebar/FileExplorer/useExplorerOperations.ts
@@ -27,7 +27,7 @@ import {
 } from "@tauri-apps/plugin-fs";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { join, basename } from "@tauri-apps/api/path";
-import { emit } from "@tauri-apps/api/event";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { toast } from "sonner";
@@ -248,7 +248,7 @@ export function useExplorerOperations() {
   );
 
   const openFile = useCallback(async (path: string): Promise<void> => {
-    await emit("open-file", { path });
+    await getCurrentWebviewWindow().emit("open-file", { path });
   }, []);
 
   const openWithDefaultApp = useCallback(async (path: string): Promise<void> => {


### PR DESCRIPTION
## Summary
- FileExplorer's `openFile()` used global `emit("open-file")` from `@tauri-apps/api/event`, which broadcasts to ALL windows
- Every window's `useFileShortcuts` listener received the event and opened/switched to that file — causing cross-window tab mirroring
- Changed to `getCurrentWebviewWindow().emit()` so the event stays within the originating window
- Wiki-link plugins (`sourceWikiLinkActions.ts`, `WikiLinkPopupView.ts`) already used window-scoped emit correctly

Closes #661

## Test plan
- [x] `pnpm check:all` passes (lint + 17,629 tests + build)
- [ ] Manual: Open two windows, click file in explorer in one — only that window opens it