### PR TITLE
fix: drop unused exports on internal regex constants

### DIFF
--- a/src/utils/markdownLinkPatterns.ts
+++ b/src/utils/markdownLinkPatterns.ts
@@ -24,7 +24,7 @@
  *
  * Does NOT match images - caller must check for preceding `!`
  */
-export const MARKDOWN_LINK_REGEX = /\[([^\]]*)\]\((?:<([^>]+)>|([^)\s"]+))(?:\s+"[^"]*")?\)/g;
+const MARKDOWN_LINK_REGEX = /\[([^\]]*)\]\((?:<([^>]+)>|([^)\s"]+))(?:\s+"[^"]*")?\)/g;
 
 /**
  * Regex to match wiki links: [[target]] or [[target|alias]]
@@ -33,7 +33,7 @@ export const MARKDOWN_LINK_REGEX = /\[([^\]]*)\]\((?:<([^>]+)>|([^)\s"]+))(?:\s+
  * - [1]: Target (required)
  * - [2]: Alias (optional)
  */
-export const WIKI_LINK_REGEX = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+const WIKI_LINK_REGEX = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
 
 /**
  * Result of finding a markdown link at a position.

--- a/src/utils/markdownPipeline/plugins/wikiLinks.ts
+++ b/src/utils/markdownPipeline/plugins/wikiLinks.ts
@@ -11,7 +11,7 @@
  *   - Pipe character `|` separates target from alias: [[target|display text]]
  *   - Empty targets after trimming return null (invalid wiki link)
  *
- * @coordinates-with markdownLinkPatterns.ts — WIKI_LINK_REGEX for source mode detection
+ * @coordinates-with markdownLinkPatterns.ts — findWikiLinksInLine for source mode detection
  * @coordinates-with markdownArtifacts/wikiLink.ts — PM node definition for wiki links
  * @module utils/markdownPipeline/plugins/wikiLinks
  */


### PR DESCRIPTION
Closes #774

Removes the `export` keyword from `MARKDOWN_LINK_REGEX` and `WIKI_LINK_REGEX` in `src/utils/markdownLinkPatterns.ts` — both are only referenced internally via `.source`. Also updates a stale `@coordinates-with` comment in `src/utils/markdownPipeline/plugins/wikiLinks.ts` to point at the helper function instead of the now-private constant.

No behavior change. `pnpm check:all` passes (670 test files, 17855 tests).