### PR TITLE
fix: add Toggle Case and Remove Blank Lines to shortcuts docs

### DIFF
--- a/website/guide/shortcuts.md
+++ b/website/guide/shortcuts.md
@@ -101,6 +101,8 @@ If you prefer keeping system functions on F-keys, you can customize VMark shortc
 | UPPERCASE | `Ctrl + Shift + U` | `Alt + Shift + U` |
 | lowercase | `Ctrl + Shift + L` | `Alt + Shift + L` |
 | Title Case | `Ctrl + Shift + T` | `Alt + Shift + T` |
+| Toggle Case | _(customizable)_ | _(customizable)_ |
+| Remove Blank Lines | _(customizable)_ | _(customizable)_ |
 | Toggle Quote Style | `Shift + Mod + '` | `Shift + Mod + '` |
 
 ## Insert


### PR DESCRIPTION
## Summary
- Add missing `Toggle Case` and `Remove Blank Lines` entries to the Text Transformations table in `website/guide/shortcuts.md`
- Both are customizable shortcuts with no default key, matching the format of other `_(customizable)_` entries

Closes #758

## Test plan
- [x] `grep -i "toggle case" website/guide/shortcuts.md` returns a match
- [x] `grep -i "blank lines" website/guide/shortcuts.md` returns a match
- [x] Table formatting is consistent with existing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)