### PR TITLE
fix: return Err from list_models on unexpected response shape

### DIFF
--- a/src-tauri/src/ai_provider/rest_api.rs
+++ b/src-tauri/src/ai_provider/rest_api.rs
@@ -44,6 +44,66 @@ async fn check_response(resp: reqwest::Response) -> Result<reqwest::Response, St
     Err(format!("HTTP {}: {}", status.as_u16(), text))
 }
 
+fn parse_ollama_models(json: &serde_json::Value) -> Result<Vec<String>, String> {
+    let arr = json
+        .get("models")
+        .and_then(|m| m.as_array())
+        .ok_or_else(|| {
+            "Unexpected model list response shape from Ollama (missing \"models\" key)".to_string()
+        })?;
+    Ok(arr
+        .iter()
+        .filter_map(|m| m.get("name").and_then(|n| n.as_str()).map(String::from))
+        .collect())
+}
+
+fn parse_openai_models(json: &serde_json::Value) -> Result<Vec<String>, String> {
+    let arr = json.get("data").and_then(|d| d.as_array()).ok_or_else(|| {
+        "Unexpected model list response shape from OpenAI (missing \"data\" key)".to_string()
+    })?;
+    // Use dash-suffixed prefixes to avoid false matches (e.g. "o1" matching "o100-*")
+    let prefixes = ["gpt-", "o1-", "o3-", "o4-", "chatgpt-"];
+    let exact = ["o1", "o3", "o4"];
+    let mut models: Vec<String> = arr
+        .iter()
+        .filter_map(|m| m.get("id").and_then(|id| id.as_str()).map(String::from))
+        .filter(|id| {
+            prefixes.iter().any(|p| id.starts_with(p)) || exact.iter().any(|e| id.as_str() == *e)
+        })
+        .collect();
+    models.sort();
+    Ok(models)
+}
+
+fn parse_google_models(json: &serde_json::Value) -> Result<Vec<String>, String> {
+    let arr = json
+        .get("models")
+        .and_then(|m| m.as_array())
+        .ok_or_else(|| {
+            "Unexpected model list response shape from Google AI (missing \"models\" key)"
+                .to_string()
+        })?;
+    let mut models: Vec<String> = arr
+        .iter()
+        .filter_map(|m| {
+            // Only include models that support generateContent
+            let supports = m
+                .get("supportedGenerationMethods")
+                .and_then(|s| s.as_array())
+                .map(|arr| arr.iter().any(|v| v.as_str() == Some("generateContent")))
+                .unwrap_or(false);
+            if !supports {
+                return None;
+            }
+            m.get("name")
+                .and_then(|n| n.as_str())
+                .map(|n| n.strip_prefix("models/").unwrap_or(n).to_string())
+        })
+        .collect();
+    models.sort();
+    Ok(models)
+}
+
 // ============================================================================
 // API Key Testing
 // ============================================================================
@@ -159,19 +219,7 @@ pub async fn list_models(
                 .json()
                 .await
                 .map_err(|e| format!("Failed to parse response: {}", e))?;
-            let models = json
-                .get("models")
-                .and_then(|m| m.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|m| m.get("name").and_then(|n| n.as_str()).map(String::from))
-                        .collect()
-                })
-                .unwrap_or_else(|| {
-                    log::warn!("[AI Provider] Unexpected model list response shape from Ollama (missing \"models\" key)");
-                    Vec::new()
-                });
-            Ok(models)
+            parse_ollama_models(&json)
         }
 
         "openai" => {
@@ -189,27 +237,7 @@ pub async fn list_models(
                 .json()
                 .await
                 .map_err(|e| format!("Failed to parse response: {}", e))?;
-            // Use dash-suffixed prefixes to avoid false matches (e.g. "o1" matching "o100-*")
-            let prefixes = ["gpt-", "o1-", "o3-", "o4-", "chatgpt-"];
-            let exact = ["o1", "o3", "o4"];
-            let mut models: Vec<String> = json
-                .get("data")
-                .and_then(|d| d.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|m| m.get("id").and_then(|id| id.as_str()).map(String::from))
-                        .filter(|id| {
-                            prefixes.iter().any(|p| id.starts_with(p))
-                                || exact.iter().any(|e| id.as_str() == *e)
-                        })
-                        .collect()
-                })
-                .unwrap_or_else(|| {
-                    log::warn!("[AI Provider] Unexpected model list response shape from OpenAI (missing \"data\" key)");
-                    Vec::new()
-                });
-            models.sort();
-            Ok(models)
+            parse_openai_models(&json)
         }
 
         "google-ai" => {
@@ -226,30 +254,7 @@ pub async fn list_models(
                 .json()
                 .await
                 .map_err(|e| format!("Failed to parse response: {}", e))?;
-            let mut models: Vec<String> = json
-                .get("models")
-                .and_then(|m| m.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|m| {
-                            // Only include models that support generateContent
-                            let supports = m.get("supportedGenerationMethods")
-                                .and_then(|s| s.as_array())
-                                .map(|arr| arr.iter().any(|v| v.as_str() == Some("generateContent")))
-                                .unwrap_or(false);
-                            if !supports { return None; }
-                            m.get("name")
-                                .and_then(|n| n.as_str())
-                                .map(|n| n.strip_prefix("models/").unwrap_or(n).to_string())
-                        })
-                        .collect()
-                })
-                .unwrap_or_else(|| {
-                    log::warn!("[AI Provider] Unexpected model list response shape from Google AI (missing \"models\" key)");
-                    Vec::new()
-                });
-            models.sort();
-            Ok(models)
+            parse_google_models(&json)
         }
 
         "anthropic" => Ok(vec![
@@ -364,5 +369,87 @@ pub async fn validate_model(
         }
 
         _ => Err(format!("Unknown provider: {}", provider)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn ollama_parser_errors_on_missing_models_key() {
+        let err = parse_ollama_models(&json!({})).unwrap_err();
+        assert!(err.contains("Ollama"));
+        assert!(err.contains("models"));
+    }
+
+    #[test]
+    fn ollama_parser_collects_names() {
+        let v = json!({
+            "models": [
+                {"name": "llama3.2"},
+                {"name": "qwen2.5"},
+            ]
+        });
+        assert_eq!(
+            parse_ollama_models(&v).unwrap(),
+            vec!["llama3.2", "qwen2.5"]
+        );
+    }
+
+    #[test]
+    fn openai_parser_errors_on_missing_data_key() {
+        let err = parse_openai_models(&json!({})).unwrap_err();
+        assert!(err.contains("OpenAI"));
+        assert!(err.contains("data"));
+    }
+
+    #[test]
+    fn openai_parser_filters_and_sorts() {
+        let v = json!({
+            "data": [
+                {"id": "gpt-4o"},
+                {"id": "text-embedding-3-small"},
+                {"id": "o1"},
+                {"id": "o100-foo"},
+                {"id": "chatgpt-4"},
+            ]
+        });
+        assert_eq!(
+            parse_openai_models(&v).unwrap(),
+            vec!["chatgpt-4", "gpt-4o", "o1"]
+        );
+    }
+
+    #[test]
+    fn google_parser_errors_on_missing_models_key() {
+        let err = parse_google_models(&json!({})).unwrap_err();
+        assert!(err.contains("Google AI"));
+        assert!(err.contains("models"));
+    }
+
+    #[test]
+    fn google_parser_keeps_only_generate_content_models() {
+        let v = json!({
+            "models": [
+                {
+                    "name": "models/gemini-2.0-flash",
+                    "supportedGenerationMethods": ["generateContent", "countTokens"]
+                },
+                {
+                    "name": "models/embedding-001",
+                    "supportedGenerationMethods": ["embedContent"]
+                },
+                {
+                    "name": "models/gemini-1.5-pro",
+                    "supportedGenerationMethods": ["generateContent"]
+                }
+            ]
+        });
+        assert_eq!(
+            parse_google_models(&v).unwrap(),
+            vec!["gemini-1.5-pro", "gemini-2.0-flash"]
+        );
     }
 }


### PR DESCRIPTION
Closes #859

## Summary

`list_models` (`src-tauri/src/ai_provider/rest_api.rs`) used to return `Ok(vec![])` when a provider responded HTTP 200 with a JSON body missing the expected key (`models`/`data`). Only a `log::warn!` was emitted, so the frontend's existing `catch` fallback to the curated suggestions in `ModelComboBox.tsx` never fired and users saw an empty model picker.

This change replaces the three `unwrap_or_else(|| { warn; Vec::new() })` sites (Ollama, OpenAI, Google AI) with early `Err` returns through small `parse_ollama_models` / `parse_openai_models` / `parse_google_models` helpers. The existing filter/map/sort logic for each provider is preserved verbatim.

## Test plan

- [x] `cargo test --lib rest_api` — 6 new unit tests pass (missing-key error + success path for each provider)
- [x] `pnpm test` — 18352 frontend tests pass
- [x] `grep -n "unwrap_or_else" src-tauri/src/ai_provider/rest_api.rs` returns zero matches inside `list_models`
- [ ] Manual: configure an Ollama endpoint that returns `{"foo": "bar"}` and confirm the model picker shows curated suggestions instead of an empty list