### PR TITLE
Fix Linux window behavior

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -628,6 +628,7 @@ pub fn run() {
             window_manager::open_file_in_new_window,
             window_manager::open_workspace_in_new_window,
             window_manager::open_workspace_with_files_in_new_window,
+            window_manager::open_settings_window,
             window_manager::close_window,
             window_manager::force_quit,
             window_manager::request_quit,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -809,33 +809,40 @@ pub fn run() {
         .expect("error while building tauri application")
         .run(|app, event| {
             match event {
-                // CRITICAL: Prevent quit on last window close (macOS behavior)
-                // App should only quit via Cmd+Q or menu Quit
+                // CRITICAL: Preserve macOS last-window-close behavior while
+                // letting Linux/Windows CLI launches terminate when no document
+                // windows remain.
                 tauri::RunEvent::ExitRequested { api, code, .. } => {
                     log::debug!("[Tauri] ExitRequested received, code={:?}", code);
 
-                    // If we explicitly allowed exit (we're done with coordinated quit), allow it through.
-                    // IMPORTANT: Quit can be "in progress" while we still need to block OS quit requests.
-                    if quit::is_exit_allowed() {
-                        log::debug!("[Tauri] ExitRequested: exit allowed, allowing exit");
-                        return;
-                    }
-
-                    // Prevent exit for last-window-close scenario (macOS behavior)
-                    api.prevent_exit();
-                    log::debug!("[Tauri] ExitRequested: prevent_exit() called");
-
-                    // Only start coordinated quit if there are document windows
                     let has_doc_windows = app
                         .webview_windows()
                         .keys()
                         .any(|label| quit::is_document_window_label(label));
 
-                    if has_doc_windows {
-                        log::debug!("[Tauri] ExitRequested: starting quit flow");
-                        quit::start_quit(app);
+                    match quit::decide_exit_request_action(
+                        quit::is_exit_allowed(),
+                        has_doc_windows,
+                        quit::keep_alive_without_document_windows(),
+                    ) {
+                        quit::ExitRequestAction::AllowExit => {
+                            log::debug!("[Tauri] ExitRequested: allowing exit");
+                            if !quit::is_exit_allowed() {
+                                mcp_server::cleanup(app);
+                            }
+                        }
+                        quit::ExitRequestAction::PreventAndStartQuit => {
+                            api.prevent_exit();
+                            log::debug!("[Tauri] ExitRequested: starting quit flow");
+                            quit::start_quit(app);
+                        }
+                        quit::ExitRequestAction::PreventAndKeepAlive => {
+                            api.prevent_exit();
+                            log::debug!(
+                                "[Tauri] ExitRequested: keeping app alive without document windows"
+                            );
+                        }
                     }
-                    // If no document windows, just stay alive (macOS dock behavior)
                 }
                 tauri::RunEvent::WindowEvent {
                     label,

--- a/src-tauri/src/menu/localized.rs
+++ b/src-tauri/src/menu/localized.rs
@@ -591,18 +591,6 @@ pub fn create_localized_menu(
         ],
     )?;
 
-    #[cfg(not(target_os = "macos"))]
-    let window_menu = Submenu::with_id_and_items(
-        app,
-        "window-menu",
-        &t!("menu.window").to_string(),
-        true,
-        &[
-            &PredefinedMenuItem::minimize(app, None)?,
-            &PredefinedMenuItem::maximize(app, None)?,
-        ],
-    )?;
-
     // ========================================================================
     // Help menu
     // ========================================================================
@@ -665,7 +653,6 @@ pub fn create_localized_menu(
             &format_menu,
             &insert_menu,
             &view_menu,
-            &window_menu,
             &help_menu,
         ],
     )

--- a/src-tauri/src/quit.rs
+++ b/src-tauri/src/quit.rs
@@ -47,6 +47,40 @@ pub fn is_document_window_label(label: &str) -> bool {
     label == "main" || label.starts_with("doc-")
 }
 
+#[derive(Debug, PartialEq)]
+pub enum ExitRequestAction {
+    AllowExit,
+    PreventAndStartQuit,
+    PreventAndKeepAlive,
+}
+
+/// Decide how to handle Tauri's process-level exit request.
+///
+/// macOS keeps the app alive when the last window closes so the Dock icon can
+/// reopen a document window. Linux/Windows should exit when no document windows
+/// remain, matching normal desktop and CLI-launched app behavior.
+pub fn decide_exit_request_action(
+    exit_allowed: bool,
+    has_document_windows: bool,
+    keep_alive_without_documents: bool,
+) -> ExitRequestAction {
+    if exit_allowed {
+        return ExitRequestAction::AllowExit;
+    }
+    if has_document_windows {
+        return ExitRequestAction::PreventAndStartQuit;
+    }
+    if keep_alive_without_documents {
+        ExitRequestAction::PreventAndKeepAlive
+    } else {
+        ExitRequestAction::AllowExit
+    }
+}
+
+pub fn keep_alive_without_document_windows() -> bool {
+    cfg!(target_os = "macos")
+}
+
 /// Return `true` when the app is ready to terminate (set just before `app.exit(0)`).
 pub fn is_exit_allowed() -> bool {
     EXIT_ALLOWED.load(Ordering::SeqCst)
@@ -216,6 +250,34 @@ mod tests {
         assert!(is_document_window_label("doc-0"));
         assert!(is_document_window_label("doc-123"));
         assert!(!is_document_window_label("settings"));
+    }
+
+    #[test]
+    fn exit_request_allows_when_already_allowed() {
+        assert_eq!(
+            decide_exit_request_action(true, true, true),
+            ExitRequestAction::AllowExit
+        );
+    }
+
+    #[test]
+    fn exit_request_with_documents_starts_coordinated_quit() {
+        assert_eq!(
+            decide_exit_request_action(false, true, false),
+            ExitRequestAction::PreventAndStartQuit
+        );
+    }
+
+    #[test]
+    fn exit_request_without_documents_keeps_alive_only_when_requested() {
+        assert_eq!(
+            decide_exit_request_action(false, false, true),
+            ExitRequestAction::PreventAndKeepAlive
+        );
+        assert_eq!(
+            decide_exit_request_action(false, false, false),
+            ExitRequestAction::AllowExit
+        );
     }
 
     #[test]

--- a/src-tauri/src/window_manager.rs
+++ b/src-tauri/src/window_manager.rs
@@ -23,7 +23,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};
-use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{menu::Menu, AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 
 use crate::PendingFileOpen;
 
@@ -535,6 +535,13 @@ pub fn show_settings_window(app: &AppHandle) -> Result<String, tauri::Error> {
     show_settings_window_section(app, None)
 }
 
+/// Tauri command wrapper for frontend Settings entry points.
+#[tauri::command]
+pub fn open_settings_window(app: AppHandle, section: Option<String>) -> Result<String, String> {
+    show_settings_window_section(&app, section.as_deref().filter(|s| !s.is_empty()))
+        .map_err(|e| e.to_string())
+}
+
 /// Create or focus the settings window, optionally navigating to a specific section.
 /// If settings window exists, focuses it and navigates to the section.
 /// Otherwise creates a new one with the section in the URL.
@@ -573,9 +580,13 @@ pub fn show_settings_window_section(app: &AppHandle, section: Option<&str>) -> R
         None => "/settings".to_string(),
     };
 
-    // Create new settings window
-    // Note: Don't use .center() here as the window-state plugin may override it.
-    // Instead, we build the window visible:false, then set size/position, then show.
+    // Create new settings window.
+    //
+    // On Linux/GTK, creating the window hidden and then changing size/position
+    // before show can leave the native titlebar hit-test region stale until the
+    // first maximize/unmaximize cycle. Create non-macOS settings windows with
+    // their final geometry up front so close/minimize/maximize respond
+    // immediately.
     let mut builder = WebviewWindowBuilder::new(
         app,
         SETTINGS_LABEL,
@@ -585,25 +596,36 @@ pub fn show_settings_window_section(app: &AppHandle, section: Option<&str>) -> R
     .inner_size(SETTINGS_WIDTH, SETTINGS_HEIGHT)
     .min_inner_size(SETTINGS_MIN_WIDTH, SETTINGS_MIN_HEIGHT)
     .resizable(true)
-    .visible(false) // Start hidden to avoid flash
     .focused(true);
 
     #[cfg(target_os = "macos")]
     {
         builder = builder
             .title_bar_style(tauri::TitleBarStyle::Overlay)
-            .hidden_title(true);
+            .hidden_title(true)
+            .visible(false);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        builder = builder
+            .menu(Menu::new(app)?)
+            .center()
+            .visible(true);
     }
 
     let window = builder.build()?;
 
-    // Override any restored state by explicitly setting size and centering
-    let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize {
-        width: SETTINGS_WIDTH,
-        height: SETTINGS_HEIGHT,
-    }));
-    let _ = window.center();
-    let _ = window.show();
+    #[cfg(target_os = "macos")]
+    {
+        // Override any restored state by explicitly setting size and centering.
+        let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize {
+            width: SETTINGS_WIDTH,
+            height: SETTINGS_HEIGHT,
+        }));
+        let _ = window.center();
+        let _ = window.show();
+    }
 
     Ok(SETTINGS_LABEL.to_string())
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -27,6 +27,7 @@ import { useTheme } from "@/hooks/useTheme";
 import { useUpdateBroadcast, useUpdateListener } from "@/hooks/useUpdateSync";
 import { isImeKeyEvent } from "@/utils/imeGuard";
 import { safeUnlistenAsync } from "@/utils/safeUnlisten";
+import { isMacPlatform } from "@/utils/platform";
 import { SettingsSearchContext } from "./settings/SettingsSearchContext";
 import { SettingsSearchResults, type SearchablePanel } from "./settings/SettingsSearchResults";
 import { SearchInput } from "./settings/components";
@@ -118,6 +119,7 @@ function isValidSection(value: string): value is Section {
 
 export function SettingsPage() {
   const { t } = useTranslation("settings");
+  const isMac = isMacPlatform();
   // Read initial section from URL query params
   const getInitialSection = (): Section => {
     const params = new URLSearchParams(window.location.search);
@@ -211,8 +213,7 @@ export function SettingsPage() {
         className="w-52 shrink-0 border-r border-gray-200 dark:border-gray-700
                    bg-[var(--bg-secondary)] flex flex-col"
       >
-        {/* Drag region for sidebar area */}
-        <div data-tauri-drag-region className="h-12 shrink-0" />
+        {isMac && <div data-tauri-drag-region className="h-12 shrink-0" />}
         {/* Search box */}
         <div className="px-3 pb-2">
           <SearchInput
@@ -244,8 +245,7 @@ export function SettingsPage() {
 
       {/* Content area */}
       <div className="flex-1 flex flex-col">
-        {/* Drag region for content area */}
-        <div data-tauri-drag-region className="h-12 shrink-0" />
+        {isMac && <div data-tauri-drag-region className="h-12 shrink-0" />}
         {/* Content */}
         <SettingsSearchContext.Provider value={normalizedQuery}>
           <div
@@ -261,16 +261,17 @@ export function SettingsPage() {
         </SettingsSearchContext.Provider>
       </div>
 
-      {/* Centered title overlay — offset past w-52 sidebar so it centers over the content pane */}
-      <div
-        data-tauri-drag-region
-        className="absolute top-0 right-0 h-12 flex items-center justify-center pointer-events-none"
-        style={{ left: "13rem" }}
-      >
-        <span className="text-sm font-medium text-[var(--text-color)]">
-          {t("title")}
-        </span>
-      </div>
+      {isMac && (
+        <div
+          data-tauri-drag-region
+          className="absolute top-0 right-0 h-12 flex items-center justify-center pointer-events-none"
+          style={{ left: "13rem" }}
+        >
+          <span className="text-sm font-medium text-[var(--text-color)]">
+            {t("title")}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/utils/settingsWindow.test.ts
+++ b/src/utils/settingsWindow.test.ts
@@ -1,349 +1,44 @@
 /**
  * Tests for src/utils/settingsWindow.ts
- *
- * Covers openSettingsWindow() with all branches:
- *   - Creating a new window (no existing settings window)
- *   - Refocusing an existing window
- *   - Section navigation (with and without section param)
- *   - Centered positioning (success and failure)
- *   - Edge cases: empty string section, undefined section
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// --- Hoisted mocks (available inside vi.mock factories) ---
-
-const {
-  mockSetPosition,
-  mockSetFocus,
-  mockScaleFactor,
-  mockOuterPosition,
-  mockOuterSize,
-  mockGetCurrentWebviewWindow,
-  mockGetByLabel,
-  MockWebviewWindowConstructor,
-} = vi.hoisted(() => {
-  const mockSetPosition = vi.fn(() => Promise.resolve());
-  const mockSetFocus = vi.fn(() => Promise.resolve());
-  const mockScaleFactor = vi.fn(() => Promise.resolve(1));
-  const mockOuterPosition = vi.fn(() => Promise.resolve({ x: 100, y: 200 }));
-  const mockOuterSize = vi.fn(() => Promise.resolve({ width: 1200, height: 800 }));
-
-  const mockGetCurrentWebviewWindow = vi.fn(() => ({
-    scaleFactor: mockScaleFactor,
-    outerPosition: mockOuterPosition,
-    outerSize: mockOuterSize,
-  }));
-
-  const mockGetByLabel = vi.fn(() => Promise.resolve(null));
-  const MockWebviewWindowConstructor = vi.fn();
-
-  return {
-    mockSetPosition,
-    mockSetFocus,
-    mockScaleFactor,
-    mockOuterPosition,
-    mockOuterSize,
-    mockGetCurrentWebviewWindow,
-    mockGetByLabel,
-    MockWebviewWindowConstructor,
-  };
-});
-
-vi.mock("@tauri-apps/api/event", () => ({
-  emit: vi.fn(() => Promise.resolve()),
-}));
-
-vi.mock("@tauri-apps/api/webviewWindow", () => ({
-  getCurrentWebviewWindow: (...args: unknown[]) => mockGetCurrentWebviewWindow(...args),
-  WebviewWindow: Object.assign(MockWebviewWindowConstructor, {
-    getByLabel: (...args: unknown[]) => mockGetByLabel(...args),
-  }),
-}));
-
-vi.mock("@tauri-apps/api/dpi", () => ({
-  LogicalPosition: class MockLogicalPosition {
-    x: number;
-    y: number;
-    constructor(x: number, y: number) {
-      this.x = x;
-      this.y = y;
-    }
-  },
-}));
-
-// --- Imports (after mocks) ---
-
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
 import { openSettingsWindow } from "./settingsWindow";
-import { emit } from "@tauri-apps/api/event";
 
-// --- Tests ---
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  // Defaults: scale factor 1, position (100, 200), size 1200x800, no existing window
-  mockScaleFactor.mockResolvedValue(1);
-  mockOuterPosition.mockResolvedValue({ x: 100, y: 200 });
-  mockOuterSize.mockResolvedValue({ width: 1200, height: 800 });
-  mockGetByLabel.mockResolvedValue(null);
-});
-
-/* ------------------------------------------------------------------ */
-/*  Creating a new Settings window                                     */
-/* ------------------------------------------------------------------ */
-
-describe("openSettingsWindow — new window creation", () => {
-  it("creates a new WebviewWindow with correct dimensions", async () => {
-    await openSettingsWindow();
-
-    expect(MockWebviewWindowConstructor).toHaveBeenCalledTimes(1);
-    const [label, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(label).toBe("settings");
-    expect(opts.width).toBe(760);
-    expect(opts.height).toBe(540);
-    expect(opts.minWidth).toBe(600);
-    expect(opts.minHeight).toBe(400);
-    expect(opts.title).toBe("Settings");
-    expect(opts.resizable).toBe(true);
-    expect(opts.hiddenTitle).toBe(true);
-    expect(opts.titleBarStyle).toBe("overlay");
-  });
-
-  it("passes centered position when calculation succeeds", async () => {
-    // Window at (100, 200), size 1200x800, scale 1
-    // x = round(100/1 + (1200/1 - 760)/2) = round(100 + 220) = 320
-    // y = round(200/1 + (800/1 - 540)/2) = round(200 + 130) = 330
-    await openSettingsWindow();
-
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.x).toBe(320);
-    expect(opts.y).toBe(330);
-    expect(opts.center).toBe(false);
-  });
-
-  it("uses center:true when position calculation fails", async () => {
-    mockScaleFactor.mockRejectedValue(new Error("no window"));
-
-    await openSettingsWindow();
-
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.x).toBeUndefined();
-    expect(opts.y).toBeUndefined();
-    expect(opts.center).toBe(true);
-  });
-
-  it("sets url to /settings when no section provided", async () => {
-    await openSettingsWindow();
-
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.url).toBe("/settings");
-  });
-
-  it("sets url to /settings when section is undefined", async () => {
-    await openSettingsWindow(undefined);
-
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.url).toBe("/settings");
-  });
-
-  it("includes section as query param in url", async () => {
-    await openSettingsWindow("integrations");
-
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.url).toBe("/settings?section=integrations");
-  });
-
-  it("does not emit settings:navigate for new window", async () => {
-    await openSettingsWindow("about");
-
-    expect(emit).not.toHaveBeenCalled();
-  });
-});
-
-/* ------------------------------------------------------------------ */
-/*  Refocusing an existing Settings window                             */
-/* ------------------------------------------------------------------ */
-
-describe("openSettingsWindow — existing window", () => {
-  const existingWindow = {
-    setPosition: mockSetPosition,
-    setFocus: mockSetFocus,
-  };
-
+describe("openSettingsWindow", () => {
   beforeEach(() => {
-    mockGetByLabel.mockResolvedValue(existingWindow);
+    vi.clearAllMocks();
+    vi.mocked(invoke).mockResolvedValue("settings");
   });
 
-  it("focuses the existing window instead of creating a new one", async () => {
+  it("delegates Settings window creation to Rust", async () => {
     await openSettingsWindow();
 
-    expect(mockSetFocus).toHaveBeenCalledTimes(1);
-    expect(MockWebviewWindowConstructor).not.toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith("open_settings_window", {
+      section: null,
+    });
   });
 
-  it("repositions the existing window to center", async () => {
-    await openSettingsWindow();
-
-    expect(mockSetPosition).toHaveBeenCalledTimes(1);
-    const posArg = mockSetPosition.mock.calls[0][0];
-    expect(posArg.x).toBe(320);
-    expect(posArg.y).toBe(330);
-  });
-
-  it("skips setPosition when position calculation fails", async () => {
-    mockOuterPosition.mockRejectedValue(new Error("fail"));
-
-    await openSettingsWindow();
-
-    expect(mockSetPosition).not.toHaveBeenCalled();
-    expect(mockSetFocus).toHaveBeenCalledTimes(1);
-  });
-
-  it("emits settings:navigate when section is provided", async () => {
+  it("passes a requested section to Rust", async () => {
     await openSettingsWindow("about");
 
-    expect(emit).toHaveBeenCalledWith("settings:navigate", "about");
-  });
-
-  it("does not emit settings:navigate when no section", async () => {
-    await openSettingsWindow();
-
-    expect(emit).not.toHaveBeenCalled();
-  });
-
-  it("does not emit settings:navigate when section is undefined", async () => {
-    await openSettingsWindow(undefined);
-
-    expect(emit).not.toHaveBeenCalled();
-  });
-});
-
-/* ------------------------------------------------------------------ */
-/*  Position calculation with different scale factors                   */
-/* ------------------------------------------------------------------ */
-
-describe("openSettingsWindow — scale factor handling", () => {
-  it("accounts for HiDPI (scale factor 2)", async () => {
-    mockScaleFactor.mockResolvedValue(2);
-    mockOuterPosition.mockResolvedValue({ x: 200, y: 400 });
-    mockOuterSize.mockResolvedValue({ width: 2400, height: 1600 });
-
-    await openSettingsWindow();
-
-    // x = round(200/2 + (2400/2 - 760)/2) = round(100 + 220) = 320
-    // y = round(400/2 + (1600/2 - 540)/2) = round(200 + 130) = 330
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.x).toBe(320);
-    expect(opts.y).toBe(330);
-  });
-
-  it("accounts for fractional scale factor (1.5)", async () => {
-    mockScaleFactor.mockResolvedValue(1.5);
-    mockOuterPosition.mockResolvedValue({ x: 150, y: 300 });
-    mockOuterSize.mockResolvedValue({ width: 1800, height: 1200 });
-
-    await openSettingsWindow();
-
-    // x = round(150/1.5 + (1800/1.5 - 760)/2) = round(100 + 220) = 320
-    // y = round(300/1.5 + (1200/1.5 - 540)/2) = round(200 + 130) = 330
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.x).toBe(320);
-    expect(opts.y).toBe(330);
-  });
-
-  it("handles very small window (settings larger than parent)", async () => {
-    mockScaleFactor.mockResolvedValue(1);
-    mockOuterPosition.mockResolvedValue({ x: 50, y: 50 });
-    mockOuterSize.mockResolvedValue({ width: 400, height: 300 });
-
-    await openSettingsWindow();
-
-    // x = round(50 + (400 - 760)/2) = round(50 + (-180)) = -130
-    // y = round(50 + (300 - 540)/2) = round(50 + (-120)) = -70
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.x).toBe(-130);
-    expect(opts.y).toBe(-70);
-  });
-
-  it("handles window at origin (0, 0)", async () => {
-    mockScaleFactor.mockResolvedValue(1);
-    mockOuterPosition.mockResolvedValue({ x: 0, y: 0 });
-    mockOuterSize.mockResolvedValue({ width: 1200, height: 800 });
-
-    await openSettingsWindow();
-
-    // x = round(0 + (1200 - 760)/2) = 220
-    // y = round(0 + (800 - 540)/2) = 130
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.x).toBe(220);
-    expect(opts.y).toBe(130);
-  });
-});
-
-/* ------------------------------------------------------------------ */
-/*  Edge cases: section parameter                                      */
-/* ------------------------------------------------------------------ */
-
-describe("openSettingsWindow — section edge cases", () => {
-  it("handles empty string section for new window", async () => {
-    await openSettingsWindow("");
-
-    // Empty string is falsy, so url should be /settings (no query param)
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.url).toBe("/settings");
-  });
-
-  it("handles empty string section for existing window (no emit)", async () => {
-    mockGetByLabel.mockResolvedValue({
-      setPosition: mockSetPosition,
-      setFocus: mockSetFocus,
+    expect(invoke).toHaveBeenCalledWith("open_settings_window", {
+      section: "about",
     });
+  });
 
+  it("normalizes empty section to null", async () => {
     await openSettingsWindow("");
 
-    // Empty string is falsy, so emit should not be called
-    expect(emit).not.toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith("open_settings_window", {
+      section: null,
+    });
   });
 
-  it("handles section with special characters", async () => {
-    await openSettingsWindow("ai-providers");
+  it("propagates backend failures to callers", async () => {
+    vi.mocked(invoke).mockRejectedValue(new Error("failed"));
 
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.url).toBe("/settings?section=ai-providers");
-  });
-});
-
-/* ------------------------------------------------------------------ */
-/*  Error resilience                                                   */
-/* ------------------------------------------------------------------ */
-
-describe("openSettingsWindow — error resilience", () => {
-  it("still creates window when outerSize rejects", async () => {
-    mockOuterSize.mockRejectedValue(new Error("size error"));
-
-    await openSettingsWindow();
-
-    // Position calculation fails, falls back to center
-    expect(MockWebviewWindowConstructor).toHaveBeenCalledTimes(1);
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.center).toBe(true);
-    expect(opts.x).toBeUndefined();
-    expect(opts.y).toBeUndefined();
-  });
-
-  it("still creates window when outerPosition rejects", async () => {
-    mockOuterPosition.mockRejectedValue(new Error("position error"));
-
-    await openSettingsWindow();
-
-    expect(MockWebviewWindowConstructor).toHaveBeenCalledTimes(1);
-    const [, opts] = MockWebviewWindowConstructor.mock.calls[0];
-    expect(opts.center).toBe(true);
-  });
-
-  it("getByLabel is always called with 'settings'", async () => {
-    await openSettingsWindow();
-
-    expect(mockGetByLabel).toHaveBeenCalledWith("settings");
+    await expect(openSettingsWindow()).rejects.toThrow("failed");
   });
 });

--- a/src/utils/settingsWindow.ts
+++ b/src/utils/settingsWindow.ts
@@ -1,86 +1,30 @@
 /**
  * Settings Window Utility
  *
- * Purpose: Shared logic for opening the Settings window, centered on the current window.
- * Handles both creating a new Settings window and refocusing an existing one.
+ * Purpose: Shared logic for opening or refocusing the Settings window.
  *
  * Key decisions:
- *   - Centers over parent window using physical-to-logical pixel conversion
- *   - Reuses existing Settings window if already open (singleton pattern)
- *   - Section navigation via Tauri event so deep linking works even when refocusing
- *   - Hidden title bar with overlay style for macOS-native feel
+ *   - Delegates native window creation to Rust so utility-window chrome,
+ *     menu inheritance, and close behavior stay consistent across platforms
+ *   - Section navigation is handled by the backend singleton window manager
  *
- * @coordinates-with menu_events.rs — "settings" menu item triggers openSettingsWindow
+ * @coordinates-with window_manager.rs — open_settings_window command
  * @coordinates-with SettingsPage.tsx — renders the settings UI in the new window
  * @module utils/settingsWindow
  */
 
-import { emit } from "@tauri-apps/api/event";
-import { getCurrentWebviewWindow, WebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { LogicalPosition } from "@tauri-apps/api/dpi";
-
-const SETTINGS_WIDTH = 760;
-const SETTINGS_HEIGHT = 540;
-
-/**
- * Calculate position to center Settings window over the current window.
- * Returns null if position cannot be determined.
- */
-async function calculateCenteredPosition(): Promise<{ x: number; y: number } | null> {
-  try {
-    const currentWindow = getCurrentWebviewWindow();
-    const scaleFactor = await currentWindow.scaleFactor();
-    const [position, size] = await Promise.all([
-      currentWindow.outerPosition(),
-      currentWindow.outerSize(),
-    ]);
-    // Convert physical pixels to logical pixels
-    const x = Math.round(position.x / scaleFactor + (size.width / scaleFactor - SETTINGS_WIDTH) / 2);
-    const y = Math.round(position.y / scaleFactor + (size.height / scaleFactor - SETTINGS_HEIGHT) / 2);
-    return { x, y };
-  } catch {
-    return null;
-  }
-}
+import { invoke } from "@tauri-apps/api/core";
 
 /**
  * Open the Settings window, optionally navigating to a specific section.
  *
- * - If Settings window exists, focuses it and navigates to the section
- * - If not, creates a new Settings window centered on the current window
+ * - If Settings window exists, Rust focuses it and navigates to the section
+ * - If not, Rust creates it with platform-specific native chrome
  *
  * @param section - Optional section to navigate to (e.g., "integrations", "about")
  */
 export async function openSettingsWindow(section?: string): Promise<void> {
-  const pos = await calculateCenteredPosition();
-
-  // If Settings window already exists, focus and navigate
-  const existing = await WebviewWindow.getByLabel("settings");
-  if (existing) {
-    if (pos) {
-      await existing.setPosition(new LogicalPosition(pos.x, pos.y));
-    }
-    await existing.setFocus();
-    if (section) {
-      await emit("settings:navigate", section);
-    }
-    return;
-  }
-
-  // Create new Settings window
-  const url = section ? `/settings?section=${section}` : "/settings";
-  new WebviewWindow("settings", {
-    url,
-    title: "Settings",
-    width: SETTINGS_WIDTH,
-    height: SETTINGS_HEIGHT,
-    minWidth: 600,
-    minHeight: 400,
-    x: pos?.x,
-    y: pos?.y,
-    center: !pos,
-    resizable: true,
-    hiddenTitle: true,
-    titleBarStyle: "overlay",
+  await invoke("open_settings_window", {
+    section: section || null,
   });
 }


### PR DESCRIPTION
## Summary

  Fix incorrect window behavior on Linux, including empty menu UI, Settings window chrome issues, and the app process staying alive after all visible windows are closed.

## Policy Gates (Required)

- [x] This PR is single-focus (one issue, one problem, one objective).
- [x] This PR includes 100% test coverage for changed behavior and changed code paths.
- [x] If this is a bug fix, the linked issue contains detailed reproduction context.

## Linked Issue

Use a closing keyword when applicable.

- Fixes #992

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only
- [ ] Other

## What Changed

  - Removed the top-level Window menu on non-macOS platforms.
  - Moved Settings window opening from frontend `WebviewWindow` creation to the Rust window manager.
  - Prevented the Settings window from inheriting the main app menu on non-macOS platforms.
  - Rendered macOS-only Settings title/drag overlay UI only on macOS.
  - Updated exit-request handling so Linux/Windows can quit when no document windows remain, while preserving macOS keep-alive behavior.
  - Added focused tests for Settings window opener delegation and exit-request decision logic.

## Validation

- [ ] I ran `pnpm check:all` locally.
- [ ] I added or updated tests to fully cover behavior changes.
- [x] I manually verified critical flows.

## UI Evidence (if applicable)

Attach screenshots or a short video for visible UI changes.

## PR Checklist

- [x] The PR avoids unrelated refactors or cleanup.
- [x] The issue context is clear (linked issue or explanation above).
- [ ] Docs/changelog were updated if behavior or usage changed.
- [x] I am ready to address review feedback.
