### PR TITLE
fix: fail closed when terminal file-link stat() rejects

### DIFF
--- a/src/components/Terminal/createTerminalInstance.test.ts
+++ b/src/components/Terminal/createTerminalInstance.test.ts
@@ -1111,14 +1111,37 @@ describe("createTerminalInstance — file link callback", () => {
     expect(mockReadTextFile).not.toHaveBeenCalled();
   });
 
-  it("proceeds when stat fails (falls through to readTextFile)", async () => {
+  it("fails closed when stat rejects (no readTextFile, surfaces warning)", async () => {
     mockStat.mockRejectedValueOnce(new Error("stat failed"));
 
     fileLinkCallback("/path/to/file.md");
 
     await vi.waitFor(() => {
-      expect(mockReadTextFile).toHaveBeenCalledWith("/path/to/file.md");
+      expect(mockTerminalLog).toHaveBeenCalledWith(
+        "stat failed for file link:",
+        "/path/to/file.md",
+        "stat failed",
+      );
     });
+    expect(termInst.term.writeln).toHaveBeenCalledWith(
+      "\x1b[33m[Cannot open file: stat failed]\x1b[0m",
+    );
+    expect(mockReadTextFile).not.toHaveBeenCalled();
+  });
+
+  it("stringifies non-Error stat rejection", async () => {
+    mockStat.mockRejectedValueOnce("unknown stat error");
+
+    fileLinkCallback("/path/to/file.md");
+
+    await vi.waitFor(() => {
+      expect(mockTerminalLog).toHaveBeenCalledWith(
+        "stat failed for file link:",
+        "/path/to/file.md",
+        "unknown stat error",
+      );
+    });
+    expect(mockReadTextFile).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/Terminal/createTerminalInstance.ts
+++ b/src/components/Terminal/createTerminalInstance.ts
@@ -315,8 +315,11 @@ export function createTerminalInstance(options: CreateOptions): TerminalInstance
           term.writeln(`\x1b[33m[File too large: ${Math.round(info.size / 1024 / 1024)}MB, max 10MB]\x1b[0m`);
           return;
         }
-      } catch {
-        // stat failed — proceed anyway, readTextFile will catch
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        terminalLog("stat failed for file link:", filePath, message);
+        term.writeln(`\x1b[33m[Cannot open file: ${message}]\x1b[0m`);
+        return;
       }
       readTextFile(filePath).then((content) => {
         const windowLabel = getCurrentWindowLabel();


### PR DESCRIPTION
Closes #829

## Summary

The terminal file-link click handler had a 10 MB size guard wrapped in a `try/catch` that silently fell through to `readTextFile` on stat failure. That meant any transient stat error (broken symlink, scope-permission edge case, network-mount timeout) would bypass the guard and load a file of unknown size — potentially OOMing the webview on multi-hundred-MB log files.

Now the catch branch fails closed: it logs the failure, writes a yellow `[Cannot open file: ...]` line to the terminal (matching the existing too-large warning style), and returns without reading.

## Test plan

- [x] `pnpm test src/components/Terminal/createTerminalInstance.test.ts` — 64 tests pass
- [x] `pnpm check:all` — passes (18211 tests)
- [x] Existing "proceeds when stat fails" test rewritten to assert fail-closed behavior + new test for non-Error stat rejection
- [x] `grep -n "stat failed — proceed anyway"` returns zero matches
- [x] `grep -n "term.writeln"` returns three matches (size, stat-failed, read-failed)