### PR TITLE
fix(coherence): make workspace scan Windows-safe; fix routing abs-path test

### DIFF
--- a/src-tauri/src/coherence/scan_walk.rs
+++ b/src-tauri/src/coherence/scan_walk.rs
@@ -21,11 +21,7 @@ pub(super) fn walk_markdown(
     let mut out = Vec::new();
     let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
-        let rel_dir = dir
-            .strip_prefix(root)
-            .unwrap_or(&dir)
-            .to_string_lossy()
-            .into_owned();
+        let rel_dir = to_workspace_rel(dir.strip_prefix(root).unwrap_or(&dir));
         // F2 (dogfood session 2): a directory carrying the standard
         // CACHEDIR.TAG (cargo `target/`, other build caches) is a
         // self-declared cache — never content. Walking one dominated M5
@@ -71,11 +67,7 @@ pub(super) fn walk_markdown(
             }
             let path = entry.path();
             let name = entry.file_name().to_string_lossy().into_owned();
-            let rel = path
-                .strip_prefix(root)
-                .unwrap_or(&path)
-                .to_string_lossy()
-                .into_owned();
+            let rel = to_workspace_rel(path.strip_prefix(root).unwrap_or(&path));
             let Ok(meta) = std::fs::symlink_metadata(&path) else {
                 report.complete = false;
                 continue;
@@ -143,6 +135,19 @@ pub(super) fn walk_markdown(
         }
     }
     finish(out)
+}
+
+/// Canonicalize a stripped relative path to the workspace's forward-slash
+/// convention. Workspace-relative paths are `/`-separated everywhere: the IPC
+/// path guard (`paths.rs`) rejects backslashes, and registry keys built from
+/// frontmatter/IPC use `/`. `to_string_lossy()` yields the OS separator, so on
+/// Windows the walked path must be rewritten to match — otherwise the guard
+/// rejects it (`path contains backslash`) and no walked file ever reconciles.
+/// On Unix `MAIN_SEPARATOR` is already `/`, so this is a no-op and a literal
+/// `\` inside a filename is left untouched.
+fn to_workspace_rel(rel: &Path) -> String {
+    rel.to_string_lossy()
+        .replace(std::path::MAIN_SEPARATOR, "/")
 }
 
 fn finish(mut out: Vec<(String, String)>) -> Result<Vec<(String, String)>, String> {

--- a/src-tauri/src/mcp_bridge/routing.test.rs
+++ b/src-tauri/src/mcp_bridge/routing.test.rs
@@ -80,7 +80,16 @@ fn missing_workspace_root_is_clean_error() {
 #[test]
 fn nonexistent_workspace_root_is_clean_error() {
     let state = coherence_state();
-    let args = serde_json::json!({ "workspace_root": "/nonexistent/path/that/does/not/exist" });
+    // Absolute on every platform but guaranteed missing: a bare
+    // "/nonexistent" is NOT absolute on Windows (needs a drive letter), so it
+    // would trip the absolute-path check first and never reach the
+    // directory-accessibility check this test asserts on. Anchoring on
+    // `temp_dir()` yields an absolute path on Windows and Unix alike.
+    let missing = std::env::temp_dir()
+        .join("vmark-does-not-exist-6f2a1c9e4b")
+        .to_string_lossy()
+        .into_owned();
+    let args = serde_json::json!({ "workspace_root": missing });
 
     let response = answer_coherence(&state, "vmark.coherence.edges", &args, None);
 


### PR DESCRIPTION
## Problem

Two tests fail on the `windows-latest` CI leg — and have been failing on `main` @ 0.9.5, not just on dependency-bump PRs. They red the required `rust` check and block Dependabot cargo PR #1134 (whose serde/futures/tokio bumps are otherwise fine).

### 1. `coherence::scan::tests::cachedir_tagged_directories_are_never_scanned` — production bug

`walk_markdown` computed workspace-relative paths with `strip_prefix(root).to_string_lossy()`, which produces **backslash** separators on Windows (`sub\target\real.md`). The kernel treats workspace-relative paths as forward-slash everywhere — the IPC path guard (`coherence/paths.rs`) explicitly rejects backslashes, and registry keys from frontmatter/IPC use `/`. So on Windows `scan_workspace` returned `Err("path contains backslash: ...")` and **no walked file ever reconciled**.

**Fix:** normalize the OS separator to `/` at the walk via a small `to_workspace_rel` helper. On Unix `MAIN_SEPARATOR` is already `/`, so it is a no-op and a literal `\` inside a filename is left untouched.

### 2. `mcp_bridge::routing::tests::nonexistent_workspace_root_is_clean_error` — test bug

The test passed `"/nonexistent/path/that/does/not/exist"`, which is **not absolute on Windows** (needs a drive letter). Validation (`coherence_answers.rs`) therefore returned `"must be an absolute path"` and never reached the `"not an accessible directory"` branch the test asserts.

**Fix:** anchor the missing path on `std::env::temp_dir()`, which is absolute on every platform while still pointing at a nonexistent child.

## Verification

- macOS: both tests pass; `cargo clippy --all-targets -D warnings` clean; `cargo fmt --check` clean.
- macOS/Linux **cannot** reproduce the scan failure (native `/`), so **CI's `windows-latest` leg is the authoritative verifier** for fix #1.

## Impact

Un-reds the `rust` check on `main` and unblocks #1134. macOS behavior is unchanged (separator normalization is a no-op on Unix).