### PR TITLE
fix: bound WebSocketBridge auth handshake with timeout

### DIFF
--- a/vmark-mcp-server/__tests__/unit/bridge/websocket.test.ts
+++ b/vmark-mcp-server/__tests__/unit/bridge/websocket.test.ts
@@ -454,6 +454,30 @@ describe('WebSocketBridge', () => {
         'Connection closed during authentication'
       );
     });
+
+    it('should reject connect() if auth_result never arrives within timeout', async () => {
+      // Simulates the wedge scenario described in audit #862: VMark accepts the
+      // WebSocket and the auth message but never replies with auth_result
+      // (e.g., serialization failure, sender-task hang). Without a bounded wait,
+      // connect() would hang forever and block the reconnect loop.
+      const authBridge = new WebSocketBridge({
+        port: TEST_PORT,
+        timeout: 200,
+        autoReconnect: false,
+        authTokenResolver: () => 'test-token',
+      });
+
+      // Server accepts connection but never responds to the auth message.
+      // beforeEach already registers a listener that just tracks connections;
+      // we don't add any message handler, so auth goes unanswered.
+
+      const start = Date.now();
+      await expect(authBridge.connect()).rejects.toThrow('Auth handshake timeout');
+      const elapsed = Date.now() - start;
+      // Should reject around `timeout` ms — allow generous slack for timer jitter.
+      expect(elapsed).toBeGreaterThanOrEqual(150);
+      expect(elapsed).toBeLessThan(700);
+    });
   });
 
   describe('connection lost during request', () => {

--- a/vmark-mcp-server/src/bridge/websocket.ts
+++ b/vmark-mcp-server/src/bridge/websocket.ts
@@ -129,6 +129,7 @@ export class WebSocketBridge implements Bridge {
   private readonly authTokenResolver: (() => string | undefined) | undefined;
   private _authResolve: (() => void) | null = null;
   private _authReject: ((reason: string) => void) | null = null;
+  private _authTimer: ReturnType<typeof setTimeout> | null = null;
 
   private ws: WebSocket | null = null;
   private connected = false;
@@ -277,6 +278,10 @@ export class WebSocketBridge implements Bridge {
     }
 
     // Reject and clear stale auth callbacks from a previous connection attempt
+    if (this._authTimer) {
+      clearTimeout(this._authTimer);
+      this._authTimer = null;
+    }
     if (this._authReject) {
       this._authReject('Connection superseded by new attempt');
     }
@@ -356,9 +361,26 @@ export class WebSocketBridge implements Bridge {
               return;
             }
 
+            // Bound the wait for auth_result so a missing reply (serialization
+            // failure on Rust side, sender-task hang, etc.) cannot wedge the
+            // connect() Promise — and therefore the reconnect loop — forever.
+            const authTimeoutTimer = setTimeout(() => {
+              if (this._authReject) {
+                const onReject = this._authReject;
+                this._authResolve = null;
+                this._authReject = null;
+                this._authTimer = null;
+                this.ws?.close();
+                onReject('Auth handshake timeout');
+              }
+            }, this.timeout);
+            this._authTimer = authTimeoutTimer;
+
             // Wait for auth_result before marking connected.
             // The message handler will call the stored callback.
             this._authResolve = () => {
+              clearTimeout(authTimeoutTimer);
+              this._authTimer = null;
               this.connected = true;
               this.connecting = false;
               this.reconnectAttempts = 0;
@@ -372,6 +394,8 @@ export class WebSocketBridge implements Bridge {
               resolve();
             };
             this._authReject = (reason: string) => {
+              clearTimeout(authTimeoutTimer);
+              this._authTimer = null;
               this.connecting = false;
               reject(new Error(`Auth failed: ${reason}`));
             };


### PR DESCRIPTION
Closes #862

## Summary

Adds a timeout around the WebSocket auth handshake in `vmark-mcp-server` so the sidecar can no longer wedge if VMark accepts the socket and the `auth` message but never replies with `auth_result`.

## Changes

- `vmark-mcp-server/src/bridge/websocket.ts`
  - New `_authTimer` field.
  - After sending the auth message, start a `setTimeout(this.timeout)` that closes the socket and rejects `connect()` with `Auth handshake timeout`.
  - Wrap `_authResolve` and `_authReject` to `clearTimeout` on success, failure, and the existing `handleDisconnect` / superseded-connect paths.
- `vmark-mcp-server/__tests__/unit/bridge/websocket.test.ts`
  - New test: server accepts the socket and never replies to `auth`; expects `connect()` to reject with `Auth handshake timeout` within ~`timeout` ms.

## Test plan

- [x] `pnpm exec vitest run __tests__/unit/bridge/websocket.test.ts` — new test passes; only pre-existing unrelated failure (`should reject when queue is full`) remains, which also fails on `main`.
- [x] `pnpm lint` (vmark-mcp-server) clean.
- [x] `pnpm build` (vmark-mcp-server) clean.
- [x] Verification grep returns the expected matches showing the timer is set, cleared on success, cleared on failure, cleared on close (via wrapped `_authReject`), and cleared on superseded connect.