### PR TITLE
feat(shortcuts): surface keyboard shortcuts in button tooltips (complete)

### DIFF
--- a/src/components/Editor/UniversalToolbar/UniversalToolbar.test.tsx
+++ b/src/components/Editor/UniversalToolbar/UniversalToolbar.test.tsx
@@ -13,6 +13,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { useUIStore } from "@/stores/uiStore";
+import { useShortcutsStore, formatKeyForDisplay } from "@/stores/settingsStore";
 
 const mockedStores = vi.hoisted(() => ({
   sourceState: {
@@ -147,6 +148,19 @@ describe("UniversalToolbar", () => {
       useUIStore.setState({ universalToolbarVisible: true });
       render(<UniversalToolbar />);
       expect(screen.getByRole("toolbar")).toBeInTheDocument();
+    });
+  });
+
+  describe("AI Prompts button tooltip", () => {
+    it("surfaces the rebindable aiPrompts shortcut (not a hardcoded ⌘Y), with title/aria-label parity", () => {
+      useShortcutsStore.setState({ customBindings: {} });
+      useUIStore.setState({ universalToolbarVisible: true });
+      render(<UniversalToolbar />);
+      const aiBtn = screen.getByRole("button", { name: /ai prompts/i });
+      const display = formatKeyForDisplay(useShortcutsStore.getState().getShortcut("aiPrompts"));
+      expect(display).not.toBe("");
+      expect(aiBtn.getAttribute("title")).toContain(display);
+      expect(aiBtn.getAttribute("title")).toBe(aiBtn.getAttribute("aria-label"));
     });
   });
 
@@ -949,7 +963,7 @@ describe("UniversalToolbar", () => {
       });
       render(<UniversalToolbar />);
 
-      const aiButton = screen.getByLabelText("AI Prompts");
+      const aiButton = screen.getByLabelText(/^AI Prompts/);
       expect(aiButton).toBeInTheDocument();
       expect(aiButton).toHaveAttribute("data-action", "genie");
     });
@@ -1275,7 +1289,7 @@ describe("UniversalToolbar", () => {
       });
       render(<UniversalToolbar />);
 
-      const aiButton = screen.getByLabelText("AI Prompts");
+      const aiButton = screen.getByLabelText(/^AI Prompts/);
       fireEvent.click(aiButton);
 
       expect(mockAdapters.mockOpenPicker).toHaveBeenCalledWith({ filterScope: "selection" });

--- a/src/components/Editor/UniversalToolbar/UniversalToolbar.tsx
+++ b/src/components/Editor/UniversalToolbar/UniversalToolbar.tsx
@@ -2,8 +2,7 @@
  * UniversalToolbar - Bottom formatting toolbar
  *
  * A universal, single-line toolbar anchored at the bottom of the window.
- * Triggered by Shift+Cmd+P, provides consistent formatting actions across
- * both WYSIWYG and Source modes.
+ * Triggered by Shift+Cmd+P, provides formatting actions across WYSIWYG and Source.
  *
  * Per redesign spec:
  * - Focus toggle model (Shift+Cmd+P toggles focus, not visibility)
@@ -15,6 +14,8 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from "react";
 import { useUIStore } from "@/stores/uiStore";
+import { useShortcutsStore, formatKeyForDisplay } from "@/stores/settingsStore";
+import { tooltipWithShortcut } from "@/utils/tooltipWithShortcut";
 import { selectSourceEditing } from "@/stores/selectSourceEditing";
 import { useEditorStore } from "@/stores/editorStore";
 import { getToolbarButtonState, getToolbarItemState } from "@/plugins/toolbarActions/enableRules";
@@ -43,6 +44,7 @@ import "./universal-toolbar.css";
 export function UniversalToolbar() {
   const { t: tDialog } = useTranslation("dialog");
   const { t } = useTranslation("editor");
+  const aiPromptsShortcut = useShortcutsStore((state) => state.getShortcut("aiPrompts"));
   const visible = useUIStore((state) => state.universalToolbarVisible);
   const toolbarHasFocus = useUIStore((state) => state.universalToolbarHasFocus);
   const sessionFocusIndex = useUIStore((state) => state.toolbarSessionFocusIndex);
@@ -87,11 +89,9 @@ export function UniversalToolbar() {
     [buttons, toolbarContext]
   );
 
-  // The AI-Prompts action button sits after the formatting groups and is
-  // folded into the roving-tabindex model as a trailing pseudo-button at index
-  // `buttons.length` (a11y/A4 — otherwise it is keyboard-unreachable: the
-  // toolbar is out of the tab order until focused, and arrow nav only spans the
-  // group buttons). It is always enabled and is an action (never a dropdown).
+  // AI-Prompts action button: trailing pseudo-button in the roving-tabindex
+  // model at index `buttons.length` (a11y/A4 — keyboard-reachable). Always
+  // enabled, an action (never a dropdown).
   const genieFocusIndex = buttons.length;
 
   const isButtonFocusable = useCallback(
@@ -513,8 +513,8 @@ export function UniversalToolbar() {
       <button
         type="button"
         className="universal-toolbar-btn"
-        title={`${t("toolbar.aiPrompts")} (⌘Y)`}
-        aria-label={t("toolbar.aiPrompts")}
+        title={tooltipWithShortcut(t("toolbar.aiPrompts"), formatKeyForDisplay(aiPromptsShortcut))}
+        aria-label={tooltipWithShortcut(t("toolbar.aiPrompts"), formatKeyForDisplay(aiPromptsShortcut))}
         data-focus-index={genieFocusIndex}
         tabIndex={toolbarHasFocus && focusedIndex === genieFocusIndex ? 0 : -1}
         data-action="genie"

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { useUIStore } from "@/stores/uiStore";
+import { useShortcutsStore, formatKeyForDisplay } from "@/stores/settingsStore";
 import { Sidebar } from "./Sidebar";
 
 // FileExplorer pulls in the workspace stack (Tauri FS, watchers, etc.) which
@@ -57,5 +58,30 @@ describe("Sidebar — close button aria-expanded", () => {
     render(<Sidebar />);
     const closeBtn = screen.getByRole("button", { name: /close sidebar/i });
     expect(closeBtn.getAttribute("aria-expanded")).toBe("false");
+  });
+});
+
+describe("Sidebar — tooltips surface shortcuts", () => {
+  beforeEach(() => {
+    useUIStore.setState({ sidebarVisible: true, sidebarViewMode: "files" });
+    useShortcutsStore.setState({ customBindings: {} });
+  });
+
+  it("close-sidebar tooltip includes the shortcut, with title/aria-label parity", () => {
+    render(<Sidebar />);
+    const closeBtn = screen.getByRole("button", { name: /close sidebar/i });
+    const display = formatKeyForDisplay(useShortcutsStore.getState().getShortcut("toggleSidebar"));
+    expect(display).not.toBe("");
+    expect(closeBtn.getAttribute("title")).toContain(display);
+    expect(closeBtn.getAttribute("title")).toBe(closeBtn.getAttribute("aria-label"));
+  });
+
+  it("new-file tooltip includes the shortcut, with title/aria-label parity", () => {
+    render(<Sidebar />);
+    const newFileBtn = screen.getByRole("button", { name: /new file/i });
+    const display = formatKeyForDisplay(useShortcutsStore.getState().getShortcut("newFile"));
+    expect(display).not.toBe("");
+    expect(newFileBtn.getAttribute("title")).toContain(display);
+    expect(newFileBtn.getAttribute("title")).toBe(newFileBtn.getAttribute("aria-label"));
   });
 });

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -11,6 +11,8 @@ import { ask } from "@tauri-apps/plugin-dialog";
 import { deleteDocumentHistory } from "@/hooks/useHistoryRecovery";
 import { emitHistoryCleared } from "@/utils/historyTypes";
 import { useUIStore, type SidebarViewMode } from "@/stores/uiStore";
+import { useShortcutsStore, formatKeyForDisplay } from "@/stores/settingsStore";
+import { tooltipWithShortcut } from "@/utils/tooltipWithShortcut";
 import { useDocumentFilePath } from "@/hooks/useDocumentState";
 import { FileExplorer, type FileExplorerHandle } from "./FileExplorer";
 import { OutlineView } from "./OutlineView";
@@ -33,6 +35,8 @@ const VIEW_CONFIG: Record<SidebarViewMode, {
 /** Navigation sidebar with switchable Files, Outline, and History views. */
 export function Sidebar() {
   const { t } = useTranslation("sidebar");
+  const sidebarShortcut = useShortcutsStore((state) => state.getShortcut("toggleSidebar"));
+  const newFileShortcut = useShortcutsStore((state) => state.getShortcut("newFile"));
   const viewMode = useUIStore((state) => state.sidebarViewMode);
   // WI-2.3 — bind aria-expanded on the close-sidebar button to live state
   // instead of hardcoding `true`. The button only renders when the sidebar
@@ -118,8 +122,8 @@ export function Sidebar() {
             <button
               className="sidebar-btn"
               onClick={() => fileExplorerRef.current?.createNewFile()}
-              title={t("newFile")}
-              aria-label={t("newFile")}
+              title={tooltipWithShortcut(t("newFile"), formatKeyForDisplay(newFileShortcut))}
+              aria-label={tooltipWithShortcut(t("newFile"), formatKeyForDisplay(newFileShortcut))}
             >
               <FilePlus size={14} />
             </button>
@@ -158,8 +162,8 @@ export function Sidebar() {
         <button
           className="sidebar-btn"
           onClick={() => useUIStore.getState().toggleSidebar()}
-          title={t("closeSidebar")}
-          aria-label={t("closeSidebar")}
+          title={tooltipWithShortcut(t("closeSidebar"), formatKeyForDisplay(sidebarShortcut))}
+          aria-label={tooltipWithShortcut(t("closeSidebar"), formatKeyForDisplay(sidebarShortcut))}
           aria-expanded={sidebarVisible}
         >
           <PanelLeftClose size={16} />

--- a/src/components/StatusBar/StatusBar.test.tsx
+++ b/src/components/StatusBar/StatusBar.test.tsx
@@ -80,10 +80,12 @@ vi.mock("@/components/Tabs/TabContextMenu", () => ({
 
 import { StatusBar } from "./StatusBar";
 import { useUIStore } from "@/stores/uiStore";
+import { useShortcutsStore, formatKeyForDisplay } from "@/stores/settingsStore";
 
 describe("StatusBar accessibility", () => {
   beforeEach(() => {
     useUIStore.setState({ sidebarVisible: false, statusBarVisible: true });
+    useShortcutsStore.setState({ customBindings: {} });
   });
 
   it("exposes aria-expanded=false on the sidebar-toggle button when the sidebar is collapsed", () => {
@@ -100,5 +102,14 @@ describe("StatusBar accessibility", () => {
     useUIStore.setState({ sidebarVisible: true, statusBarVisible: true });
     render(<StatusBar />);
     expect(screen.queryByLabelText(/open sidebar/i)).toBeNull();
+  });
+
+  it("open-sidebar tooltip surfaces the shortcut, with title/aria-label parity", () => {
+    render(<StatusBar />);
+    const toggle = screen.getByLabelText(/open sidebar/i);
+    const display = formatKeyForDisplay(useShortcutsStore.getState().getShortcut("toggleSidebar"));
+    expect(display).not.toBe("");
+    expect(toggle.getAttribute("title")).toContain(display);
+    expect(toggle.getAttribute("title")).toBe(toggle.getAttribute("aria-label"));
   });
 });

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -52,7 +52,8 @@ import { FileLoadIndicator } from "./FileLoadIndicator";
 import { StatusBarTabStrip } from "./StatusBarTabStrip";
 import { useAutoSaveDisplay } from "./useAutoSaveDisplay";
 import { looksLikeWorkflowPath } from "@/lib/ghaWorkflow/detection";
-import { useShortcutsStore } from "@/stores/settingsStore";
+import { useShortcutsStore, formatKeyForDisplay } from "@/stores/settingsStore";
+import { tooltipWithShortcut } from "@/utils/tooltipWithShortcut";
 import { useMcpServer } from "@/hooks/useMcpServer";
 import { useMcpClients } from "@/hooks/useMcpClients";
 import { openSettingsWindow } from "@/services/navigation/settingsWindow";
@@ -106,6 +107,7 @@ export function StatusBar() {
   const readOnlyShortcut = useShortcutsStore((state) => state.getShortcut("readOnly"));
   const terminalShortcut = useShortcutsStore((state) => state.getShortcut("toggleTerminal"));
   const saveShortcut = useShortcutsStore((state) => state.getShortcut("save"));
+  const sidebarShortcut = useShortcutsStore((state) => state.getShortcut("toggleSidebar"));
   const aiRunning = useAiInvocationStore((state) => state.isRunning);
   const aiElapsed = useAiInvocationStore((state) => state.elapsedSeconds);
   const aiError = useAiInvocationStore((state) => state.error);
@@ -226,14 +228,11 @@ export function StatusBar() {
                 type="button"
                 className="status-sidebar-toggle"
                 onClick={() => useUIStore.getState().toggleSidebar()}
-                // WI-2.3 — bind to live state instead of hardcoding `false`.
-                // The button currently only renders when sidebar is hidden,
-                // so this is structurally always false today; binding keeps
-                // it correct if rendering conditions ever change and signals
-                // to maintainers that the value is dynamic.
+                // WI-2.3 — bind aria-expanded to live state, not a literal
+                // (the button only renders while the sidebar is hidden).
                 aria-expanded={sidebarVisible}
-                aria-label={t("openSidebar")}
-                title={t("openSidebar")}
+                aria-label={tooltipWithShortcut(t("openSidebar"), formatKeyForDisplay(sidebarShortcut))}
+                title={tooltipWithShortcut(t("openSidebar"), formatKeyForDisplay(sidebarShortcut))}
               >
                 <PanelLeft size={14} />
               </button>

--- a/src/components/StatusBar/StatusBarTabStrip.test.tsx
+++ b/src/components/StatusBar/StatusBarTabStrip.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { StatusBarTabStrip } from "./StatusBarTabStrip";
 import type { Tab as TabType } from "@/stores/tabStore";
 import { useDocumentStore } from "@/stores/documentStore";
+import { useShortcutsStore, formatKeyForDisplay } from "@/stores/settingsStore";
 
 function makeTab(overrides: Partial<TabType> = {}): TabType {
   return {
@@ -75,6 +76,16 @@ describe("StatusBarTabStrip", () => {
     setup({ onNewTab });
     await user.click(screen.getByRole("button", { name: /new tab/i }));
     expect(onNewTab).toHaveBeenCalledOnce();
+  });
+
+  it("new-tab tooltip surfaces the shortcut, with title/aria-label parity", () => {
+    useShortcutsStore.setState({ customBindings: {} });
+    setup();
+    const btn = screen.getByRole("button", { name: /new tab/i });
+    const display = formatKeyForDisplay(useShortcutsStore.getState().getShortcut("newTab"));
+    expect(display).not.toBe("");
+    expect(btn.getAttribute("title")).toContain(display);
+    expect(btn.getAttribute("title")).toBe(btn.getAttribute("aria-label"));
   });
 
   it("hides the new-tab button when showNewTabButton is false", () => {

--- a/src/components/StatusBar/StatusBarTabStrip.tsx
+++ b/src/components/StatusBar/StatusBarTabStrip.tsx
@@ -15,6 +15,8 @@ import { Plus } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Tab } from "@/components/Tabs/Tab";
 import type { Tab as TabType } from "@/stores/tabStore";
+import { useShortcutsStore, formatKeyForDisplay } from "@/stores/settingsStore";
+import { tooltipWithShortcut } from "@/utils/tooltipWithShortcut";
 import type { useStatusBarTabDrag } from "./useStatusBarTabDrag";
 
 type TabDragResult = ReturnType<typeof useStatusBarTabDrag>;
@@ -59,6 +61,8 @@ export function StatusBarTabStrip({
   onNewTab,
 }: StatusBarTabStripProps) {
   const { t } = useTranslation("statusbar");
+  const newTabShortcut = useShortcutsStore((state) => state.getShortcut("newTab"));
+  const newTabTooltip = tooltipWithShortcut(t("newTabTitle"), formatKeyForDisplay(newTabShortcut));
 
   return (
     <>
@@ -67,8 +71,8 @@ export function StatusBarTabStrip({
           type="button"
           className="status-new-tab"
           onClick={onNewTab}
-          aria-label={t("newTab")}
-          title={t("newTabTitle")}
+          aria-label={newTabTooltip}
+          title={newTabTooltip}
         >
           <Plus className="w-3 h-3" />
         </button>

--- a/src/hooks/useViewShortcuts.test.ts
+++ b/src/hooks/useViewShortcuts.test.ts
@@ -7,8 +7,11 @@
  *   - resolveViewAction: maps a keyboard event to an action identifier
  */
 
-import { describe, it, expect, vi } from "vitest";
-import { shouldSkipKeyEvent, resolveViewAction } from "./useViewShortcuts";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { shouldSkipKeyEvent, resolveViewAction, useViewShortcuts } from "./useViewShortcuts";
+import { useUIStore } from "@/stores/uiStore";
+import { useShortcutsStore } from "@/stores/settingsStore";
 
 // ---------------------------------------------------------------------------
 // shouldSkipKeyEvent
@@ -56,6 +59,7 @@ describe("resolveViewAction", () => {
     validateMarkdown: "",
     lintNext: "",
     lintPrev: "",
+    toggleSidebar: "Ctrl-Shift-0",
     toggleOutline: "Alt-Mod-o",
     fileExplorer: "Alt-Mod-e",
     viewHistory: "Alt-Mod-h",
@@ -130,6 +134,15 @@ describe("resolveViewAction", () => {
     expect(result).toBe("typewriterMode");
   });
 
+  it("returns 'toggleSidebar' for the sidebar shortcut (Ctrl-Shift-0, code-matched)", () => {
+    // Shift+0 yields ")", so the matcher keys on event.code (Digit0). This is the
+    // ONLY handler that owns toggleSidebar — the TipTap keymap deliberately does
+    // not bind it (see editorPlugins.tiptap.test.ts) to avoid a double-toggle.
+    const event = createKeyEvent(")", { ctrlKey: true, shiftKey: true, code: "Digit0" });
+    const result = resolveViewAction(event, shortcuts, "other");
+    expect(result).toBe("toggleSidebar");
+  });
+
   it("returns 'toggleOutline' for outline shortcut", () => {
     const event = createKeyEvent("o", { altKey: true, metaKey: true });
     const result = resolveViewAction(event, shortcuts, "mac");
@@ -159,5 +172,50 @@ describe("resolveViewAction", () => {
     const event = createKeyEvent("`", { ctrlKey: true, code: "Backquote" });
     const result = resolveViewAction(event, shortcuts, "other");
     expect(result).toBe("toggleTerminal");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook integration — proves the window handler toggles the sidebar exactly
+// once. Combined with editorPlugins.tiptap.test.ts asserting toggleSidebar is
+// NOT in the TipTap keymap, this guarantees no double-toggle.
+// ---------------------------------------------------------------------------
+
+describe("useViewShortcuts — sidebar toggle integration", () => {
+  beforeEach(() => {
+    useShortcutsStore.setState({ customBindings: {} }); // default toggleSidebar = Ctrl-Shift-0
+    useUIStore.setState({ sidebarVisible: false });
+  });
+  afterEach(() => {
+    useUIStore.setState({ sidebarVisible: false });
+  });
+
+  it("Ctrl-Shift-0 toggles the sidebar exactly once via the window handler", () => {
+    const before = useUIStore.getState().sidebarVisible;
+    const { unmount } = renderHook(() => useViewShortcuts());
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: ")",
+        code: "Digit0",
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+      }),
+    );
+
+    // Toggled once (true), not twice (which would land back on `before`).
+    expect(useUIStore.getState().sidebarVisible).toBe(!before);
+    unmount();
+  });
+
+  it("removes the window listener on unmount (no toggle after teardown)", () => {
+    const { unmount } = renderHook(() => useViewShortcuts());
+    unmount();
+    const before = useUIStore.getState().sidebarVisible;
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: ")", code: "Digit0", ctrlKey: true, shiftKey: true, bubbles: true }),
+    );
+    expect(useUIStore.getState().sidebarVisible).toBe(before);
   });
 });

--- a/src/hooks/useViewShortcuts.ts
+++ b/src/hooks/useViewShortcuts.ts
@@ -58,6 +58,7 @@ export type ViewAction =
   | "validateMarkdown"
   | "lintNext"
   | "lintPrev"
+  | "toggleSidebar"
   | "toggleOutline"
   | "fileExplorer"
   | "viewHistory"
@@ -77,6 +78,7 @@ const VIEW_SHORTCUT_IDS: ViewAction[] = [
   "validateMarkdown",
   "lintNext",
   "lintPrev",
+  "toggleSidebar",
   "toggleOutline",
   "fileExplorer",
   "viewHistory",
@@ -127,6 +129,7 @@ export function resolveViewAction(
     ["validateMarkdown", "validateMarkdown"],
     ["lintNext", "lintNext"],
     ["lintPrev", "lintPrev"],
+    ["toggleSidebar", "toggleSidebar"],
     ["toggleOutline", "toggleOutline"],
     ["fileExplorer", "fileExplorer"],
     ["viewHistory", "viewHistory"],
@@ -191,6 +194,7 @@ const VIEW_ACTION_EXECUTORS: Record<ViewAction, () => void> = {
   validateMarkdown: executeValidateMarkdown,
   lintNext: () => executeLintNav("next"),
   lintPrev: () => executeLintNav("prev"),
+  toggleSidebar: () => useUIStore.getState().toggleSidebar(),
   toggleOutline: () => useUIStore.getState().toggleSidebarView("outline"),
   fileExplorer: () => useUIStore.getState().toggleSidebarView("files"),
   viewHistory: () => useUIStore.getState().toggleSidebarView("history"),

--- a/src/locales/de/statusbar.json
+++ b/src/locales/de/statusbar.json
@@ -1,6 +1,5 @@
 {
   "openSidebar": "Seitenleiste öffnen",
-  "newTab": "Neuer Tab",
   "newTabTitle": "Neuer Tab",
   "autoSavePaused": "Automatisches Speichern pausiert",
   "autoSavePausedTitle": "Automatisches Speichern pausiert: Datei wurde vom Datenträger gelöscht. Manuell speichern mit {{shortcut}}.",

--- a/src/locales/en/statusbar.json
+++ b/src/locales/en/statusbar.json
@@ -1,6 +1,5 @@
 {
   "openSidebar": "Open Sidebar",
-  "newTab": "New tab",
   "newTabTitle": "New Tab",
   "autoSavePaused": "Auto-save paused",
   "autoSavePausedTitle": "Auto-save paused: file was deleted from disk. Save manually with {{shortcut}}.",

--- a/src/locales/es/statusbar.json
+++ b/src/locales/es/statusbar.json
@@ -1,6 +1,5 @@
 {
   "openSidebar": "Abrir barra lateral",
-  "newTab": "Nueva pestaña",
   "newTabTitle": "Nueva pestaña",
   "autoSavePaused": "Guardado automático pausado",
   "autoSavePausedTitle": "Guardado automático pausado: el archivo fue eliminado del disco. Guarda manualmente con {{shortcut}}.",

--- a/src/locales/fr/statusbar.json
+++ b/src/locales/fr/statusbar.json
@@ -1,6 +1,5 @@
 {
   "openSidebar": "Ouvrir la barre latérale",
-  "newTab": "Nouvel onglet",
   "newTabTitle": "Nouvel onglet",
   "autoSavePaused": "Enregistrement automatique suspendu",
   "autoSavePausedTitle": "Enregistrement automatique suspendu : le fichier a été supprimé du disque. Enregistrez manuellement avec {{shortcut}}.",

--- a/src/locales/it/statusbar.json
+++ b/src/locales/it/statusbar.json
@@ -1,6 +1,5 @@
 {
   "openSidebar": "Apri barra laterale",
-  "newTab": "Nuova scheda",
   "newTabTitle": "Nuova scheda",
   "autoSavePaused": "Salvataggio automatico sospeso",
   "autoSavePausedTitle": "Salvataggio automatico sospeso: il file è stato eliminato dal disco. Salva manualmente con {{shortcut}}.",

--- a/src/locales/ja/statusbar.json
+++ b/src/locales/ja/statusbar.json
@@ -1,6 +1,5 @@
 {
   "openSidebar": "サイドバーを開く",
-  "newTab": "新しいタブ",
   "newTabTitle": "新しいタブ",
   "autoSavePaused": "自動保存停止中",
   "autoSavePausedTitle": "自動保存停止中: ファイルがディスクから削除されました。{{shortcut}} で手動保存してください。",

--- a/src/locales/ko/statusbar.json
+++ b/src/locales/ko/statusbar.json
@@ -1,6 +1,5 @@
 {
   "openSidebar": "사이드바 열기",
-  "newTab": "새 탭",
   "newTabTitle": "새 탭",
   "autoSavePaused": "자동 저장 일시 중지",
   "autoSavePausedTitle": "자동 저장 일시 중지: 파일이 디스크에서 삭제되었습니다. {{shortcut}}로 수동 저장하세요.",

--- a/src/locales/pt-BR/statusbar.json
+++ b/src/locales/pt-BR/statusbar.json
@@ -1,6 +1,5 @@
 {
   "openSidebar": "Abrir barra lateral",
-  "newTab": "Nova aba",
   "newTabTitle": "Nova aba",
   "autoSavePaused": "Salvamento automático pausado",
   "autoSavePausedTitle": "Salvamento automático pausado: o arquivo foi excluído do disco. Salve manualmente com {{shortcut}}.",

--- a/src/locales/zh-CN/statusbar.json
+++ b/src/locales/zh-CN/statusbar.json
@@ -1,6 +1,5 @@
 {
   "openSidebar": "打开侧边栏",
-  "newTab": "新标签页",
   "newTabTitle": "新标签页",
   "autoSavePaused": "自动保存已暂停",
   "autoSavePausedTitle": "自动保存已暂停:文件已从磁盘删除。请使用 {{shortcut}} 手动保存。",

--- a/src/locales/zh-TW/statusbar.json
+++ b/src/locales/zh-TW/statusbar.json
@@ -1,6 +1,5 @@
 {
   "openSidebar": "開啟側邊欄",
-  "newTab": "新增標籤頁",
   "newTabTitle": "新標籤頁",
   "autoSavePaused": "自動儲存已暫停",
   "autoSavePausedTitle": "自動儲存已暫停：檔案已從磁碟刪除。請使用 {{shortcut}} 手動儲存。",

--- a/src/plugins/editorPlugins.tiptap.test.ts
+++ b/src/plugins/editorPlugins.tiptap.test.ts
@@ -119,13 +119,13 @@ describe("buildEditorKeymapBindings", () => {
     }
   });
 
-  it("includes toggleSidebar shortcut", () => {
+  it("does NOT bind toggleSidebar in the editor keymap (handled globally to avoid double-toggle)", () => {
     const bindings = buildEditorKeymapBindings();
-    const shortcuts = useShortcutsStore.getState();
-    const key = shortcuts.getShortcut("toggleSidebar");
-    if (key) {
-      expect(bindings[key]).toBeTypeOf("function");
-    }
+    const key = useShortcutsStore.getState().getShortcut("toggleSidebar");
+    expect(key).toBe("Ctrl-Shift-0");
+    // toggleSidebar is scope:"global", handled by useViewShortcuts at window level.
+    // Binding it here too would double-toggle when both handlers fire.
+    expect(bindings[key]).toBeUndefined();
   });
 
   it("includes blockquote shortcut", () => {
@@ -173,16 +173,6 @@ describe("buildEditorKeymapBindings", () => {
   it("binds Escape to a handler that returns a boolean", () => {
     const bindings = buildEditorKeymapBindings();
     expect(typeof bindings.Escape).toBe("function");
-  });
-
-  it("toggleSidebar binding calls useUIStore.toggleSidebar", () => {
-    const bindings = buildEditorKeymapBindings();
-    const shortcuts = useShortcutsStore.getState();
-    const key = shortcuts.getShortcut("toggleSidebar");
-    if (key) {
-      // The binding should be a function
-      expect(typeof bindings[key]).toBe("function");
-    }
   });
 
   it("does not duplicate bindings when called multiple times", () => {
@@ -295,17 +285,6 @@ describe("editorKeymapExtension integration", () => {
 });
 
 describe("buildEditorKeymapBindings handler execution", () => {
-  it("toggleSidebar binding returns true", () => {
-    const bindings = buildEditorKeymapBindings();
-    const shortcuts = useShortcutsStore.getState();
-    const key = shortcuts.getShortcut("toggleSidebar");
-    if (key) {
-      // Commands receive (state, dispatch, view) — toggleSidebar doesn't use them
-      const result = bindings[key]({} as never, undefined, undefined);
-      expect(result).toBe(true);
-    }
-  });
-
   it("Escape handler returns false when no popup/toolbar open and no mark boundary", () => {
     const bindings = buildEditorKeymapBindings();
     // Escape is wrapped with guardProseMirrorCommand which calls the inner fn
@@ -829,19 +808,6 @@ describe("buildEditorKeymapBindings — inner callback coverage", () => {
     };
   }
 
-  it("toggleSidebar inner body runs when called with a mock view", () => {
-    const bindings = buildEditorKeymapBindings();
-    const shortcuts = useShortcutsStore.getState();
-    const key = shortcuts.getShortcut("toggleSidebar");
-    if (key && bindings[key]) {
-      // toggleSidebar binding is plain (no wrapWithMultiSelectionGuard) — just guardProseMirrorCommand
-      const mockView = makeMockView();
-      // Should not throw and returns true
-      const result = bindings[key](mockView.state as never, vi.fn(), mockView as never);
-      expect(result).toBe(true);
-    }
-  });
-
   it("mark formatting inner body is reachable when wrapWithMultiSelectionGuard passes", () => {
     // The wrapWithMultiSelectionGuard returns false when view is undefined.
     // The inner body (if (!view) return false) is only reached when the outer guard
@@ -1051,19 +1017,6 @@ describe("buildEditorKeymapBindings — inner callback coverage", () => {
     }
   });
 
-  it("toggleSidebar inner body executes (covers lines 62-63)", () => {
-    // bindIfKey wraps with guardProseMirrorCommand. Passing a view with composing=false
-    // ensures the guard passes and the inner () => { toggleSidebar(); return true } runs.
-    const bindings = buildEditorKeymapBindings();
-    const shortcuts = useShortcutsStore.getState();
-    const key = shortcuts.getShortcut("toggleSidebar");
-    if (key && bindings[key]) {
-      const mockView = makeMockView();
-      const result = bindings[key](mockView.state as never, vi.fn(), mockView as never);
-      expect(result).toBe(true);
-    }
-  });
-
   it("inline mark inner bodies execute with view (covers if(!view) false branches)", () => {
     const bindings = buildEditorKeymapBindings();
     const shortcuts = useShortcutsStore.getState();
@@ -1232,27 +1185,6 @@ describe("buildEditorKeymapBindings — inner callback coverage", () => {
     }
   });
 
-  it("toggleSidebar inner body executes without view guard (lines 61-64)", async () => {
-    // toggleSidebar uses bindIfKey without wrapWithMultiSelectionGuard,
-    // so it just calls guardProseMirrorCommand(() => { toggleSidebar(); return true })
-    // This tests the actual inner body by ensuring toggleSidebar is called
-    const { useUIStore } = await import("@/stores/uiStore");
-    const initialSidebar = useUIStore.getState().sidebarVisible;
-
-    const bindings = buildEditorKeymapBindings();
-    const shortcuts = useShortcutsStore.getState();
-    const key = shortcuts.getShortcut("toggleSidebar");
-    if (key && bindings[key]) {
-      // Call without view (toggleSidebar doesn't need a view)
-      const result = bindings[key]({} as never, undefined, undefined);
-      expect(result).toBe(true);
-      // Sidebar visibility should have toggled
-      expect(useUIStore.getState().sidebarVisible).toBe(!initialSidebar);
-      // Toggle back
-      useUIStore.getState().toggleSidebar();
-    }
-  });
-
   it("subscript and superscript inner bodies execute with view (covers if(!view) branches)", () => {
     const bindings = buildEditorKeymapBindings();
     const shortcuts = useShortcutsStore.getState();
@@ -1289,27 +1221,6 @@ describe("buildEditorKeymapBindings — inner callback coverage", () => {
       const mockView = makeMockView();
       const result = bindings[key](mockView.state as never, vi.fn(), mockView as never);
       expect(result).toBe(true);
-    }
-  });
-
-  it("toggleSidebar inner callback toggles sidebar state (covers lines 62-63)", async () => {
-    // The inner callback of bindIfKey for toggleSidebar executes
-    // useUIStore.getState().toggleSidebar() and returns true.
-    // The key is that guardProseMirrorCommand wraps it and we pass a view
-    // so the composing guard passes through.
-    const { useUIStore } = await import("@/stores/uiStore");
-    const before = useUIStore.getState().sidebarVisible;
-
-    const bindings = buildEditorKeymapBindings();
-    const shortcuts = useShortcutsStore.getState();
-    const key = shortcuts.getShortcut("toggleSidebar");
-    if (key && bindings[key]) {
-      const mockView = makeMockView();
-      const result = bindings[key](mockView.state as never, mockView.dispatch as never, mockView as never);
-      expect(result).toBe(true);
-      expect(useUIStore.getState().sidebarVisible).toBe(!before);
-      // Restore
-      useUIStore.getState().toggleSidebar();
     }
   });
 
@@ -1405,49 +1316,6 @@ describe("buildEditorKeymapBindings — transformToggleCase with custom key", ()
 describe("buildEditorKeymapBindings — direct inner body coverage", () => {
   // These tests call the raw inner arrow functions directly, bypassing guardProseMirrorCommand,
   // to ensure V8 coverage tracks the function bodies at lines 62-63 and 309-310.
-
-  it("toggleSidebar inner arrow body executes (direct call, covers lines 62-63)", async () => {
-    const { useUIStore } = await import("@/stores/uiStore");
-    const before = useUIStore.getState().sidebarVisible;
-
-    // Build bindings and retrieve the raw command for toggleSidebar
-    const shortcuts = useShortcutsStore.getState();
-    const key = shortcuts.getShortcut("toggleSidebar");
-    if (!key) return;
-
-    const bindings = buildEditorKeymapBindings();
-    const handler = bindings[key];
-    if (!handler) return;
-
-    // Call five times to ensure branch coverage tracks the body
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { Schema } = require("@tiptap/pm/model");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { EditorState } = require("@tiptap/pm/state");
-    const schema = new Schema({
-      nodes: {
-        doc: { content: "paragraph+" },
-        paragraph: { content: "text*" },
-        text: { inline: true },
-      },
-    });
-    const doc = schema.node("doc", null, [schema.node("paragraph")]);
-    const state = EditorState.create({ doc, schema });
-    const mockView = {
-      state,
-      dispatch: vi.fn(),
-      focus: vi.fn(),
-      composing: false,
-      dom: document.createElement("div"),
-    };
-
-    const result = handler(state as never, vi.fn(), mockView as never);
-    expect(result).toBe(true);
-    // Sidebar should have toggled
-    expect(useUIStore.getState().sidebarVisible).toBe(!before);
-    // Restore
-    useUIStore.getState().toggleSidebar();
-  });
 
   it("transformToggleCase inner body executes with view (direct call, covers lines 309-310)", () => {
     const shortcuts = useShortcutsStore.getState();

--- a/src/plugins/editorPlugins.tiptap.ts
+++ b/src/plugins/editorPlugins.tiptap.ts
@@ -63,13 +63,10 @@ export function buildEditorKeymapBindings(): Record<string, Command> {
   const shortcuts = useShortcutsStore.getState();
   const bindings: Record<string, Command> = {};
 
-  bindIfKey(bindings, shortcuts.getShortcut("toggleSidebar"), /* v8 ignore start -- @preserve reason: toggleSidebar keymap handler only fires in live editor; not exercised in unit tests */ () => {
-    useUIStore.getState().toggleSidebar();
-    return true;
-  } /* v8 ignore stop */);
-
-  // Note: sourceMode toggle is handled by useViewShortcuts hook at window level
-  // to avoid double-toggle when both TipTap keymap and window handler fire
+  // Note: toggleSidebar and sourceMode toggles are handled by the useViewShortcuts
+  // hook at window level (scope: "global"), NOT here — binding them in the TipTap
+  // keymap too would double-toggle when both the keymap and the window handler
+  // fire on the same keypress.
 
   // --- Inline mark formatting ---
   bindIfKey(

--- a/src/stores/settingsStore/shortcuts.ts
+++ b/src/stores/settingsStore/shortcuts.ts
@@ -30,11 +30,7 @@ export type ShortcutCategory =
   | "view"        // Sidebar, Outline, Focus mode
   | "file";       // New, Open, Save, etc.
 
-/**
- * Shortcut scope determines when a shortcut is active.
- * - global: Works everywhere in the application
- * - editor: Only works when editor is focused (default)
- */
+/** Shortcut scope: "global" = active everywhere; "editor" (default) = only while the editor is focused. */
 export type ShortcutScope = "global" | "editor";
 
 /** A single keyboard shortcut entry with ID, label, category, default key, and optional menu binding. */
@@ -137,6 +133,8 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   { id: "removeBlankLines", label: "Remove Blank Lines", category: "editing", defaultKey: "", menuId: "remove-blank-lines", description: "Remove blank lines from selection" },
 
   // === View ===
+  // toggleSidebar: no menuId (a Rust accel would clash with `paragraph` Mod-Shift-0 on Win/Linux); handled in useViewShortcuts only, never the TipTap keymap, to avoid double-toggle.
+  { id: "toggleSidebar", label: "Toggle Sidebar", category: "view", defaultKey: "Ctrl-Shift-0", scope: "global" },
   { id: "toggleOutline", label: "Toggle Outline", category: "view", defaultKey: "Ctrl-Shift-1", menuId: "outline", scope: "global" },
   { id: "fileExplorer", label: "Toggle File Explorer", category: "view", defaultKey: "Ctrl-Shift-2", menuId: "file-explorer", scope: "global" },
   { id: "viewHistory", label: "Toggle History", category: "view", defaultKey: "Ctrl-Shift-3", menuId: "view-history", scope: "global" },

--- a/src/utils/tooltipWithShortcut.test.ts
+++ b/src/utils/tooltipWithShortcut.test.ts
@@ -1,0 +1,26 @@
+// Empty-safe tooltip builder: appends "(KEY)" only when a shortcut exists.
+
+import { describe, it, expect } from "vitest";
+import { tooltipWithShortcut } from "./tooltipWithShortcut";
+
+describe("tooltipWithShortcut", () => {
+  it("returns the label unchanged when the key is empty", () => {
+    expect(tooltipWithShortcut("Open Sidebar", "")).toBe("Open Sidebar");
+  });
+
+  it("appends the formatted key in parentheses when present", () => {
+    expect(tooltipWithShortcut("Toggle Sidebar", "⌃⇧0")).toBe("Toggle Sidebar (⌃⇧0)");
+  });
+
+  it("treats a whitespace-only key as empty (no empty parens)", () => {
+    expect(tooltipWithShortcut("Open Sidebar", "   ")).toBe("Open Sidebar");
+  });
+
+  it("trims surrounding whitespace from the key", () => {
+    expect(tooltipWithShortcut("New Tab", "  ⌘T  ")).toBe("New Tab (⌘T)");
+  });
+
+  it("works with non-mac display strings", () => {
+    expect(tooltipWithShortcut("Open Sidebar", "Ctrl+Shift+0")).toBe("Open Sidebar (Ctrl+Shift+0)");
+  });
+});

--- a/src/utils/tooltipWithShortcut.ts
+++ b/src/utils/tooltipWithShortcut.ts
@@ -1,0 +1,14 @@
+/**
+ * Purpose: Build a button tooltip string that appends a keyboard shortcut hint
+ * only when one exists, avoiding an empty "()" when the shortcut is unbound.
+ *
+ * Leaf-pure (ADR-013): takes an already-formatted key so it never imports the
+ * formatter from `stores/`. Callers format with `formatKeyForDisplay` first.
+ *
+ * @example tooltipWithShortcut("Open Sidebar", "⌃⇧0") // "Open Sidebar (⌃⇧0)"
+ * @example tooltipWithShortcut("Open Sidebar", "")     // "Open Sidebar"
+ */
+export function tooltipWithShortcut(label: string, formattedKey: string): string {
+  const key = formattedKey.trim();
+  return key ? `${label} (${key})` : label;
+}

--- a/website/guide/shortcuts.md
+++ b/website/guide/shortcuts.md
@@ -167,6 +167,7 @@ If you prefer keeping system functions on F-keys, you can customize VMark shortc
 | Zoom In | `Mod + =` |
 | Zoom Out | `Mod + -` |
 | Word Wrap | `Alt + Z` |
+| Toggle Sidebar | `Ctrl + Shift + 0` |
 | Toggle Outline | `Ctrl + Shift + 1` |
 | Toggle File Explorer | `Ctrl + Shift + 2` |
 | Toggle History | `Ctrl + Shift + 3` |


### PR DESCRIPTION
Completes the feature promise of #1060 and supersedes #1059 (which was a partial draft with two real bugs — see below). Every native `title=` button whose action has a rebindable shortcut now surfaces it, degrading to a paren-free label when unbound. Verified locally with full `pnpm check:all`.

## What's delivered
- **Helper** `tooltipWithShortcut(label, formattedKey)` — leaf-pure (ADR-013), appends `(KEY)` only when bound.
- **Dead sidebar shortcut fixed** — `toggleSidebar` = `Ctrl-Shift-0` (global, no menuId), handled **only** in `useViewShortcuts` (window level).
- **Tooltips wired** (title + aria-label parity): StatusBar open-sidebar, Sidebar close-sidebar + new-file, StatusBarTabStrip new-tab, UniversalToolbar AI-Prompts (was a hardcoded `(⌘Y)` → now dynamic/rebindable/cross-platform).
- **i18n**: removed the orphaned `newTab` key (sole user switched to `newTabTitle`).
- **Docs**: `Toggle Sidebar — Ctrl + Shift + 0` added to the shortcuts guide.

## Bugs fixed vs #1059
1. **Double-toggle**: #1059 added the window handler but left `toggleSidebar` in the TipTap keymap too — both fire when the editor is focused → toggles twice (no-op). The same file documents this exact hazard for `sourceMode`. Fixed by removing the keymap binding (+ a test asserting it's absent).
2. **i18n regression**: #1059 deleted the `newTab` key while `StatusBarTabStrip` still used it. Fixed by switching that usage first, then removing the key.

## Coverage (the gap that hid the bugs)
- Helper unit tests (empty/whitespace/trim/non-mac).
- A `useViewShortcuts` **integration test** that dispatches `Ctrl-Shift-0` and asserts a **single** toggle — the behavior test #1059 lacked.
- Per-surface tooltip + title/aria-label-parity tests.

## Out of scope (deliberate)
- FindBar prev/next already embed `Enter`/`Shift+Enter` hints — wiring the global shortcut would double up.
- The toolbar **dropdown**'s hardcoded Mac shortcut strings (28 of them) are a separate defect (non-rebindable, wrong on Win/Linux) — worth its own PR.

Closes #1060.