### PR TITLE
fix(markdownCodeMask): treat unpaired backtick as literal text (#1126)

### DIFF
--- a/src/utils/markdownCodeMask.test.ts
+++ b/src/utils/markdownCodeMask.test.ts
@@ -161,13 +161,46 @@ describe("buildCodeMask", () => {
     expect(maskToString(mask)).toBe("0011100");
   });
 
-  it("marks inline code content correctly when unclosed at EOF", () => {
-    // Inline code that is never closed
+  it("treats an unpaired backtick as literal text, not an open code span", () => {
+    // A single backtick with no matching closing run is literal text in
+    // CommonMark — it must NOT mask the rest of the string as code.
     const md = "`abc";
     const mask = buildCodeMask(md);
     //           `  a  b  c
-    //           0  1  1  1
-    expect(maskToString(mask)).toBe("0111");
+    //           0  0  0  0
+    expect(maskToString(mask)).toBe("0000");
+  });
+
+  it("does not mask trailing text after a stray backtick in prose", () => {
+    // Regression: an unpaired backtick used to open a span that never closed,
+    // masking everything after it (see markdownCodeMask issue). The `\*` after
+    // the stray backtick must stay unmasked so escape-stripping still applies.
+    const md = "Price is 5` and here \\* keep";
+    const mask = buildCodeMask(md);
+    expect(maskToString(mask)).toBe("0".repeat(md.length));
+  });
+
+  it("still opens a span when a matching closing run exists later", () => {
+    // Two single backticks on the same run of text form a valid span; the
+    // look-ahead must not break the normal paired case.
+    const md = "a `b` `c";
+    const mask = buildCodeMask(md);
+    //           a     `  b  `     `  c
+    //           0  0  0  1  0  0  0  0
+    // First pair masks "b"; the trailing lone ` has no close → literal.
+    expect(maskToString(mask)).toBe("00010000");
+  });
+
+  it("processes a fenced block that follows a stray backtick", () => {
+    // The stray backtick no longer swallows the document, so the later fenced
+    // block is still detected.
+    const md = "lone ` here\n```\ncode\n```";
+    const mask = buildCodeMask(md);
+    const codeIdx = md.indexOf("code");
+    // "code" is inside the fenced block → masked.
+    expect(mask[codeIdx]).toBe(1);
+    // The stray backtick region stays unmasked.
+    expect(mask[md.indexOf("`")]).toBe(0);
   });
 
   it("handles inline code with double backtick containing single backtick", () => {

--- a/src/utils/markdownCodeMask.ts
+++ b/src/utils/markdownCodeMask.ts
@@ -15,6 +15,28 @@
  * @coordinates-with cjkFormatter/formatter.ts — mask prevents CJK rules from mangling code
  * @module utils/markdownCodeMask
  */
+/**
+ * True if a backtick run of exactly `runLen` exists in `markdown` at or after
+ * `from`. A CommonMark code span is closed only by a run of equal length; runs
+ * of a different length are content and are skipped. An opener with no such
+ * closing run is literal text, NOT a code span.
+ */
+function hasClosingBacktickRun(markdown: string, from: number, runLen: number): boolean {
+  const len = markdown.length;
+  let i = from;
+  while (i < len) {
+    if (markdown[i] === "`") {
+      let r = 1;
+      while (i + r < len && markdown[i + r] === "`") r += 1;
+      if (r === runLen) return true;
+      i += r;
+    } else {
+      i += 1;
+    }
+  }
+  return false;
+}
+
 export function buildCodeMask(markdown: string): Uint8Array {
   const len = markdown.length;
   const mask = new Uint8Array(len); // all zeros
@@ -96,6 +118,16 @@ export function buildCodeMask(markdown: string): Uint8Array {
       }
 
       if (!inInlineCode) {
+        // An opener only starts a code span if a matching-length closing run
+        // exists later; otherwise the backticks are literal text (CommonMark).
+        // Without this check an unpaired backtick would mask the entire rest of
+        // the document as code.
+        if (!hasClosingBacktickRun(markdown, i + runLen, runLen)) {
+          // Literal backticks: leave as 0 and continue normal processing so any
+          // fenced block / code span in the tail is still detected.
+          i += runLen;
+          continue;
+        }
         inInlineCode = true;
         inlineFenceLen = runLen;
         // Opening backticks: leave as 0


### PR DESCRIPTION
## What

`buildCodeMask()` opened an inline code span on the first backtick run and only cleared it when it found a matching-length closing run. An **unpaired backtick** — which is literal text in CommonMark, not a code-span opener — therefore left the span "open" and masked **everything after it to EOF** as code.

The two real consumers (`cleanPastedMarkdown.ts` and `htmlToMarkdown.ts`) use the mask to decide whether to strip redundant backslash escapes, so a stray backtick silently disabled escape-stripping for the rest of the text (leftover `\*`, `\|`, … survived).

Fixes #1126.

## Fix

Before opening a span, look ahead for a matching-length closing run. If none exists, the backticks are literal text: leave them unmasked and continue normal processing so any fenced block / code span in the tail is still detected.

Behavior for text that already had a valid closing run is unchanged — the span opens and masks exactly as before. Only the previously-buggy unpaired case changes.

## Before / after

```ts
buildCodeMask("Price is 5` and here \\* keep");
// before: 0000000000 1111111111111111  (masked to EOF)
// after:  0000000000 0000000000000000  (stray backtick is literal)

cleanPastedMarkdown("Price is 5` and here \\* keep");
// before: "Price is 5` and here \* keep"  (escape NOT stripped)
// after:  "Price is 5` and here * keep"   (escape stripped, as without the backtick)
```

## Tests

- Updated the one existing test that asserted the old "mask to EOF" behavior for `` `abc ``.
- Added: unpaired backtick → all-zero mask; no masking of trailing prose after a stray backtick; the normal paired-span case still opens; a fenced block following a stray backtick is still detected.

`markdownCodeMask`, `cleanPastedMarkdown`, and `htmlToMarkdown` suites pass (130 tests); `eslint` clean on the changed files.

## Note

The `@coordinates-with` header in `markdownCodeMask.ts` lists `markdownLinkPatterns.ts` and `cjkFormatter/formatter.ts` as consumers, but neither imports `buildCodeMask` today (only `cleanPastedMarkdown` and `htmlToMarkdown` do). Left as-is here, but worth reconciling separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
