### PR TITLE
fix: wrap code preview live render in try/catch

### DIFF
--- a/src/plugins/codePreview/liveErrorHandling.test.ts
+++ b/src/plugins/codePreview/liveErrorHandling.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { EditorState } from "@tiptap/pm/state";
+import StarterKit from "@tiptap/starter-kit";
+import { Editor, getSchema } from "@tiptap/core";
+import { Decoration } from "@tiptap/pm/view";
+
+// Mock the mermaid renderer to reject — covers the try/catch around
+// setTimeout's awaited render calls in updateLivePreview.
+vi.mock("./renderers/renderMermaidPreview", () => ({
+  updateMermaidLivePreview: vi.fn(async () => {
+    throw new Error("boom");
+  }),
+  createMermaidPreviewWidget: vi.fn((nodeEnd: number) =>
+    Decoration.widget(nodeEnd, () => document.createElement("div"), {
+      key: "mock-mermaid",
+    }),
+  ),
+}));
+
+import {
+  codePreviewExtension,
+  EDITING_STATE_CHANGED,
+} from "./tiptap";
+
+type DecorationLike = { type?: { attrs?: Record<string, string> } };
+
+function createStateWithCodeBlock(language: string, text: string) {
+  const schema = getSchema([StarterKit]);
+  const extensionContext = {
+    name: codePreviewExtension.name,
+    options: codePreviewExtension.options,
+    storage: codePreviewExtension.storage,
+    editor: {} as Editor,
+    type: null,
+    parent: undefined,
+  };
+  const plugins =
+    codePreviewExtension.config.addProseMirrorPlugins?.call(extensionContext) ?? [];
+  const emptyDoc = schema.nodes.doc.create(null, [
+    schema.nodes.paragraph.create(),
+  ]);
+  const state = EditorState.create({ schema, doc: emptyDoc, plugins });
+
+  const codeBlock = schema.nodes.codeBlock.create(
+    { language },
+    schema.text(text),
+  );
+  const nextState = state.apply(
+    state.tr.replaceRangeWith(0, state.doc.content.size, codeBlock),
+  );
+
+  return { state: nextState, plugins, schema };
+}
+
+function makeDispatchView(baseState: EditorState) {
+  const mockView = {
+    state: baseState,
+    dispatch: vi.fn((tr) => {
+      mockView.state = mockView.state.apply(tr);
+    }),
+    focus: vi.fn(),
+    composing: false,
+    dom: document.createElement("div"),
+  };
+  return mockView;
+}
+
+describe("updateLivePreview error handling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders error placeholder and does not emit unhandled rejection when renderer throws", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on("unhandledRejection", onRejection);
+
+    try {
+      const { useBlockMathEditingStore } = await import(
+        "@/stores/blockMathEditingStore"
+      );
+      const { state } = createStateWithCodeBlock("mermaid", "graph TD; A-->B");
+
+      let codeBlockPos = -1;
+      state.doc.descendants((node, pos) => {
+        if (node.type.name === "codeBlock" || node.type.name === "code_block") {
+          codeBlockPos = pos;
+          return false;
+        }
+        return true;
+      });
+
+      useBlockMathEditingStore
+        .getState()
+        .startEditing(codeBlockPos, "graph TD; A-->B");
+
+      const extensionContext = {
+        name: codePreviewExtension.name,
+        options: codePreviewExtension.options,
+        storage: codePreviewExtension.storage,
+        editor: {} as Editor,
+        type: null,
+        parent: undefined,
+      };
+      const freshPlugins =
+        codePreviewExtension.config.addProseMirrorPlugins?.call(
+          extensionContext,
+        ) ?? [];
+      const mockView = makeDispatchView(state);
+      const viewResult = freshPlugins[0].spec.view!(mockView as never);
+
+      const tr = state.tr.setMeta(EDITING_STATE_CHANGED, true);
+      const editingState = state.apply(tr);
+      viewResult.update!(
+        Object.assign({}, mockView, { state: editingState }) as never,
+        {} as never,
+      );
+      mockView.state = editingState;
+
+      const pluginState = freshPlugins[0].getState(editingState);
+      const decs = pluginState.decorations.find();
+      const widgetDecs = decs.filter(
+        (d: DecorationLike) => !d.type?.attrs?.class,
+      );
+
+      // The live preview widget is the last widget decoration (side=1).
+      const livePreviewDec = widgetDecs[widgetDecs.length - 1];
+      const previewEl = (livePreviewDec as any).type.toDOM(mockView);
+      expect(previewEl).toBeInstanceOf(HTMLElement);
+
+      // Fire the debounced callback; mocked renderer rejects with "boom".
+      await vi.runAllTimersAsync();
+      // Let microtasks flush so the catch runs.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(previewEl.innerHTML).toContain("code-block-live-preview-error");
+
+      useBlockMathEditingStore.getState().exitEditing();
+      viewResult.destroy!();
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+
+    expect(rejections).toEqual([]);
+  });
+});

--- a/src/plugins/codePreview/tiptap.ts
+++ b/src/plugins/codePreview/tiptap.ts
@@ -108,21 +108,27 @@ function updateLivePreview(
     /* v8 ignore next -- @preserve stale-token guard: fires only when a prior timer somehow outlives a later updateLivePreview call; in practice all callers clear the timeout before incrementing the token, making the early-return unreachable in synchronous tests */
     if (currentToken !== livePreviewToken) return;
 
-    const trimmed = content.trim();
-    if (!trimmed) {
-      element.innerHTML = '<div class="code-block-live-preview-empty">Empty</div>';
-      return;
-    }
+    try {
+      const trimmed = content.trim();
+      if (!trimmed) {
+        element.innerHTML = '<div class="code-block-live-preview-empty">Empty</div>';
+        return;
+      }
 
-    if (isLatexLanguage(language)) {
-      updateLatexLivePreview(element, trimmed, currentToken, getToken);
-    } else if (language === "mermaid") {
-      await updateMermaidLivePreview(element, trimmed, currentToken, getToken);
-    } else if (language === "markmap") {
-      await updateMarkmapLivePreview(element, trimmed, currentToken, getToken);
-    } else {
-      // Only "svg" reaches this branch among PREVIEW_ONLY_LANGUAGES
-      updateSvgLivePreview(element, trimmed, currentToken, getToken);
+      if (isLatexLanguage(language)) {
+        updateLatexLivePreview(element, trimmed, currentToken, getToken);
+      } else if (language === "mermaid") {
+        await updateMermaidLivePreview(element, trimmed, currentToken, getToken);
+      } else if (language === "markmap") {
+        await updateMarkmapLivePreview(element, trimmed, currentToken, getToken);
+      } else {
+        // Only "svg" reaches this branch among PREVIEW_ONLY_LANGUAGES
+        updateSvgLivePreview(element, trimmed, currentToken, getToken);
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      diagramWarn("code preview live render failed:", msg);
+      element.innerHTML = '<div class="code-block-live-preview-error">Preview failed</div>';
     }
   }, DEBOUNCE_MS);
 }


### PR DESCRIPTION
Closes #769

## Summary
- Wrap the async body of `updateLivePreview`'s `setTimeout` in a `try/catch` so rejections from `updateMermaidLivePreview` / `updateMarkmapLivePreview` (or any other renderer call) no longer surface as unhandled promise rejections.
- Log via `diagramWarn` and render a `code-block-live-preview-error` fallback inside the preview element, mirroring the widget render path.
- Add a focused test that mocks the mermaid renderer to throw and asserts the error placeholder is rendered with no unhandled rejection captured.

## Test plan
- [x] `pnpm test src/plugins/codePreview` — 237 tests pass, including the new `liveErrorHandling` test.
- [x] `pnpm check:all` — lint, coverage, and build gates all pass.