### PR TITLE
fix(secrets): flush secure store to disk on write/delete (#1061)

### DIFF
--- a/src/services/secrets/secureStorage.test.ts
+++ b/src/services/secrets/secureStorage.test.ts
@@ -116,7 +116,7 @@ describe("secureStorage", () => {
       expect(storage.getItem("new-key")).toBe("new-value");
     });
 
-    it("setItem syncs to Tauri store in background (no explicit save)", async () => {
+    it("setItem syncs to Tauri store AND flushes to disk via save() (#1061)", async () => {
       await initSecureStorage([]);
       const storage = createSecureStorage();
       storage.setItem("bg-key", "bg-value");
@@ -124,8 +124,9 @@ describe("secureStorage", () => {
       // Wait for async sync
       await new Promise((r) => setTimeout(r, 50));
       expect(mockStore.set).toHaveBeenCalledWith("bg-key", "bg-value");
-      // Plugin auto-saves — no explicit save() call on writes
-      expect(mockStore.save).not.toHaveBeenCalled();
+      // store.set() only mutates memory; save() must flush to disk, otherwise
+      // the change is lost on restart (the Ollama-config-not-persisted bug).
+      expect(mockStore.save).toHaveBeenCalled();
     });
 
     it("removeItem clears cache immediately", async () => {
@@ -136,14 +137,17 @@ describe("secureStorage", () => {
       expect(storage.getItem("del-key")).toBeNull();
     });
 
-    it("removeItem syncs to Tauri store in background", async () => {
+    it("removeItem syncs to Tauri store AND flushes the deletion via save() (#1061)", async () => {
       await initSecureStorage([]);
       const storage = createSecureStorage();
       storage.setItem("rm-key", "rm-value");
+      mockStore.save.mockClear();
       storage.removeItem("rm-key");
 
       await new Promise((r) => setTimeout(r, 50));
       expect(mockStore.delete).toHaveBeenCalledWith("rm-key");
+      // Deletion must be flushed to disk too, not just removed from memory.
+      expect(mockStore.save).toHaveBeenCalled();
     });
 
     it("setItem handles Tauri store write failure gracefully", async () => {

--- a/src/services/secrets/secureStorage.ts
+++ b/src/services/secrets/secureStorage.ts
@@ -149,10 +149,13 @@ export function createSecureStorage(): StateStorage {
         // In fallback mode, persist to localStorage (best effort)
         try { localStorage.setItem(name, value); } catch { /* quota exceeded */ }
       } else {
-        // Background sync to Tauri store
+        // Background sync to Tauri store. store.set() only mutates the in-memory
+        // store; save() flushes it to .vmark-secure.json — without it the change
+        // is lost on restart (issue #1061).
         getStore()
           .then(async (store) => {
             await store.set(name, value);
+            await store.save();
           })
           .catch((error) => {
             safeStorageError("Failed to persist to secure storage:", error);
@@ -170,6 +173,7 @@ export function createSecureStorage(): StateStorage {
         getStore()
           .then(async (store) => {
             await store.delete(name);
+            await store.save(); // flush deletion to disk (see #1061)
           })
           .catch((error) => {
             safeStorageError("Failed to remove from secure storage:", error);


### PR DESCRIPTION
Fixes #1061 — Ollama provider config (and any non-secret AI config) silently reverting after restart.

## Root cause
`createSecureStorage()` in `src/services/secrets/secureStorage.ts` called `store.set()` (and `store.delete()`) but never `store.save()`. tauri-plugin-store's `set`/`delete` only mutate the in-memory store object; `save()` is what flushes to `.vmark-secure.json`. So edits survived until quit, then were lost — the reported "model reverts to `llama3.2`" symptom.

`removeItem` had the **same flaw** (deletions weren't flushed) — the reporter only spotted `setItem`; fixed both.

## Fix
- `await store.save()` after `store.set()` in `setItem`.
- `await store.save()` after `store.delete()` in `removeItem`.

This matches `initSecureStorage()`'s migration path, which already does set+save.

## Tests
- Updated the two relevant tests to assert `save()` **is** called. The previous `setItem` test asserted `save()` was *not* called, with a "plugin auto-saves" comment — a false assumption that had codified the bug. Full `pnpm check:all` green.

## Out of scope
The reporter also noted the `catch` block only logs (no user-facing toast on persist failure). That's a separate error-UX enhancement (needs an i18n string + toast wiring); the persistence bug itself is fully fixed here.