### PR TITLE
fix(mcp-bridge): validate position bounds in cursor.setPosition

### DIFF
--- a/src/hooks/mcpBridge/cursorHandlers.test.ts
+++ b/src/hooks/mcpBridge/cursorHandlers.test.ts
@@ -217,7 +217,7 @@ describe("cursorHandlers", () => {
     it("sets cursor position via setTextSelection", async () => {
       const setTextSelection = vi.fn();
       const editor = {
-        state: { selection: { from: 0 }, doc: {} },
+        state: { selection: { from: 0 }, doc: { content: { size: 100 } } },
         commands: { setTextSelection },
       };
 
@@ -228,6 +228,63 @@ describe("cursorHandlers", () => {
       expect(setTextSelection).toHaveBeenCalledWith(42);
       expect(respond).toHaveBeenCalledWith({
         id: "req-10",
+        success: true,
+        data: null,
+      });
+    });
+
+    it("rejects negative position with a clear error", async () => {
+      const setTextSelection = vi.fn();
+      const editor = {
+        state: { selection: { from: 0 }, doc: { content: { size: 100 } } },
+        commands: { setTextSelection },
+      };
+
+      vi.mocked(getEditor).mockReturnValue(editor as never);
+
+      await handleCursorSetPosition("req-neg", { position: -1 });
+
+      expect(setTextSelection).not.toHaveBeenCalled();
+      expect(respond).toHaveBeenCalledWith({
+        id: "req-neg",
+        success: false,
+        error: "Invalid position: -1 (document size: 100)",
+      });
+    });
+
+    it("rejects position beyond document size with a clear error", async () => {
+      const setTextSelection = vi.fn();
+      const editor = {
+        state: { selection: { from: 0 }, doc: { content: { size: 100 } } },
+        commands: { setTextSelection },
+      };
+
+      vi.mocked(getEditor).mockReturnValue(editor as never);
+
+      await handleCursorSetPosition("req-over", { position: 1_000_000_000 });
+
+      expect(setTextSelection).not.toHaveBeenCalled();
+      expect(respond).toHaveBeenCalledWith({
+        id: "req-over",
+        success: false,
+        error: "Invalid position: 1000000000 (document size: 100)",
+      });
+    });
+
+    it("accepts position equal to document size (end of document)", async () => {
+      const setTextSelection = vi.fn();
+      const editor = {
+        state: { selection: { from: 0 }, doc: { content: { size: 100 } } },
+        commands: { setTextSelection },
+      };
+
+      vi.mocked(getEditor).mockReturnValue(editor as never);
+
+      await handleCursorSetPosition("req-edge", { position: 100 });
+
+      expect(setTextSelection).toHaveBeenCalledWith(100);
+      expect(respond).toHaveBeenCalledWith({
+        id: "req-edge",
         success: true,
         data: null,
       });

--- a/src/hooks/mcpBridge/cursorHandlers.ts
+++ b/src/hooks/mcpBridge/cursorHandlers.ts
@@ -156,6 +156,10 @@ export async function handleCursorSetPosition(
     if (!editor) throw new Error("No active editor");
 
     const position = requireNumber(args, "position");
+    const docSize = editor.state.doc.content.size;
+    if (position < 0 || position > docSize) {
+      throw new Error(`Invalid position: ${position} (document size: ${docSize})`);
+    }
     editor.commands.setTextSelection(position);
 
     await respond({ id, success: true, data: null });


### PR DESCRIPTION
Closes #791

## Summary
- Adds a bounds check in `handleCursorSetPosition` so out-of-range positions produce a clear error (`Invalid position: N (document size: M)`) instead of an opaque ProseMirror failure.
- Mirrors the existing pattern in `handleInsertAtPositionWithSuggestion` (`suggestion/insertHandlers.ts:152-156`).
- Adds unit tests for negative, overflow, and boundary (`position === docSize`) cases.

## Test plan
- [x] `pnpm test src/hooks/mcpBridge/cursorHandlers.test.ts` — 16/16 pass
- [x] `pnpm check:all` — 18033 tests pass, build succeeds