### PR TITLE
fix: enforce separator boundary in resourceResolver baseDir checks

### DIFF
--- a/src/export/resourceResolver.test.ts
+++ b/src/export/resourceResolver.test.ts
@@ -74,6 +74,7 @@ import {
   isRemoteUrl,
   isDataUri,
   isAssetUrl,
+  isInsideBase,
   extractImageSources,
   resolveRelativePath,
   fileToDataUri,
@@ -398,6 +399,33 @@ describe("resolveRelativePath", () => {
     });
   });
 
+});
+
+// ---------------------------------------------------------------------------
+// isInsideBase — direct unit tests for the helper, including the Windows
+// separator branch that is unreachable via the POSIX-only normalize() mock.
+// ---------------------------------------------------------------------------
+describe("isInsideBase", () => {
+  it("returns true when path equals base (===  branch)", () => {
+    expect(isInsideBase("/a/b", "/a/b")).toBe(true);
+  });
+
+  it("returns true when path is inside base via POSIX separator", () => {
+    expect(isInsideBase("/a/b/x.png", "/a/b")).toBe(true);
+  });
+
+  it("returns true when path is inside base via Windows separator", () => {
+    expect(isInsideBase("C:\\a\\b\\x.png", "C:\\a\\b")).toBe(true);
+  });
+
+  it("returns false for sibling directory whose name shares the base prefix", () => {
+    expect(isInsideBase("/a/b-evil/x.png", "/a/b")).toBe(false);
+    expect(isInsideBase("C:\\a\\b-evil\\x.png", "C:\\a\\b")).toBe(false);
+  });
+
+  it("returns false for completely unrelated paths", () => {
+    expect(isInsideBase("/c/d", "/a/b")).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/export/resourceResolver.test.ts
+++ b/src/export/resourceResolver.test.ts
@@ -345,6 +345,59 @@ describe("resolveRelativePath", () => {
     expect(result).toBe("/Users/test/docs/photo.png");
   });
 
+  // ------------------------------------------------------------------
+  // Sibling-directory prefix-confusion: /a/b-evil must not match /a/b
+  // ------------------------------------------------------------------
+  describe("sibling-directory prefix confusion", () => {
+    it("absolute branch: blocks sibling directory whose name starts with baseDir", async () => {
+      const result = await resolveRelativePath("/a/b-evil/x.png", "/a/b");
+      expect(result).toBeNull();
+    });
+
+    it("absolute branch: allows file inside baseDir", async () => {
+      const result = await resolveRelativePath("/a/b/x.png", "/a/b");
+      expect(result).toBe("/a/b/x.png");
+    });
+
+    it("absolute branch: allows the baseDir itself", async () => {
+      const result = await resolveRelativePath("/a/b", "/a/b");
+      expect(result).toBe("/a/b");
+    });
+
+    it("relative branch: blocks `../b-evil/x.png` from /a/b", async () => {
+      const result = await resolveRelativePath("../b-evil/x.png", "/a/b");
+      expect(result).toBeNull();
+    });
+
+    it("relative branch: allows file resolved into baseDir", async () => {
+      const result = await resolveRelativePath("./x.png", "/a/b");
+      expect(result).toBe("/a/b/x.png");
+    });
+
+    it("relative branch: allows `.` resolving to baseDir itself", async () => {
+      const result = await resolveRelativePath(".", "/a/b");
+      expect(result).toBe("/a/b");
+    });
+
+    it("asset-URL branch: blocks sibling directory via asset:// scheme", async () => {
+      const src = `asset://localhost/${encodeURIComponent("/a/b-evil/x.png")}`;
+      const result = await resolveRelativePath(src, "/a/b");
+      expect(result).toBeNull();
+    });
+
+    it("asset-URL branch: allows file inside baseDir via asset:// scheme", async () => {
+      const src = `asset://localhost/${encodeURIComponent("/a/b/x.png")}`;
+      const result = await resolveRelativePath(src, "/a/b");
+      expect(result).toBe("/a/b/x.png");
+    });
+
+    it("asset-URL branch: allows the baseDir itself via asset:// scheme", async () => {
+      const src = `asset://localhost/${encodeURIComponent("/a/b")}`;
+      const result = await resolveRelativePath(src, "/a/b");
+      expect(result).toBe("/a/b");
+    });
+  });
+
 });
 
 // ---------------------------------------------------------------------------

--- a/src/export/resourceResolver.ts
+++ b/src/export/resourceResolver.ts
@@ -51,17 +51,15 @@ export interface ResolveOptions {
 /**
  * Check that `normalizedPath` is `normalizedBase` or sits under it, with a
  * separator boundary so a sibling directory like `/a/b-evil` cannot pass a
- * `/a/b` baseDir check via plain `startsWith`.
+ * `/a/b` baseDir check via plain `startsWith`. Tries both POSIX and Windows
+ * separators because Tauri's `normalize()` returns platform-native paths.
  */
-function isInsideBase(normalizedPath: string, normalizedBase: string): boolean {
+export function isInsideBase(normalizedPath: string, normalizedBase: string): boolean {
   if (normalizedPath === normalizedBase) return true;
-  // Use both POSIX and Windows separators since `normalize()` returns
-  // platform-native paths.
-  const sep = normalizedBase.includes("\\") ? "\\" : "/";
-  const baseWithSep = normalizedBase.endsWith(sep)
-    ? normalizedBase
-    : normalizedBase + sep;
-  return normalizedPath.startsWith(baseWithSep);
+  return (
+    normalizedPath.startsWith(normalizedBase + "/") ||
+    normalizedPath.startsWith(normalizedBase + "\\")
+  );
 }
 
 /**

--- a/src/export/resourceResolver.ts
+++ b/src/export/resourceResolver.ts
@@ -49,6 +49,22 @@ export interface ResolveOptions {
 }
 
 /**
+ * Check that `normalizedPath` is `normalizedBase` or sits under it, with a
+ * separator boundary so a sibling directory like `/a/b-evil` cannot pass a
+ * `/a/b` baseDir check via plain `startsWith`.
+ */
+function isInsideBase(normalizedPath: string, normalizedBase: string): boolean {
+  if (normalizedPath === normalizedBase) return true;
+  // Use both POSIX and Windows separators since `normalize()` returns
+  // platform-native paths.
+  const sep = normalizedBase.includes("\\") ? "\\" : "/";
+  const baseWithSep = normalizedBase.endsWith(sep)
+    ? normalizedBase
+    : normalizedBase + sep;
+  return normalizedPath.startsWith(baseWithSep);
+}
+
+/**
  * Check if a URL is remote (http/https).
  */
 export function isRemoteUrl(src: string): boolean {
@@ -109,7 +125,7 @@ export async function resolveRelativePath(
   if (src.startsWith("/")) {
     const normalizedPath = await normalize(src);
     const normalizedBase = await normalize(baseDir);
-    if (!normalizedPath.startsWith(normalizedBase)) {
+    if (!isInsideBase(normalizedPath, normalizedBase)) {
       exportWarn(`Absolute path traversal blocked: ${src}`);
       return null;
     }
@@ -132,7 +148,7 @@ export async function resolveRelativePath(
       const extractedPath = decodeURIComponent(url.pathname.slice(1));
       const normalizedPath = await normalize(extractedPath);
       const normalizedBase = await normalize(baseDir);
-      if (!normalizedPath.startsWith(normalizedBase)) {
+      if (!isInsideBase(normalizedPath, normalizedBase)) {
         exportWarn(`Asset URL path traversal blocked: ${src}`);
         return null;
       }
@@ -154,7 +170,7 @@ export async function resolveRelativePath(
   const normalizedBase = await normalize(baseDir);
 
   // Block path traversal: resolved path must stay within baseDir
-  if (!normalizedPath.startsWith(normalizedBase)) {
+  if (!isInsideBase(normalizedPath, normalizedBase)) {
     exportWarn(`Path traversal blocked: ${src}`);
     return null;
   }


### PR DESCRIPTION
Closes #882

## Summary
- Adds an `isInsideBase()` helper that requires `normalizedPath` to equal `normalizedBase` or to start with `normalizedBase + separator`.
- Replaces all three plain-`startsWith` checks in `resolveRelativePath` (absolute, asset URL, relative) with the helper, closing the prefix-confusion gap where `/a/b-evil/x.png` passed a `/a/b` baseDir check.
- Adds regression tests covering sibling-directory, inside-baseDir, and baseDir-equals-path cases on all three branches.

## Test plan
- [x] `pnpm test src/export/resourceResolver.test.ts` (96 passed, including 9 new sibling-directory cases)
- [x] `grep -n 'startsWith(normalizedBase)' src/export/resourceResolver.ts` returns no matches