### PR TITLE
docs: update shortcut count from 117 to 122 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ VMark is a modern, local-first Markdown editor designed for the AI era. Three ed
 - **CJK Done Right** — 20+ formatting rules for Chinese, Japanese, Korean text
 - **5 Themes** — White, Paper, Mint, Sepia, Night
 - **Local-First** — No cloud, no accounts, no analytics. Documents stay on your machine.
-- **123 Shortcuts** — All customizable in Settings
+- **122 Shortcuts** — All customizable in Settings
 
 See the full feature list at **[vmark.app/guide/features](https://vmark.app/guide/features)**.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ VMark is a modern, local-first Markdown editor designed for the AI era. Three ed
 - **CJK Done Right** — 20+ formatting rules for Chinese, Japanese, Korean text
 - **5 Themes** — White, Paper, Mint, Sepia, Night
 - **Local-First** — No cloud, no accounts, no analytics. Documents stay on your machine.
-- **117 Shortcuts** — All customizable in Settings
+- **123 Shortcuts** — All customizable in Settings
 
 See the full feature list at **[vmark.app/guide/features](https://vmark.app/guide/features)**.
 


### PR DESCRIPTION
## Summary

README.md listed "117 Shortcuts" which was outdated. Updated to 122, the actual count verified by counting `{ id:` entries in `shortcutsStore.ts`. The `defaultKey:` count shows 123 but includes a type definition on line 60, not a shortcut entry.

## Policy Gates (Required)

- [x] This PR is single-focus (one issue, one problem, one objective).
- [x] This PR includes 100% test coverage for changed behavior and changed code paths.
- [ ] If this is a bug fix, the linked issue contains detailed reproduction context.

## Linked Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Refactor
- [ ] Test-only
- [ ] Other

## What Changed

- Updated shortcut count in README.md from 117 → 122

## Validation

- [x] I manually verified critical flows.

## PR Checklist

- [x] The PR avoids unrelated refactors or cleanup.
- [x] The issue context is clear (linked issue or explanation above).
- [x] Docs/changelog were updated if behavior or usage changed.
- [x] I am ready to address review feedback.