### PR TITLE
fix(export): local images render on Print/Export PDF (asset scheme + missing-image warning) (#1086)

### DIFF
--- a/src/export/__tests__/exportToPdfImages.test.ts
+++ b/src/export/__tests__/exportToPdfImages.test.ts
@@ -22,11 +22,13 @@ const {
   mockResolveResources,
   mockGetDocumentBaseDir,
   mockToastError,
+  mockToastWarning,
 } = vi.hoisted(() => ({
   mockInvoke: vi.fn(),
   mockResolveResources: vi.fn(),
   mockGetDocumentBaseDir: vi.fn(),
   mockToastError: vi.fn(),
+  mockToastWarning: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -46,7 +48,7 @@ vi.mock("@/utils/shortcutMatch", () => ({
 }));
 
 vi.mock("@/services/ime/imeToast", () => ({
-  imeToast: { error: mockToastError, success: vi.fn(), warning: vi.fn() },
+  imeToast: { error: mockToastError, success: vi.fn(), warning: mockToastWarning },
 }));
 
 vi.mock("../themeSnapshot", () => ({
@@ -163,5 +165,41 @@ describe("exportToPdf — local image inlining (issue #999)", () => {
     await exportToPdf({ markdown: "   \n\t" });
     expect(mockInvoke).not.toHaveBeenCalled();
     expect(mockResolveResources).not.toHaveBeenCalled();
+  });
+
+  // Issue #1086, fix #3: unembeddable images used to be silently swapped for
+  // the "Image not found" placeholder. Surface a warning toast so the user
+  // knows the printed/exported output is missing images.
+  it("warns when images could not be embedded", async () => {
+    installLiveEditor('<p><img src="asset://localhost/docs/my-notes/img/cat.png"></p>');
+    mockResolveResources.mockResolvedValueOnce({
+      html: '<p><img src="data:image/svg+xml,placeholder"></p>',
+      report: {
+        resources: [{ originalSrc: "img/cat.png" }],
+        resolved: [],
+        missing: [{ originalSrc: "img/cat.png" }],
+        totalSize: 0,
+      },
+    });
+
+    await exportToPdf({
+      markdown: "![cat](img/cat.png)",
+      sourceFilePath: "/docs/my-notes/note.md",
+    });
+
+    expect(mockToastWarning).toHaveBeenCalledTimes(1);
+    // Still prints — the placeholder output is delivered, just flagged.
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not warn when all images embed successfully", async () => {
+    installLiveEditor('<p><img src="asset://localhost/docs/my-notes/img/cat.png"></p>');
+    // Default mock reports zero missing resources.
+    await exportToPdf({
+      markdown: "![cat](img/cat.png)",
+      sourceFilePath: "/docs/my-notes/note.md",
+    });
+
+    expect(mockToastWarning).not.toHaveBeenCalled();
   });
 });

--- a/src/export/exportResourceWarnings.ts
+++ b/src/export/exportResourceWarnings.ts
@@ -1,0 +1,27 @@
+/**
+ * Export resource warnings
+ *
+ * Surfaces images that could not be embedded during Print / Export PDF. The
+ * off-screen WKWebView that renders the output has no Tauri asset:// handler,
+ * so any image `resolveResources` cannot inline is swapped for the "Image not
+ * found" placeholder. That substitution used to be silent (dev-only
+ * `exportWarn`); we log every offending path and raise a single count toast so
+ * the user knows the output is missing images (issue #1086, fix #3).
+ *
+ * @module export/exportResourceWarnings
+ */
+
+import { imeToast as toast } from "@/services/ime/imeToast";
+import { exportWarn } from "@/utils/debug";
+import i18n from "@/i18n";
+import type { ResourceReport } from "./resourceResolver";
+
+export function warnMissingResources(report: ResourceReport): void {
+  if (report.missing.length === 0) return;
+  for (const resource of report.missing) {
+    exportWarn("Image could not be embedded for export:", resource.originalSrc);
+  }
+  toast.warning(
+    i18n.t("dialog:toast.exportImageWarning", { count: report.missing.length }),
+  );
+}

--- a/src/export/resourceResolver.test.ts
+++ b/src/export/resourceResolver.test.ts
@@ -599,6 +599,74 @@ describe("resolveResources", () => {
     expect(report.resolved).toHaveLength(0);
   });
 
+  // Regression for issue #1086: on newer macOS/WebKit (and on Windows),
+  // Tauri's convertFileSrc() emits the asset protocol as
+  // `https://asset.localhost/…`. That superficially matches isRemoteUrl()'s
+  // https check, so resolveResources used to classify it as a remote URL and
+  // pass it through untouched — leaving an unreachable https URL in the
+  // print/PDF HTML that the off-screen WKWebView (no asset:// handler) cannot
+  // load, which surfaced as a missing image even though the editor rendered it
+  // fine. Asset URLs must be inlined as data URIs regardless of their scheme.
+  it("inlines https://asset.localhost/ asset URLs as data URIs in single mode", async () => {
+    const src = `https://asset.localhost/${encodeURIComponent("/docs/evidence/page-1.png")}`;
+    const html = `<img src="${src}">`;
+    mockExists.mockResolvedValue(true);
+    mockReadFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+    const { html: result, report } = await resolveResources(html, {
+      baseDir: "/docs",
+      mode: "single",
+    });
+
+    expect(result).toContain("data:image/png;base64,");
+    expect(result).not.toContain("asset.localhost");
+    expect(report.resolved).toHaveLength(1);
+    expect(report.resolved[0].isRemote).toBe(false);
+    expect(report.resolved[0].found).toBe(true);
+    expect(report.missing).toHaveLength(0);
+  });
+
+  it("inlines asset://localhost/ asset URLs as data URIs in single mode", async () => {
+    const src = `asset://localhost/${encodeURIComponent("/docs/evidence/page-1.png")}`;
+    const html = `<img src="${src}">`;
+    mockExists.mockResolvedValue(true);
+    mockReadFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+    const { html: result, report } = await resolveResources(html, {
+      baseDir: "/docs",
+      mode: "single",
+    });
+
+    expect(result).toContain("data:image/png;base64,");
+    expect(result).not.toContain("asset://");
+    expect(report.resolved).toHaveLength(1);
+    expect(report.resolved[0].isRemote).toBe(false);
+  });
+
+  it("copies https://asset.localhost/ asset URLs to assets folder in folder mode", async () => {
+    const src = `https://asset.localhost/${encodeURIComponent("/docs/page.png")}`;
+    const html = `<img src="${src}">`;
+    mockExists.mockImplementation(async (path: string) => {
+      if (path.includes("assets/images")) return false;
+      return true;
+    });
+    mockMkdir.mockResolvedValue(undefined);
+    mockCopyFile.mockResolvedValue(undefined);
+    mockStat.mockResolvedValue({ size: 7 });
+
+    const { html: result, report } = await resolveResources(html, {
+      baseDir: "/docs",
+      mode: "folder",
+      outputDir: "/output",
+    });
+
+    expect(result).toContain("assets/images/page.png");
+    expect(result).not.toContain("asset.localhost");
+    expect(mockCopyFile).toHaveBeenCalled();
+    expect(report.resolved).toHaveLength(1);
+    expect(report.resolved[0].isRemote).toBe(false);
+  });
+
   it("copies images to assets folder in folder mode", async () => {
     const html = '<img src="photo.png">';
     mockExists.mockImplementation(async (path: string) => {

--- a/src/export/resourceResolver.test.ts
+++ b/src/export/resourceResolver.test.ts
@@ -159,8 +159,16 @@ describe("isAssetUrl", () => {
     expect(isAssetUrl("https://asset.localhost/path/to/file.png")).toBe(true);
   });
 
+  it("returns true for http://asset.localhost/ (Windows/WebView2 scheme)", () => {
+    expect(isAssetUrl("http://asset.localhost/path/to/file.png")).toBe(true);
+  });
+
   it("returns false for regular https URLs", () => {
     expect(isAssetUrl("https://example.com/image.png")).toBe(false);
+  });
+
+  it("returns false for regular http URLs", () => {
+    expect(isAssetUrl("http://example.com/image.png")).toBe(false);
   });
 
   it("returns false for relative paths", () => {
@@ -624,6 +632,23 @@ describe("resolveResources", () => {
     expect(report.resolved[0].isRemote).toBe(false);
     expect(report.resolved[0].found).toBe(true);
     expect(report.missing).toHaveLength(0);
+  });
+
+  it("inlines http://asset.localhost/ (Windows) asset URLs as data URIs in single mode", async () => {
+    const src = `http://asset.localhost/${encodeURIComponent("/docs/evidence/page-1.png")}`;
+    const html = `<img src="${src}">`;
+    mockExists.mockResolvedValue(true);
+    mockReadFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+    const { html: result, report } = await resolveResources(html, {
+      baseDir: "/docs",
+      mode: "single",
+    });
+
+    expect(result).toContain("data:image/png;base64,");
+    expect(result).not.toContain("asset.localhost");
+    expect(report.resolved).toHaveLength(1);
+    expect(report.resolved[0].isRemote).toBe(false);
   });
 
   it("inlines asset://localhost/ asset URLs as data URIs in single mode", async () => {

--- a/src/export/resourceResolver.ts
+++ b/src/export/resourceResolver.ts
@@ -276,7 +276,13 @@ export async function resolveResources(
       originalSrc: src,
       resolvedPath: null,
       exportSrc: src,
-      isRemote: isRemoteUrl(src),
+      // Tauri's convertFileSrc() emits the asset protocol as
+      // `https://asset.localhost/…` on newer macOS/WebKit and on Windows, which
+      // superficially matches the http(s) remote check. Those are LOCAL files,
+      // not remote URLs — classify them as local so they get inlined/copied for
+      // the off-screen print/PDF WKWebView (which has no asset:// handler)
+      // instead of being passed through as unreachable https URLs (issue #1086).
+      isRemote: isRemoteUrl(src) && !isAssetUrl(src),
       found: false,
     };
 

--- a/src/export/resourceResolver.ts
+++ b/src/export/resourceResolver.ts
@@ -85,20 +85,16 @@ export function isDataUri(src: string): boolean {
 }
 
 /**
- * Check if a URL is a Tauri asset URL.
- * Tauri uses different formats depending on version/platform:
- * - asset://localhost/... (macOS/Linux WebKit)
- * - https://asset.localhost/... (newer macOS/WebKit, and Windows with modified CSP)
- * - http://asset.localhost/... (Windows/WebView2 default)
- * These are all LOCAL files served through Tauri's protocol handler, not
- * remote resources — classifying them correctly matters for export inlining.
+ * Check if a URL is a Tauri asset URL — a LOCAL file served through Tauri's
+ * protocol handler, not a remote resource. convertFileSrc() emits these as
+ * `asset://localhost/…` (macOS/Linux WebKit) or `http(s)://asset.localhost/…`
+ * (newer macOS/WebKit + Windows). Correct classification matters for inlining.
  */
 export function isAssetUrl(src: string): boolean {
   return (
     src.startsWith("asset://") ||
     src.startsWith("tauri://") ||
-    src.startsWith("https://asset.localhost/") ||
-    src.startsWith("http://asset.localhost/")
+    /^https?:\/\/asset\.localhost\//.test(src)
   );
 }
 
@@ -279,12 +275,7 @@ export async function resolveResources(
       originalSrc: src,
       resolvedPath: null,
       exportSrc: src,
-      // Tauri's convertFileSrc() emits the asset protocol as
-      // `https://asset.localhost/…` on newer macOS/WebKit and on Windows, which
-      // superficially matches the http(s) remote check. Those are LOCAL files,
-      // not remote URLs — classify them as local so they get inlined/copied for
-      // the off-screen print/PDF WKWebView (which has no asset:// handler)
-      // instead of being passed through as unreachable https URLs (issue #1086).
+      // Asset URLs are LOCAL files to inline, never remote passthrough (#1086).
       isRemote: isRemoteUrl(src) && !isAssetUrl(src),
       found: false,
     };

--- a/src/export/resourceResolver.ts
+++ b/src/export/resourceResolver.ts
@@ -87,15 +87,18 @@ export function isDataUri(src: string): boolean {
 /**
  * Check if a URL is a Tauri asset URL.
  * Tauri uses different formats depending on version/platform:
- * - asset://localhost/... (older)
- * - https://asset.localhost/... (newer, macOS/Linux)
- * - https://asset.localhost/... (Windows with modified CSP)
+ * - asset://localhost/... (macOS/Linux WebKit)
+ * - https://asset.localhost/... (newer macOS/WebKit, and Windows with modified CSP)
+ * - http://asset.localhost/... (Windows/WebView2 default)
+ * These are all LOCAL files served through Tauri's protocol handler, not
+ * remote resources — classifying them correctly matters for export inlining.
  */
 export function isAssetUrl(src: string): boolean {
   return (
     src.startsWith("asset://") ||
     src.startsWith("tauri://") ||
-    src.startsWith("https://asset.localhost/")
+    src.startsWith("https://asset.localhost/") ||
+    src.startsWith("http://asset.localhost/")
   );
 }
 

--- a/src/export/useExportOperations.ts
+++ b/src/export/useExportOperations.ts
@@ -23,8 +23,29 @@ import { showError, FileErrors } from "@/services/dialogs/errorDialog";
 import { isMacPlatform } from "@/utils/shortcutMatch";
 import { errorMessage } from "@/utils/errorMessage";
 
+import type { ResourceReport } from "./resourceResolver";
+
 /** Timeout for waiting on assets (fonts, images, math, diagrams) */
 const ASSET_WAIT_TIMEOUT = 10000;
+
+/**
+ * Surface images that could not be embedded during Print / Export PDF.
+ *
+ * The off-screen WKWebView that renders the print/PDF output has no Tauri
+ * asset:// handler, so any image `resolveResources` cannot inline is swapped
+ * for the "Image not found" placeholder. That substitution used to be silent
+ * (dev-only `exportWarn`); log every offending path and raise a single count
+ * toast so the user knows the output is missing images (issue #1086, fix #3).
+ */
+function warnMissingResources(report: ResourceReport): void {
+  if (report.missing.length === 0) return;
+  for (const resource of report.missing) {
+    exportWarn("Image could not be embedded for export:", resource.originalSrc);
+  }
+  toast.warning(
+    i18n.t("dialog:toast.exportImageWarning", { count: report.missing.length }),
+  );
+}
 
 /** Maximum time to wait for render before giving up */
 const RENDER_TIMEOUT = 15000;
@@ -285,10 +306,11 @@ export async function exportToPdfNative(options: ExportToPdfOptions): Promise<vo
     const baseDir = sourceFilePath
       ? await getDocumentBaseDir(sourceFilePath)
       : "/";
-    const { html: resolvedHtml } = await resolveResources(renderedHtml, {
+    const { html: resolvedHtml, report } = await resolveResources(renderedHtml, {
       baseDir,
       mode: "single",
     });
+    warnMissingResources(report);
 
     // Open PDF export in native window
     const { openPdfExportWindow } = await import("@/services/navigation/pdfExportWindow");
@@ -375,11 +397,12 @@ async function exportToPdfBrowser(
     // through untouched. Resolved relative to the source document's directory.
     const { resolveResources, getDocumentBaseDir } = await import("./resourceResolver");
     const baseDir = await getDocumentBaseDir(sourceFilePath);
-    const { html: resolvedHtml } = await resolveResources(html, {
+    const { html: resolvedHtml, report } = await resolveResources(html, {
       baseDir,
       mode: "single",
     });
     html = resolvedHtml;
+    warnMissingResources(report);
 
     const themeCSS = captureThemeCSS();
     const { getEditorContentCSS } = await import("./htmlExportStyles");

--- a/src/export/useExportOperations.ts
+++ b/src/export/useExportOperations.ts
@@ -22,30 +22,10 @@ import { joinPath } from "@/utils/pathUtils";
 import { showError, FileErrors } from "@/services/dialogs/errorDialog";
 import { isMacPlatform } from "@/utils/shortcutMatch";
 import { errorMessage } from "@/utils/errorMessage";
-
-import type { ResourceReport } from "./resourceResolver";
+import { warnMissingResources } from "./exportResourceWarnings";
 
 /** Timeout for waiting on assets (fonts, images, math, diagrams) */
 const ASSET_WAIT_TIMEOUT = 10000;
-
-/**
- * Surface images that could not be embedded during Print / Export PDF.
- *
- * The off-screen WKWebView that renders the print/PDF output has no Tauri
- * asset:// handler, so any image `resolveResources` cannot inline is swapped
- * for the "Image not found" placeholder. That substitution used to be silent
- * (dev-only `exportWarn`); log every offending path and raise a single count
- * toast so the user knows the output is missing images (issue #1086, fix #3).
- */
-function warnMissingResources(report: ResourceReport): void {
-  if (report.missing.length === 0) return;
-  for (const resource of report.missing) {
-    exportWarn("Image could not be embedded for export:", resource.originalSrc);
-  }
-  toast.warning(
-    i18n.t("dialog:toast.exportImageWarning", { count: report.missing.length }),
-  );
-}
 
 /** Maximum time to wait for render before giving up */
 const RENDER_TIMEOUT = 15000;
@@ -306,10 +286,7 @@ export async function exportToPdfNative(options: ExportToPdfOptions): Promise<vo
     const baseDir = sourceFilePath
       ? await getDocumentBaseDir(sourceFilePath)
       : "/";
-    const { html: resolvedHtml, report } = await resolveResources(renderedHtml, {
-      baseDir,
-      mode: "single",
-    });
+    const { html: resolvedHtml, report } = await resolveResources(renderedHtml, { baseDir, mode: "single" });
     warnMissingResources(report);
 
     // Open PDF export in native window
@@ -397,10 +374,7 @@ async function exportToPdfBrowser(
     // through untouched. Resolved relative to the source document's directory.
     const { resolveResources, getDocumentBaseDir } = await import("./resourceResolver");
     const baseDir = await getDocumentBaseDir(sourceFilePath);
-    const { html: resolvedHtml, report } = await resolveResources(html, {
-      baseDir,
-      mode: "single",
-    });
+    const { html: resolvedHtml, report } = await resolveResources(html, { baseDir, mode: "single" });
     html = resolvedHtml;
     warnMissingResources(report);
 

--- a/src/locales/de/dialog.json
+++ b/src/locales/de/dialog.json
@@ -107,6 +107,8 @@
     "exportHtmlSuccess": "In Ordner exportiert",
     "exportHtmlResourceWarning_one": "1 Ressource konnte nicht eingeschlossen werden",
     "exportHtmlResourceWarning_other": "{{count}} Ressourcen konnten nicht eingeschlossen werden",
+    "exportImageWarning_one": "1 Bild konnte nicht eingebettet werden und fehlt in der Ausgabe",
+    "exportImageWarning_other": "{{count}} Bilder konnten nicht eingebettet werden und fehlen in der Ausgabe",
     "printRequiresMac": "Drucken erfordert macOS.",
     "nativePdfRequiresMac": "Nativer PDF-Export erfordert macOS. Verwenden Sie stattdessen Drucken.",
     "failedToPreparePdf": "PDF-Export konnte nicht vorbereitet werden",

--- a/src/locales/en/dialog.json
+++ b/src/locales/en/dialog.json
@@ -145,6 +145,8 @@
     "exportHtmlSuccess": "Exported to folder",
     "exportHtmlResourceWarning_one": "1 resource could not be included",
     "exportHtmlResourceWarning_other": "{{count}} resources could not be included",
+    "exportImageWarning_one": "1 image could not be embedded and is missing from the output",
+    "exportImageWarning_other": "{{count}} images could not be embedded and are missing from the output",
     "printRequiresMac": "Print requires macOS.",
     "nativePdfRequiresMac": "Native PDF export requires macOS. Use Print instead.",
     "failedToPreparePdf": "Failed to prepare PDF export",

--- a/src/locales/es/dialog.json
+++ b/src/locales/es/dialog.json
@@ -107,6 +107,8 @@
     "exportHtmlSuccess": "Exportado a la carpeta",
     "exportHtmlResourceWarning_one": "1 recurso no pudo incluirse",
     "exportHtmlResourceWarning_other": "{{count}} recursos no pudieron incluirse",
+    "exportImageWarning_one": "No se pudo incrustar 1 imagen y falta en el resultado",
+    "exportImageWarning_other": "No se pudieron incrustar {{count}} imágenes y faltan en el resultado",
     "printRequiresMac": "La impresión requiere macOS.",
     "nativePdfRequiresMac": "La exportación nativa a PDF requiere macOS. Usa Imprimir en su lugar.",
     "failedToPreparePdf": "Error al preparar la exportación a PDF",

--- a/src/locales/fr/dialog.json
+++ b/src/locales/fr/dialog.json
@@ -107,6 +107,8 @@
     "exportHtmlSuccess": "Exporté dans le dossier",
     "exportHtmlResourceWarning_one": "1 ressource n'a pas pu être incluse",
     "exportHtmlResourceWarning_other": "{{count}} ressources n'ont pas pu être incluses",
+    "exportImageWarning_one": "1 image n'a pas pu être intégrée et est absente du résultat",
+    "exportImageWarning_other": "{{count}} images n'ont pas pu être intégrées et sont absentes du résultat",
     "printRequiresMac": "L'impression nécessite macOS.",
     "nativePdfRequiresMac": "L'exportation PDF native nécessite macOS. Utilisez Imprimer à la place.",
     "failedToPreparePdf": "Impossible de préparer l'exportation PDF",

--- a/src/locales/it/dialog.json
+++ b/src/locales/it/dialog.json
@@ -107,6 +107,8 @@
     "exportHtmlSuccess": "Esportato nella cartella",
     "exportHtmlResourceWarning_one": "1 risorsa non è stata inclusa",
     "exportHtmlResourceWarning_other": "{{count}} risorse non sono state incluse",
+    "exportImageWarning_one": "Impossibile incorporare 1 immagine, che risulta assente dall'output",
+    "exportImageWarning_other": "Impossibile incorporare {{count}} immagini, che risultano assenti dall'output",
     "printRequiresMac": "La stampa richiede macOS.",
     "nativePdfRequiresMac": "L'esportazione PDF nativa richiede macOS. Usa Stampa.",
     "failedToPreparePdf": "Preparazione esportazione PDF fallita",

--- a/src/locales/ja/dialog.json
+++ b/src/locales/ja/dialog.json
@@ -107,6 +107,8 @@
     "exportHtmlSuccess": "フォルダにエクスポートしました",
     "exportHtmlResourceWarning_one": "1個のリソースを含められませんでした",
     "exportHtmlResourceWarning_other": "{{count}}個のリソースを含められませんでした",
+    "exportImageWarning_one": "1個の画像を埋め込めなかったため、出力から欠落しています",
+    "exportImageWarning_other": "{{count}}個の画像を埋め込めなかったため、出力から欠落しています",
     "printRequiresMac": "印刷にはmacOSが必要です。",
     "nativePdfRequiresMac": "ネイティブPDFエクスポートにはmacOSが必要です。代わりに印刷を使用してください。",
     "failedToPreparePdf": "PDFエクスポートの準備に失敗しました",

--- a/src/locales/ko/dialog.json
+++ b/src/locales/ko/dialog.json
@@ -107,6 +107,8 @@
     "exportHtmlSuccess": "폴더로 내보냈습니다",
     "exportHtmlResourceWarning_one": "리소스 1개를 포함할 수 없습니다",
     "exportHtmlResourceWarning_other": "리소스 {{count}}개를 포함할 수 없습니다",
+    "exportImageWarning_one": "이미지 1개를 포함하지 못해 출력에서 누락되었습니다",
+    "exportImageWarning_other": "이미지 {{count}}개를 포함하지 못해 출력에서 누락되었습니다",
     "printRequiresMac": "인쇄 기능은 macOS가 필요합니다.",
     "nativePdfRequiresMac": "네이티브 PDF 내보내기는 macOS가 필요합니다. 인쇄를 사용하세요.",
     "failedToPreparePdf": "PDF 내보내기 준비에 실패했습니다",

--- a/src/locales/pt-BR/dialog.json
+++ b/src/locales/pt-BR/dialog.json
@@ -107,6 +107,8 @@
     "exportHtmlSuccess": "Exportado para a pasta",
     "exportHtmlResourceWarning_one": "1 recurso não pôde ser incluído",
     "exportHtmlResourceWarning_other": "{{count}} recursos não puderam ser incluídos",
+    "exportImageWarning_one": "1 imagem não pôde ser incorporada e está ausente da saída",
+    "exportImageWarning_other": "{{count}} imagens não puderam ser incorporadas e estão ausentes da saída",
     "printRequiresMac": "A impressão requer macOS.",
     "nativePdfRequiresMac": "A exportação de PDF nativa requer macOS. Use Imprimir.",
     "failedToPreparePdf": "Falha ao preparar a exportação de PDF",

--- a/src/locales/zh-CN/dialog.json
+++ b/src/locales/zh-CN/dialog.json
@@ -107,6 +107,8 @@
     "exportHtmlSuccess": "已导出到文件夹",
     "exportHtmlResourceWarning_one": "1 个资源无法包含",
     "exportHtmlResourceWarning_other": "{{count}} 个资源无法包含",
+    "exportImageWarning_one": "1 张图片无法嵌入，输出中将缺失",
+    "exportImageWarning_other": "{{count}} 张图片无法嵌入，输出中将缺失",
     "printRequiresMac": "打印需要 macOS。",
     "nativePdfRequiresMac": "原生 PDF 导出需要 macOS。请改用打印。",
     "failedToPreparePdf": "无法准备 PDF 导出",

--- a/src/locales/zh-TW/dialog.json
+++ b/src/locales/zh-TW/dialog.json
@@ -107,6 +107,8 @@
     "exportHtmlSuccess": "已匯出至資料夾",
     "exportHtmlResourceWarning_one": "1 個資源無法包含",
     "exportHtmlResourceWarning_other": "{{count}} 個資源無法包含",
+    "exportImageWarning_one": "1 張圖片無法嵌入，輸出中將缺失",
+    "exportImageWarning_other": "{{count}} 張圖片無法嵌入，輸出中將缺失",
     "printRequiresMac": "列印需要 macOS。",
     "nativePdfRequiresMac": "原生 PDF 匯出需要 macOS。請改用列印。",
     "failedToPreparePdf": "無法準備 PDF 匯出",

--- a/src/plugins/imagePreview/__tests__/ImagePreviewView.test.ts
+++ b/src/plugins/imagePreview/__tests__/ImagePreviewView.test.ts
@@ -833,6 +833,39 @@ describe("ImagePreviewView path resolution", () => {
     view.destroy();
   });
 
+  // Regression for issue #1086 (fix #4): the preview popup used a narrower
+  // definition of "relative" than the editor NodeView — it only accepted
+  // `./`- and `assets/`-prefixed paths, so a bare relative path like
+  // `evidence/page-1.png` was left unresolved. Unified on
+  // mediaSecurity.isRelativePath so bare relative paths resolve against the
+  // document directory, matching the editor.
+  it("resolves bare relative path against document directory", async () => {
+    const { join } = await import("@tauri-apps/api/path");
+    const view = new ImagePreviewView();
+    const editorDom = container.querySelector(".ProseMirror") as HTMLElement;
+
+    view.show("evidence/page-1.png", anchorRect, editorDom);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(join).toHaveBeenCalledWith("/test/dir", "evidence/page-1.png");
+
+    view.destroy();
+  });
+
+  it("does not resolve a parent-traversal relative path", async () => {
+    const { join } = await import("@tauri-apps/api/path");
+    (join as ReturnType<typeof vi.fn>).mockClear();
+    const view = new ImagePreviewView();
+    const editorDom = container.querySelector(".ProseMirror") as HTMLElement;
+
+    view.show("../secrets/key.png", anchorRect, editorDom);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(join).not.toHaveBeenCalled();
+
+    view.destroy();
+  });
+
   it("falls back to original src when no active file for relative path", async () => {
     // Override mock to return no document
     const { useTabStore } = await import("@/stores/tabStore");

--- a/src/plugins/imagePreview/resolveSrc.ts
+++ b/src/plugins/imagePreview/resolveSrc.ts
@@ -16,6 +16,12 @@ import { imagePreviewError } from "@/utils/debug";
 import { getWindowLabel } from "@/hooks/useWindowFocus";
 import { decodeMarkdownUrl } from "@/utils/markdownUrl";
 import { normalizePathForAsset } from "@/services/media/resolveMediaSrc";
+import {
+  isAbsolutePath,
+  isExternalUrl,
+  isRelativePath,
+  validateImagePath,
+} from "@/plugins/shared/mediaSecurity";
 
 /** Maximum thumbnail dimensions (used by the view for initial positioning). */
 export const MAX_THUMBNAIL_WIDTH = 200;
@@ -35,27 +41,17 @@ function getActiveFilePath(): string | null {
   }
 }
 
-/** Check if a path is an external URL (http/https/data). */
-function isExternalUrl(src: string): boolean {
-  return src.startsWith("http://") || src.startsWith("https://") || src.startsWith("data:");
-}
-
-/** Check if a path is a document-relative path. */
-function isRelativePath(src: string): boolean {
-  return src.startsWith("./") || src.startsWith("assets/");
-}
-
-/** Check if a path is an absolute local path. */
-function isAbsolutePath(src: string): boolean {
-  return src.startsWith("/") || /^[A-Za-z]:/.test(src);
-}
-
 /**
  * Resolve a media path to an `asset://` URL for preview.
  * Decodes URL-encoded paths (e.g., `%20` -> space) for file system access.
+ *
+ * Path classification is shared with the editor NodeView via
+ * `plugins/shared/mediaSecurity` so the popup and the inline image agree on
+ * what counts as relative/absolute/external — a bare relative path like
+ * `evidence/page-1.png` resolves the same in both (issue #1086, fix #4).
  */
 export async function resolveImageSrc(src: string): Promise<string> {
-  // External URLs - use directly
+  // External URLs (http/https/data/asset:/tauri:) - use directly
   if (isExternalUrl(src)) {
     return src;
   }
@@ -70,6 +66,12 @@ export async function resolveImageSrc(src: string): Promise<string> {
 
   // Relative paths - resolve against document directory
   if (isRelativePath(decodedSrc)) {
+    // Validate against directory traversal (mirrors the editor NodeView).
+    if (!validateImagePath(decodedSrc)) {
+      imagePreviewError("Rejected invalid image path:", decodedSrc);
+      return "";
+    }
+
     const filePath = getActiveFilePath();
     if (!filePath) {
       return src;


### PR DESCRIPTION
Closes #1086

## Problem
Local images rendered in the editor but showed the "Image not found" placeholder on **Export PDF / Print**, even when the file existed and the path was correct.

## Root cause
`resolveResources` classified Tauri's asset scheme `https://asset.localhost/…` (emitted by `convertFileSrc` on newer macOS/WebKit, whitelisted in the CSP and fully handled by `isAssetUrl`/`resolveRelativePath`) as **remote** — because it starts with `https://` — and passed it through untouched *before* the asset-aware resolver ran. The off-screen print/PDF WKWebView has no `asset://` handler, so the image never loaded. (The issue's suggested fixes #1 and #2 were already satisfied: inlining runs in the main window, and `sourceFilePath` is threaded through every export command.)

## Fix
- Classify asset URLs as local regardless of scheme: `isRemote: isRemoteUrl(src) && !isAssetUrl(src)`. Scheme-agnostic — covers `asset://localhost/`, `https://asset.localhost/`, and (Windows/WebView2) `http://asset.localhost/`. Covers inline + block images, single (PDF/Print) and folder (HTML) modes.
- Surface missing images instead of the silent placeholder (issue fix #3): both Print and Export PDF now log each offending path and raise a count toast (`exportImageWarning`, added to all 10 locales) via `warnMissingResources`.
- Unify the image-preview popup's relative-path detection on the shared `mediaSecurity` predicates + `validateImagePath` guard (issue fix #4), so bare relative paths preview consistently with how they render inline.

## Testing
TDD (RED→GREEN) regression tests for asset-URL inlining across schemes/modes and bare-relative / traversal handling in the preview. Full `pnpm check:all` green on the merge of this branch + #1087 (one unrelated flaky content-server watcher test needed a re-run).