### PR TITLE
fix(editor): Escape can't collapse an all-empty multi-caret when a stored mark is present

### DIFF
--- a/src/plugins/editorPlugins/keymapUtils.test.ts
+++ b/src/plugins/editorPlugins/keymapUtils.test.ts
@@ -175,7 +175,7 @@ describe("escapeMarkBoundary", () => {
   it("returns false when no mark range and no stored marks", () => {
     const view = {
       state: {
-        selection: { $from: { pos: 1 }, empty: true },
+        selection: { $from: { pos: 1 }, empty: true, ranges: [{}] },
         storedMarks: null,
       },
       dispatch: vi.fn(),
@@ -187,7 +187,7 @@ describe("escapeMarkBoundary", () => {
   it("returns false when no mark range and stored marks is empty array", () => {
     const view = {
       state: {
-        selection: { $from: { pos: 1 }, empty: true },
+        selection: { $from: { pos: 1 }, empty: true, ranges: [{}] },
         storedMarks: [],
       },
       dispatch: vi.fn(),
@@ -201,7 +201,7 @@ describe("escapeMarkBoundary", () => {
     const mockTr = { setStoredMarks: vi.fn().mockReturnThis() };
     const view = {
       state: {
-        selection: { $from: { pos: 1 }, empty: true },
+        selection: { $from: { pos: 1 }, empty: true, ranges: [{}] },
         storedMarks: [{ type: "bold" }],
         tr: mockTr,
       },
@@ -221,7 +221,7 @@ describe("escapeMarkBoundary", () => {
     const mockTr = { setStoredMarks: vi.fn().mockReturnThis() };
     const view = {
       state: {
-        selection: { $from: { pos: 5 }, empty: true },
+        selection: { $from: { pos: 5 }, empty: true, ranges: [{}] },
         storedMarks: null,
         tr: mockTr,
       },
@@ -283,7 +283,7 @@ describe("escapeMarkBoundary", () => {
     const mockTr = { setStoredMarks: vi.fn().mockReturnThis() };
     const view = {
       state: {
-        selection: { $from: { pos: 1 }, empty: true },
+        selection: { $from: { pos: 1 }, empty: true, ranges: [{}] },
         storedMarks: null,
         tr: mockTr,
       },
@@ -294,6 +294,32 @@ describe("escapeMarkBoundary", () => {
     expect(result).toBe(true);
     expect(mockTr.setStoredMarks).toHaveBeenCalledWith([]);
     expect(dispatchFn).toHaveBeenCalledWith(mockTr);
+  });
+
+  it("does not act on a multi-range (multi-cursor) selection, even with stored marks", () => {
+    // Regression: a MultiSelection whose primary is a caret reports empty===true,
+    // so it slips past the `!empty` guard. With a stored mark present,
+    // escapeMarkBoundary used to return true and swallow Escape — preempting the
+    // multi-cursor collapse so the secondary selection (e.g. over a list) never
+    // cleared. It must bail for multi-range selections and let the multi-cursor
+    // Escape handler reduce them.
+    const dispatchFn = vi.fn();
+    const mockTr = { setStoredMarks: vi.fn().mockReturnThis() };
+    const view = {
+      state: {
+        selection: {
+          $from: { pos: 1 },
+          empty: true, // primary range is a caret
+          ranges: [{}, {}], // multi-cursor: more than one range
+        },
+        storedMarks: [{ type: "bold" }], // would otherwise trigger the swallow
+        tr: mockTr,
+      },
+      dispatch: dispatchFn,
+    } as never;
+
+    expect(escapeMarkBoundary(view)).toBe(false);
+    expect(dispatchFn).not.toHaveBeenCalled();
   });
 
   it("moves cursor to mark end when inside mark range using real state", () => {

--- a/src/plugins/editorPlugins/keymapUtils.test.ts
+++ b/src/plugins/editorPlugins/keymapUtils.test.ts
@@ -31,6 +31,8 @@ import {
 } from "./keymapUtils";
 import { canRunActionInMultiSelection } from "@/plugins/toolbarActions/multiSelectionPolicy";
 import { findAnyMarkRangeAtCursor } from "@/plugins/syntaxReveal/marks";
+import { MultiSelection } from "@/plugins/multiCursor/MultiSelection";
+import { collapseMultiSelection } from "@/plugins/multiCursor/commands";
 import type { Command } from "@tiptap/pm/state";
 
 describe("toProseMirrorKey", () => {
@@ -297,12 +299,13 @@ describe("escapeMarkBoundary", () => {
   });
 
   it("does not act on a multi-range (multi-cursor) selection, even with stored marks", () => {
-    // Regression: a MultiSelection whose primary is a caret reports empty===true,
-    // so it slips past the `!empty` guard. With a stored mark present,
-    // escapeMarkBoundary used to return true and swallow Escape — preempting the
-    // multi-cursor collapse so the secondary selection (e.g. over a list) never
-    // cleared. It must bail for multi-range selections and let the multi-cursor
-    // Escape handler reduce them.
+    // Regression: a multi-caret MultiSelection where every range is an empty
+    // caret reports empty===true (Selection.empty is true only when ALL ranges
+    // are empty), so it slips past the `!empty` guard. With a stored mark
+    // present, escapeMarkBoundary used to return true and swallow Escape —
+    // preempting the multi-cursor collapse, so the extra carets were never
+    // reduced. It must bail for multi-range selections and let the multi-cursor
+    // Escape handler collapse them.
     const dispatchFn = vi.fn();
     const mockTr = { setStoredMarks: vi.fn().mockReturnThis() };
     const view = {
@@ -320,6 +323,64 @@ describe("escapeMarkBoundary", () => {
 
     expect(escapeMarkBoundary(view)).toBe(false);
     expect(dispatchFn).not.toHaveBeenCalled();
+  });
+
+  it("real multi-caret MultiSelection + stored mark: does not swallow, and the multi-cursor handler then collapses it (#981 chain)", () => {
+    // Integration proof of the two-handler Escape chain with a REAL
+    // MultiSelection (not a mock). The swallow only happens when EVERY range is
+    // an empty caret — Selection.empty is true only when all ranges are empty,
+    // so a multi-cursor selection with any non-empty range has empty===false and
+    // escapeMarkBoundary already bails via `!empty`. For the all-carets case the
+    // editor keymap's escapeMarkBoundary must return false (no swallow) even with
+    // a stored mark at the primary caret, and the multi-cursor keymap's
+    // collapseMultiSelection must then reduce it to a plain TextSelection.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { Schema } = require("@tiptap/pm/model");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { EditorState, SelectionRange } = require("@tiptap/pm/state");
+
+    const testSchema = new Schema({
+      nodes: {
+        doc: { content: "paragraph+" },
+        paragraph: { content: "text*", group: "block" },
+        text: { inline: true },
+      },
+      marks: { bold: {} },
+    });
+    const doc = testSchema.node("doc", null, [
+      testSchema.node("paragraph", null, [testSchema.text("hello world")]),
+    ]);
+    let state = EditorState.create({ doc, schema: testSchema });
+
+    // Two empty carets (pos 1 and pos 5) — the all-empty multi-caret case.
+    const primary = new SelectionRange(doc.resolve(1), doc.resolve(1));
+    const secondary = new SelectionRange(doc.resolve(5), doc.resolve(5));
+    const multiSel = new MultiSelection([primary, secondary], 0);
+    state = state.apply(
+      state.tr
+        .setSelection(multiSel)
+        .setStoredMarks([testSchema.marks.bold.create()])
+    );
+
+    // Preconditions: the trap shape — all-empty multi-caret + stored mark.
+    expect(state.selection.empty).toBe(true);
+    expect(state.selection.ranges.length).toBe(2);
+
+    // 1) The mark-escape helper must NOT handle it (no swallow, marks untouched).
+    const dispatch = vi.fn();
+    expect(escapeMarkBoundary({ state, dispatch } as never)).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+
+    // 2) The multi-cursor Escape handler then collapses it to a single,
+    //    non-MultiSelection caret. (Assert against MultiSelection — the
+    //    top-level import — rather than a require()'d TextSelection, which would
+    //    be a different module instance and break instanceof.)
+    const tr = collapseMultiSelection(state);
+    expect(tr).not.toBeNull();
+    const collapsed = state.apply(tr);
+    expect(collapsed.selection).not.toBeInstanceOf(MultiSelection);
+    expect(collapsed.selection.ranges.length).toBe(1);
+    expect(collapsed.selection.empty).toBe(true);
   });
 
   it("moves cursor to mark end when inside mark range using real state", () => {

--- a/src/plugins/editorPlugins/keymapUtils.ts
+++ b/src/plugins/editorPlugins/keymapUtils.ts
@@ -26,6 +26,12 @@ export function escapeMarkBoundary(view: EditorView): boolean {
   const { $from, empty } = selection;
 
   if (!empty) return false;
+  // Bail for multi-range (multi-cursor) selections. A MultiSelection whose
+  // primary is a caret reports empty===true, so it reaches here — but operating
+  // on its primary $from (and clearing stored marks) would return true and
+  // swallow Escape, preempting the multi-cursor keymap's own Escape handler that
+  // collapses the secondary ranges. Let that handler run instead.
+  if (selection.ranges.length > 1) return false;
 
   const pos = $from.pos;
   const anyMarkRange = findAnyMarkRangeAtCursor(


### PR DESCRIPTION
## Scope correction
This started as an attempt to fix "Escape sometimes can't clear a selection over a list," but the real-state regression test (added per a Codex audit) **disproved that root cause**: `Selection.empty` is true only when *all* ranges are empty, so a multi-cursor selection with any non-empty (visible) range has `empty === false` and `escapeMarkBoundary` already bails via `!empty`. Escape already works for the visible-selection case.

What this PR actually fixes is a **narrower, real** bug.

## Bug
With **multiple empty carets** (multi-cursor, no selection) and a **stored mark / mark at the primary caret**, pressing Escape was *swallowed*: the editor keymap (priority 1000) runs first, `collapseNonEmptySelection` skips (`empty`), and `escapeMarkBoundary` — guarding only `!empty` — cleared the stored marks and returned `true`. That preempted the multi-cursor keymap's `collapseMultiSelection`, so the extra carets were never reduced.

## Fix
`escapeMarkBoundary` now bails on multi-range selections (`selection.ranges.length > 1`), mirroring the guard `collapseNonEmptySelection` already has. The editor keymap's Escape then returns false and the multi-cursor handler collapses the carets.

## Test
`keymapUtils.test.ts`:
- A mock-shaped unit test (multi-range + stored marks → not handled).
- A **real-EditorState** integration test: a `MultiSelection` of two empty carets + a stored mark → `escapeMarkBoundary` returns false (no swallow), then `collapseMultiSelection` reduces it to a single caret. (The existing single-cursor mocks gained a realistic `ranges: [{}]`.)

## Not covered (separate issue)
The originally-reported "visible multi-cursor selection over a list won't clear with one Escape" is a **different** behavior — `collapseMultiSelection` collapses to the primary *range* (not a caret), so a non-empty primary leaves a selection after one Escape. Needs its own investigation/decision.

## Verification
- `pnpm test src/plugins/editorPlugins/keymapUtils.test.ts` + multiCursor suites pass
- `pnpm check:all` green