### PR TITLE
chore: fix pre-existing repo hygiene issues

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6196,7 +6196,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src/components/Editor/SplitPaneEditor/SourcePane.tsx
+++ b/src/components/Editor/SplitPaneEditor/SourcePane.tsx
@@ -233,7 +233,8 @@ export function SourcePane({
       viewRef.current = null;
     };
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- callbacks read via refs (see H3 comment above); excluding them from deps is intentional so the editor doesn't remount on every parent render.
+    // Callbacks read via refs (see H3 comment above) are intentionally excluded
+    // from this dep array so the editor doesn't remount on every parent render.
   }, [tabId, formatId, readOnly, validator, loadLanguage]);
 
   // Re-sync the editor when the store content diverges from the last


### PR DESCRIPTION
Small, independent cleanups for two pre-existing defects on `main` (unrelated to PR #972 or any feature work).

## Fixes

1. **Stale `Cargo.lock`** — the 0.7.31 version bump updated the five tracked manifest files but not `Cargo.lock`, leaving the `vmark` package pinned at `0.7.30`. Any `cargo` invocation silently regenerated it as dirty working state. Resynced to `0.7.31` (one-line change).
2. **Unused eslint-disable** in `SourcePane.tsx` — the dep array already satisfied `react-hooks/exhaustive-deps`, so the directive was dead (eslint flagged it as an unused directive — the one warning `pnpm lint` emitted). Converted to a plain comment that preserves the ref-exclusion rationale.

## Not included (deliberately)

- **mcp-server stale tests** (`websocket` queue-full, `parentProcess` win32) — also pre-existing, but fixed in **#972** (same file area as that PR's #959 work).
- **Rust clippy warnings** — non-gating debt (CI only runs `cargo test`, not clippy). Out of scope for a hygiene pass; touching unrelated code carries more risk than value here.

## Verification

`pnpm lint` clean (0 problems, was 1 warning); `pnpm build`, website build, `cargo check`, and the SplitPaneEditor test suite all pass.