### PR TITLE
fix: harden Finder file open — emit fallback, extension filter, cancelled guards

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,8 @@
 //!   - Window close is intercepted for document windows (main, doc-*) to allow
 //!     dirty-document prompts; non-document windows close immediately.
 //!   - File opens from Finder are queued in `PENDING_FILE_OPENS` until the frontend
-//!     signals readiness, solving a cold-start race condition. Hot opens (app already
+//!     signals readiness, solving a cold-start race condition. Only .md/.markdown
+//!     files are accepted; other extensions are skipped. Hot opens (app already
 //!     running) use `app.emit()` (global broadcast) — NOT `window.emit()` — so the
 //!     frontend's global `listen()` in `useFinderFileOpen` receives them. Tauri v2
 //!     webview-specific events are not delivered to global `listen()`.

--- a/src/hooks/useFinderFileOpen.ts
+++ b/src/hooks/useFinderFileOpen.ts
@@ -22,6 +22,8 @@
  * @edge-case Cold start: files opened before React mounts are queued in Rust
  * @edge-case Hot open: app already running — app:open-file event fires directly
  * @edge-case Hot exit: waits for restore to complete to avoid tab overwrite
+ * @edge-case File deleted: read fails → tab path stays untouched, early return
+ * @edge-case Window destroyed: cancelled guards after every await prevent unmounted-component errors
  * @coordinates-with openPolicy.ts — resolveOpenAction for routing decision
  * @module hooks/useFinderFileOpen
  */


### PR DESCRIPTION
## Summary

Addresses remaining gaps in the Finder file open feature that has been fixed 11 times over 3 months.

**Rust (`lib.rs`):**
- **Emit fallback**: if `app.emit()` fails, fall back to queueing instead of silently dropping the file
- **Extension filter**: only accept `.md`/`.markdown` files from Finder; skip others with a warning (prevents broken empty tabs from `.txt` etc in multi-select)
- **Logging**: `log::info`/`warn` at every decision point (emit vs queue vs create window) for debuggability

**TypeScript (`useFinderFileOpen.ts`):**
- **Read before update**: `readTextFile` now runs before `updateTabPath` — if the file doesn't exist (deleted, unmounted volume), the tab path stays untouched instead of pointing to a broken path
- **Cancelled guards**: added `if (cancelled) return` after every `await` to prevent "unmounted component" errors when the window is destroyed during async file loading
- **Early return on failure**: failed file reads in the replaceable-tab path now return early instead of activating a broken tab

## Test plan
- [x] `cargo check` passes
- [x] `pnpm check:all` passes (lint + 17,629 tests + build)
- [ ] Manual: double-click .md file in Finder while VMark running
- [ ] Manual: select .md + .txt files in Finder → Open With VMark → only .md opens
- [ ] Manual: double-click .md file that is then deleted before VMark reads it