### PR TITLE
fix(export): substitute placeholder for traversal-blocked images

### DIFF
--- a/src/export/resourceResolver.test.ts
+++ b/src/export/resourceResolver.test.ts
@@ -755,12 +755,33 @@ describe("resolveResources", () => {
     expect(mockCopyFile).not.toHaveBeenCalled();
   });
 
+  it("substitutes placeholder for traversal-blocked asset:// images in exported HTML", async () => {
+    // asset://localhost URLs that resolve outside baseDir must not survive into
+    // exported HTML — they have no meaning outside VMark and render broken.
+    const evilSrc = `asset://localhost/${encodeURIComponent("/etc/passwd")}`;
+    const html = `<img src="${evilSrc}">`;
+
+    const { html: result, report } = await resolveResources(html, {
+      baseDir: "/Users/test/docs",
+      mode: "single",
+    });
+
+    expect(report.missing).toHaveLength(1);
+    expect(report.resolved).toHaveLength(0);
+    // Original asset:// URL must be gone from exported HTML
+    expect(result).not.toContain("asset://localhost");
+    expect(result).not.toContain(evilSrc);
+    // Placeholder must be present
+    expect(result).toContain("data:image/svg+xml");
+    expect(result).toContain("Image not found");
+  });
+
   it("blocks symlinks to prevent traversal", async () => {
     const html = '<img src="evil.png">';
     mockExists.mockResolvedValue(true);
     mockLstat.mockResolvedValue({ isSymlink: true });
 
-    const { report } = await resolveResources(html, {
+    const { html: result, report } = await resolveResources(html, {
       baseDir: "/docs",
       mode: "single",
     });
@@ -768,6 +789,11 @@ describe("resolveResources", () => {
     expect(report.missing).toHaveLength(1);
     expect(report.resolved).toHaveLength(0);
     expect(mockReadFile).not.toHaveBeenCalled();
+    // Symlink-blocked images must be replaced with the placeholder so the
+    // exported HTML doesn't carry an unresolvable internal src.
+    expect(result).not.toContain('src="evil.png"');
+    expect(result).toContain("data:image/svg+xml");
+    expect(result).toContain("Image not found");
   });
 
   it("blocks symlinks in folder mode without copying", async () => {

--- a/src/export/resourceResolver.ts
+++ b/src/export/resourceResolver.ts
@@ -38,6 +38,14 @@ export interface ResourceReport {
   totalSize: number;
 }
 
+/** SVG placeholder used when an image cannot be embedded (missing, traversal-blocked, symlink, or unreadable). */
+const MISSING_IMAGE_PLACEHOLDER =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='150' viewBox='0 0 200 150'%3E%3Crect fill='%23f0f0f0' width='200' height='150'/%3E%3Ctext x='100' y='75' text-anchor='middle' fill='%23999' font-family='sans-serif' font-size='14'%3EImage not found%3C/text%3E%3C/svg%3E";
+
+/** SVG placeholder used in folder mode when the source file exists but copy fails. */
+const COPY_FAIL_PLACEHOLDER =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='150' viewBox='0 0 200 150'%3E%3Crect fill='%23f0f0f0' width='200' height='150'/%3E%3Ctext x='100' y='75' text-anchor='middle' fill='%23999' font-family='sans-serif' font-size='14'%3ECopy failed%3C/text%3E%3C/svg%3E";
+
 /** Options for resource resolution during export. */
 export interface ResolveOptions {
   /** Base directory for resolving relative paths (usually document directory) */
@@ -270,9 +278,13 @@ export async function resolveResources(
     try {
       const resolvedPath = await resolveRelativePath(src, baseDir);
 
-      // Path traversal blocked — treat as missing
+      // Path traversal blocked — treat as missing.
+      // Substitute the placeholder so the exported HTML doesn't carry the
+      // original asset://localhost URL (broken outside VMark).
       if (resolvedPath === null) {
         info.found = false;
+        info.exportSrc = MISSING_IMAGE_PLACEHOLDER;
+        modifiedHtml = modifiedHtml.split(src).join(MISSING_IMAGE_PLACEHOLDER);
         resources.push(info);
         missing.push(info);
         continue;
@@ -286,9 +298,8 @@ export async function resolveResources(
         info.found = false;
         // Replace broken asset:// URLs with a transparent placeholder
         // This prevents browser errors from trying to load Tauri-specific URLs
-        const placeholderDataUri = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='150' viewBox='0 0 200 150'%3E%3Crect fill='%23f0f0f0' width='200' height='150'/%3E%3Ctext x='100' y='75' text-anchor='middle' fill='%23999' font-family='sans-serif' font-size='14'%3EImage not found%3C/text%3E%3C/svg%3E";
-        info.exportSrc = placeholderDataUri;
-        modifiedHtml = modifiedHtml.split(src).join(placeholderDataUri);
+        info.exportSrc = MISSING_IMAGE_PLACEHOLDER;
+        modifiedHtml = modifiedHtml.split(src).join(MISSING_IMAGE_PLACEHOLDER);
         resources.push(info);
         missing.push(info);
         continue;
@@ -300,6 +311,8 @@ export async function resolveResources(
         if (fileStat.isSymlink) {
           exportWarn(`Symlink traversal blocked: ${src}`);
           info.found = false;
+          info.exportSrc = MISSING_IMAGE_PLACEHOLDER;
+          modifiedHtml = modifiedHtml.split(src).join(MISSING_IMAGE_PLACEHOLDER);
           resources.push(info);
           missing.push(info);
           continue;
@@ -307,6 +320,8 @@ export async function resolveResources(
       } catch {
         // lstat failure — treat as inaccessible
         info.found = false;
+        info.exportSrc = MISSING_IMAGE_PLACEHOLDER;
+        modifiedHtml = modifiedHtml.split(src).join(MISSING_IMAGE_PLACEHOLDER);
         resources.push(info);
         missing.push(info);
         continue;
@@ -349,9 +364,8 @@ export async function resolveResources(
           exportWarn(`Failed to copy ${resolvedPath}:`, e);
           info.found = false;
           // Replace with placeholder to avoid broken Tauri-internal URLs in exported HTML
-          const copyFailPlaceholder = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='150' viewBox='0 0 200 150'%3E%3Crect fill='%23f0f0f0' width='200' height='150'/%3E%3Ctext x='100' y='75' text-anchor='middle' fill='%23999' font-family='sans-serif' font-size='14'%3ECopy failed%3C/text%3E%3C/svg%3E";
-          info.exportSrc = copyFailPlaceholder;
-          modifiedHtml = modifiedHtml.split(src).join(copyFailPlaceholder);
+          info.exportSrc = COPY_FAIL_PLACEHOLDER;
+          modifiedHtml = modifiedHtml.split(src).join(COPY_FAIL_PLACEHOLDER);
         }
 
         // Use stat() to get size without re-reading the file


### PR DESCRIPTION
Closes #885

## Summary
- Path-traversal and symlink-blocked images now get the same SVG placeholder substitution as the not-found / copy-fail branches in `resolveResources`. Previously the original `asset://localhost/...` (or absolute) `src` was retained in exported HTML and rendered broken outside VMark.
- Extracted the inline placeholder data URIs into module-level constants (`MISSING_IMAGE_PLACEHOLDER`, `COPY_FAIL_PLACEHOLDER`) so all four failure sites stay consistent.
- No change to the blocking logic or `missing` reporting.

## Test plan
- [x] Added unit tests in `src/export/resourceResolver.test.ts`:
  - traversal-blocked `asset://` image -> placeholder, original src absent
  - symlink-blocked image -> placeholder, original src absent
- [x] `pnpm test src/export/resourceResolver.test.ts` (88 tests pass)
- [x] `pnpm lint`, `pnpm build` pass