### PR TITLE
fix: pre-merge overlapping ranges in multi-cursor cut/paste

### DIFF
--- a/src/plugins/multiCursor/__tests__/clipboard.test.ts
+++ b/src/plugins/multiCursor/__tests__/clipboard.test.ts
@@ -187,3 +187,58 @@ describe("handleMultiCursorPaste edge cases", () => {
     }
   });
 });
+
+describe("overlapping ranges", () => {
+  it("merges overlapping ranges before cut", () => {
+    // Ranges [3,7] and [5,9] overlap at positions 5-7
+    // Merged: [3,9] covers "llo wo" in "hello world"
+    // Cut → "he" + "rld" = "herld"
+    const state = createState("hello world", [
+      { from: 3, to: 7 },
+      { from: 5, to: 9 },
+    ]);
+
+    const tr = handleMultiCursorCut(state);
+    expect(tr).not.toBeNull();
+
+    const newState = state.apply(tr!);
+    expect(newState.doc.textContent).toBe("herld");
+    const sel = newState.selection as MultiSelection;
+    expect(sel.ranges.length).toBe(1);
+  });
+
+  it("merges overlapping ranges before paste", () => {
+    // Ranges [3,7] and [5,9] overlap → merged to [3,9]
+    // Paste "X" into merged range → "he" + "X" + "rld" = "heXrld"
+    const state = createState("hello world", [
+      { from: 3, to: 7 },
+      { from: 5, to: 9 },
+    ]);
+
+    const tr = handleMultiCursorPaste(state, "X");
+    expect(tr).not.toBeNull();
+
+    const newState = state.apply(tr!);
+    expect(newState.doc.textContent).toBe("heXrld");
+    const sel = newState.selection as MultiSelection;
+    expect(sel.ranges.length).toBe(1);
+  });
+
+  it("merges chain of 3 overlapping ranges before cut", () => {
+    // [2,5]+[4,7]+[6,9] → merged to [2,9] covers "ello wo"
+    // Cut → "h" + "rld" = "hrld"
+    const state = createState("hello world", [
+      { from: 2, to: 5 },
+      { from: 4, to: 7 },
+      { from: 6, to: 9 },
+    ]);
+
+    const tr = handleMultiCursorCut(state);
+    expect(tr).not.toBeNull();
+
+    const newState = state.apply(tr!);
+    expect(newState.doc.textContent).toBe("hrld");
+    const sel = newState.selection as MultiSelection;
+    expect(sel.ranges.length).toBe(1);
+  });
+});

--- a/src/plugins/multiCursor/clipboard.ts
+++ b/src/plugins/multiCursor/clipboard.ts
@@ -48,7 +48,11 @@ export function handleMultiCursorCut(
   );
   if (!hasNonEmptyRange) return null;
 
-  const sortedRanges = sortRangesDescending(selection.ranges);
+  // Pre-merge overlapping ranges so each edit targets a disjoint span
+  const preMerged = normalizeRangesWithPrimary(
+    selection.ranges, state.doc, selection.primaryIndex, true
+  );
+  const sortedRanges = sortRangesDescending(preMerged.ranges);
   let tr = state.tr;
 
   for (const range of sortedRanges) {
@@ -60,7 +64,7 @@ export function handleMultiCursorCut(
   }
 
   // Remap all cursors to collapsed positions
-  const newRanges: SelectionRange[] = selection.ranges.map((range) => {
+  const newRanges: SelectionRange[] = preMerged.ranges.map((range) => {
     const newPos = tr.mapping.map(range.$from.pos);
     const $pos = tr.doc.resolve(newPos);
     return new SelectionRange($pos, $pos);
@@ -69,7 +73,7 @@ export function handleMultiCursorCut(
   const normalized = normalizeRangesWithPrimary(
     newRanges,
     tr.doc,
-    selection.primaryIndex,
+    preMerged.primaryIndex,
     true
   );
 
@@ -94,7 +98,11 @@ export function handleMultiCursorPaste(
     return null;
   }
 
-  const ranges = selection.ranges;
+  // Pre-merge overlapping ranges so each edit targets a disjoint span
+  const preMerged = normalizeRangesWithPrimary(
+    selection.ranges, state.doc, selection.primaryIndex, true
+  );
+  const ranges = preMerged.ranges;
   /* v8 ignore next -- @preserve MultiSelection always has at least one range; empty guard is defensive */
   if (ranges.length === 0) return null;
 
@@ -123,7 +131,7 @@ export function handleMultiCursorPaste(
   const normalized = normalizeRangesWithPrimary(
     newRanges,
     tr.doc,
-    selection.primaryIndex,
+    preMerged.primaryIndex,
     true
   );
 


### PR DESCRIPTION
Closes #762

## Summary
- `handleMultiCursorCut` and `handleMultiCursorPaste` in `clipboard.ts` now call `normalizeRangesWithPrimary` before editing, matching the pattern used by `handleMultiCursorInput`, `handleMultiCursorBackspace`, and `handleMultiCursorDelete` in `inputHandling.ts`
- Without pre-merge, overlapping selection ranges (e.g., `[3,7]` and `[5,9]`) could double-delete the overlapping region or corrupt document positions
- Post-edit normalization now uses `preMerged.primaryIndex` for consistency

## Test plan
- [x] Added 3 new tests for overlapping ranges: cut with 2 overlapping ranges, paste with 2 overlapping ranges, cut with chain of 3 overlapping ranges
- [x] All 14 clipboard tests pass
- [x] All 14 edge case tests still pass
- [x] `pnpm check:all` passes (lint + test + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)