### PR TITLE
fix: remove dead deleteAllRecoveryFiles function

### DIFF
--- a/src/utils/crashRecovery.test.ts
+++ b/src/utils/crashRecovery.test.ts
@@ -16,7 +16,6 @@ import {
   writeRecoverySnapshot,
   readRecoverySnapshots,
   deleteRecoverySnapshot,
-  deleteAllRecoveryFiles,
   deleteRecoveryFilesForTabs,
   deleteStaleRecoveryFiles,
   type RecoverySnapshot,
@@ -207,26 +206,6 @@ describe("crashRecovery", () => {
     });
   });
 
-  describe("deleteAllRecoveryFiles", () => {
-    it("removes all snapshot files in recovery dir", async () => {
-      mockExists.mockResolvedValue(true);
-      mockReadDir.mockResolvedValue([
-        { name: "snapshot-tab-1.json", isDirectory: false, isFile: true, isSymlink: false },
-        { name: "snapshot-tab-2.json", isDirectory: false, isFile: true, isSymlink: false },
-        { name: ".tmp-tab-3", isDirectory: false, isFile: true, isSymlink: false },
-      ] as never);
-
-      await deleteAllRecoveryFiles();
-      // Should remove snapshot files and tmp files
-      expect(mockRemove).toHaveBeenCalledTimes(3);
-    });
-
-    it("does not throw if dir does not exist", async () => {
-      mockExists.mockResolvedValue(false);
-      await expect(deleteAllRecoveryFiles()).resolves.toBeUndefined();
-    });
-  });
-
   describe("deleteStaleRecoveryFiles", () => {
     it("deletes files older than maxAgeDays", async () => {
       mockExists.mockResolvedValue(true);
@@ -312,41 +291,6 @@ describe("crashRecovery", () => {
     });
   });
 
-  describe("deleteAllRecoveryFiles - edge cases", () => {
-    it("skips entries without names", async () => {
-      mockExists.mockResolvedValue(true);
-      mockReadDir.mockResolvedValue([
-        { name: null, isDirectory: false, isFile: true, isSymlink: false },
-        { name: "snapshot-tab-1.json", isDirectory: false, isFile: true, isSymlink: false },
-      ] as never);
-
-      await deleteAllRecoveryFiles();
-      // Should only remove the one with a name
-      expect(mockRemove).toHaveBeenCalledTimes(1);
-    });
-
-    it("handles individual remove errors gracefully", async () => {
-      mockExists.mockResolvedValue(true);
-      mockReadDir.mockResolvedValue([
-        { name: "snapshot-tab-1.json", isDirectory: false, isFile: true, isSymlink: false },
-        { name: "snapshot-tab-2.json", isDirectory: false, isFile: true, isSymlink: false },
-      ] as never);
-      mockRemove
-        .mockRejectedValueOnce(new Error("permission denied"))
-        .mockResolvedValueOnce(undefined);
-
-      // Should not throw even if individual remove fails
-      await expect(deleteAllRecoveryFiles()).resolves.toBeUndefined();
-    });
-
-    it("handles readDir throwing", async () => {
-      mockExists.mockResolvedValue(true);
-      mockReadDir.mockRejectedValue(new Error("readDir failed"));
-
-      await expect(deleteAllRecoveryFiles()).resolves.toBeUndefined();
-    });
-  });
-
   describe("readRecoverySnapshots - edge cases", () => {
     it("skips entries without names", async () => {
       mockExists.mockResolvedValue(true);
@@ -418,15 +362,7 @@ describe("crashRecovery", () => {
     });
   });
 
-  describe("deleteAllRecoveryFiles - non-Error rejection (line 185)", () => {
-    it("handles non-Error thrown by readDir", async () => {
-      mockExists.mockResolvedValue(true);
-      mockReadDir.mockRejectedValue("string error");
-      await expect(deleteAllRecoveryFiles()).resolves.toBeUndefined();
-    });
-  });
-
-  describe("deleteStaleRecoveryFiles - non-Error rejection (line 238)", () => {
+  describe("deleteStaleRecoveryFiles - non-Error rejection", () => {
     it("handles non-Error thrown by readDir", async () => {
       mockExists.mockResolvedValue(true);
       mockReadDir.mockRejectedValue("string error");

--- a/src/utils/crashRecovery.ts
+++ b/src/utils/crashRecovery.ts
@@ -160,34 +160,6 @@ export async function deleteRecoverySnapshot(tabId: string): Promise<void> {
 }
 
 /**
- * Delete all recovery files (snapshots and tmp files).
- * Called on normal exit.
- */
-export async function deleteAllRecoveryFiles(): Promise<void> {
-  try {
-    const dir = await getRecoveryDir();
-    if (!(await exists(dir))) return;
-
-    const entries = await readDir(dir);
-    for (const entry of entries) {
-      if (!entry.name) continue;
-      try {
-        const filePath = await join(dir, entry.name);
-        await remove(filePath);
-      } catch {
-        // Best-effort deletion
-      }
-    }
-    crashRecoveryLog("Deleted all recovery files");
-  } catch (error) {
-    crashRecoveryLog(
-      "Failed to delete all recovery files:",
-      error instanceof Error ? error.message : String(error)
-    );
-  }
-}
-
-/**
  * Delete recovery files for specific tabs only.
  * Used for per-window cleanup on normal exit.
  */


### PR DESCRIPTION
## Summary
- Removes `deleteAllRecoveryFiles()` from `src/utils/crashRecovery.ts` — exported but never called by production code
- Per-window cleanup uses `deleteRecoveryFilesForTabs()` instead
- Removes 3 associated test `describe` blocks (66 lines of dead test code)

Closes #757

## Test plan
- [x] `grep -r "deleteAllRecoveryFiles" src/` returns zero matches
- [x] `pnpm test src/utils/crashRecovery.test.ts` — 31 tests pass
- [x] `pnpm lint` — no new errors
- [x] `pnpm build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)