### PR TITLE
fix: dedup suffix chunks in terminal IME re-emission

### DIFF
--- a/src/components/Terminal/compositionGuard.test.ts
+++ b/src/components/Terminal/compositionGuard.test.ts
@@ -429,6 +429,130 @@ describe("back-to-back compositionend without compositionstart (#659 — fcitx5+
   });
 });
 
+describe("chunked onData re-emission dedup (#768)", () => {
+  const DEDUP_WINDOW_MS = IME_DEDUP_WINDOW_MS;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Mirrors the dedup guard in useTerminalSessions.ts, including the
+   * consumed-prefix pointer that advances as chunks are absorbed.
+   * This enables matching suffix chunks when xterm splits a commit
+   * like "你好世界" into "你好" + "世界" across two onData calls.
+   */
+  function makeOnData(guard: ReturnType<typeof createCompositionGuard>, ptyWrite: (d: string) => void) {
+    let lastSeenCommitTime = 0;
+    let consumed = 0;
+    return (data: string) => {
+      if (guard.composing) return;
+      const lastText = guard.lastCommittedText;
+      const lastTime = guard.lastCommitTime;
+      if (lastText && Date.now() - lastTime < DEDUP_WINDOW_MS) {
+        if (lastSeenCommitTime !== lastTime) {
+          lastSeenCommitTime = lastTime;
+          consumed = 0;
+        }
+        const remainder = lastText.slice(consumed);
+        if (data.length > 0 && (remainder === data || remainder.startsWith(data))) {
+          consumed += data.length;
+          return;
+        }
+      }
+      ptyWrite(data);
+    };
+  }
+
+  it("blocks both prefix and suffix chunks of a split re-emission", () => {
+    const guard = createCompositionGuard();
+    const commit = vi.fn();
+    const ptyWrite = vi.fn();
+    guard.onCompositionCommit = commit;
+
+    // Full commit "你好世界" fires via onCompositionCommit after grace.
+    guard.compositionStart();
+    guard.compositionEnd("你好世界");
+    vi.advanceTimersByTime(GRACE_MS);
+    expect(commit).toHaveBeenCalledWith("你好世界");
+
+    // xterm then re-emits the same text chunked across two onData calls.
+    const onData = makeOnData(guard, ptyWrite);
+    vi.advanceTimersByTime(10);
+    onData("你好");
+    onData("世界");
+
+    // PTY must receive ZERO writes — both chunks absorbed by the pointer.
+    expect(ptyWrite).not.toHaveBeenCalled();
+  });
+
+  it("still allows unrelated text after a chunked re-emission is consumed", () => {
+    const guard = createCompositionGuard();
+    const ptyWrite = vi.fn();
+    // commitCallback must be set — the guard only records lastCommittedText
+    // when there is a commit sink to notify.
+    guard.onCompositionCommit = vi.fn();
+
+    guard.compositionStart();
+    guard.compositionEnd("你好");
+    vi.advanceTimersByTime(GRACE_MS);
+
+    const onData = makeOnData(guard, ptyWrite);
+    vi.advanceTimersByTime(10);
+    onData("你");
+    onData("好");
+    // Full committed text consumed — subsequent unrelated data must pass.
+    onData("ls\n");
+    expect(ptyWrite).toHaveBeenCalledTimes(1);
+    expect(ptyWrite).toHaveBeenCalledWith("ls\n");
+  });
+
+  it("resets consumed pointer when a new commit arrives", () => {
+    const guard = createCompositionGuard();
+    const commit = vi.fn();
+    const ptyWrite = vi.fn();
+    guard.onCompositionCommit = commit;
+
+    guard.compositionStart();
+    guard.compositionEnd("你好");
+    vi.advanceTimersByTime(GRACE_MS);
+
+    const onData = makeOnData(guard, ptyWrite);
+    vi.advanceTimersByTime(5);
+    onData("你"); // consume prefix of first commit
+
+    // New commit — pointer should reset so first chunk of new commit is blocked.
+    guard.compositionStart();
+    guard.compositionEnd("世界");
+    vi.advanceTimersByTime(GRACE_MS);
+
+    onData("世界");
+    expect(ptyWrite).not.toHaveBeenCalled();
+  });
+
+  it("does not dedup when data is longer than remainder", () => {
+    const guard = createCompositionGuard();
+    const ptyWrite = vi.fn();
+    guard.onCompositionCommit = vi.fn();
+
+    guard.compositionStart();
+    guard.compositionEnd("你好");
+    vi.advanceTimersByTime(GRACE_MS);
+
+    const onData = makeOnData(guard, ptyWrite);
+    vi.advanceTimersByTime(10);
+    onData("你"); // consumed by pointer, remainder becomes "好"
+    // Data longer than remainder — don't absorb, pass to PTY.
+    onData("好世界");
+    expect(ptyWrite).toHaveBeenCalledTimes(1);
+    expect(ptyWrite).toHaveBeenCalledWith("好世界");
+  });
+});
+
 describe("WeChat IME onData dedup (#525)", () => {
   const DEDUP_WINDOW_MS = IME_DEDUP_WINDOW_MS;
 

--- a/src/components/Terminal/useTerminalSessions.ts
+++ b/src/components/Terminal/useTerminalSessions.ts
@@ -75,6 +75,20 @@ interface SessionEntry {
   shellSpawning: boolean;
   disposed: boolean;
   pendingRafId: number | null;
+  /**
+   * Last observed `instance.lastCommitTime`. When it changes, a new IME
+   * commit has occurred and `lastCommittedConsumed` must reset to 0.
+   * Without this we cannot distinguish "same commit, next chunk" from
+   * "new commit, fresh state" when deduping chunked re-emissions.
+   */
+  lastSeenCommitTime: number;
+  /**
+   * Number of chars from `instance.lastCommittedText` that have already
+   * been deduped via onData. Enables suffix-chunk matching when xterm
+   * splits a commit like "你好世界" into "你好" + "世界" — the second
+   * chunk is matched against the remainder, not the full committed text.
+   */
+  lastCommittedConsumed: number;
 }
 
 /** Callbacks passed to the terminal sessions hook for panel-level actions. */
@@ -265,6 +279,8 @@ export function useTerminalSessions(
         shellSpawning: false,
         disposed: false,
         pendingRafId: null,
+        lastSeenCommitTime: 0,
+        lastCommittedConsumed: 0,
       };
       sessionsRef.current.set(sessionId, entry);
 
@@ -300,14 +316,25 @@ export function useTerminalSessions(
         if (instance.composing) return;
         // Safety net: some IMEs (WeChat) may emit onData with the committed
         // text AFTER the grace period ends. Deduplicate within 150ms (#525).
-        // Uses startsWith to also catch chunked re-emission (e.g., xterm
-        // splitting "你好世界" into "你好" + "世界" as separate onData calls).
+        // Tracks a consumed-prefix pointer so chunked re-emissions — e.g.
+        // xterm splitting "你好世界" into "你好" + "世界" — match against
+        // the remainder of the committed text, not the full string. Without
+        // this, the suffix chunk ("世界") would slip through and duplicate.
         if (
           instance.lastCommittedText &&
-          Date.now() - instance.lastCommitTime < IME_DEDUP_WINDOW_MS &&
-          (data === instance.lastCommittedText || instance.lastCommittedText.startsWith(data))
+          Date.now() - instance.lastCommitTime < IME_DEDUP_WINDOW_MS
         ) {
-          return;
+          // Reset consumed pointer when a new commit lands (lastCommitTime
+          // changes), so prior-chunk bookkeeping doesn't leak across commits.
+          if (e.lastSeenCommitTime !== instance.lastCommitTime) {
+            e.lastSeenCommitTime = instance.lastCommitTime;
+            e.lastCommittedConsumed = 0;
+          }
+          const remainder = instance.lastCommittedText.slice(e.lastCommittedConsumed);
+          if (data.length > 0 && (remainder === data || remainder.startsWith(data))) {
+            e.lastCommittedConsumed += data.length;
+            return;
+          }
         }
         if (e.shellExited && !e.pty) {
           e.shellExited = false;


### PR DESCRIPTION
Closes #768

## Summary
- `onData` IME dedup used `lastCommittedText.startsWith(data)`, which blocked prefix chunks but let suffix chunks slip through when xterm split a commit like `"你好世界"` into `"你好" + "世界"`.
- Added a consumed-prefix pointer (`lastCommittedConsumed` + `lastSeenCommitTime`) on `SessionEntry` so each chunk is matched against the *remainder* of `lastCommittedText`, and the pointer resets when a new commit lands.
- Preserves existing equal/prefix/full-text match behavior; only tightens the split-chunk case.

## Test plan
- [x] `pnpm test src/components/Terminal` — 282 tests, all pass (includes 4 new `#768` tests covering: split suffix blocking, unrelated text passthrough after full consumption, pointer reset across commits, and data longer than remainder)
- [x] `pnpm check:all` — 17855 tests pass, build succeeds
- [ ] Manual (macOS, CJK IME): type a multi-character phrase; terminal shows the phrase exactly once