### PR TITLE
fix: set TERM_PROGRAM to vmark in PTY env

### DIFF
--- a/src/components/Terminal/spawnPty.test.ts
+++ b/src/components/Terminal/spawnPty.test.ts
@@ -363,6 +363,17 @@ describe("spawnPty shell selection", () => {
     expect(spawnCallEnv.env.VMARK_WORKSPACE).toBe("/my/workspace");
   });
 
+  it("sets TERM_PROGRAM env to vmark so CLI tools identify the host correctly", async () => {
+    vi.mocked(useSettingsStore.getState).mockReturnValue({
+      terminal: { shell: "" },
+    } as ReturnType<typeof useSettingsStore.getState>);
+
+    await spawnPty({ term: mockTerm, onExit: vi.fn(), disposed: () => false });
+
+    const spawnCallEnv = vi.mocked(spawn).mock.calls[0][2] as { env: Record<string, string> };
+    expect(spawnCallEnv.env.TERM_PROGRAM).toBe("vmark");
+  });
+
   it("throws original error when spawn fails and no configured shell", async () => {
     vi.mocked(useSettingsStore.getState).mockReturnValue({
       terminal: { shell: "" },

--- a/src/components/Terminal/spawnPty.ts
+++ b/src/components/Terminal/spawnPty.ts
@@ -175,7 +175,7 @@ export async function spawnPty(options: SpawnOptions): Promise<IPty> {
   const env: Record<string, string> = {
     // Ensure consistent color capabilities in xterm.js; Tauri GUI apps may not inherit terminal env vars.
     TERM: "xterm-256color",
-    TERM_PROGRAM: "WezTerm",
+    TERM_PROGRAM: "vmark",
     EDITOR: "vmark",
     // macOS GUI apps launched from Dock/Spotlight have minimal environment —
     // set UTF-8 encoding so the shell and tools handle CJK/multibyte correctly.


### PR DESCRIPTION
Closes #826

## Summary
- `src/components/Terminal/spawnPty.ts` had `TERM_PROGRAM: "WezTerm"`, contradicting its own Purpose header and the adjacent `EDITOR: "vmark"`. Changed to `"vmark"` so CLI tools that branch on `TERM_PROGRAM` detect VMark correctly.
- Added a regression test next to the existing `VMARK_WORKSPACE` env test.

## Test plan
- [x] `pnpm test src/components/Terminal/spawnPty.test.ts` — 31 tests pass (includes new assertion)
- [x] `pnpm check:all` — lint/test/build pass (691 test files)
- [x] `grep -rn "WezTerm" src/ src-tauri/` returns zero matches