### PR TITLE
fix: count consecutive backslashes when detecting escaped table pipes

### DIFF
--- a/src/plugins/codemirror/structuralCharProtection.test.ts
+++ b/src/plugins/codemirror/structuralCharProtection.test.ts
@@ -212,6 +212,15 @@ describe("Structural Character Protection", () => {
       const pipePos = getCellStartPipePos(view);
       expect(pipePos).toBe(-1);
     });
+
+    it("returns pipe position when preceded by literal `\\\\` (even backslashes)", () => {
+      // Text: "| cell \\| next |" — `\\` is a literal backslash, so `|` is a real delimiter.
+      // Cursor is right after the delimiter.
+      const view = createView("| cell \\\\|^ next |");
+      const pipePos = getCellStartPipePos(view);
+      // Positions: 0=|, 1= , 2=c, 3=e, 4=l, 5=l, 6= , 7=\, 8=\, 9=|, 10= , ...
+      expect(pipePos).toBe(9);
+    });
   });
 
   describe("getListMarkerRange", () => {
@@ -681,6 +690,14 @@ describe("Structural Character Protection", () => {
       const view = createView("| cell \\^| with pipe | next |");
       const handled = smartDelete(view);
       expect(handled).toBe(false);
+    });
+
+    it("protects pipe preceded by literal `\\\\` (even backslashes)", () => {
+      // Text: "| cell \\| next |" — `\\` is a literal backslash, `|` is a real delimiter.
+      // Cursor is right before that delimiter, so it should be protected.
+      const view = createView("| cell \\\\^| next |");
+      const handled = smartDelete(view);
+      expect(handled).toBe(true);
     });
 
     it("protects pipes with multiple cursors", () => {

--- a/src/plugins/codemirror/structuralCharProtection.ts
+++ b/src/plugins/codemirror/structuralCharProtection.ts
@@ -37,6 +37,20 @@ export const TASK_ITEM_PATTERN = /^(\s*)([-*+])\s\[([ xX])\]\s/;
 export const BLOCKQUOTE_PATTERN = /^(\s*)(>+)\s?/;
 
 /**
+ * Check if a pipe is escaped — preceded by an odd number of backslashes.
+ * `\|` is escaped (cell content); `\\|` is a literal backslash + delimiter.
+ */
+function isPipeEscaped(text: string, pipeIndex: number): boolean {
+  let n = 0;
+  let i = pipeIndex - 1;
+  while (i >= 0 && text[i] === "\\") {
+    n++;
+    i--;
+  }
+  return n % 2 === 1;
+}
+
+/**
  * Check if a position is right after a table pipe at cell start.
  * Returns the pipe position if true, or -1 if not.
  */
@@ -50,11 +64,12 @@ function getCellStartPipePosAt(state: EditorState, head: number): number {
   const offsetInLine = head - line.from;
   const textBefore = line.text.slice(0, offsetInLine);
 
-  // Check if we're right after a pipe (with only whitespace between).
-  // Negative lookbehind excludes escaped pipes (\|) which are cell content, not delimiters.
-  const match = textBefore.match(/(?<!\\)\|\s*$/);
-  if (match) {
-    return line.from + textBefore.length - match[0].length;
+  // Walk back through trailing whitespace, find nearest `|`, and check if it's
+  // escaped by an odd number of leading backslashes.
+  let i = textBefore.length - 1;
+  while (i >= 0 && /\s/.test(textBefore[i])) i--;
+  if (i >= 0 && textBefore[i] === "|" && !isPipeEscaped(textBefore, i)) {
+    return line.from + i;
   }
 
   return -1;
@@ -314,7 +329,7 @@ function deleteSpecForCursor(
   const charAfter = line.text[offsetInLine];
   if (charAfter === "|" && TABLE_ROW_PATTERN.test(line.text)) {
     // Don't protect escaped pipes (\|) — they are cell content, not delimiters
-    if (offsetInLine > 0 && line.text[offsetInLine - 1] === "\\") return null;
+    if (isPipeEscaped(line.text, offsetInLine)) return null;
     return { changes: [], range: EditorSelection.cursor(head + 1) };
   }
 


### PR DESCRIPTION
Closes #838