### PR TITLE
fix: resolve 11 audit issues + repair audit-fix pipeline

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -108,16 +108,21 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.PAT_TOKEN }}
 
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: pnpm
 
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: ./.github/actions/setup-tauri-deps
 
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Fix issue #${{ matrix.issue }}
         id: fix

--- a/src-tauri/src/hot_exit/coordinator.rs
+++ b/src-tauri/src/hot_exit/coordinator.rs
@@ -514,15 +514,29 @@ pub fn restore_session_multi_window(
             }
             Err(e) => {
                 log::error!(
-                    "[HotExit] Failed to create window {}: {}",
+                    "[HotExit] Failed to create window {} — aborting restore to preserve session: {}",
                     label, e
                 );
-                // Remove from expected_labels so other windows can complete restore
-                // without being blocked by a window that was never created.
+                // Abort the whole restore rather than silently dropping this
+                // window's tabs (including any dirty in-memory documents).
+                // Clear the pending state (advance_and_clear bumps the
+                // generation, invalidating the stale timeout task) and close any
+                // already-created windows. Returning Err makes the frontend
+                // invoke throw, so session.json is NOT cleared and the full
+                // session is retried on the next launch (#968).
                 let pending = get_pending_restore_state();
                 let mut state = lock_pending_restore(&pending);
-                state.expected_labels.remove(label);
-                state.window_states.remove(label);
+                state.advance_and_clear();
+                drop(state);
+                for created in &windows_created {
+                    if let Some(w) = app.get_webview_window(created) {
+                        let _ = w.close();
+                    }
+                }
+                return Err(format!(
+                    "Failed to create window {} during multi-window restore: {}",
+                    label, e
+                ));
             }
         }
     }

--- a/src/hooks/lifecycle/MainWindowRunners.tsx
+++ b/src/hooks/lifecycle/MainWindowRunners.tsx
@@ -24,6 +24,7 @@ import { useMcpAutoStart } from "@/hooks/useMcpAutoStart";
 import { useUpdateChecker } from "@/hooks/useUpdateChecker";
 import { useUpdateBroadcast, useUpdateListener } from "@/hooks/useUpdateSync";
 import { useResilienceStartup } from "@/services/persistence/resilience";
+import { useHotExitCaptureWarning } from "@/services/persistence/hotExit/useHotExitCaptureWarning";
 import { useFinderFileOpen } from "@/hooks/useFinderFileOpen";
 import { useGenieShortcuts } from "@/hooks/useGenieShortcuts";
 import { useQuickOpenShortcuts } from "@/hooks/useQuickOpenShortcuts";
@@ -39,6 +40,8 @@ function MainWindowLifecycle(): null {
   // crash-recovery scan). useResilienceStartup enforces the
   // hot-exit-before-crash-recovery order internally.
   useResilienceStartup();
+  // Warn the user if hot-exit capture dropped any window (#969).
+  useHotExitCaptureWarning();
   useFinderFileOpen();
   return null;
 }

--- a/src/lib/ghaWorkflow/types.ts
+++ b/src/lib/ghaWorkflow/types.ts
@@ -348,36 +348,3 @@ export interface Diagnostic {
    */
   context?: Record<string, string | number | boolean>;
 }
-
-// ─── Type guards ──────────────────────────────────────────────────────
-
-export function isPermissionsObject(
-  v: PermissionsValue,
-): v is PermissionsIR {
-  return typeof v === "object" && v !== null;
-}
-
-export function isPermissionsAlias(
-  v: PermissionsValue,
-): v is "read-all" | "write-all" | "none" {
-  return v === "read-all" || v === "write-all" || v === "none";
-}
-
-/** A job is a reusable-workflow call (has `uses:`) rather than a step list. */
-export function isReusableJob(
-  job: JobIR,
-): job is JobIR & { uses: string; steps: [] } {
-  return typeof job.uses === "string" && job.steps.length === 0;
-}
-
-/** A step is a `uses:` step (action invocation). */
-export function isUsesStep(
-  step: StepIR,
-): step is StepIR & { uses: string } {
-  return typeof step.uses === "string";
-}
-
-/** A step is a `run:` step (shell command). */
-export function isRunStep(step: StepIR): step is StepIR & { run: string } {
-  return typeof step.run === "string";
-}

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -1,4 +1,7 @@
 {
+  "hotExit.partialCapture.title": "Sitzung nicht vollständig gespeichert",
+  "hotExit.partialCapture.description": "Einige Fenster haben nicht rechtzeitig reagiert, daher wurden ihre ungespeicherten Änderungen nicht erfasst: {{windows}}. Speichern Sie diese Fenster manuell, bevor Sie das Programm beenden oder neu starten.",
+  "hotExit.partialCapture.unknownWindows": "ein oder mehrere Fenster",
   "save": "Speichern",
   "cancel": "Abbrechen",
   "ok": "OK",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,4 +1,7 @@
 {
+  "hotExit.partialCapture.title": "Session not fully saved",
+  "hotExit.partialCapture.description": "Some windows didn't respond in time, so their unsaved changes were not captured: {{windows}}. Save those windows manually before quitting or restarting.",
+  "hotExit.partialCapture.unknownWindows": "one or more windows",
   "save": "Save",
   "cancel": "Cancel",
   "ok": "OK",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -1,4 +1,7 @@
 {
+  "hotExit.partialCapture.title": "La sesión no se guardó por completo",
+  "hotExit.partialCapture.description": "Algunas ventanas no respondieron a tiempo, por lo que sus cambios sin guardar no se capturaron: {{windows}}. Guarda esas ventanas manualmente antes de salir o reiniciar.",
+  "hotExit.partialCapture.unknownWindows": "una o más ventanas",
   "save": "Guardar",
   "cancel": "Cancelar",
   "ok": "Aceptar",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -1,4 +1,7 @@
 {
+  "hotExit.partialCapture.title": "Session non entièrement enregistrée",
+  "hotExit.partialCapture.description": "Certaines fenêtres n'ont pas répondu à temps, leurs modifications non enregistrées n'ont donc pas été capturées : {{windows}}. Enregistrez ces fenêtres manuellement avant de quitter ou de redémarrer.",
+  "hotExit.partialCapture.unknownWindows": "une ou plusieurs fenêtres",
   "save": "Enregistrer",
   "cancel": "Annuler",
   "ok": "OK",

--- a/src/locales/it/common.json
+++ b/src/locales/it/common.json
@@ -1,4 +1,7 @@
 {
+  "hotExit.partialCapture.title": "Sessione non salvata completamente",
+  "hotExit.partialCapture.description": "Alcune finestre non hanno risposto in tempo, quindi le loro modifiche non salvate non sono state acquisite: {{windows}}. Salva manualmente quelle finestre prima di uscire o riavviare.",
+  "hotExit.partialCapture.unknownWindows": "una o più finestre",
   "save": "Salva",
   "cancel": "Annulla",
   "ok": "OK",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -1,4 +1,7 @@
 {
+  "hotExit.partialCapture.title": "セッションが完全に保存されませんでした",
+  "hotExit.partialCapture.description": "一部のウィンドウが時間内に応答しなかったため、未保存の変更が取得されませんでした: {{windows}}。終了または再起動する前に、それらのウィンドウを手動で保存してください。",
+  "hotExit.partialCapture.unknownWindows": "1 つ以上のウィンドウ",
   "save": "保存",
   "cancel": "キャンセル",
   "ok": "OK",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -1,4 +1,7 @@
 {
+  "hotExit.partialCapture.title": "세션이 완전히 저장되지 않았습니다",
+  "hotExit.partialCapture.description": "일부 창이 제때 응답하지 않아 저장되지 않은 변경 사항이 캡처되지 않았습니다: {{windows}}. 종료하거나 다시 시작하기 전에 해당 창을 수동으로 저장하세요.",
+  "hotExit.partialCapture.unknownWindows": "하나 이상의 창",
   "save": "저장",
   "cancel": "취소",
   "ok": "확인",

--- a/src/locales/pt-BR/common.json
+++ b/src/locales/pt-BR/common.json
@@ -1,4 +1,7 @@
 {
+  "hotExit.partialCapture.title": "Sessão não salva completamente",
+  "hotExit.partialCapture.description": "Algumas janelas não responderam a tempo, então suas alterações não salvas não foram capturadas: {{windows}}. Salve essas janelas manualmente antes de sair ou reiniciar.",
+  "hotExit.partialCapture.unknownWindows": "uma ou mais janelas",
   "save": "Salvar",
   "cancel": "Cancelar",
   "ok": "OK",

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -1,4 +1,7 @@
 {
+  "hotExit.partialCapture.title": "会话未完全保存",
+  "hotExit.partialCapture.description": "部分窗口未能及时响应，因此其未保存的更改未被捕获：{{windows}}。请在退出或重启前手动保存这些窗口。",
+  "hotExit.partialCapture.unknownWindows": "一个或多个窗口",
   "save": "保存",
   "cancel": "取消",
   "ok": "确定",

--- a/src/locales/zh-TW/common.json
+++ b/src/locales/zh-TW/common.json
@@ -1,4 +1,7 @@
 {
+  "hotExit.partialCapture.title": "工作階段未完整儲存",
+  "hotExit.partialCapture.description": "部分視窗未能及時回應，因此其未儲存的變更未被擷取：{{windows}}。請在結束或重新啟動前手動儲存這些視窗。",
+  "hotExit.partialCapture.unknownWindows": "一個或多個視窗",
   "save": "儲存",
   "cancel": "取消",
   "ok": "確定",

--- a/src/pages/settings/AdvancedSettings.tsx
+++ b/src/pages/settings/AdvancedSettings.tsx
@@ -11,6 +11,7 @@ import { imeToast as toast } from "@/services/ime/imeToast";
 import { SettingRow, SettingsGroup, Toggle, TagInput } from "./components";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { restartWithHotExit } from "@/services/persistence/hotExit/restartWithHotExit";
+import { restoreCommandFor } from "@/services/persistence/hotExit/restoreDispatch";
 import type { SessionData } from "@/services/persistence/hotExit/types";
 import { isMacPlatform } from "@/utils/shortcutMatch";
 
@@ -193,8 +194,11 @@ export function AdvancedSettings() {
                     t("advanced.hotExit.restoreFailed")
                   );
                   if (session) {
+                    // Match the auto-restore flow: a multi-window session must
+                    // use the multi-window command, or secondary windows are
+                    // silently dropped (#970).
                     const result = await withErrorHandling(
-                      () => invoke<void>("hot_exit_restore", { session }),
+                      () => invoke<void>(restoreCommandFor(session), { session }),
                       t("advanced.hotExit.restoreFailed")
                     );
                     if (result !== null) {

--- a/src/plugins/codemirror/sourceMermaidPreview.test.ts
+++ b/src/plugins/codemirror/sourceMermaidPreview.test.ts
@@ -424,6 +424,39 @@ describe("sourceMermaidPreview", () => {
       // This test just verifies no crash
       expect(true).toBe(true);
     });
+
+    it("shows preview for a mermaid block that follows a plain code block (#964)", async () => {
+      mockIsVisible.mockReturnValue(false); // fresh preview → show() path
+      coordsSpy.mockReturnValue({ top: 100, left: 50, bottom: 120, right: 200 });
+      const content = "```\nplain code\n```\n```mermaid\ngraph TD\n```";
+      const pos = content.indexOf("graph TD");
+      const view = tracked(content, pos);
+      await flushRaf();
+
+      expect(mockShow).toHaveBeenCalledWith(
+        expect.stringContaining("graph TD"),
+        expect.any(Object),
+        view.dom,
+        "mermaid",
+      );
+    });
+
+    it("shows preview for a ~~~mermaid block whose content contains ``` lines (#964)", async () => {
+      mockIsVisible.mockReturnValue(false); // fresh preview → show() path
+      coordsSpy.mockReturnValue({ top: 100, left: 50, bottom: 120, right: 200 });
+      // The inner ``` lines are content of the tilde fence, not closing fences.
+      const content = "~~~mermaid\n```\nnot a real close\n```\ngraph TD\n~~~";
+      const pos = content.indexOf("graph TD");
+      const view = tracked(content, pos);
+      await flushRaf();
+
+      expect(mockShow).toHaveBeenCalledWith(
+        expect.stringContaining("graph TD"),
+        expect.any(Object),
+        view.dom,
+        "mermaid",
+      );
+    });
   });
 
   describe("update plugin method — selectionSet / docChanged branches (lines 145–148)", () => {

--- a/src/plugins/codemirror/sourceMermaidPreview.ts
+++ b/src/plugins/codemirror/sourceMermaidPreview.ts
@@ -37,90 +37,91 @@ function findDiagramBlockAtCursor(
   pos: number
 ): DiagramBlock | null {
   const doc = view.state.doc;
-  const currentLine = doc.lineAt(pos);
+  const cursorLineNum = doc.lineAt(pos).number;
 
-  // Scan upward to find the opening code fence.
-  // Must pair fences correctly: skip closing fences that belong to
-  // inner blocks so we don't misidentify a close as an open (#277).
-  let fenceStart: { line: number; from: number } | null = null;
-  let language = "";
-  let fenceChar = "";
-  let closeFencesSkipped = 0;
+  // Forward pass from line 1, pairing fences by document order rather than by
+  // "has a language" — a plain ``` opener is indistinguishable from a close by
+  // that heuristic (#964). A fence closes the current block only when it uses
+  // the same character, is at least as long, and carries no info string
+  // (CommonMark); otherwise it is content. This correctly handles a block of
+  // one delimiter that contains lines of the other (e.g. ``` lines inside a
+  // ~~~mermaid block) and nested/sibling blocks (#277, #278).
+  let open: {
+    line: number;
+    from: number;
+    char: string;
+    len: number;
+    language: string;
+  } | null = null;
+  let block: {
+    fromLine: number;
+    from: number;
+    toLine: number;
+    to: number;
+    language: string;
+  } | null = null;
 
-  for (let i = currentLine.number; i >= 1; i--) {
+  for (let i = 1; i <= doc.lines; i++) {
     const line = doc.line(i);
-    const text = line.text.trimStart();
+    const match = line.text.trimStart().match(/^(`{3,}|~{3,})(.*)$/);
+    if (!match) continue;
 
-    const fenceMatch = text.match(/^(`{3,}|~{3,})(\w*)/);
-    if (fenceMatch) {
-      const hasLang = fenceMatch[2].length > 0;
-      const isCloseOnly = !hasLang && /^(`{3,}|~{3,})\s*$/.test(text);
+    const fence = match[1];
+    const rest = match[2].trim();
 
-      if (isCloseOnly) {
-        // This is a closing fence for a block above — skip it and its pair
-        closeFencesSkipped++;
-      } else if (closeFencesSkipped > 0) {
-        // This opening fence pairs with a skipped closing fence
-        closeFencesSkipped--;
-      } else {
-        // Found our opening fence
-        fenceStart = { line: i, from: line.from };
-        language = fenceMatch[2].toLowerCase();
-        fenceChar = fenceMatch[1][0]; // "`" or "~"
-        break;
-      }
+    if (!open) {
+      // Opening fence — capture delimiter run and info-string language.
+      open = {
+        line: i,
+        from: line.from,
+        char: fence[0],
+        len: fence.length,
+        /* v8 ignore next -- @preserve null-coalesce: the word-char match always succeeds */
+        language: (rest.match(/^\w*/)?.[0] ?? "").toLowerCase(),
+      };
+      continue;
     }
-  }
 
-  if (!fenceStart || !DIAGRAM_LANGUAGES.has(language)) {
-    return null;
-  }
+    // Inside a fence: a valid close needs the same char, >= length, no info.
+    const isClose =
+      fence[0] === open.char && fence.length >= open.len && rest === "";
+    if (!isClose) continue; // content line within the open fence
 
-  // Scan downward to find code fence end.
-  // Only accept a closing fence that uses the same character as the
-  // opening fence, per CommonMark spec (#278).
-  let fenceEnd: { line: number; to: number } | null = null;
-  const closingRegex = new RegExp(`^${fenceChar === "`" ? "`" : "~"}{3,}\\s*$`);
-
-  for (let i = currentLine.number; i <= doc.lines; i++) {
-    const line = doc.line(i);
-    const text = line.text.trimStart();
-
-    // Skip the opening fence line
-    if (i === fenceStart.line) continue;
-
-    // Check for closing fence of the same type
-    if (closingRegex.test(text)) {
-      fenceEnd = { line: i, to: line.to };
+    if (cursorLineNum >= open.line && cursorLineNum <= i) {
+      block = {
+        fromLine: open.line,
+        from: open.from,
+        toLine: i,
+        to: line.to,
+        language: open.language,
+      };
       break;
     }
+    open = null;
   }
 
-  // If no closing fence, treat as incomplete block
-  if (!fenceEnd) {
+  // No enclosing (closed) fence, or not a diagram language → no preview.
+  if (!block || !DIAGRAM_LANGUAGES.has(block.language)) {
     return null;
   }
 
-  // Verify cursor is actually inside the block (not on fence lines)
-  if (currentLine.number <= fenceStart.line || currentLine.number >= fenceEnd.line) {
-    // Cursor is on fence line - still show preview if within range
-    /* v8 ignore next -- @preserve Defensive guard: pos is always within [fenceStart.from, fenceEnd.to] when the cursor is on a fence line; the out-of-range case requires a cursor position that cannot exist on those lines */
-    if (pos < fenceStart.from || pos > fenceEnd.to) {
-      return null;
-    }
+  // Cursor on a fence line still previews as long as pos is within the block.
+  /* v8 ignore next -- @preserve Defensive guard: pos is always within [block.from, block.to] when cursorLineNum is inside the block range */
+  if (pos < block.from || pos > block.to) {
+    return null;
   }
 
-  // Extract content (lines between fences)
-  const contentStart = doc.line(fenceStart.line + 1).from;
-  const contentEnd = doc.line(fenceEnd.line - 1).to;
+  // Extract content (lines strictly between the fences).
+  const contentStart = doc.line(block.fromLine + 1).from;
+  const contentEnd = doc.line(block.toLine - 1).to;
 
   if (contentStart > contentEnd) {
     // Empty block
-    return { from: fenceStart.from, to: fenceEnd.to, content: "", language };
+    return { from: block.from, to: block.to, content: "", language: block.language };
   }
 
   const content = doc.sliceString(contentStart, contentEnd);
-  return { from: fenceStart.from, to: fenceEnd.to, content, language };
+  return { from: block.from, to: block.to, content, language: block.language };
 }
 
 class SourceDiagramPreviewPlugin {

--- a/src/plugins/codemirror/sourceSelectOccurrence.test.ts
+++ b/src/plugins/codemirror/sourceSelectOccurrence.test.ts
@@ -111,6 +111,35 @@ describe("selectNextOccurrenceSource", () => {
     }
   });
 
+  it("does not select across tilde (~~~) fence boundaries (#963)", () => {
+    const text = "hello\n~~~\nhello inside fence\n~~~\nhello after";
+    // Select "hello" at 0-5 (before the tilde fence)
+    const state = createState(text, 0, 5);
+    const result = selectNextOccurrenceSource(state);
+    expect(result).not.toBeNull();
+    if (!result) return;
+    const positions = result.selection.ranges.map((r) => ({ from: r.from, to: r.to }));
+    expect(positions).toContainEqual({ from: 0, to: 5 });
+    // The "hello" inside the tilde fence (at offset 10) must be skipped.
+    expect(positions.find((p) => p.from === 10)).toBeUndefined();
+  });
+
+  it("select-all stays within a tilde (~~~) fence when cursor is inside it (#963)", () => {
+    const text = "hello outside\n~~~\nhello inside hello\n~~~\nhello after";
+    // Cursor inside the fence on first "hello" (18-23)
+    const state = createState(text, 18, 23);
+    const result = selectAllOccurrencesSource(state);
+    expect(result).not.toBeNull();
+    if (!result) return;
+    const ranges = result.selection.ranges;
+    // Only the two in-fence "hello" matches, not the outside ones.
+    expect(ranges).toHaveLength(2);
+    for (const r of ranges) {
+      expect(r.from).toBeGreaterThanOrEqual(18);
+      expect(r.to).toBeLessThanOrEqual(36);
+    }
+  });
+
   it("adds next occurrence when called repeatedly", () => {
     // Simulate: user presses Cmd+D on "foo" → selects word → presses Cmd+D again
     const text = "foo bar foo baz foo";

--- a/src/plugins/codemirror/sourceSelectOccurrence.ts
+++ b/src/plugins/codemirror/sourceSelectOccurrence.ts
@@ -17,7 +17,10 @@ import type { EditorState, TransactionSpec } from "@codemirror/state";
 import { EditorSelection } from "@codemirror/state";
 import { findWordBoundaries } from "@/utils/wordSegmentation";
 
-const FENCE_OPEN_PATTERN = /^(\s*)(```+)(\w*)?/;
+// Matches a fenced-code opener: 3+ backticks OR 3+ tildes (CommonMark), with
+// an optional info string. Group 2 captures the delimiter run so the matching
+// close can require the same delimiter character.
+const FENCE_OPEN_PATTERN = /^(\s*)(`{3,}|~{3,})(\w*)?/;
 
 /* ------------------------------------------------------------------ */
 /*  Code fence boundary detection (position-based, no EditorView)     */
@@ -41,6 +44,7 @@ function getCodeFenceBounds(state: EditorState, pos: number): FenceBounds | null
   // Search backwards for opening fence
   let openLineNum: number | null = null;
   let fenceLength = 0;
+  let fenceChar = "`";
 
   for (let lineNum = cursorLine.number; lineNum >= 1; lineNum--) {
     const line = doc.line(lineNum);
@@ -48,6 +52,7 @@ function getCodeFenceBounds(state: EditorState, pos: number): FenceBounds | null
     if (match) {
       openLineNum = lineNum;
       fenceLength = match[2].length;
+      fenceChar = match[2][0];
       break;
     }
   }
@@ -66,8 +71,9 @@ function getCodeFenceBounds(state: EditorState, pos: number): FenceBounds | null
   // If cursor is on the opening line itself, it's not "inside" the fence
   if (cursorLine.number === openLineNum) return null;
 
-  // Search forwards for closing fence
-  const closePattern = new RegExp(`^\\s*\`{${fenceLength},}\\s*$`);
+  // Search forwards for closing fence — must use the SAME delimiter character
+  // as the opener (a tilde fence cannot be closed by a backtick line).
+  const closePattern = new RegExp(`^\\s*${fenceChar}{${fenceLength},}\\s*$`);
   for (let lineNum = openLineNum + 1; lineNum <= doc.lines; lineNum++) {
     const line = doc.line(lineNum);
     if (closePattern.test(line.text)) {

--- a/src/plugins/codemirror/sourceTableCellHighlight.test.ts
+++ b/src/plugins/codemirror/sourceTableCellHighlight.test.ts
@@ -28,6 +28,18 @@ vi.mock("@/plugins/sourceContextDetection/tableDetection", () => ({
 }));
 
 vi.mock("@/utils/tableParser", () => ({
+  // Backslash-parity check — mirrors the real helper. An even run of `\` before
+  // the trailing `|` (including zero) ⇒ real delimiter.
+  endsWithDelimiterPipe: (content: string) => {
+    if (!content.endsWith("|")) return false;
+    let run = 0;
+    let i = content.length - 2;
+    while (i >= 0 && content[i] === "\\") {
+      run++;
+      i--;
+    }
+    return run % 2 === 0;
+  },
   splitTableCells: (content: string) => {
     // Simple split on unescaped pipe — mirrors the real logic for test purposes
     const cells: string[] = [];
@@ -252,6 +264,43 @@ describe("sourceTableCellHighlight", () => {
       view.dispatch({ selection: { anchor: 3 } });
       const specs = getDecorationSpecs(view);
       expect(specs.length).toBe(1);
+    });
+  });
+
+  // Exercises both branches of the trailing-delimiter strip (endsWithDelimiterPipe):
+  // a real delimiter after a literal backslash (strip) vs an escaped pipe (no strip).
+  describe("escaped/real trailing pipe (#962)", () => {
+    const info = (lines: string[], colIndex: number) => ({
+      start: 0,
+      end: 80,
+      startLine: 0,
+      endLine: 0,
+      rowIndex: 0,
+      colIndex,
+      colCount: 2,
+      lines,
+    });
+
+    it("strips a real delimiter pipe even when the last cell ends with a literal backslash", () => {
+      // Row: | a | b \\|  → cell 1 is " b \\" (b + literal backslash), trailing delimiter.
+      const content = "| a | b \\\\|";
+      mockGetSourceTableInfo.mockReturnValue(info([content], 1));
+      const view = tracked(content, 6);
+      const specs = getDecorationSpecs(view);
+      expect(specs).toHaveLength(1);
+      // Highlight covers " b \\" and stops before the trailing delimiter pipe.
+      expect(content.slice(specs[0].from, specs[0].to)).toBe(" b \\\\");
+      expect(content[specs[0].to]).toBe("|");
+    });
+
+    it("keeps an escaped pipe inside the last cell (no strip)", () => {
+      // Row: | a | b \|  → cell 1 is " b \|" (escaped pipe is cell content, no trailing delimiter).
+      const content = "| a | b \\|";
+      mockGetSourceTableInfo.mockReturnValue(info([content], 1));
+      const view = tracked(content, 6);
+      const specs = getDecorationSpecs(view);
+      expect(specs).toHaveLength(1);
+      expect(content.slice(specs[0].from, specs[0].to)).toBe(" b \\|");
     });
   });
 });

--- a/src/plugins/codemirror/sourceTableCellHighlight.ts
+++ b/src/plugins/codemirror/sourceTableCellHighlight.ts
@@ -18,7 +18,7 @@ import {
   type ViewUpdate,
 } from "@codemirror/view";
 import { getSourceTableInfo } from "@/plugins/sourceContextDetection/tableDetection";
-import { splitTableCells } from "@/utils/tableParser";
+import { splitTableCells, endsWithDelimiterPipe } from "@/utils/tableParser";
 
 /**
  * Get the character range of the current cell within the table row.
@@ -42,10 +42,12 @@ function getCellRange(
     offset += 1;
   }
 
-  // Normalize trailing whitespace then strip trailing pipe
+  // Normalize trailing whitespace then strip a real (non-escaped) trailing
+  // delimiter pipe. Uses backslash-parity (endsWithDelimiterPipe) rather than a
+  // naive `\\|` check so a literal backslash before a real delimiter (`\\|`) is
+  // not misread as an escaped pipe.
   content = content.trimEnd();
-  /* v8 ignore next -- @preserve else path: table row always ends with pipe in tests */
-  if (content.endsWith("|") && !content.endsWith("\\|")) {
+  if (endsWithDelimiterPipe(content)) {
     content = content.slice(0, -1);
   }
 

--- a/src/plugins/codemirror/tabIndent.test.ts
+++ b/src/plugins/codemirror/tabIndent.test.ts
@@ -210,4 +210,12 @@ describe("shiftTabIndentFallbackKeymap", () => {
     // leadingSpaces = 4, removes 4
     expect(view.state.doc.toString()).toBe("hello world");
   });
+
+  it("outdents once (no overlapping-change crash) with two cursors on one line (#961)", () => {
+    // Two cursors at different offsets on the same indented line.
+    const view = createMultiCursorView("        code", [8, 12]);
+    expect(() => shiftTabIndentFallbackKeymap.run!(view)).not.toThrow();
+    // A single outdent of tabSize (4) — not two stacked removals.
+    expect(view.state.doc.toString()).toBe("    code");
+  });
 });

--- a/src/plugins/codemirror/tabIndent.ts
+++ b/src/plugins/codemirror/tabIndent.ts
@@ -9,7 +9,9 @@
  *   - Uses tabSize from settings for consistent indentation
  *   - Shift+Tab removes up to tabSize spaces from the line start
  *   - Lower priority than tabEscape and listSmartIndent in the keymap chain
- *   - Handles all selection ranges for multi-cursor support
+ *   - Handles all selection ranges for multi-cursor support; Shift+Tab dedupes
+ *     by line so multiple cursors on one line produce a single outdent change
+ *     (no overlapping changes)
  *
  * @coordinates-with tabEscape.ts — higher-priority Tab handler for bracket/link escape
  * @coordinates-with listSmartIndent.ts — higher-priority Tab handler for list items
@@ -74,8 +76,13 @@ export const shiftTabIndentFallbackKeymap: KeyBinding = guardCodeMirrorKeyBindin
   run: (view) => {
     const { state } = view;
     const tabSize = getTabSize();
-    const changes: ChangeSpec[] = [];
 
+    // Dedupe by line: multiple cursors on the same line must yield ONE outdent
+    // change, not one per cursor. Two changes anchored at the same line.from
+    // overlap; rather than rely on CodeMirror silently merging them, collapse
+    // them here and remove the widest amount any cursor on the line warrants
+    // (matching the union of the per-cursor removals).
+    const removalByLine = new Map<number, number>();
     for (const range of state.selection.ranges) {
       const line = state.doc.lineAt(range.from);
       const textBefore = state.doc.sliceString(line.from, range.from);
@@ -84,8 +91,15 @@ export const shiftTabIndentFallbackKeymap: KeyBinding = guardCodeMirrorKeyBindin
       if (leadingSpaces === 0) continue;
 
       const spacesToRemove = Math.min(leadingSpaces, tabSize);
-      changes.push({ from: line.from, to: line.from + spacesToRemove, insert: "" });
+      const prev = removalByLine.get(line.from) ?? 0;
+      if (spacesToRemove > prev) removalByLine.set(line.from, spacesToRemove);
     }
+
+    const changes: ChangeSpec[] = [...removalByLine].map(([from, count]) => ({
+      from,
+      to: from + count,
+      insert: "",
+    }));
 
     if (changes.length > 0) {
       view.dispatch({ changes, scrollIntoView: true });

--- a/src/services/persistence/hotExit/restartWithHotExit.ts
+++ b/src/services/persistence/hotExit/restartWithHotExit.ts
@@ -16,6 +16,7 @@ import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import type { SessionData } from './types';
 import { HOT_EXIT_EVENTS } from './types';
 import { migrateSession, canMigrate, needsMigration, SCHEMA_VERSION } from './schemaMigration';
+import { hasSecondaryWindows } from './restoreDispatch';
 import { restoreMainWindowState } from '../resilience/_hotExitRestore';
 import { hotExitLog, hotExitWarn, hotExitError } from '@/utils/debug';
 
@@ -136,11 +137,11 @@ export async function checkAndRestoreSession(
       migratedSession = migrateSession(session);
     }
 
-    const hasSecondaryWindows = migratedSession.windows.some(w => !w.is_main_window);
+    const hasSecondary = hasSecondaryWindows(migratedSession);
 
     hotExitLog('Found saved session:', {
       windows: migratedSession.windows.length,
-      hasSecondaryWindows,
+      hasSecondaryWindows: hasSecondary,
       timestamp: formatTimestamp(migratedSession.timestamp),
       version: migratedSession.vmark_version,
       schemaVersion: migratedSession.version,
@@ -153,7 +154,7 @@ export async function checkAndRestoreSession(
     try {
       // Use multi-window restore if session has secondary windows
       // Otherwise use legacy single-window restore
-      if (hasSecondaryWindows) {
+      if (hasSecondary) {
         const result = await invoke<{ windows_created: string[] }>(
           HOT_EXIT_COMMANDS.RESTORE_MULTI,
           { session: migratedSession }

--- a/src/services/persistence/hotExit/restoreDispatch.test.ts
+++ b/src/services/persistence/hotExit/restoreDispatch.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for hot-exit restore dispatch (#970).
+ *
+ * The manual "Test Restore" button previously always invoked the single-window
+ * command, silently dropping secondary windows. Both paths now derive the
+ * command from this shared helper.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  hasSecondaryWindows,
+  restoreCommandFor,
+  HOT_EXIT_RESTORE,
+  HOT_EXIT_RESTORE_MULTI,
+} from "./restoreDispatch";
+import type { SessionData, WindowState } from "./types";
+
+function win(is_main_window: boolean): WindowState {
+  // The dispatch helper only reads is_main_window; keep the fixture minimal.
+  return { is_main_window } as unknown as WindowState;
+}
+
+function session(windows: WindowState[]): SessionData {
+  return { windows } as unknown as SessionData;
+}
+
+describe("hasSecondaryWindows", () => {
+  it("is false for a single main-only window", () => {
+    expect(hasSecondaryWindows(session([win(true)]))).toBe(false);
+  });
+
+  it("is true when any non-main window exists", () => {
+    expect(hasSecondaryWindows(session([win(true), win(false)]))).toBe(true);
+  });
+
+  it("is true even when no window is flagged main", () => {
+    expect(hasSecondaryWindows(session([win(false), win(false)]))).toBe(true);
+  });
+
+  it("is false for an empty window list", () => {
+    expect(hasSecondaryWindows(session([]))).toBe(false);
+  });
+});
+
+describe("restoreCommandFor", () => {
+  it("uses the single-window command for a main-only session", () => {
+    expect(restoreCommandFor(session([win(true)]))).toBe(HOT_EXIT_RESTORE);
+  });
+
+  it("uses the multi-window command when secondary windows are present", () => {
+    expect(restoreCommandFor(session([win(true), win(false)]))).toBe(
+      HOT_EXIT_RESTORE_MULTI,
+    );
+  });
+});

--- a/src/services/persistence/hotExit/restoreDispatch.ts
+++ b/src/services/persistence/hotExit/restoreDispatch.ts
@@ -1,0 +1,33 @@
+/**
+ * Hot-exit restore dispatch
+ *
+ * Purpose: Single source of truth for choosing between single-window and
+ * multi-window restore. Both the automatic restart flow (restartWithHotExit)
+ * and the manual "Test Restore" button (AdvancedSettings) must use this so a
+ * multi-window session is never silently collapsed to its main window (#970).
+ *
+ * @module services/persistence/hotExit/restoreDispatch
+ */
+
+import type { SessionData } from "./types";
+
+/** Tauri command: restore only the main window from a session. */
+export const HOT_EXIT_RESTORE = "hot_exit_restore";
+/** Tauri command: restore the main window plus all secondary windows. */
+export const HOT_EXIT_RESTORE_MULTI = "hot_exit_restore_multi_window";
+
+/** True if the session contains any non-main (secondary) window. */
+export function hasSecondaryWindows(session: SessionData): boolean {
+  return session.windows.some((w) => !w.is_main_window);
+}
+
+/**
+ * The restore command that matches the session's window topology: the
+ * multi-window command when secondary windows are present, otherwise the
+ * single-window command.
+ */
+export function restoreCommandFor(
+  session: SessionData,
+): typeof HOT_EXIT_RESTORE | typeof HOT_EXIT_RESTORE_MULTI {
+  return hasSecondaryWindows(session) ? HOT_EXIT_RESTORE_MULTI : HOT_EXIT_RESTORE;
+}

--- a/src/services/persistence/hotExit/types.ts
+++ b/src/services/persistence/hotExit/types.ts
@@ -169,6 +169,7 @@ export const HOT_EXIT_EVENTS = {
   CAPTURE_REQUEST: 'hot-exit:capture-request',
   CAPTURE_RESPONSE: 'hot-exit:capture-response',
   CAPTURE_TIMEOUT: 'hot-exit:capture-timeout',
+  PARTIAL_CAPTURE: 'hot-exit:partial-capture',
   RESTORE_START: 'hot-exit:restore-start',
   RESTORE_COMPLETE: 'hot-exit:restore-complete',
   RESTORE_FAILED: 'hot-exit:restore-failed',

--- a/src/services/persistence/hotExit/useHotExitCaptureWarning.test.ts
+++ b/src/services/persistence/hotExit/useHotExitCaptureWarning.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for useHotExitCaptureWarning (#969).
+ *
+ * The partial-capture event previously had no frontend listener, so a
+ * timed-out window's dropped edits were silent. This hook must register a
+ * listener and surface a warning toast when the event fires.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const listeners = new Map<string, (e: { payload: unknown }) => void>();
+const mockListen = vi.fn(
+  (event: string, cb: (e: { payload: unknown }) => void) => {
+    listeners.set(event, cb);
+    return Promise.resolve(() => listeners.delete(event));
+  },
+);
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (...args: unknown[]) =>
+    mockListen(...(args as [string, (e: { payload: unknown }) => void])),
+}));
+
+const mockWarning = vi.fn();
+vi.mock("@/services/ime/imeToast", () => ({
+  imeToast: { warning: (...args: unknown[]) => mockWarning(...args) },
+}));
+
+vi.mock("@/i18n", () => ({
+  // Passthrough that echoes the key + interpolated windows for assertions.
+  default: {
+    t: (key: string, opts?: { windows?: string }) =>
+      opts?.windows ? `${key}|${opts.windows}` : key,
+  },
+}));
+
+import { useHotExitCaptureWarning } from "./useHotExitCaptureWarning";
+
+beforeEach(() => {
+  listeners.clear();
+  mockListen.mockClear();
+  mockWarning.mockClear();
+});
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("useHotExitCaptureWarning", () => {
+  it("registers a listener for the partial-capture event", async () => {
+    renderHook(() => useHotExitCaptureWarning());
+    await flush();
+    expect(mockListen).toHaveBeenCalledWith(
+      "hot-exit:partial-capture",
+      expect.any(Function),
+    );
+  });
+
+  it("shows a warning toast naming the missing windows when capture is partial", async () => {
+    renderHook(() => useHotExitCaptureWarning());
+    await flush();
+
+    listeners.get("hot-exit:partial-capture")?.({
+      payload: { captured: 1, expected: 2, missing: ["doc-1", "doc-2"] },
+    });
+
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+    const [title, opts] = mockWarning.mock.calls[0] as [
+      string,
+      { description: string },
+    ];
+    expect(title).toBe("common:hotExit.partialCapture.title");
+    expect(opts.description).toContain("doc-1, doc-2");
+  });
+
+  it("falls back to a generic phrase when no window labels are provided", async () => {
+    renderHook(() => useHotExitCaptureWarning());
+    await flush();
+
+    listeners.get("hot-exit:partial-capture")?.({ payload: {} });
+
+    expect(mockWarning).toHaveBeenCalledTimes(1);
+    const [, opts] = mockWarning.mock.calls[0] as [string, { description: string }];
+    expect(opts.description).toContain(
+      "common:hotExit.partialCapture.unknownWindows",
+    );
+  });
+
+  it("removes its listeners on unmount", async () => {
+    const { unmount } = renderHook(() => useHotExitCaptureWarning());
+    await flush();
+    expect(listeners.has("hot-exit:partial-capture")).toBe(true);
+    unmount();
+    expect(listeners.has("hot-exit:partial-capture")).toBe(false);
+  });
+});

--- a/src/services/persistence/hotExit/useHotExitCaptureWarning.ts
+++ b/src/services/persistence/hotExit/useHotExitCaptureWarning.ts
@@ -1,0 +1,66 @@
+/**
+ * useHotExitCaptureWarning
+ *
+ * Purpose: Surface a warning when hot-exit session capture is incomplete.
+ * When a window does not respond before CAPTURE_TIMEOUT_SECS, the Rust
+ * coordinator saves a partial session and emits `hot-exit:partial-capture`.
+ * Without a listener the user gets no signal that unsaved work in the
+ * timed-out window may have been dropped — the green "captured" path looks
+ * like success (#969).
+ *
+ * Key decisions:
+ *   - Global listen(): Rust emits via app.emit() (global broadcast).
+ *   - Warning toast (not info/success) so it is urgent and not IME-deferred.
+ *   - Listens for both partial-capture and capture-timeout for resilience to
+ *     which event the coordinator emits.
+ *
+ * @coordinates-with src-tauri/src/hot_exit/coordinator.rs — emits partial-capture
+ * @module services/persistence/hotExit/useHotExitCaptureWarning
+ */
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { imeToast as toast } from "@/services/ime/imeToast";
+import i18n from "@/i18n";
+import { HOT_EXIT_EVENTS } from "./types";
+
+interface PartialCapturePayload {
+  captured?: number;
+  expected?: number;
+  missing?: string[];
+}
+
+/** Warn the user when hot-exit capture drops one or more windows. */
+export function useHotExitCaptureWarning(): void {
+  useEffect(() => {
+    let cancelled = false;
+    const unlisteners: Array<() => void> = [];
+
+    const warn = (payload: PartialCapturePayload | undefined) => {
+      const missing = payload?.missing ?? [];
+      const windows =
+        missing.length > 0
+          ? missing.join(", ")
+          : i18n.t("common:hotExit.partialCapture.unknownWindows");
+      toast.warning(i18n.t("common:hotExit.partialCapture.title"), {
+        description: i18n.t("common:hotExit.partialCapture.description", { windows }),
+      });
+    };
+
+    const register = (event: string) => {
+      listen<PartialCapturePayload>(event, (e) => warn(e.payload)).then(
+        (un) => {
+          if (cancelled) un();
+          else unlisteners.push(un);
+        },
+      );
+    };
+
+    register(HOT_EXIT_EVENTS.PARTIAL_CAPTURE);
+    register(HOT_EXIT_EVENTS.CAPTURE_TIMEOUT);
+
+    return () => {
+      cancelled = true;
+      unlisteners.forEach((un) => un());
+    };
+  }, []);
+}

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -394,10 +394,5 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   resetApproval: () => set({ approval: initialApproval }),
 }));
 
-/* ───────────────────────────── selectors ──────────────────────────────── */
-
-export const selectWorkflowEditDirty = (s: WorkflowStore): boolean =>
-  s.edit.pendingPatches.length > 0;
-
 /* re-export legacy patch type for compat */
 export type { IRPatch };

--- a/src/utils/debug/error.ts
+++ b/src/utils/debug/error.ts
@@ -158,11 +158,6 @@ export const appError = isDev
   ? (...args: unknown[]) => console.error("[App]", ...args)
   : (...args: unknown[]) => prodError("[App]", ...args);
 
-/** Error logger for PDF Preview. */
-export const pdfPreviewError = isDev
-  ? (...args: unknown[]) => console.error("[PDF Preview]", ...args)
-  : (...args: unknown[]) => prodError("[PDF Preview]", ...args);
-
 /** Error logger for Print. */
 export const printError = isDev
   ? (...args: unknown[]) => console.error("[Print]", ...args)

--- a/vmark-mcp-server/__tests__/unit/bridge/websocket.test.ts
+++ b/vmark-mcp-server/__tests__/unit/bridge/websocket.test.ts
@@ -703,4 +703,44 @@ describe('WebSocketBridge', () => {
       await noQueueBridge.disconnect();
     });
   });
+
+  describe('queue-wait timer / flush race (#959)', () => {
+    const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+    it('resolves a queued request that flush completes after the queue timer fires', async () => {
+      // Short queue-wait timeout so the timer fires while sendImmediate is
+      // still in flight (sendImmediate is stubbed to resolve later).
+      const raceBridge = new WebSocketBridge({ timeout: 20 });
+      const internal = raceBridge as unknown as {
+        queueRequest: (r: BridgeRequest) => Promise<BridgeResponse>;
+        flushRequestQueue: () => Promise<void>;
+        sendImmediate: (r: BridgeRequest) => Promise<BridgeResponse>;
+      };
+
+      const success: BridgeResponse = { success: true, data: 'flushed' };
+      // Resolves AFTER the 20ms queue-wait timeout has elapsed.
+      internal.sendImmediate = async () => {
+        await delay(60);
+        return success;
+      };
+
+      const pending = internal.queueRequest({ type: 'vmark.session.get_state' });
+      await internal.flushRequestQueue();
+
+      // The queue-wait timer fired at ~20ms (queue already drained by flush);
+      // the request must still resolve with the success value, not reject.
+      await expect(pending).resolves.toMatchObject({ success: true, data: 'flushed' });
+    });
+
+    it('still rejects with a timeout when a queued request is never flushed', async () => {
+      const raceBridge = new WebSocketBridge({ timeout: 20 });
+      const internal = raceBridge as unknown as {
+        queueRequest: (r: BridgeRequest) => Promise<BridgeResponse>;
+      };
+
+      await expect(
+        internal.queueRequest({ type: 'vmark.session.get_state' }),
+      ).rejects.toThrow(/timed out/);
+    });
+  });
 });

--- a/vmark-mcp-server/__tests__/unit/bridge/websocket.test.ts
+++ b/vmark-mcp-server/__tests__/unit/bridge/websocket.test.ts
@@ -630,7 +630,10 @@ describe('WebSocketBridge', () => {
       await queueBridge.disconnect();
     }, 10000);
 
-    it('should reject when queue is full', async () => {
+    it('should drop the oldest queued request when the queue is full', async () => {
+      // Overflow policy is drop-oldest (bounded memory, newest-wins): when the
+      // queue is full the oldest request is evicted and rejected, and the new
+      // request is accepted. The new request is NOT rejected on arrival.
       const queueBridge = new WebSocketBridge({
         port: TEST_PORT,
         autoReconnect: true,
@@ -645,16 +648,19 @@ describe('WebSocketBridge', () => {
       serverConnections[0].close();
       await new Promise((resolve) => setTimeout(resolve, 50));
 
-      // Fill queue - catch to avoid unhandled rejections on disconnect
-      const p1 = queueBridge.send({ type: 'queued1' }).catch(() => {});
+      // Fill the queue to capacity (maxQueueSize = 2).
+      const p1 = queueBridge.send({ type: 'queued1' });
       const p2 = queueBridge.send({ type: 'queued2' }).catch(() => {});
 
-      // Third request should fail
-      await expect(queueBridge.send({ type: 'queued3' })).rejects.toThrow('Request queue full');
+      // Third send overflows: the oldest queued request (p1) is evicted and
+      // rejected, while queued3 is accepted into the queue.
+      const p3 = queueBridge.send({ type: 'queued3' }).catch(() => {});
+      await expect(p1).rejects.toThrow('queue overflow');
 
+      // queued3 was queued (not rejected on arrival) — it rejects only once the
+      // bridge is intentionally disconnected, proving it survived the overflow.
       await queueBridge.disconnect();
-      // Wait for queued promises to reject
-      await Promise.all([p1, p2]);
+      await Promise.all([p2, p3]);
     });
 
     it('should reject queued requests on intentional disconnect', async () => {

--- a/vmark-mcp-server/__tests__/unit/utils/parentProcess.test.ts
+++ b/vmark-mcp-server/__tests__/unit/utils/parentProcess.test.ts
@@ -169,30 +169,36 @@ describe('getParentProcessName', () => {
 
       getParentProcessName(4567, 'win32');
 
+      // PID is bound to $args[0] and passed positionally after `--`, not
+      // interpolated into the -Command string (#280).
       expect(mockExecFileSync).toHaveBeenCalledWith(
         'powershell',
-        ['-NoProfile', '-Command', '(Get-Process -Id 4567).ProcessName'],
+        ['-NoProfile', '-Command', '(Get-Process -Id $args[0]).ProcessName', '--', '4567'],
         expect.objectContaining({ encoding: 'utf8', timeout: 500 }),
       );
       expect(Array.isArray(mockExecFileSync.mock.calls[0][1])).toBe(true);
     });
 
-    it('win32: malicious ppid in PowerShell command is in argument array, not shell', () => {
+    it('win32: malicious ppid is a positional PowerShell argument, never in the command string', () => {
       mockExecFileSync.mockImplementation(() => {
         throw new Error('Get-Process error');
       });
 
-      // Even though ppid is interpolated into the PowerShell -Command string,
-      // execFileSync passes it as an array arg to powershell.exe — no shell expansion
       getParentProcessName('1; Remove-Item -Recurse C:\\' as unknown as number, 'win32');
 
       const args = mockExecFileSync.mock.calls[0][1] as string[];
-      // The -Command value contains the malicious string but it's ONE argument
-      expect(args).toHaveLength(3);
-      expect(args[0]).toBe('-NoProfile');
-      expect(args[1]).toBe('-Command');
-      // PowerShell will fail to parse this as a valid process ID
-      expect(args[2]).toContain('1; Remove-Item');
+      // The PID is passed positionally (bound to $args[0]) — execFileSync sends
+      // it to powershell.exe as a separate argument, never through a shell.
+      expect(args).toEqual([
+        '-NoProfile',
+        '-Command',
+        '(Get-Process -Id $args[0]).ProcessName',
+        '--',
+        '1; Remove-Item -Recurse C:\\',
+      ]);
+      // The -Command string holds only the $args[0] placeholder — the malicious
+      // value is NOT interpolated into it.
+      expect(args[2]).not.toContain('Remove-Item');
     });
   });
 

--- a/vmark-mcp-server/src/bridge/websocket.ts
+++ b/vmark-mcp-server/src/bridge/websocket.ts
@@ -529,12 +529,16 @@ export class WebSocketBridge implements Bridge {
 
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
-        // Remove from queue if still pending
+        // Only time out while the request is still queued. Once
+        // flushRequestQueue has taken ownership of it (idx === -1), the
+        // in-flight sendImmediate governs the wait via its own timeout —
+        // rejecting here would spuriously fail an operation that is still
+        // succeeding (#959).
         const idx = this.requestQueue.findIndex((q) => q.request === request);
         if (idx !== -1) {
           this.requestQueue.splice(idx, 1);
+          reject(new Error(`Queued request ${request.type} timed out`));
         }
-        reject(new Error(`Queued request ${request.type} timed out`));
       }, this.timeout);
 
       this.requestQueue.push({


### PR DESCRIPTION
Resolves all 11 open `[audit]` issues, fixes the broken audit-fix automation that should have handled them, and repairs two pre-existing stale tests in the mcp-server suite.

## Why the auto-fix failed (today's run)

The `audit-fix` matrix in `claude.yml` installed pnpm via an **unpinned** `npm install -g pnpm`. The npm `latest` tag is now **pnpm 11**, which no longer reads `pnpm.overrides` from `package.json` — so `pnpm install --frozen-lockfile` aborts with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` against the committed lockfile. Every job died at "Install dependencies" before Claude ran. CI was unaffected because it pins `pnpm/action-setup@v6` → `version: 10`. Fixed by aligning `claude.yml` with the other workflows (first commit).

## Audit fixes (one commit per issue)

| Issue | Type | Summary |
|---|---|---|
| #965 #966 #967 | dead-code | Remove unused selector, logger, and 5 IR type guards |
| #962 | bug | Backslash-parity delimiter check in table-cell highlight |
| #963 | bug | Recognize `~~~` tilde code fences in select-occurrence |
| #961 | bug | Dedupe Shift+Tab outdent per line (no overlapping changes) |
| #964 | bug | Pair fences by document order (fixes `~~~mermaid` containing ``` ``` ```) |
| #959 | bug | Guard mcp-bridge queue-wait timer against the flush race |
| #970 | hot-exit | Test Restore honors multi-window sessions (shared dispatch helper) |
| #969 | hot-exit | Warn on partial session capture (new listener + i18n, 9 locales) |
| #968 | hot-exit | Abort multi-window restore on window-creation failure (preserve session.json) |

## Also: two stale mcp-server tests repaired

The `vmark-mcp-server` suite is not run by the root `check:all` CI gate, so two tests had been red on `main` unnoticed. Both implementations are correct; the tests lagged behind hardening changes:
- **websocket "queue full"** — overflow policy was deliberately changed to drop-oldest (`3551372f`); test still expected the removed reject-new path. Rewritten to assert drop-oldest.
- **parentProcess win32** — PowerShell PID lookup was hardened (#280) to bind the PID to `$args[0]` and pass it positionally after `--` (no command-string interpolation); tests still expected the old interpolated command. Updated to assert the stronger argument-isolation.

## Findings worth a reviewer's attention (I challenged the audit, didn't rubber-stamp)

- **#962, #961** — the audit's claimed crash/misalignment does **not** reproduce in the current CodeMirror (it merges overlapping changes, drops zero-width ranges, normalizes identical cursors). Applied as hardening so the code no longer depends on that tolerance, with both-branch tests. Details in each commit body.
- **#964** — the issue's stated example already worked; the real failure was the cross-delimiter case (``` lines inside a `~~~mermaid` block), now fixed and tested.
- **#968** — **Option A** (abort + preserve `session.json`). No unit test: injecting a window-creation failure needs a trait seam the issue's scope guard forbids; covered by the issue's E2E step and mirrors the existing emit-failure cleanup.

## Verification

Everything green: root `pnpm check:all` (all lints, **19017** frontend tests, coverage thresholds, build, size), the full **mcp-server** suite (**185** tests), and Rust (`cargo check` + **558** lib tests).

Closes #959
Closes #961
Closes #962
Closes #963
Closes #964
Closes #965
Closes #966
Closes #967
Closes #968
Closes #969
Closes #970