### PR TITLE
fix: add aria-label to TerminalTabBar session buttons

### DIFF
--- a/src/components/Terminal/TerminalTabBar.test.tsx
+++ b/src/components/Terminal/TerminalTabBar.test.tsx
@@ -28,6 +28,13 @@ describe("TerminalTabBar", () => {
     expect(screen.getByTitle("Terminal 1")).toBeInTheDocument();
   });
 
+  it("exposes session tab to assistive tech via aria-label", () => {
+    renderWithSession();
+    expect(
+      screen.getByRole("button", { name: /Terminal 1/i }),
+    ).toBeInTheDocument();
+  });
+
   it("creates a new session on + click", () => {
     renderWithSession();
     const addBtn = screen.getByTitle("New Terminal");

--- a/src/components/Terminal/TerminalTabBar.tsx
+++ b/src/components/Terminal/TerminalTabBar.tsx
@@ -61,6 +61,7 @@ export function TerminalTabBar({ onClose, onRestart, orientation = "vertical" }:
             className={`terminal-tab ${s.id === activeId ? "terminal-tab-active" : ""} ${!s.isAlive ? "terminal-tab-dead" : ""}`}
             onClick={() => handleSwitch(s.id)}
             title={s.label}
+            aria-label={s.label}
           >
             {getTabDisplay(s.label)}
           </button>


### PR DESCRIPTION
Closes #802

## Summary
- Adds `aria-label={s.label}` to the session-switch button in `TerminalTabBar`, matching the pattern of the adjacent create/close/restart buttons.
- Screen readers now announce the full session name (e.g. "Terminal 1") instead of just the abbreviated character ("1", "T").
- Adds a regression test asserting `getByRole("button", { name: /Terminal 1/i })` resolves.

## Test plan
- [x] `pnpm test src/components/Terminal/TerminalTabBar.test.tsx` — all tests pass
- [x] `pnpm check:all` — lint/build/tests green
- [x] `grep -n 'aria-label' src/components/Terminal/TerminalTabBar.tsx` lists 4 matches