### PR TITLE
fix(export): fit tables to page width on Print/Export PDF (#1087)

### DIFF
--- a/src/export/__tests__/htmlExportStylesContent.test.ts
+++ b/src/export/__tests__/htmlExportStylesContent.test.ts
@@ -5,9 +5,21 @@ import { getEditorContentCSS } from "../htmlExportStyles";
 describe("getExportOverrides", () => {
   const css = getExportOverrides();
 
-  it("includes @media print block with table-layout: fixed", () => {
+  it("includes an @media print block", () => {
     expect(css).toContain("@media print");
-    expect(css).toContain("table-layout: fixed");
+  });
+
+  // Issue #1087: editor "fit to width" is ephemeral DOM state with no markdown
+  // representation, so it never survives the fresh re-render into export HTML,
+  // and stored ProseMirror colwidth / resized-cell pixel widths would push the
+  // table past the @page box where WebKit clips it. Export CSS must fit every
+  // table to the page by neutralizing fixed pixel sizing.
+  it("fits tables to the page width for print (no fixed pixel columns)", () => {
+    expect(css).toContain("table-layout: auto");
+    expect(css).not.toContain("table-layout: fixed");
+    // <col> pixel widths and resized-cell min-widths are reset so columns reflow
+    expect(css).toContain("width: auto !important");
+    expect(css).toContain("min-width: 0 !important");
   });
 
   it("forces table scroll wrapper to visible overflow", () => {

--- a/src/export/__tests__/pdfHtmlTemplate.test.ts
+++ b/src/export/__tests__/pdfHtmlTemplate.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { buildPdfExportHtml, type PdfOptions } from "../pdfHtmlTemplate";
+import { buildPdfExportHtml, getSharedContentCSS, type PdfOptions } from "../pdfHtmlTemplate";
 
 function baseOptions(overrides: Partial<PdfOptions> = {}): PdfOptions {
   return {
@@ -62,6 +62,33 @@ describe("pdfHtmlTemplate buildPdfExportHtml — @page size", () => {
     );
     const pageCss = getPageCss(html);
     expect(pageCss).toContain("margin: 10mm 15mm 20mm 25mm");
+  });
+});
+
+// Issue #1087: the PDF/Print shared CSS must fit tables to the fixed page
+// width. Stored ProseMirror colwidth (<col style="width:Npx">) and resized-cell
+// inline pixel widths otherwise survive the export re-render and, under
+// table-layout: fixed, push the table past the @page box where WebKit clips it.
+describe("pdfHtmlTemplate shared content CSS — table fit-to-page", () => {
+  const css = getSharedContentCSS();
+
+  it("uses auto table layout, never fixed", () => {
+    expect(css).toContain("table-layout: auto");
+    expect(css).not.toContain("table-layout: fixed");
+  });
+
+  it("resets stored column and cell pixel widths so columns reflow", () => {
+    expect(css).toContain("width: auto !important");
+    expect(css).toContain("min-width: 0 !important");
+  });
+
+  it("keeps cell word-wrapping for long content", () => {
+    expect(css).toContain("overflow-wrap: break-word");
+    expect(css).toContain("word-break: break-word");
+  });
+
+  it("constrains the table to full page width", () => {
+    expect(css).toContain("width: 100% !important");
   });
 });
 

--- a/src/export/editorCSSBundle.ts
+++ b/src/export/editorCSSBundle.ts
@@ -88,8 +88,11 @@ const INTERACTIVE_SELECTOR_PREFIXES = [
   ".ProseMirror-focused",
   ".ProseMirror-hideselection",
   ".pm-selection-",
-  // Note: .media-border-*, .media-align-*, .heading-align-*, .table-fit-to-width
-  // are NOT stripped — they control content layout and are propagated to the export wrapper.
+  // Note: .media-border-*, .media-align-*, .heading-align- classes are NOT
+  // stripped — they control content layout and carry over to the export
+  // wrapper. (.table-fit-to-width is ephemeral, markdown-less editor state that
+  // never survives the fresh export re-render; tables are instead fitted to the
+  // page unconditionally by the export table CSS — see exportOverrides.ts.)
   // Interactive plugin elements
   ".code-lang-dropdown",
   ".code-block-edit-",

--- a/src/export/exportOverrides.ts
+++ b/src/export/exportOverrides.ts
@@ -88,12 +88,28 @@ h1, h2, h3, h4, h5, h6 {
 .export-surface .table-scroll-wrapper {
   overflow-x: visible;
 }
-.export-surface .table-scroll-wrapper table {
+/*
+ * Fit every table to the fixed printable page width (issue #1087). Editor
+ * "fit to width" is ephemeral DOM state with no markdown representation, so it
+ * never survives the fresh re-render into export HTML; and stored ProseMirror
+ * colwidth (<col style="width:Npx">) plus resized-cell inline widths would
+ * otherwise force the table past the @page box, where WebKit's print pipeline
+ * clips the overflow. Neutralize all fixed pixel sizing so columns reflow.
+ */
+.export-surface table {
   width: 100% !important;
-  table-layout: fixed;
+  max-width: 100% !important;
+  table-layout: auto !important;
+}
+.export-surface colgroup,
+.export-surface col {
+  width: auto !important;
 }
 .export-surface td,
 .export-surface th {
+  width: auto !important;
+  min-width: 0 !important;
+  max-width: none !important;
   overflow-wrap: break-word;
   word-break: break-word;
 }

--- a/src/export/pdfHtmlTemplate.ts
+++ b/src/export/pdfHtmlTemplate.ts
@@ -105,12 +105,28 @@ function sharedContentCSS(): string {
 .export-surface-editor .table-scroll-wrapper {
   overflow-x: visible;
 }
-.export-surface-editor .table-scroll-wrapper table {
+/*
+ * Fit every table to the fixed printable page width (issue #1087). Editor
+ * "fit to width" is ephemeral DOM state with no markdown representation, so it
+ * never survives the fresh re-render into export HTML; and stored ProseMirror
+ * colwidth (<col style="width:Npx">) plus resized-cell inline widths would
+ * otherwise force the table past the @page box, where WebKit's print pipeline
+ * clips the overflow. Neutralize all fixed pixel sizing so columns reflow.
+ */
+.export-surface-editor table {
   width: 100% !important;
-  table-layout: fixed;
+  max-width: 100% !important;
+  table-layout: auto !important;
+}
+.export-surface-editor colgroup,
+.export-surface-editor col {
+  width: auto !important;
 }
 .export-surface-editor td,
 .export-surface-editor th {
+  width: auto !important;
+  min-width: 0 !important;
+  max-width: none !important;
   overflow-wrap: break-word;
   word-break: break-word;
 }


### PR DESCRIPTION
Closes #1087

## Problem
Wide tables that fit in the editor were rendered at full/natural column widths on **Print / Export PDF**, overflowed the `@page` content box, and WebKit clipped the rightmost columns.

## Root cause
Two compounding problems:
1. Editor "fit to width" is ephemeral DOM state (`table-fit-to-width` class) with no markdown representation, so it's lost when `ExportSurface` re-renders from markdown into a fresh Tiptap editor.
2. Stored ProseMirror `colwidth` (`<col style="width:Npx">`) and resized-cell inline widths *do* survive. Under `table-layout: fixed`, the browser honored those pixel widths, so `width: 100%` couldn't shrink the columns → overflow → clip.

## Fix
Fit every table to the page unconditionally in the export CSS: switch to `table-layout: auto` and reset `col`/`colgroup` widths and cell `width`/`min-width` with `!important` (a stylesheet `!important` overrides the non-important inline widths). Applied to both export CSS sources — `exportOverrides.ts` (`.export-surface`, HTML export + Print) and `pdfHtmlTemplate.ts` `sharedContentCSS` (`.export-surface-editor`, Print + native PDF). Also corrected the stale `editorCSSBundle.ts` note claiming `.table-fit-to-width` propagates to export (it doesn't — export re-renders from markdown).

## Testing
TDD (RED→GREEN): updated the test that encoded the old `table-layout: fixed`, added shared-CSS coverage for the PDF template. Full `pnpm check:all` green on the merge of this branch + #1086.