### PR TITLE
fix: register pending save in MCP document.write to suppress external-change dialog

### DIFF
--- a/src/hooks/mcpBridge/v2/__tests__/document.test.ts
+++ b/src/hooks/mcpBridge/v2/__tests__/document.test.ts
@@ -37,6 +37,15 @@ vi.mock("@tauri-apps/plugin-fs", () => ({
     writeTextFileMock(path, content),
 }));
 
+const registerPendingSaveMock = vi.fn(() => 1);
+const clearPendingSaveMock = vi.fn();
+vi.mock("@/utils/pendingSaves", () => ({
+  registerPendingSave: (path: string, content: string) =>
+    registerPendingSaveMock(path, content),
+  clearPendingSave: (path: string, token?: number) =>
+    clearPendingSaveMock(path, token),
+}));
+
 import { respond } from "../../utils";
 
 function resetStores() {
@@ -247,6 +256,8 @@ describe("vmark.document.write — save-on-write (UX fix for buffered writes)", 
     vi.clearAllMocks();
     resetStores();
     writeTextFileMock.mockReset().mockResolvedValue(undefined);
+    registerPendingSaveMock.mockReset().mockReturnValue(1);
+    clearPendingSaveMock.mockReset();
   });
 
   it("persists to disk by default and reports saved=true", async () => {
@@ -307,6 +318,36 @@ describe("vmark.document.write — save-on-write (UX fix for buffered writes)", 
     expect(useDocumentStore.getState().documents["t-untitled"].content).toBe(
       "draft",
     );
+  });
+
+  it("registers and clears pending save around writeTextFile to suppress the external-change dialog", async () => {
+    seedTab("t-pending", "before", "/tmp/notes.md");
+    await handleDocumentWrite("req-pending", {
+      tabId: "t-pending",
+      content: "after",
+    });
+
+    expect(registerPendingSaveMock).toHaveBeenCalledWith("/tmp/notes.md", "after");
+    expect(clearPendingSaveMock).toHaveBeenCalledWith("/tmp/notes.md", 1);
+    // Ordering: register before write, clear after write.
+    const registerOrder = registerPendingSaveMock.mock.invocationCallOrder[0];
+    const writeOrder = writeTextFileMock.mock.invocationCallOrder[0];
+    const clearOrder = clearPendingSaveMock.mock.invocationCallOrder[0];
+    expect(registerOrder).toBeLessThan(writeOrder);
+    expect(writeOrder).toBeLessThan(clearOrder);
+  });
+
+  it("clears pending save even when writeTextFile rejects", async () => {
+    seedTab("t-pending-fail", "before", "/readonly/notes.md");
+    writeTextFileMock.mockRejectedValueOnce(new Error("EACCES"));
+
+    await handleDocumentWrite("req-pending-fail", {
+      tabId: "t-pending-fail",
+      content: "after",
+    });
+
+    expect(registerPendingSaveMock).toHaveBeenCalledWith("/readonly/notes.md", "after");
+    expect(clearPendingSaveMock).toHaveBeenCalledWith("/readonly/notes.md", 1);
   });
 
   it("FS write failure surfaces save_error (NOT save_skipped) without failing the write", async () => {

--- a/src/hooks/mcpBridge/v2/document.ts
+++ b/src/hooks/mcpBridge/v2/document.ts
@@ -38,6 +38,7 @@
  */
 
 import { writeTextFile } from "@tauri-apps/plugin-fs";
+import { registerPendingSave, clearPendingSave } from "@/utils/pendingSaves";
 import { useTabStore } from "@/stores/tabStore";
 import { useDocumentStore } from "@/stores/documentStore";
 import { useRevisionStore } from "@/stores/documentStore";
@@ -333,9 +334,14 @@ export async function handleDocumentWrite(
       saveSkipped = "untitled";
     } else {
       try {
-        await writeTextFile(resolved.filePath, args.content);
-        useDocumentStore.getState().markSaved(resolved.tabId, args.content);
-        saved = true;
+        const saveToken = registerPendingSave(resolved.filePath, args.content);
+        try {
+          await writeTextFile(resolved.filePath, args.content);
+          useDocumentStore.getState().markSaved(resolved.tabId, args.content);
+          saved = true;
+        } finally {
+          clearPendingSave(resolved.filePath, saveToken);
+        }
       } catch (err) {
         saveError = err instanceof Error ? err.message : String(err);
       }


### PR DESCRIPTION
Closes #975

## Summary
- Wrap `writeTextFile` in `vmark.document.write` with `registerPendingSave` / `clearPendingSave` (token-scoped) so the external file watcher recognises the write as VMark-originated and suppresses the "file changed externally" dialog.
- Match the established pattern in `src/services/persistence/saveToPath.ts`.

## Test plan
- [x] New unit tests in `src/hooks/mcpBridge/v2/__tests__/document.test.ts` assert `registerPendingSave` runs before `writeTextFile` and `clearPendingSave` runs after — both on success and FS rejection.
- [x] `pnpm vitest run src/hooks/mcpBridge/v2/__tests__/document.test.ts` — 21/21 pass.
- [x] `pnpm check:all` — 19009/19009 pass; build succeeds.
- [x] `grep -n "registerPendingSave" src/hooks/mcpBridge/v2/document.ts` — 2 matches (import + call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)