### PR TITLE
fix: flush pending IME commit text on terminal dispose

### DIFF
--- a/src/components/Terminal/createTerminalInstance.test.ts
+++ b/src/components/Terminal/createTerminalInstance.test.ts
@@ -672,6 +672,53 @@ describe("createTerminalInstance — IME composition with textarea", () => {
     vi.useRealTimers();
   });
 
+  it("flushes pending committed text on dispose before grace period ends", () => {
+    vi.useFakeTimers();
+    const inst = makeInstanceWithTextarea();
+    const textarea = inst.container.querySelector(".xterm-helper-textarea")!;
+    const commitCb = vi.fn();
+    inst.onCompositionCommit = commitCb;
+
+    // Start composition and end it to queue pendingCommitText
+    textarea.dispatchEvent(new Event("compositionstart"));
+    const compEnd = new Event("compositionend") as CompositionEvent;
+    Object.defineProperty(compEnd, "data", { value: "你好世界" });
+    textarea.dispatchEvent(compEnd);
+
+    // Not yet fired — still in grace period
+    expect(commitCb).not.toHaveBeenCalled();
+
+    // Dispose inside the grace window — should flush pending text
+    inst.dispose();
+    expect(commitCb).toHaveBeenCalledTimes(1);
+    expect(commitCb).toHaveBeenCalledWith("你好世界");
+
+    // Timer firing after dispose must not re-invoke the callback
+    vi.advanceTimersByTime(100);
+    expect(commitCb).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  it("swallows onCompositionCommit errors during dispose flush", () => {
+    vi.useFakeTimers();
+    const inst = makeInstanceWithTextarea();
+    const textarea = inst.container.querySelector(".xterm-helper-textarea")!;
+    inst.onCompositionCommit = () => {
+      throw new Error("PTY closed");
+    };
+
+    textarea.dispatchEvent(new Event("compositionstart"));
+    const compEnd = new Event("compositionend") as CompositionEvent;
+    Object.defineProperty(compEnd, "data", { value: "abc" });
+    textarea.dispatchEvent(compEnd);
+
+    // Should not throw even though callback raises
+    expect(() => inst.dispose()).not.toThrow();
+
+    vi.useRealTimers();
+  });
+
   it("does not log textarea-not-found when textarea exists", () => {
     makeInstanceWithTextarea();
     expect(mockTerminalLog).not.toHaveBeenCalledWith(

--- a/src/components/Terminal/createTerminalInstance.ts
+++ b/src/components/Terminal/createTerminalInstance.ts
@@ -350,6 +350,14 @@ export function createTerminalInstance(options: CreateOptions): TerminalInstance
     if (compositionGraceTimer) {
       clearTimeout(compositionGraceTimer);
       compositionGraceTimer = null;
+      if (pendingCommitText && onCompositionCommit) {
+        try {
+          onCompositionCommit(pendingCommitText);
+        } catch {
+          // best-effort: PTY may already be closing
+        }
+      }
+      pendingCommitText = null;
     }
     if (copyOnSelectTimer) {
       clearTimeout(copyOnSelectTimer);


### PR DESCRIPTION
Closes #793

## Summary
- `createTerminalInstance.dispose()` previously cleared the 80ms IME grace timer without flushing `pendingCommitText`, silently dropping committed CJK input if the user closed the terminal inside the grace window.
- Mirror the existing `onCompositionStart` flush pattern: if a pending commit exists when `dispose()` runs, invoke `onCompositionCommit(pendingCommitText)` (wrapped in try/catch since the PTY may already be closing) before nulling the state.

## Test plan
- [x] New unit test: dispose during grace window invokes `onCompositionCommit` with the pending text exactly once and the timer firing later is a no-op.
- [x] New unit test: errors thrown from `onCompositionCommit` during dispose flush do not propagate.
- [x] `pnpm test src/components/Terminal/` — 291/291 passing.
- [x] `pnpm check:all` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)