### PR TITLE
fix: add .catch() handling to PdfExportDialog unlisten cleanup

### DIFF
--- a/src/export/PdfExportDialog.tsx
+++ b/src/export/PdfExportDialog.tsx
@@ -17,6 +17,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { safeUnlistenAsync } from "@/utils/safeUnlisten";
 import { save } from "@tauri-apps/plugin-dialog";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
@@ -210,7 +211,7 @@ export function PdfExportContent({
         setExportStage(key ? t(key) : event.payload.stage);
       },
     );
-    return () => { unlisten.then((f) => f()); };
+    return () => { safeUnlistenAsync(unlisten); };
   }, [t]);
 
   // Extract headings from rendered HTML for PDF bookmarks


### PR DESCRIPTION
## Summary
- Replace bare `unlisten.then((f) => f())` with `safeUnlistenAsync(unlisten)` in `PdfExportDialog.tsx` to prevent unhandled promise rejections
- Aligns with every other Tauri event listener cleanup in the codebase

## Verification
- `grep -n 'unlisten.then' src/export/PdfExportDialog.tsx` returns zero matches
- `grep -n 'safeUnlistenAsync' src/export/PdfExportDialog.tsx` returns one match
- `pnpm check:all` passes (699 tests, 0 failures)

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)