### PR TITLE
Propagate settings, shortcuts, and AI providers across windows

### DIFF
--- a/src/components/Terminal/fitAndResizePty.test.ts
+++ b/src/components/Terminal/fitAndResizePty.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PTY_RESIZE_DEBOUNCE_MS, fitAndResizePty } from "./fitAndResizePty";
+import type { FitResizeTarget } from "./fitAndResizePty";
+
+function createTarget(
+  overrides: Partial<FitResizeTarget> = {},
+  dims: { cols: number; rows: number } = { cols: 120, rows: 40 },
+): FitResizeTarget & { resize: ReturnType<typeof vi.fn>; fit: ReturnType<typeof vi.fn> } {
+  const resize = vi.fn();
+  const fit = vi.fn();
+  const target = {
+    instance: {
+      term: dims,
+      fitAddon: { fit },
+    },
+    pty: { resize } as unknown as FitResizeTarget["pty"],
+    disposed: false,
+    ...overrides,
+  } as FitResizeTarget & { resize: typeof resize; fit: typeof fit };
+  target.resize = resize;
+  target.fit = fit;
+  return target;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("fitAndResizePty", () => {
+  // Regression: the terminal settings-sync effect called fitAddon.fit() on a
+  // font change but never pty.resize(), so the shell kept its old TIOCSWINSZ
+  // dimensions — line wrapping and TUI layout corrupt until an unrelated panel
+  // resize happened to fix it. fit() and resize() are one operation.
+  it("fits immediately and resizes the PTY after the debounce", () => {
+    const target = createTarget();
+
+    fitAndResizePty(target);
+
+    expect(target.fit).toHaveBeenCalledTimes(1);
+    expect(target.resize).not.toHaveBeenCalled(); // deferred
+
+    vi.advanceTimersByTime(PTY_RESIZE_DEBOUNCE_MS);
+
+    expect(target.resize).toHaveBeenCalledWith(120, 40);
+  });
+
+  it("debounces bursts into a single PTY resize with the final dimensions", () => {
+    const target = createTarget();
+
+    fitAndResizePty(target);
+    target.instance.term.cols = 80;
+    target.instance.term.rows = 24;
+    fitAndResizePty(target);
+
+    vi.advanceTimersByTime(PTY_RESIZE_DEBOUNCE_MS);
+
+    expect(target.fit).toHaveBeenCalledTimes(2);
+    expect(target.resize).toHaveBeenCalledTimes(1);
+    expect(target.resize).toHaveBeenCalledWith(80, 24);
+  });
+
+  it("keeps each session's debounce independent", () => {
+    // A single shared timer ref would let one session's fit cancel another's
+    // pending PTY resize, leaving that shell permanently stale.
+    const a = createTarget({}, { cols: 100, rows: 30 });
+    const b = createTarget({}, { cols: 60, rows: 20 });
+
+    fitAndResizePty(a);
+    fitAndResizePty(b);
+    vi.advanceTimersByTime(PTY_RESIZE_DEBOUNCE_MS);
+
+    expect(a.resize).toHaveBeenCalledWith(100, 30);
+    expect(b.resize).toHaveBeenCalledWith(60, 20);
+  });
+
+  it("does not resize a disposed session", () => {
+    const target = createTarget();
+
+    fitAndResizePty(target);
+    target.disposed = true;
+    vi.advanceTimersByTime(PTY_RESIZE_DEBOUNCE_MS);
+
+    expect(target.resize).not.toHaveBeenCalled();
+  });
+
+  it("does not resize when the caller reports the entry is stale", () => {
+    const target = createTarget();
+
+    fitAndResizePty(target, () => true);
+    vi.advanceTimersByTime(PTY_RESIZE_DEBOUNCE_MS);
+
+    expect(target.resize).not.toHaveBeenCalled();
+  });
+
+  it("skips the PTY resize when there is no PTY", () => {
+    const target = createTarget({ pty: null });
+
+    expect(() => {
+      fitAndResizePty(target);
+      vi.advanceTimersByTime(PTY_RESIZE_DEBOUNCE_MS);
+    }).not.toThrow();
+  });
+
+  it("skips the PTY resize for zero dimensions (hidden container)", () => {
+    const target = createTarget({}, { cols: 0, rows: 0 });
+
+    fitAndResizePty(target);
+    vi.advanceTimersByTime(PTY_RESIZE_DEBOUNCE_MS);
+
+    expect(target.resize).not.toHaveBeenCalled();
+  });
+
+  it("swallows a throwing fit() and schedules no resize", () => {
+    const target = createTarget();
+    (target.fit as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("container not visible");
+    });
+
+    expect(() => fitAndResizePty(target)).not.toThrow();
+    vi.advanceTimersByTime(PTY_RESIZE_DEBOUNCE_MS);
+
+    expect(target.resize).not.toHaveBeenCalled();
+  });
+
+  it("cancels a previously-scheduled resize when a later fit throws", () => {
+    // audit Low-15: a successful fit schedules a resize; if the next call's
+    // fit() throws (container hidden), the earlier resize must be cancelled,
+    // not fire with stale dimensions.
+    const target = createTarget({}, { cols: 100, rows: 30 });
+
+    fitAndResizePty(target); // schedules a resize for 100x30
+    (target.fit as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("container hidden");
+    });
+    fitAndResizePty(target); // fit throws — must cancel the pending resize
+
+    vi.advanceTimersByTime(PTY_RESIZE_DEBOUNCE_MS);
+
+    expect(target.resize).not.toHaveBeenCalled();
+  });
+
+  it("swallows a PTY that exits between the fit and the debounce tick", () => {
+    const target = createTarget();
+    (target.resize as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("pty exited");
+    });
+
+    fitAndResizePty(target);
+
+    expect(() => vi.advanceTimersByTime(PTY_RESIZE_DEBOUNCE_MS)).not.toThrow();
+  });
+});

--- a/src/components/Terminal/fitAndResizePty.ts
+++ b/src/components/Terminal/fitAndResizePty.ts
@@ -1,0 +1,89 @@
+/**
+ * fitAndResizePty
+ *
+ * Purpose: The single place that fits an xterm to its container AND tells the
+ * PTY the dimensions that fit produced. These are one logical operation: an
+ * xterm whose cols/rows changed without a matching TIOCSWINSZ leaves the shell
+ * drawing to the wrong width, which shows up as broken line wrapping, misplaced
+ * prompt redraws, and corrupt TUI layout.
+ *
+ * Key decisions:
+ *   - The PTY resize is debounced (the visual fit is instant; the syscall is
+ *     not worth doing on every frame of a drag).
+ *   - The debounce timer lives on the session entry, NOT in a shared ref. A
+ *     shared timer lets one session's fit cancel another session's pending
+ *     resize, permanently stranding that shell at stale dimensions.
+ *   - `fit()` throwing (hidden container) cancels the resize rather than
+ *     reporting whatever dimensions the failed fit left behind.
+ *
+ * @coordinates-with useTerminalSessions.ts — panel fit callback
+ * @coordinates-with terminalSessionStoreSync.ts — font-size/line-height and
+ *   mono-font changes, which both alter cell metrics
+ * @coordinates-with terminalSessionRegistry.ts — visibility switch refit
+ * @module components/Terminal/fitAndResizePty
+ */
+import type { IPty } from "@/lib/pty";
+
+export const PTY_RESIZE_DEBOUNCE_MS = 100;
+
+/**
+ * Minimum shape this helper needs. Structural rather than importing
+ * SessionEntry so the store-sync module can keep its narrower entry type.
+ */
+export interface FitResizeTarget {
+  instance: {
+    term: { cols: number; rows: number };
+    fitAddon: { fit: () => void };
+  };
+  pty: IPty | null;
+  disposed?: boolean;
+  /** Per-entry debounce handle — see "Key decisions" above. */
+  ptyResizeTimer?: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Fit the terminal to its container and propagate the resulting dimensions to
+ * the PTY.
+ *
+ * @param entry   The session to fit.
+ * @param isStale Optional guard evaluated at debounce time. Callers that hold a
+ *                session map should use it to check the entry is still the one
+ *                registered under its id, so a session swapped out mid-debounce
+ *                doesn't resize its replacement's PTY.
+ */
+export function fitAndResizePty(
+  entry: FitResizeTarget,
+  isStale?: () => boolean,
+): void {
+  // Cancel any resize this entry had pending BEFORE fitting. If fit() throws
+  // (hidden container), we return with no resize scheduled — otherwise a resize
+  // queued by an earlier successful fit would still fire and push now-stale
+  // dimensions to the PTY, contradicting this function's cancellation contract
+  // (audit Low-15). A successful fit re-schedules below.
+  clearTimeout(entry.ptyResizeTimer);
+  entry.ptyResizeTimer = undefined;
+
+  try {
+    entry.instance.fitAddon.fit();
+  } catch {
+    // Container is not visible (display:none, zero-size). fit() made no
+    // meaningful change, so there is nothing to tell the PTY.
+    return;
+  }
+
+  entry.ptyResizeTimer = setTimeout(() => {
+    entry.ptyResizeTimer = undefined;
+    if (entry.disposed || isStale?.()) return;
+
+    const { term } = entry.instance;
+    // Zero dims mean the fit ran against a hidden container; sending 0×0 would
+    // tell the shell it has no viewport at all.
+    if (!entry.pty || term.cols <= 0 || term.rows <= 0) return;
+
+    try {
+      entry.pty.resize(term.cols, term.rows);
+    } catch {
+      // PTY exited or was disposed between the fit and this tick.
+    }
+  }, PTY_RESIZE_DEBOUNCE_MS);
+}

--- a/src/components/Terminal/terminalSessionRegistry.ts
+++ b/src/components/Terminal/terminalSessionRegistry.ts
@@ -9,6 +9,7 @@
  * @module components/Terminal/terminalSessionRegistry
  */
 import type { SessionEntry, SessionsRef } from "./terminalSessionTypes";
+import { fitAndResizePty } from "./fitAndResizePty";
 
 /** Remove a session — cancel pending rAF, kill PTY, and dispose instance. */
 export function removeSessionEntry(
@@ -62,8 +63,14 @@ export function switchVisibility(
   }
   entry.pendingRafId = requestAnimationFrame(() => {
     entry.pendingRafId = null;
+    // Fit AND resize: a hidden session that missed geometry changes while it
+    // was display:none (a font-size change applies term.options to every
+    // session, but fit() no-ops on a zero-size container) would otherwise come
+    // back with its PTY still on the pre-change dimensions. For a session whose
+    // shell hasn't started yet this is harmless — spawnPty reads term.cols
+    // after the fit, and the debounced resize is skipped via the null pty.
+    fitAndResizePty(entry, () => sessionsRef.current.get(activeId) !== entry);
     try {
-      entry.instance.fitAddon.fit();
       entry.instance.term.focus();
     } catch {
       /* ignore */
@@ -88,6 +95,8 @@ export function disposeAllSessions(sessions: Map<string, SessionEntry>): void {
       cancelAnimationFrame(entry.pendingRafId);
       entry.pendingRafId = null;
     }
+    clearTimeout(entry.ptyResizeTimer);
+    entry.ptyResizeTimer = undefined;
     if (entry.pty) {
       try {
         entry.pty.kill();

--- a/src/components/Terminal/terminalSessionStoreSync.ts
+++ b/src/components/Terminal/terminalSessionStoreSync.ts
@@ -11,14 +11,15 @@
  *   - Theme or monoFont changes update each session's term.options.theme and/or
  *     fontFamily, resolving the mono stack straight from the monoFont setting
  *     (not the --font-mono CSS var, which useTheme writes only in a later
- *     effect, so it would lag a monoFont-only change) (G6/WI-4.1).
+ *     effect, so it would lag a monoFont-only change) (G6/WI-4.1). A monoFont
+ *     change also re-fits and resizes the PTY, since cell width changes.
  *   - Workspace-root changes inject a `cd` command into every alive PTY whose
  *     current cwd differs from the new root — the live OSC 7 cwd when known,
  *     else the spawn-time cwd (WI-2.2); PTY-less or exited sessions are skipped.
  *   - Terminal-setting changes update fontSize/lineHeight/cursorStyle/
  *     cursorBlink/macOptionIsMeta/screenReaderMode/scrollback/
- *     minimumContrastRatio on each xterm; a font change also re-fits the
- *     addon to repaint at the new metrics.
+ *     minimumContrastRatio on each xterm; a font change also re-fits the addon
+ *     AND resizes the PTY (see fitAndResizePty — the two are one operation).
  *
  * @coordinates-with useTerminalSessions.ts — sole caller
  * @module components/Terminal/terminalSessionStoreSync
@@ -35,6 +36,7 @@ import { getActiveWorkspaceScope } from "@/services/workspaces/activeWorkspaceSc
 import { buildXtermThemeForId } from "@/theme";
 import { resolveMonoFontStack } from "@/utils/fontStacks";
 import type { TerminalInstance } from "./createTerminalInstance";
+import { fitAndResizePty } from "./fitAndResizePty";
 
 /**
  * Minimum shape of a session entry that the sync effects need. Kept narrow
@@ -45,6 +47,10 @@ export interface SyncableSessionEntry {
   pty: IPty | null;
   shellExited: boolean;
   spawnedCwd: string | undefined;
+  /** Set once the session is torn down; suppresses a pending PTY resize. */
+  disposed?: boolean;
+  /** Per-entry debounce handle owned by fitAndResizePty. */
+  ptyResizeTimer?: ReturnType<typeof setTimeout>;
   /**
    * Workspace root that arrived while this session's shell was busy and so
    * could not be cd'd immediately. Flushed when the shell returns to idle
@@ -117,6 +123,11 @@ export function useUIStoreSync(
       for (const [, entry] of sessions) {
         if (newTheme) entry.instance.term.options.theme = newTheme;
         entry.instance.term.options.fontFamily = newFont;
+        // A different mono family changes cell advance width, so cols/rows
+        // change just as they do for a font-size change. This effect used to
+        // set fontFamily and stop, leaving BOTH xterm geometry and the PTY
+        // stale — strictly worse than the font-size path.
+        if (monoChanged) fitAndResizePty(entry);
       }
     };
     const unsubs = [
@@ -205,11 +216,17 @@ export function useUIStoreSync(
 
   // Terminal-settings sync (font, cursor, macOptionIsMeta)
   useEffect(() => {
-    const getTermSettings = () => useSettingsStore.getState().terminal;
-    let prev = getTermSettings();
-    return useSettingsStore.subscribe((state) => {
+    // `prev` comes from zustand, not a hand-rolled ref. The previous manual
+    // version carried `if (!curr || !prev) { prev = curr; return; }`, which
+    // could strand the baseline: one falsy `curr` set `prev = undefined`, and
+    // the next fire then took the same branch and swallowed a REAL change —
+    // permanently, since the fire after that compared against the
+    // already-applied value. Letting the store supply prev removes the state
+    // that could get stranded.
+    return useSettingsStore.subscribe((state, prevState) => {
       const curr = state.terminal;
-      if (!curr || !prev) { prev = curr; return; }
+      const prev = prevState.terminal;
+      if (!curr || !prev || curr === prev) return;
       const fontChanged = curr.fontSize !== prev.fontSize || curr.lineHeight !== prev.lineHeight;
       const cursorChanged = curr.cursorStyle !== prev.cursorStyle || curr.cursorBlink !== prev.cursorBlink;
       const metaChanged = curr.macOptionIsMeta !== prev.macOptionIsMeta;
@@ -217,7 +234,6 @@ export function useUIStoreSync(
       const scrollbackChanged = curr.scrollback !== prev.scrollback;
       const contrastChanged = curr.minimumContrastRatio !== prev.minimumContrastRatio;
       if (!fontChanged && !cursorChanged && !metaChanged && !screenReaderChanged && !scrollbackChanged && !contrastChanged) return;
-      prev = curr;
 
       const sessions = sessionsRef.current;
       if (!sessions) return;
@@ -247,7 +263,11 @@ export function useUIStoreSync(
           opts.minimumContrastRatio = Math.min(Math.max(curr.minimumContrastRatio, 1), 21);
         }
         if (fontChanged) {
-          try { entry.instance.fitAddon.fit(); } catch { /* ignore */ }
+          // Font metrics changed, so cols/rows changed — the PTY must be told,
+          // not just xterm. A bare fitAddon.fit() here left the shell drawing
+          // to the old width until an unrelated panel resize happened to
+          // correct it.
+          fitAndResizePty(entry);
         }
       }
     });

--- a/src/components/Terminal/terminalSessionTypes.ts
+++ b/src/components/Terminal/terminalSessionTypes.ts
@@ -26,6 +26,12 @@ export interface SessionEntry {
   spawnGen: number;
   pendingRafId: number | null;
   /**
+   * Debounce handle for the PTY resize that follows a fit. Owned by
+   * fitAndResizePty; per-entry so one session's fit cannot cancel another's
+   * pending resize.
+   */
+  ptyResizeTimer?: ReturnType<typeof setTimeout>;
+  /**
    * Workspace root that arrived while the shell was busy and so was deferred;
    * flushed on the next idle (see terminalSessionStoreSync).
    */

--- a/src/components/Terminal/useTerminalSessions.ts
+++ b/src/components/Terminal/useTerminalSessions.ts
@@ -48,8 +48,7 @@ import { removeSessionEntry, switchVisibility, disposeAllSessions } from "./term
 import { wireSessionInput } from "./terminalSessionInputWiring";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { SessionEntry } from "./terminalSessionTypes";
-
-const PTY_RESIZE_DEBOUNCE_MS = 100;
+import { fitAndResizePty } from "./fitAndResizePty";
 
 /** Callbacks passed to the terminal sessions hook for panel-level actions. */
 export interface UseTerminalSessionsCallbacks {
@@ -72,34 +71,16 @@ export function useTerminalSessions(
     callbacksRef.current = callbacks;
   });
 
-  // Debounce PTY resize to avoid excessive resize calls during drag
-  const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-
-  // Fit the active terminal
+  // Fit the active terminal (and propagate the new dimensions to its PTY)
   const fit = useCallback(() => {
     const activeId = useUIStore.getState().terminal.activeSessionId;
     if (!activeId) return;
     const entry = sessionsRef.current.get(activeId);
     if (!entry) return;
 
-    try {
-      entry.instance.fitAddon.fit();
-      // Debounce PTY resize — visual fit is instant, but PTY resize is deferred
-      clearTimeout(resizeTimerRef.current);
-      resizeTimerRef.current = setTimeout(() => {
-        if (entry.disposed || sessionsRef.current.get(activeId) !== entry) return;
-        const { term } = entry.instance;
-        if (entry.pty && term.cols > 0 && term.rows > 0) {
-          try {
-            entry.pty.resize(term.cols, term.rows);
-          } catch {
-            // PTY may have exited/disposed between debounce ticks
-          }
-        }
-      }, PTY_RESIZE_DEBOUNCE_MS);
-    } catch {
-      // Container may not be visible
-    }
+    // Debounce lives on the entry, so fitting one session can no longer cancel
+    // another session's pending PTY resize.
+    fitAndResizePty(entry, () => sessionsRef.current.get(activeId) !== entry);
   }, []);
 
   /** Get search addon of active session. */
@@ -276,8 +257,7 @@ export function useTerminalSessions(
     const sessions = sessionsRef.current;
     return () => {
       unsubscribe();
-      clearTimeout(resizeTimerRef.current);
-      resizeTimerRef.current = undefined;
+      // Per-entry PTY resize timers are cleared by disposeAllSessions.
       disposeAllSessions(sessions);
       initializedRef.current = false;
     };

--- a/src/hooks/lifecycle/__tests__/useWorkspaceLifecycle.test.ts
+++ b/src/hooks/lifecycle/__tests__/useWorkspaceLifecycle.test.ts
@@ -16,6 +16,12 @@ vi.mock("@/hooks/useWorkspaceRailSeed", () => ({
 vi.mock("@/hooks/useSettingsSync", () => ({
   useSettingsSync: () => calls.push("settingsSync"),
 }));
+vi.mock("@/hooks/useShortcutsSync", () => ({
+  useShortcutsSync: () => calls.push("shortcutsSync"),
+}));
+vi.mock("@/hooks/useAiProviderSync", () => ({
+  useAiProviderSync: () => calls.push("aiProviderSync"),
+}));
 vi.mock("@/hooks/useConfirmQuitSync", () => ({
   useConfirmQuitSync: () => calls.push("confirmQuitSync"),
 }));
@@ -42,6 +48,8 @@ describe("useWorkspaceLifecycle", () => {
       "workspaceBootstrap",
       "workspaceRailSeed",
       "settingsSync",
+      "shortcutsSync",
+      "aiProviderSync",
       "confirmQuitSync",
       "recentFilesSync",
       "recentWorkspacesSync",

--- a/src/hooks/lifecycle/useWorkspaceLifecycle.ts
+++ b/src/hooks/lifecycle/useWorkspaceLifecycle.ts
@@ -8,7 +8,7 @@
  * persisted workspace config from disk so downstream stores see the
  * correct initial state).
  *
- *   useWorkspaceBootstrap → useSettingsSync → useConfirmQuitSync
+ *   useWorkspaceBootstrap → useSettingsSync → useShortcutsSync → useConfirmQuitSync
  *   → useRecentFilesSync → useRecentWorkspacesSync
  *   → useFormatSettingsBridge
  *
@@ -21,6 +21,8 @@
 import { useWorkspaceBootstrap } from "@/hooks/useWorkspaceBootstrap";
 import { useWorkspaceRailSeed } from "@/hooks/useWorkspaceRailSeed";
 import { useSettingsSync } from "@/hooks/useSettingsSync";
+import { useShortcutsSync } from "@/hooks/useShortcutsSync";
+import { useAiProviderSync } from "@/hooks/useAiProviderSync";
 import { useConfirmQuitSync } from "@/hooks/useConfirmQuitSync";
 import { useRecentFilesSync } from "@/hooks/useRecentFilesSync";
 import { useRecentWorkspacesSync } from "@/hooks/useRecentWorkspacesSync";
@@ -30,6 +32,8 @@ export function useWorkspaceLifecycle(): void {
   useWorkspaceBootstrap();
   useWorkspaceRailSeed();
   useSettingsSync();
+  useShortcutsSync();
+  useAiProviderSync();
   useConfirmQuitSync();
   useRecentFilesSync();
   useRecentWorkspacesSync();

--- a/src/hooks/useAiProviderSync.test.ts
+++ b/src/hooks/useAiProviderSync.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { RestProviderConfig } from "@/types/aiGenies";
+
+// Capture Tauri event listeners so tests can drive them like the real bus.
+const emitMock = vi.fn(() => Promise.resolve());
+const listeners = new Map<string, (event: { payload: unknown }) => void>();
+const listenMock = vi.fn((name: string, cb: (event: { payload: unknown }) => void) => {
+  listeners.set(name, cb);
+  return Promise.resolve(() => listeners.delete(name));
+});
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: (...args: unknown[]) => emitMock(...args),
+  listen: (name: string, cb: (event: { payload: unknown }) => void) => listenMock(name, cb),
+}));
+
+const getApiKeyMock = vi.fn((type: string) => Promise.resolve(`keychain-key-for-${type}`));
+vi.mock("@/services/secrets/apiKeySecrets", () => ({
+  getApiKey: (type: string) => getApiKeyMock(type),
+}));
+
+import { useAiProviderStore } from "@/stores/aiStore/provider";
+import {
+  AI_PROVIDER_STATE_EVENT,
+  AI_PROVIDER_REQUEST_EVENT,
+  __resetAiProviderSyncStateForTests,
+  applyRemoteAiProviderState,
+  buildAiProviderSnapshot,
+  useAiProviderSync,
+  type AiProviderStatePayload,
+} from "./useAiProviderSync";
+
+/** A production-shaped REST provider (type, name, endpoint, apiKey, model). */
+function restProvider(over: Partial<RestProviderConfig> = {}): RestProviderConfig {
+  return {
+    type: "openai",
+    name: "OpenAI",
+    endpoint: "https://api.openai.com",
+    apiKey: "sk-SECRET-must-never-leave-this-window",
+    model: "gpt-4",
+    ...over,
+  };
+}
+
+/** A secret-free remote payload as it would arrive over the event bus. */
+function payload(over: Partial<AiProviderStatePayload> = {}): AiProviderStatePayload {
+  return {
+    activeProvider: "openai",
+    restProviders: [
+      { type: "openai", name: "OpenAI", endpoint: "https://api.openai.com", model: "gpt-4" },
+    ],
+    credentialsRevision: 0,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  emitMock.mockClear();
+  listenMock.mockClear();
+  getApiKeyMock.mockClear();
+  listeners.clear();
+  __resetAiProviderSyncStateForTests();
+  useAiProviderStore.setState({
+    activeProvider: null,
+    restProviders: [restProvider()],
+    credentialsRevision: 0,
+  });
+});
+
+describe("buildAiProviderSnapshot", () => {
+  // SECURITY: apiKey lives in memory (rehydrated from the OS keychain) but is
+  // never persisted or broadcast. Broadcasting it would put it on the Tauri
+  // event bus, a strictly wider exposure than the keychain.
+  it("never includes apiKey in the broadcast payload", () => {
+    const snapshot = buildAiProviderSnapshot();
+
+    expect(JSON.stringify(snapshot)).not.toContain("sk-SECRET-must-never-leave-this-window");
+    for (const provider of snapshot.restProviders) {
+      expect(provider).not.toHaveProperty("apiKey");
+    }
+  });
+
+  it("carries the production fields peers need (endpoint, model, revision)", () => {
+    useAiProviderStore.setState({ activeProvider: "openai", credentialsRevision: 3 });
+
+    const snapshot = buildAiProviderSnapshot();
+
+    expect(snapshot.activeProvider).toBe("openai");
+    expect(snapshot.credentialsRevision).toBe(3);
+    expect(snapshot.restProviders[0]).toMatchObject({
+      type: "openai",
+      endpoint: "https://api.openai.com",
+      model: "gpt-4",
+    });
+  });
+});
+
+describe("applyRemoteAiProviderState", () => {
+  it("adopts a provider config change made in another window", () => {
+    applyRemoteAiProviderState(
+      payload({
+        restProviders: [
+          { type: "openai", name: "OpenAI", endpoint: "https://proxy.local", model: "gpt-4o" },
+        ],
+      }),
+    );
+
+    expect(useAiProviderStore.getState().activeProvider).toBe("openai");
+    expect(useAiProviderStore.getState().restProviders[0].endpoint).toBe("https://proxy.local");
+    expect(useAiProviderStore.getState().restProviders[0].model).toBe("gpt-4o");
+  });
+
+  it("preserves this window's in-memory apiKey when no rotation is signalled", () => {
+    applyRemoteAiProviderState(
+      payload({
+        restProviders: [
+          { type: "openai", name: "OpenAI", endpoint: "https://proxy.local", model: "gpt-4o" },
+        ],
+      }),
+    );
+
+    const provider = useAiProviderStore.getState().restProviders[0];
+    expect(provider.endpoint).toBe("https://proxy.local"); // config applied
+    expect(provider.apiKey).toBe("sk-SECRET-must-never-leave-this-window"); // local key kept
+    expect(getApiKeyMock).not.toHaveBeenCalled(); // no keychain read without rotation
+  });
+
+  it("reloads keys from the keychain when the peer signals a rotation", async () => {
+    await act(async () => {
+      applyRemoteAiProviderState(payload({ credentialsRevision: 1 }));
+      // let the fire-and-forget reload resolve
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getApiKeyMock).toHaveBeenCalledWith("openai");
+    expect(useAiProviderStore.getState().restProviders[0].apiKey).toBe("keychain-key-for-openai");
+    expect(useAiProviderStore.getState().credentialsRevision).toBe(1);
+  });
+
+  it("adopts a newly added provider this window has never seen", () => {
+    applyRemoteAiProviderState(
+      payload({
+        activeProvider: "anthropic",
+        restProviders: [
+          { type: "openai", name: "OpenAI", endpoint: "https://api.openai.com", model: "gpt-4" },
+          { type: "anthropic", name: "Anthropic", endpoint: "https://api.anthropic.com", model: "claude" },
+        ],
+      }),
+    );
+
+    const types = useAiProviderStore.getState().restProviders.map((p) => p.type);
+    expect(types).toContain("anthropic");
+    expect(useAiProviderStore.getState().activeProvider).toBe("anthropic");
+  });
+
+  it("ignores a malformed payload rather than wiping providers", () => {
+    applyRemoteAiProviderState({
+      activeProvider: null,
+      restProviders: "nope" as never,
+      credentialsRevision: 0,
+    });
+
+    expect(useAiProviderStore.getState().restProviders).toHaveLength(1);
+  });
+
+  it("drops entries without a valid type and coerces non-string fields", () => {
+    applyRemoteAiProviderState(
+      payload({
+        activeProvider: { evil: true } as never,
+        restProviders: [
+          { type: "openai", name: "OpenAI", endpoint: "https://api.openai.com", model: "gpt-4" },
+          { name: "no type" } as never, // dropped: no string `type`
+          null as never,
+        ],
+      }),
+    );
+
+    const rest = useAiProviderStore.getState().restProviders;
+    expect(rest).toHaveLength(1);
+    expect(rest[0].type).toBe("openai");
+    // activeProvider was a non-string object → coerced to null.
+    expect(useAiProviderStore.getState().activeProvider).toBeNull();
+  });
+});
+
+describe("useAiProviderSync hook", () => {
+  it("registers state + request listeners and requests state on mount", () => {
+    renderHook(() => useAiProviderSync());
+
+    expect(listeners.has(AI_PROVIDER_STATE_EVENT)).toBe(true);
+    expect(listeners.has(AI_PROVIDER_REQUEST_EVENT)).toBe(true);
+    expect(emitMock).toHaveBeenCalledWith(AI_PROVIDER_REQUEST_EVENT);
+  });
+
+  it("does not broadcast its own hydration snapshot on mount", () => {
+    renderHook(() => useAiProviderSync());
+
+    const stateEmits = emitMock.mock.calls.filter((c) => c[0] === AI_PROVIDER_STATE_EVENT);
+    expect(stateEmits).toHaveLength(0);
+  });
+
+  it("replies to a peer's state request with the current snapshot", () => {
+    renderHook(() => useAiProviderSync());
+    emitMock.mockClear();
+
+    act(() => {
+      listeners.get(AI_PROVIDER_REQUEST_EVENT)?.({ payload: undefined });
+    });
+
+    const stateEmits = emitMock.mock.calls.filter((c) => c[0] === AI_PROVIDER_STATE_EVENT);
+    expect(stateEmits).toHaveLength(1);
+  });
+
+  it("does NOT echo a snapshot it just applied from a peer", () => {
+    // The real echo-suppression check: mount the hook, drive its registered
+    // listener with a remote payload, and assert the outbound effect does not
+    // re-emit that same state. Deleting the suppression would fail this.
+    renderHook(() => useAiProviderSync());
+    emitMock.mockClear();
+
+    act(() => {
+      listeners.get(AI_PROVIDER_STATE_EVENT)?.({
+        payload: payload({ activeProvider: "anthropic" }),
+      });
+    });
+
+    const stateEmits = emitMock.mock.calls.filter((c) => c[0] === AI_PROVIDER_STATE_EVENT);
+    expect(stateEmits).toHaveLength(0);
+    // ...but the store DID adopt the peer state (proving the listener ran).
+    expect(useAiProviderStore.getState().activeProvider).toBe("anthropic");
+  });
+
+  it("broadcasts a genuine local change", () => {
+    renderHook(() => useAiProviderSync());
+    emitMock.mockClear();
+
+    act(() => {
+      useAiProviderStore.setState({ activeProvider: "openai" });
+    });
+
+    const stateEmits = emitMock.mock.calls.filter((c) => c[0] === AI_PROVIDER_STATE_EVENT);
+    expect(stateEmits).toHaveLength(1);
+  });
+
+  it("removes its listeners on unmount", async () => {
+    const { unmount } = renderHook(() => useAiProviderSync());
+    expect(listeners.size).toBeGreaterThan(0);
+
+    await act(async () => {
+      unmount();
+      // safeUnlistenAsync awaits the listen promise before calling unlisten.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(listeners.size).toBe(0);
+  });
+});

--- a/src/hooks/useAiProviderSync.ts
+++ b/src/hooks/useAiProviderSync.ts
@@ -1,0 +1,226 @@
+/**
+ * AI Provider Sync Hook
+ *
+ * Purpose: Propagates AI provider configuration between windows over the Tauri
+ * event bus.
+ *
+ * Why events and not localStorage: every other cross-window store in this app
+ * syncs via `storage` events, but useAiProviderStore persists through
+ * tauri-plugin-store — a JSON FILE fronted by an in-memory cache — so a
+ * `storage` event can never fire for it under any circumstances. Without this
+ * bridge, adding a provider or switching the active one in the Settings window
+ * is invisible to open document windows until restart, and both windows
+ * blind-write the whole file (last write wins, no merge).
+ *
+ * SECURITY: the broadcast payload NEVER contains `apiKey`. Keys live in the OS
+ * keychain and are rehydrated into memory per window; the persist layer already
+ * strips them (see `partialize` in aiStore/provider.ts). Putting a key on the
+ * event bus would be a strictly wider exposure than the keychain, for no gain —
+ * the receiving window rehydrates the key itself from the keychain when a
+ * `credentialsRevision` bump signals a rotation. Applying a remote snapshot
+ * therefore preserves each window's locally-held key until such a reload.
+ *
+ * Key decisions:
+ *   - Symmetric (both windows broadcast and listen), because either can edit.
+ *   - Echo-suppressed via a module-level applied-snapshot ref, exactly as
+ *     useUpdateSync does. That file documents what happens without it: the
+ *     A↔B feedback loop hit the store thousands of times per second.
+ *   - Request-state handshake on mount (like useUpdateSync): a freshly opened
+ *     window asks peers for the current config instead of racing the async
+ *     plugin-store save, and does not broadcast its own hydration snapshot.
+ *   - Untrusted inbound payloads pass through sanitizeAiProviderPersist — the
+ *     same validator hydration uses — before touching the store.
+ *
+ * @coordinates-with stores/aiStore/provider.ts — the synced store + revision
+ * @coordinates-with hooks/useUpdateSync.ts — same bridge pattern
+ * @module hooks/useAiProviderSync
+ */
+
+import { useEffect, useRef } from "react";
+import { emit, listen } from "@tauri-apps/api/event";
+import {
+  sanitizeAiProviderPersist,
+  useAiProviderStore,
+} from "@/stores/aiStore/provider";
+import { getApiKey } from "@/services/secrets/apiKeySecrets";
+import { safeUnlistenAsync } from "@/utils/safeUnlisten";
+import { aiProviderWarn } from "@/utils/debug";
+
+export const AI_PROVIDER_STATE_EVENT = "ai-providers:state-changed";
+export const AI_PROVIDER_REQUEST_EVENT = "ai-providers:request-state";
+
+/** A REST provider entry with the secret removed. */
+type SharedRestProvider = Omit<
+  ReturnType<typeof useAiProviderStore.getState>["restProviders"][number],
+  "apiKey"
+>;
+
+export interface AiProviderStatePayload {
+  activeProvider: ReturnType<typeof useAiProviderStore.getState>["activeProvider"];
+  restProviders: SharedRestProvider[];
+  credentialsRevision: number;
+}
+
+/**
+ * Window-scoped record of the last snapshot applied from a peer. The broadcast
+ * pass compares against it and skips the emit, breaking the A↔B echo.
+ */
+let lastAppliedSnapshot: string | null = null;
+
+/** Build the shareable snapshot of this window's provider config (no secrets). */
+export function buildAiProviderSnapshot(): AiProviderStatePayload {
+  const { activeProvider, restProviders, credentialsRevision } =
+    useAiProviderStore.getState();
+  return {
+    activeProvider,
+    restProviders: restProviders.map(({ apiKey: _apiKey, ...rest }) => rest),
+    credentialsRevision,
+  };
+}
+
+/**
+ * Reload API keys from the keychain into memory for the given provider types.
+ * Fire-and-forget: a peer signalled a rotation via credentialsRevision, and the
+ * keychain (written before the bump) is the source of truth. Never touches the
+ * event bus with a key.
+ */
+async function reloadKeysFromKeychain(types: string[]): Promise<void> {
+  const entries = await Promise.all(
+    types.map(async (type) => [type, await getApiKey(type)] as const),
+  );
+  const keyByType = new Map(entries);
+  useAiProviderStore.setState((state) => ({
+    restProviders: state.restProviders.map((p) =>
+      keyByType.has(p.type) ? { ...p, apiKey: keyByType.get(p.type) ?? "" } : p,
+    ),
+  }));
+}
+
+/**
+ * Apply a peer's provider config to this window, keeping this window's own
+ * in-memory API keys unless the peer signalled a rotation. Exported for testing.
+ */
+export function applyRemoteAiProviderState(payload: AiProviderStatePayload): void {
+  if (!payload || typeof payload !== "object") return;
+  if (!Array.isArray(payload.restProviders)) return; // malformed — keep local
+
+  // Same trust boundary hydration uses: coerces activeProvider to string|null
+  // and drops entries without a string `type` or with non-string fields.
+  const { activeProvider, restProviders: validated } = sanitizeAiProviderPersist({
+    activeProvider: payload.activeProvider,
+    restProviders: payload.restProviders,
+  });
+
+  const store = useAiProviderStore.getState();
+  const localByType = new Map(store.restProviders.map((p) => [p.type, p]));
+  const incomingRevision =
+    typeof payload.credentialsRevision === "number" &&
+    Number.isFinite(payload.credentialsRevision)
+      ? payload.credentialsRevision
+      : store.credentialsRevision;
+  const credentialsRotated = incomingRevision > store.credentialsRevision;
+
+  const merged = validated.map((entry) => ({
+    ...entry,
+    // Remote owns the configuration; the key is this window's, rehydrated from
+    // the keychain. A remote payload carries no key, so preserving the local
+    // one is what stops an adopted config from blanking a working credential.
+    apiKey: localByType.get(entry.type)?.apiKey ?? "",
+  }));
+
+  lastAppliedSnapshot = JSON.stringify({
+    activeProvider,
+    restProviders: merged.map(({ apiKey: _apiKey, ...rest }) => rest),
+    credentialsRevision: incomingRevision,
+  });
+
+  useAiProviderStore.setState({
+    activeProvider,
+    restProviders: merged,
+    credentialsRevision: incomingRevision,
+  });
+
+  // A rotation elsewhere: reload the affected keys from the keychain (source of
+  // truth). The key value never rides the event that triggered this.
+  if (credentialsRotated) {
+    void reloadKeysFromKeychain(merged.map((p) => p.type)).catch((error) => {
+      aiProviderWarn("failed to reload rotated keys from keychain", error);
+    });
+  }
+}
+
+/**
+ * Broadcasts local provider-config changes to other windows and applies
+ * incoming ones. Mount in every window that reads or edits providers.
+ */
+export function useAiProviderSync(): void {
+  const activeProvider = useAiProviderStore((state) => state.activeProvider);
+  const restProviders = useAiProviderStore((state) => state.restProviders);
+  const credentialsRevision = useAiProviderStore(
+    (state) => state.credentialsRevision,
+  );
+  const prevSnapshot = useRef<string | null>(null);
+
+  // Inbound: apply peer snapshots, and answer peers' state requests.
+  useEffect(() => {
+    const unlistenState = listen<AiProviderStatePayload>(
+      AI_PROVIDER_STATE_EVENT,
+      (event) => applyRemoteAiProviderState(event.payload),
+    );
+    unlistenState.catch((error) => {
+      aiProviderWarn("ai provider state listener failed to register", error);
+    });
+    const unlistenRequest = listen(AI_PROVIDER_REQUEST_EVENT, () => {
+      emit(AI_PROVIDER_STATE_EVENT, buildAiProviderSnapshot()).catch((error) => {
+        aiProviderWarn("ai provider state reply failed", error);
+      });
+    });
+    unlistenRequest.catch((error) => {
+      aiProviderWarn("ai provider request listener failed to register", error);
+    });
+    return () => {
+      safeUnlistenAsync(unlistenState);
+      safeUnlistenAsync(unlistenRequest);
+    };
+  }, []);
+
+  // Mount handshake: ask peers for the current config rather than trusting this
+  // window's just-hydrated (possibly stale) plugin-store read.
+  useEffect(() => {
+    emit(AI_PROVIDER_REQUEST_EVENT).catch((error) => {
+      aiProviderWarn("ai provider state request failed", error);
+    });
+  }, []);
+
+  // Outbound: broadcast local changes.
+  useEffect(() => {
+    const snapshot = JSON.stringify(buildAiProviderSnapshot());
+
+    // This state came from a peer — re-emitting it would echo back.
+    if (lastAppliedSnapshot !== null && lastAppliedSnapshot === snapshot) {
+      lastAppliedSnapshot = null;
+      prevSnapshot.current = snapshot;
+      return;
+    }
+    // Nothing actually changed (e.g. a set with identical values).
+    if (prevSnapshot.current === snapshot) return;
+
+    const isFirstPass = prevSnapshot.current === null;
+    prevSnapshot.current = snapshot;
+    lastAppliedSnapshot = null;
+    // Don't broadcast the mount-time snapshot: it is just this window's
+    // hydration, and emitting it would push a freshly-opened window's state
+    // over a peer that has since changed something. The mount handshake pulls
+    // the authoritative state instead.
+    if (isFirstPass) return;
+
+    emit(AI_PROVIDER_STATE_EVENT, JSON.parse(snapshot)).catch((error) => {
+      aiProviderWarn("ai provider sync emit failed:", error);
+    });
+  }, [activeProvider, restProviders, credentialsRevision]);
+}
+
+/** Test-only: reset module-level echo-suppression state between cases. */
+export function __resetAiProviderSyncStateForTests(): void {
+  lastAppliedSnapshot = null;
+}

--- a/src/hooks/useSettingsSync.test.ts
+++ b/src/hooks/useSettingsSync.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { useSettingsStore } from "@/stores/settingsStore";
-import { handleSettingsStorageEvent } from "./useSettingsSync";
+import { initialState } from "@/stores/settingsStore/defaults";
+import { SYNC_GROUPS, handleSettingsStorageEvent } from "./useSettingsSync";
 
 // Helper to create a storage event with settings
 function createStorageEvent(newSettings: Record<string, unknown>): StorageEvent {
@@ -36,7 +37,12 @@ describe("useSettingsSync cross-window sync", () => {
     });
   });
 
-  describe("syncs all setting groups", () => {
+  // Per-group behavioural checks. Exhaustiveness is NOT established here —
+  // these are hand-written samples. The "SYNC_GROUPS covers every persisted
+  // settings section" contract test below is what proves full coverage; this
+  // block was previously named "syncs all setting groups", which read as a
+  // completeness guarantee it never provided and hid three missing groups.
+  describe("syncs individual setting groups", () => {
     it("syncs appearance settings", () => {
       const newAppearance = {
         ...useSettingsStore.getState().appearance,
@@ -264,6 +270,126 @@ describe("useSettingsSync cross-window sync", () => {
       expect(spy).not.toHaveBeenCalled();
       spy.mockRestore();
     });
+  });
+});
+
+describe("SYNC_GROUPS covers every persisted settings section", () => {
+  // Regression: the list was hand-maintained and silently omitted `terminal`,
+  // `largeFile` and `browser`. Because persist has no `partialize`, a window
+  // that skips a group later writes its whole stale state back over it — so a
+  // missing group is silent DATA LOSS, not just staleness. Deriving the list
+  // from the store makes the drift unrepresentable; this test pins that.
+  it("syncs every object-valued key of SettingsState", () => {
+    const sections = Object.keys(initialState).filter(
+      (key) =>
+        typeof initialState[key as keyof typeof initialState] === "object" &&
+        initialState[key as keyof typeof initialState] !== null,
+    );
+
+    expect([...SYNC_GROUPS].sort()).toEqual(sections.sort());
+  });
+
+  it.each(["terminal", "largeFile", "browser"] as const)(
+    "propagates the %s group (previously dropped)",
+    (group) => {
+      expect(SYNC_GROUPS).toContain(group);
+    },
+  );
+
+  it("applies a terminal font-size change from another window", () => {
+    const incoming = { ...useSettingsStore.getState().terminal, fontSize: 20 };
+
+    handleSettingsStorageEvent(createStorageEvent({ terminal: incoming }));
+
+    expect(useSettingsStore.getState().terminal.fontSize).toBe(20);
+  });
+
+  it("applies a browser enable/posture change from another window", () => {
+    const incoming = {
+      ...useSettingsStore.getState().browser,
+      enabled: true,
+      aiSession: "sandbox" as const,
+    };
+
+    handleSettingsStorageEvent(createStorageEvent({ browser: incoming }));
+
+    expect(useSettingsStore.getState().browser.enabled).toBe(true);
+    expect(useSettingsStore.getState().browser.aiSession).toBe("sandbox");
+  });
+
+  it("applies a largeFile threshold change from another window", () => {
+    const before = useSettingsStore.getState().largeFile.autoSourceMode;
+    const incoming = {
+      ...useSettingsStore.getState().largeFile,
+      autoSourceMode: !before,
+    };
+
+    handleSettingsStorageEvent(createStorageEvent({ largeFile: incoming }));
+
+    expect(useSettingsStore.getState().largeFile.autoSourceMode).toBe(!before);
+  });
+});
+
+describe("applies the same trust boundary as hydration", () => {
+  // C4: the sync path used a raw setState, so a value that hydration would
+  // clamp was accepted live from another window — the one hole in the D4
+  // defence. Both routes now share reconcileSettings().
+  it("clamps an out-of-range numeric from another window", () => {
+    const incoming = { ...useSettingsStore.getState().appearance, fontSize: 9999 };
+
+    handleSettingsStorageEvent(createStorageEvent({ appearance: incoming }));
+
+    const applied = useSettingsStore.getState().appearance.fontSize;
+    expect(applied).toBeLessThan(9999);
+    expect(applied).toBeGreaterThan(0);
+  });
+
+  it("normalizes an invalid browser posture to the safe mode", () => {
+    const incoming = {
+      ...useSettingsStore.getState().browser,
+      aiSession: "totally-invalid" as never,
+    };
+
+    handleSettingsStorageEvent(createStorageEvent({ browser: incoming }));
+
+    expect(useSettingsStore.getState().browser.aiSession).toBe("sandbox");
+  });
+
+  it("drops a type-mismatched leaf instead of poisoning the store", () => {
+    const before = useSettingsStore.getState().general.tabSize;
+    const incoming = { ...useSettingsStore.getState().general, tabSize: "four" as never };
+
+    handleSettingsStorageEvent(createStorageEvent({ general: incoming }));
+
+    expect(useSettingsStore.getState().general.tabSize).toBe(before);
+  });
+
+  it("drops non-string customLinkProtocols elements from another window", () => {
+    // audit Medium-10: hydration filtered these but the storage path did not,
+    // so the two untrusted routes applied unequal validation.
+    const incoming = {
+      ...useSettingsStore.getState().advanced,
+      customLinkProtocols: ["obsidian", 42, null, {}, "vscode"] as never,
+    };
+
+    handleSettingsStorageEvent(createStorageEvent({ advanced: incoming }));
+
+    const protocols = useSettingsStore.getState().advanced.customLinkProtocols;
+    expect(protocols).toEqual(protocols.filter((p) => typeof p === "string"));
+    expect(protocols).toContain("obsidian");
+    expect(protocols).toContain("vscode");
+    expect(protocols.every((p) => typeof p === "string")).toBe(true);
+  });
+
+  it("defaults keys the writer omitted rather than dropping them", () => {
+    // setState replaced a group wholesale; a key absent from the writer's blob
+    // vanished instead of keeping its default. A deep merge defaults it.
+    const before = useSettingsStore.getState().terminal.cursorStyle;
+
+    handleSettingsStorageEvent(createStorageEvent({ terminal: { fontSize: 17 } }));
+
+    expect(useSettingsStore.getState().terminal.fontSize).toBe(17);
+    expect(useSettingsStore.getState().terminal.cursorStyle).toBe(before);
   });
 });
 

--- a/src/hooks/useSettingsSync.ts
+++ b/src/hooks/useSettingsSync.ts
@@ -7,8 +7,11 @@
  *
  * Key decisions:
  *   - Uses localStorage (not Tauri events) because settingsStore already
- *     persists to localStorage via Zustand persist middleware
- *   - Syncs setting groups independently (appearance, general, markdown, etc.)
+ *     persists to localStorage via Zustand persist middleware. Verified: the
+ *     `storage` event does cross Tauri v2 webviews (all windows share one
+ *     custom-protocol origin), so this is a real transport, not an assumption.
+ *   - Syncs every persisted section, derived from the store's own defaults
+ *     rather than a hand-maintained allow-list (see SYNC_GROUPS).
  *   - processStorageEvent exported for testing
  *
  * @coordinates-with settingsStore.ts — reads/writes persisted settings
@@ -17,25 +20,36 @@
 
 import { useEffect } from "react";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { initialState } from "@/stores/settingsStore/defaults";
+import type { ObjectSections } from "@/stores/settingsStore/defaults";
+import { reconcileSettings } from "@/stores/settingsStore/reconcile";
+import { settingsSyncWarn } from "@/utils/debug";
 
 const STORAGE_KEY = "vmark-settings";
-const SYNC_GROUPS = [
-  "appearance",
-  "general",
-  "markdown",
-  "image",
-  "cjkFormatting",
-  "advanced",
-  "update",
-  // `formats` must sync cross-window so that toggling a category in the
-  // Settings window (a separate Tauri webview) re-bootstraps the format
-  // registry in the document window via useFormatSettingsBridge. Without
-  // this, the toggle only takes effect after restart and `.mmd`/`.svg`/
-  // `.html`/code-viewer adapters keep falling through to plain text.
-  "formats",
-] as const;
 
-type SyncGroup = (typeof SYNC_GROUPS)[number];
+type SyncGroup = ObjectSections;
+
+/**
+ * Every object-valued settings section, derived from the store's own defaults.
+ *
+ * This list must never be hand-maintained. It previously was, and silently
+ * omitted `terminal`, `largeFile` and `browser` — which is not merely a
+ * staleness bug: because the store's `persist` has no `partialize`, every
+ * window serializes its WHOLE state on any write, so a window that skips a
+ * group later writes its stale copy back over the other window's change. A
+ * missing group is silent data loss on a background timer.
+ *
+ * Deriving from `initialState` mirrors `ObjectSections` (defaults.ts), so a
+ * newly added section syncs automatically instead of drifting. `showDevSection`
+ * is excluded by construction — it is a boolean UI flag read only inside the
+ * Settings window itself.
+ */
+export const SYNC_GROUPS: readonly SyncGroup[] = Object.keys(initialState).filter(
+  (key) => {
+    const value = initialState[key as keyof typeof initialState];
+    return typeof value === "object" && value !== null;
+  },
+) as SyncGroup[];
 
 /**
  * Process a storage event and sync settings to the store.
@@ -46,17 +60,27 @@ export function handleSettingsStorageEvent(event: StorageEvent): void {
     return;
   }
 
+  let parsed: { state?: Record<string, unknown> };
   try {
-    const parsed = JSON.parse(event.newValue);
+    parsed = JSON.parse(event.newValue);
+  } catch {
+    return; // malformed JSON from another window — ignore
+  }
+
+  // Application errors below (reconcile, setState, synchronous store
+  // subscribers) are NOT parse errors and must not be silently swallowed as
+  // if they were — that hid real failures behind a "corrupt JSON" catch and
+  // could leave partially applied state (audit Medium-11).
+  try {
     if (!parsed.state) return;
 
     const currentState = useSettingsStore.getState();
-    const updates: Record<string, unknown> = {};
+    const incoming: Record<string, unknown> = {};
 
-    // Sync all setting groups. Validate each group's SHAPE before merging
-    // (WI-4.2, T3): a malformed cross-tab localStorage write must not inject a
-    // string/array/primitive where a settings group object is expected and
-    // corrupt live settings. Settings groups are always plain objects.
+    // Collect the groups that actually differ. Validate each group's SHAPE
+    // first (WI-4.2, T3): a malformed cross-window write must not inject a
+    // string/array/primitive where a settings group object is expected.
+    // Settings groups are always plain objects.
     for (const group of SYNC_GROUPS) {
       const newValue = parsed.state[group];
       if (
@@ -68,16 +92,30 @@ export function handleSettingsStorageEvent(event: StorageEvent): void {
       }
       const currentValue = currentState[group as SyncGroup];
       if (JSON.stringify(currentValue) !== JSON.stringify(newValue)) {
-        updates[group] = newValue;
+        incoming[group] = newValue;
       }
     }
 
-    // Apply updates if any
-    if (Object.keys(updates).length > 0) {
-      useSettingsStore.setState(updates);
+    if (Object.keys(incoming).length === 0) return;
+
+    // Route through the SAME trust boundary hydration uses (C4). A raw
+    // setState here bypassed sanitize/clamp/normalize — so a corrupt value
+    // rejected at startup was accepted live from another window — and replaced
+    // each group wholesale, dropping keys the writer happened to omit instead
+    // of defaulting them.
+    const reconciled = reconcileSettings(
+      currentState as unknown as Record<string, unknown>,
+      incoming,
+    );
+    const updates: Record<string, unknown> = {};
+    for (const group of Object.keys(incoming)) {
+      updates[group] = reconciled[group];
     }
-  } catch {
-    // Ignore parse errors
+    useSettingsStore.setState(updates);
+  } catch (error) {
+    // A real failure applying a well-formed event — surface it rather than
+    // pretend the write was malformed.
+    settingsSyncWarn("failed to apply cross-window settings", error);
   }
 }
 

--- a/src/hooks/useShortcutsSync.test.ts
+++ b/src/hooks/useShortcutsSync.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useShortcutsStore } from "@/stores/settingsStore/shortcuts";
+import { handleShortcutsStorageEvent } from "./useShortcutsSync";
+
+function createStorageEvent(state: Record<string, unknown>, key = "vmark-shortcuts"): StorageEvent {
+  return new StorageEvent("storage", {
+    key,
+    newValue: JSON.stringify({ state, version: 0 }),
+  });
+}
+
+beforeEach(() => {
+  useShortcutsStore.setState({ customBindings: {} });
+});
+
+describe("useShortcutsSync cross-window sync", () => {
+  // C2: vmark-shortcuts had no storage listener and no Tauri event. Native menu
+  // accelerators updated (app-global via invoke) but the document window's
+  // Tiptap/CodeMirror keymaps did not, so BOTH the old and new binding stayed
+  // live until restart. Shortcuts with no menuId did not apply at all.
+  it("adopts a rebind made in another window", () => {
+    handleShortcutsStorageEvent(
+      createStorageEvent({ customBindings: { "view.zoomIn": "Mod-Shift-=" } }),
+    );
+
+    expect(useShortcutsStore.getState().customBindings["view.zoomIn"]).toBe("Mod-Shift-=");
+  });
+
+  it("notifies subscribers so keymaps rebuild", () => {
+    const listener = vi.fn();
+    const unsubscribe = useShortcutsStore.subscribe(listener);
+
+    handleShortcutsStorageEvent(
+      createStorageEvent({ customBindings: { "file.save": "Mod-Alt-s" } }),
+    );
+
+    expect(listener).toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it("adopts a reset (bindings cleared in another window)", () => {
+    useShortcutsStore.setState({ customBindings: { "file.save": "Mod-Alt-s" } });
+
+    handleShortcutsStorageEvent(createStorageEvent({ customBindings: {} }));
+
+    expect(useShortcutsStore.getState().customBindings).toEqual({});
+  });
+
+  it("ignores events for other storage keys", () => {
+    handleShortcutsStorageEvent(
+      createStorageEvent({ customBindings: { "file.save": "Mod-x" } }, "vmark-settings"),
+    );
+
+    expect(useShortcutsStore.getState().customBindings).toEqual({});
+  });
+
+  it("does not apply when nothing changed", () => {
+    useShortcutsStore.setState({ customBindings: { "file.save": "Mod-Alt-s" } });
+    const listener = vi.fn();
+    const unsubscribe = useShortcutsStore.subscribe(listener);
+
+    handleShortcutsStorageEvent(
+      createStorageEvent({ customBindings: { "file.save": "Mod-Alt-s" } }),
+    );
+
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  describe("rejects malformed writes", () => {
+    it.each([
+      ["a string", "not-an-object"],
+      ["an array", ["a", "b"]],
+      ["null", null],
+    ])("ignores customBindings that is %s", (_label, value) => {
+      useShortcutsStore.setState({ customBindings: { "file.save": "Mod-Alt-s" } });
+
+      handleShortcutsStorageEvent(createStorageEvent({ customBindings: value }));
+
+      expect(useShortcutsStore.getState().customBindings).toEqual({
+        "file.save": "Mod-Alt-s",
+      });
+    });
+
+    it("drops non-string binding values but keeps valid siblings", () => {
+      handleShortcutsStorageEvent(
+        createStorageEvent({
+          customBindings: { "file.save": "Mod-Alt-s", "file.open": 42, "file.new": null },
+        }),
+      );
+
+      expect(useShortcutsStore.getState().customBindings).toEqual({
+        "file.save": "Mod-Alt-s",
+      });
+    });
+
+    it("ignores unparseable JSON", () => {
+      useShortcutsStore.setState({ customBindings: { "file.save": "Mod-Alt-s" } });
+
+      handleShortcutsStorageEvent(
+        new StorageEvent("storage", { key: "vmark-shortcuts", newValue: "{not json" }),
+      );
+
+      expect(useShortcutsStore.getState().customBindings).toEqual({
+        "file.save": "Mod-Alt-s",
+      });
+    });
+
+    it("ignores an event with no new value", () => {
+      handleShortcutsStorageEvent(
+        new StorageEvent("storage", { key: "vmark-shortcuts", newValue: null }),
+      );
+
+      expect(useShortcutsStore.getState().customBindings).toEqual({});
+    });
+  });
+});
+
+describe("useShortcutsSync hook", () => {
+  it("adds and removes the storage listener", async () => {
+    const { renderHook } = await import("@testing-library/react");
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const { useShortcutsSync } = await import("./useShortcutsSync");
+    const { unmount } = renderHook(() => useShortcutsSync());
+
+    expect(addSpy).toHaveBeenCalledWith("storage", expect.any(Function));
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith("storage", expect.any(Function));
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/src/hooks/useShortcutsSync.ts
+++ b/src/hooks/useShortcutsSync.ts
@@ -1,0 +1,88 @@
+/**
+ * Shortcuts Sync Hook
+ *
+ * Purpose: Propagates keyboard-shortcut rebinds between windows, the same way
+ * useSettingsSync does for settings.
+ *
+ * Why this exists: shortcuts are edited in the Settings window (a separate
+ * Tauri webview with its own store instance), but they are CONSUMED in document
+ * windows — the Tiptap keymap, the CodeMirror keymap, and ~15 non-menu handlers
+ * all read useShortcutsStore and rebuild on its subscription. Without a
+ * cross-window path those subscriptions never fire in the document window.
+ *
+ * The native menu path was already correct and hid the bug: setShortcut invokes
+ * `update_menu_accelerators`, and the macOS menu bar is app-global, so
+ * menu-backed shortcuts appeared to work. What actually happened is that the
+ * document window kept its OLD frontend binding while the menu gained the NEW
+ * one — both live at once — and shortcuts with no menuId (command palette,
+ * quick open, genies) did not change at all until restart.
+ *
+ * Key decisions:
+ *   - Applies via setState rather than the store's actions on purpose: the
+ *     actions re-invoke the native menu sync, which the originating window has
+ *     already done. Going through them would bounce accelerator updates between
+ *     windows for no benefit.
+ *   - Validates values are strings before adopting them (zero-trust at the
+ *     storage boundary, matching useSettingsSync).
+ *
+ * @coordinates-with stores/settingsStore/shortcuts.ts — the synced store
+ * @coordinates-with hooks/useSettingsSync.ts — sibling for the settings store
+ * @module hooks/useShortcutsSync
+ */
+
+import { useEffect } from "react";
+import { useShortcutsStore } from "@/stores/settingsStore/shortcuts";
+import { shortcutsSyncWarn } from "@/utils/debug";
+
+const STORAGE_KEY = "vmark-shortcuts";
+
+/**
+ * Process a storage event and adopt another window's shortcut bindings.
+ * Exported for testing.
+ */
+export function handleShortcutsStorageEvent(event: StorageEvent): void {
+  if (event.key !== STORAGE_KEY || !event.newValue) return;
+
+  let parsed: { state?: { customBindings?: unknown } };
+  try {
+    parsed = JSON.parse(event.newValue);
+  } catch {
+    return; // malformed JSON — a corrupt write must not clear live bindings
+  }
+
+  // Application errors below are not parse errors — surface them instead of
+  // masking them as malformed JSON (audit Medium-11).
+  try {
+    const incoming = parsed?.state?.customBindings;
+    if (
+      incoming == null ||
+      typeof incoming !== "object" ||
+      Array.isArray(incoming)
+    ) {
+      return; // malformed write — leave live bindings alone
+    }
+
+    // Bindings are id -> key strings. Drop anything else rather than letting a
+    // non-string reach the keymap builders.
+    const clean: Record<string, string> = {};
+    for (const [id, key] of Object.entries(incoming as Record<string, unknown>)) {
+      if (typeof key === "string") clean[id] = key;
+    }
+
+    const current = useShortcutsStore.getState().customBindings;
+    if (JSON.stringify(current) === JSON.stringify(clean)) return;
+
+    useShortcutsStore.setState({ customBindings: clean });
+  } catch (error) {
+    shortcutsSyncWarn("failed to apply cross-window shortcuts", error);
+  }
+}
+
+/** Adopts shortcut rebinds made in other windows. */
+export function useShortcutsSync() {
+  useEffect(() => {
+    window.addEventListener("storage", handleShortcutsStorageEvent);
+    return () =>
+      window.removeEventListener("storage", handleShortcutsStorageEvent);
+  }, []);
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -23,6 +23,7 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import resourcesToBackend from "i18next-resources-to-backend";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { i18nWarn } from "@/utils/debug";
 import { setSafeStorageMessageResolver } from "@/services/persistence/safeStorage";
 import { setWorkspaceStorageMessageResolver } from "@/services/persistence/workspaceStorage";
 
@@ -90,12 +91,28 @@ i18n.on("languageChanged", (lng) => {
 // update this window's i18n instance to match.
 /* v8 ignore start -- @preserve reason: cross-window sync subscription only fires in multi-window runtime */
 let lastLang = i18n.language;
+// Monotonic id of the most recently requested switch. changeLanguage is async,
+// so two rapid switches can resolve out of order; only the newest request may
+// commit the baseline. Without this, a superseded switch resolving last would
+// record its stale language, and re-selecting the language actually showing
+// would then be skipped as a no-op (audit Medium-12).
+let langRequestId = 0;
 useSettingsStore.subscribe((state) => {
   const lang = state.general.language;
-  if (lang && lang !== lastLang) {
-    lastLang = lang;
-    i18n.changeLanguage(lang);
-  }
+  if (!lang || lang === lastLang) return;
+  const requestId = ++langRequestId;
+  // Commit the baseline only once the switch actually succeeds AND it is still
+  // the newest request. Committing first meant a rejected changeLanguage
+  // (missing bundle) left the baseline claiming success, so the subscriber
+  // never retried — with an unhandled rejection to boot.
+  i18n
+    .changeLanguage(lang)
+    .then(() => {
+      if (requestId === langRequestId) lastLang = lang;
+    })
+    .catch((error: unknown) => {
+      i18nWarn("changeLanguage failed; keeping previous locale", error);
+    });
 });
 /* v8 ignore stop */
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -23,6 +23,9 @@ import {
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useSettingsSync } from "@/hooks/useSettingsSync";
+import { useShortcutsSync } from "@/hooks/useShortcutsSync";
+import { useAiProviderSync } from "@/hooks/useAiProviderSync";
 import { useTheme } from "@/hooks/useTheme";
 import { useUpdateBroadcast, useUpdateListener } from "@/hooks/useUpdateSync";
 import { isImeKeyEvent } from "@/utils/imeGuard";
@@ -141,6 +144,17 @@ export function SettingsPage() {
 
   // Apply theme to this window
   useTheme();
+  // Adopt settings changed in a document window. Without this the sync is
+  // one-directional (document windows listen, Settings does not), so Settings
+  // holds a snapshot from the moment it opened and its next write persists
+  // that stale copy — e.g. zooming with Cmd+= in a document window is silently
+  // reverted the next time any Settings control is touched.
+  useSettingsSync();
+  // Same for shortcut rebinds made in a document window's own UI.
+  useShortcutsSync();
+  // Providers are edited here but consumed in document windows; the store
+  // persists to a JSON file, so a Tauri event is the only possible path.
+  useAiProviderSync();
   // Handle Cmd+W to close settings
   useSettingsClose();
   // Handle Cmd+Shift+D to toggle dev section

--- a/src/services/formats/formatSettingsBridge.ts
+++ b/src/services/formats/formatSettingsBridge.ts
@@ -90,9 +90,15 @@ export function installFormatSettingsSubscription(): () => void {
     const nextAssociations = state.formats.associations;
 
     const togglesChanged = !togglesEqual(lastToggles, nextToggles);
-    // Reference comparison is sufficient: updateFormatsSetting replaces the
-    // whole object, so a real change always yields a new reference.
-    const associationsChanged = lastAssociations !== nextAssociations;
+    // Compare by VALUE, not reference. Reference comparison held only for the
+    // same-window path (updateFormatsSetting replaces the object). The
+    // cross-window path parses JSON, so every storage event hands this
+    // subscriber a fresh-but-identical `associations` object — making any
+    // unrelated `formats` change (even the internal `upgradeNudgeShown` flag)
+    // trigger a full recomputeAllFormatIds() across every open tab.
+    const associationsChanged =
+      lastAssociations !== nextAssociations &&
+      JSON.stringify(lastAssociations) !== JSON.stringify(nextAssociations);
     if (!togglesChanged && !associationsChanged) return;
 
     lastToggles = nextToggles;

--- a/src/stores/aiStore/provider.ts
+++ b/src/stores/aiStore/provider.ts
@@ -30,12 +30,26 @@ import type {
   RestProviderType,
 } from "@/types/aiGenies";
 import { DEFAULT_REST_PROVIDERS } from "./providerDefaults";
+import {
+  sanitizeAiProviderPersist,
+  REST_TYPES,
+  KEY_OPTIONAL_REST,
+} from "./providerSanitize";
 
 interface AiProviderState {
   activeProvider: ProviderType | null;
   cliProviders: CliProviderInfo[];
   restProviders: RestProviderConfig[];
   detecting: boolean;
+  /**
+   * Bumped whenever a REST provider's API key is successfully written to the
+   * keychain. API keys are never broadcast cross-window, so this non-secret
+   * counter is what tells peer windows "a credential changed — reload it from
+   * the keychain" (see useAiProviderSync). Session-only: not persisted, resets
+   * to 0 on each launch, when every window rehydrates keys from the keychain
+   * anyway.
+   */
+  credentialsRevision: number;
 }
 
 interface AiProviderActions {
@@ -53,62 +67,9 @@ interface AiProviderActions {
   getActiveProviderName(): string;
 }
 
-/**
- * Shape-guard one persisted REST provider entry (T4). Coerces missing/
- * wrong-typed string fields to `""` so a tampered or stale secure-store blob
- * can't inject `undefined`/non-string fields downstream. Returns null for
- * entries with no string `type` — the identity key is unusable without it.
- */
-function sanitizeRestProvider(raw: unknown): RestProviderConfig | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const r = raw as Record<string, unknown>;
-  if (typeof r.type !== "string") return null;
-  const str = (v: unknown): string => (typeof v === "string" ? v : "");
-  return {
-    type: r.type as RestProviderType,
-    name: str(r.name),
-    endpoint: str(r.endpoint),
-    apiKey: str(r.apiKey),
-    model: str(r.model),
-  };
-}
-
-/**
- * Validate/normalize the persisted AI-provider blob at the migrate boundary
- * (T4, zero-trust). Replaces a blind `as unknown as AiProviderState` cast:
- * drops a non-array `restProviders` and malformed entries, and coerces
- * `activeProvider` to `string | null`. A fully-malformed blob recovers to
- * defaults (onRehydrateStorage backfills DEFAULT_REST_PROVIDERS).
- *
- * Exported for testing.
- */
-export function sanitizeAiProviderPersist(data: Record<string, unknown>): {
-  activeProvider: ProviderType | null;
-  restProviders: RestProviderConfig[];
-} {
-  const activeProvider =
-    typeof data.activeProvider === "string"
-      ? (data.activeProvider as ProviderType)
-      : null;
-  const restProviders = Array.isArray(data.restProviders)
-    ? data.restProviders
-        .map(sanitizeRestProvider)
-        .filter((p): p is RestProviderConfig => p !== null)
-    : [];
-  return { activeProvider, restProviders };
-}
-
-/** REST provider type identifiers that require API key configuration. CLI types are everything else. */
-export const REST_TYPES = new Set<string>([
-  "anthropic",
-  "openai",
-  "openai-compatible",
-  "google-ai",
-  "ollama-api",
-]);
-
-/** Ollama API doesn't require an API key. */
-export const KEY_OPTIONAL_REST = new Set<string>(["ollama-api"]);
+// Re-export the public validation surface so the aiStore barrel and existing
+// importers keep working after the extraction to providerSanitize.ts.
+export { sanitizeAiProviderPersist, REST_TYPES, KEY_OPTIONAL_REST };
 
 // Race guard counter for detectProviders
 let _detectId = 0;
@@ -141,6 +102,7 @@ export const useAiProviderStore = create<AiProviderState & AiProviderActions>()(
       cliProviders: [],
       restProviders: DEFAULT_REST_PROVIDERS,
       detecting: false,
+      credentialsRevision: 0,
 
       detectProviders: async () => {
         const thisDetectId = ++_detectId;
@@ -222,7 +184,15 @@ export const useAiProviderStore = create<AiProviderState & AiProviderActions>()(
         // stays fire-and-forget so the sync action never blocks on the keychain.
         if (Object.prototype.hasOwnProperty.call(updates, "apiKey")) {
           void setApiKey(type, updates.apiKey ?? "").then((ok) => {
-            if (!ok) reportKeySaveFailure(type);
+            if (!ok) {
+              reportKeySaveFailure(type);
+              return;
+            }
+            // Signal peer windows to reload this credential from the keychain.
+            // Bumped AFTER the keychain write resolves, so a peer that reacts by
+            // reading the keychain is guaranteed to see the new value, not a
+            // half-written one.
+            set((state) => ({ credentialsRevision: state.credentialsRevision + 1 }));
           });
         }
       },

--- a/src/stores/aiStore/providerSanitize.ts
+++ b/src/stores/aiStore/providerSanitize.ts
@@ -1,0 +1,72 @@
+/**
+ * AI provider sanitization — the zero-trust validation boundary (T4) for
+ * untrusted provider blobs, shared by the persist `migrate` path and the
+ * cross-window sync path (useAiProviderSync). Extracted from provider.ts so the
+ * store definition stays focused; these are pure functions with no store
+ * dependency.
+ *
+ * @coordinates-with stores/aiStore/provider.ts — the store that uses these
+ * @coordinates-with hooks/useAiProviderSync.ts — cross-window inbound guard
+ * @module stores/aiStore/providerSanitize
+ */
+
+import type {
+  ProviderType,
+  RestProviderConfig,
+  RestProviderType,
+} from "@/types/aiGenies";
+
+/**
+ * Shape-guard one persisted REST provider entry (T4). Coerces missing/
+ * wrong-typed string fields to `""` so a tampered or stale secure-store blob
+ * can't inject `undefined`/non-string fields downstream. Returns null for
+ * entries with no string `type` — the identity key is unusable without it.
+ */
+function sanitizeRestProvider(raw: unknown): RestProviderConfig | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.type !== "string") return null;
+  const str = (v: unknown): string => (typeof v === "string" ? v : "");
+  return {
+    type: r.type as RestProviderType,
+    name: str(r.name),
+    endpoint: str(r.endpoint),
+    apiKey: str(r.apiKey),
+    model: str(r.model),
+  };
+}
+
+/**
+ * Validate/normalize the persisted AI-provider blob at the migrate boundary
+ * (T4, zero-trust). Replaces a blind `as unknown as AiProviderState` cast:
+ * drops a non-array `restProviders` and malformed entries, and coerces
+ * `activeProvider` to `string | null`. A fully-malformed blob recovers to
+ * defaults (onRehydrateStorage backfills DEFAULT_REST_PROVIDERS).
+ */
+export function sanitizeAiProviderPersist(data: Record<string, unknown>): {
+  activeProvider: ProviderType | null;
+  restProviders: RestProviderConfig[];
+} {
+  const activeProvider =
+    typeof data.activeProvider === "string"
+      ? (data.activeProvider as ProviderType)
+      : null;
+  const restProviders = Array.isArray(data.restProviders)
+    ? data.restProviders
+        .map(sanitizeRestProvider)
+        .filter((p): p is RestProviderConfig => p !== null)
+    : [];
+  return { activeProvider, restProviders };
+}
+
+/** REST provider type identifiers that require API key configuration. CLI types are everything else. */
+export const REST_TYPES = new Set<string>([
+  "anthropic",
+  "openai",
+  "openai-compatible",
+  "google-ai",
+  "ollama-api",
+]);
+
+/** Ollama API doesn't require an API key. */
+export const KEY_OPTIONAL_REST = new Set<string>(["ollama-api"]);

--- a/src/stores/persistedSectionMerge.test.ts
+++ b/src/stores/persistedSectionMerge.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StateStorage } from "zustand/middleware";
+import { createSectionMergingStorage } from "./persistedSectionMerge";
+
+/** In-memory StateStorage standing in for the shared localStorage key. */
+function createDisk(initial: Record<string, unknown> | null = null) {
+  const disk = { value: initial ? envelope(initial) : null as string | null };
+  const base: StateStorage = {
+    getItem: (_name) => disk.value,
+    setItem: (_name, value) => {
+      disk.value = value;
+    },
+    removeItem: (_name) => {
+      disk.value = null;
+    },
+  };
+  return {
+    base,
+    read: () => (disk.value ? JSON.parse(disk.value).state : null),
+    raw: () => disk.value,
+    writeExternally: (state: Record<string, unknown>) => {
+      disk.value = envelope(state);
+    },
+  };
+}
+
+function envelope(state: Record<string, unknown>): string {
+  return JSON.stringify({ state, version: 1 });
+}
+
+const KEY = "vmark-settings";
+
+let disk: ReturnType<typeof createDisk>;
+let storage: StateStorage;
+
+beforeEach(() => {
+  disk = createDisk({ terminal: { fontSize: 13 }, appearance: { theme: "paper" } });
+  storage = createSectionMergingStorage(disk.base);
+  // Persist hydrates via getItem — this is what establishes the baseline.
+  storage.getItem(KEY);
+});
+
+describe("createSectionMergingStorage", () => {
+  // Reproduced live in the app: window A set terminal.fontSize=21, window B
+  // (which never synced that group) later wrote its whole state for an
+  // unrelated reason and reverted it to 13. A window must only persist the
+  // sections it actually changed.
+  it("does not write sections this window did not change", () => {
+    disk.writeExternally({
+      terminal: { fontSize: 21 }, // another window's change
+      appearance: { theme: "paper" },
+    });
+
+    // This window still holds fontSize 13 and writes for an unrelated reason.
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 13 }, appearance: { theme: "paper" } }));
+
+    expect(disk.read().terminal.fontSize).toBe(21); // preserved, not clobbered
+  });
+
+  it("persists a section this window did change", () => {
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 16 }, appearance: { theme: "paper" } }));
+
+    expect(disk.read().terminal.fontSize).toBe(16);
+  });
+
+  it("merges this window's change onto another window's concurrent change", () => {
+    disk.writeExternally({
+      terminal: { fontSize: 21 }, // theirs
+      appearance: { theme: "paper" },
+    });
+
+    // Ours changes only appearance.
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 13 }, appearance: { theme: "night" } }));
+
+    const state = disk.read();
+    expect(state.appearance.theme).toBe("night"); // ours applied
+    expect(state.terminal.fontSize).toBe(21); // theirs survived
+  });
+
+  it("skips the physical write entirely when nothing changed", () => {
+    const spy = vi.spyOn(disk.base, "setItem");
+
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 13 }, appearance: { theme: "paper" } }));
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("skips the write when this window is only echoing what disk already has", () => {
+    // The cross-window sync handler applies another window's value via
+    // setState, which makes it look 'changed' relative to our baseline. Writing
+    // it back would fire a redundant storage event in every other window.
+    disk.writeExternally({ terminal: { fontSize: 21 }, appearance: { theme: "paper" } });
+    const spy = vi.spyOn(disk.base, "setItem");
+
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 21 }, appearance: { theme: "paper" } }));
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("does not re-clobber an external section after two consecutive local writes", () => {
+    // Regression (audit High-1): the baseline must track what THIS window
+    // holds, not the merged disk result. If it took the merged value, the
+    // external section (terminal=21) would enter the baseline even though this
+    // window never adopted it into memory — and the window's still-stale
+    // in-memory terminal=13 would then look "changed" on the next write and
+    // overwrite 21, recreating the data loss this wrapper prevents.
+    disk.writeExternally({ terminal: { fontSize: 21 }, appearance: { theme: "paper" } });
+
+    // First local write: change only appearance. Disk terminal must stay 21.
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 13 }, appearance: { theme: "night" } }));
+    expect(disk.read().terminal.fontSize).toBe(21);
+
+    // Second local write: change appearance again, terminal still locally 13.
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 13 }, appearance: { theme: "sepia" } }));
+
+    expect(disk.read().terminal.fontSize).toBe(21); // external value preserved
+    expect(disk.read().appearance.theme).toBe("sepia");
+  });
+
+  it("tracks its own writes so a later unrelated write does not re-clobber", () => {
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 16 }, appearance: { theme: "paper" } }));
+    disk.writeExternally({ terminal: { fontSize: 30 }, appearance: { theme: "paper" } });
+
+    // Unrelated write; our terminal value (16) is stale vs disk (30) but we did
+    // not change it since our last write, so it must not be persisted.
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 16 }, appearance: { theme: "paper" } }));
+
+    expect(disk.read().terminal.fontSize).toBe(30);
+  });
+
+  it("writes everything when the key has never been read (fail open)", () => {
+    const fresh = createDisk(null);
+    const s = createSectionMergingStorage(fresh.base);
+
+    s.setItem(KEY, envelope({ terminal: { fontSize: 14 } }));
+
+    expect(fresh.read().terminal.fontSize).toBe(14);
+  });
+
+  it("preserves sections present on disk but absent from this window's state", () => {
+    disk.writeExternally({
+      terminal: { fontSize: 13 },
+      appearance: { theme: "paper" },
+      futureSection: { added: "by a newer build" },
+    });
+
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 15 }, appearance: { theme: "paper" } }));
+
+    expect(disk.read().futureSection).toEqual({ added: "by a newer build" });
+  });
+
+  it("falls back to a plain write when disk holds corrupt JSON", () => {
+    disk.base.setItem(KEY, "{not json");
+
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 17 }, appearance: { theme: "paper" } }));
+
+    expect(disk.read().terminal.fontSize).toBe(17);
+  });
+
+  it("resets its baseline on removeItem", () => {
+    storage.removeItem(KEY);
+
+    storage.setItem(KEY, envelope({ terminal: { fontSize: 18 } }));
+
+    expect(disk.read().terminal.fontSize).toBe(18);
+  });
+});

--- a/src/stores/persistedSectionMerge.ts
+++ b/src/stores/persistedSectionMerge.ts
@@ -1,0 +1,148 @@
+/**
+ * persistedSectionMerge — read-merge-write for an OBJECT blob persisted to a
+ * shared localStorage key by per-window store instances.
+ *
+ * Purpose: the object-shaped sibling of persistedListMerge. zustand's `persist`
+ * serializes the WHOLE state on every `set()`, so in a multi-window app any
+ * write from window A pushes A's entire snapshot over the key — including the
+ * sections A never touched, and whose values another window changed since A
+ * last read. That is silent data loss, and it needs no simultaneity: any write
+ * at all (a view toggle, a background update-check timestamp) is enough.
+ *
+ * This wrapper makes a write carry only what THIS window actually changed:
+ *
+ *   1. `getItem` (hydration) records the on-disk state as the baseline.
+ *   2. `setItem` diffs the outgoing state against that baseline to find the
+ *      sections this window changed, re-reads the key, applies only those
+ *      sections on top, and writes the result. The baseline then advances.
+ *   3. A section whose outgoing value already equals what is on disk is
+ *      dropped — that is this window echoing a value the cross-window sync
+ *      handler just applied, and rewriting it would fire a pointless storage
+ *      event in every other window.
+ *   4. If nothing survives, no physical write happens at all.
+ *
+ * Tradeoff (deliberate, same as persistedListMerge): if two windows change the
+ * SAME section between reads, the later write wins that section. Resolving that
+ * needs per-field causality this app has no use for; what matters is that
+ * independent sections no longer destroy each other.
+ *
+ * @coordinates-with settingsStore.ts — wraps its persist storage
+ * @coordinates-with useSettingsSync.ts — the inbound half of the same problem
+ * @module stores/persistedSectionMerge
+ */
+
+import type { StateStorage } from "zustand/middleware";
+
+/** A zustand-persist envelope: `{"state": {...}, "version": n}`. */
+interface PersistEnvelope {
+  state?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** Parse an envelope, returning null when absent or unparseable. */
+function parseEnvelope(raw: string | null | undefined): PersistEnvelope | null {
+  if (typeof raw !== "string") return null;
+  try {
+    const parsed = JSON.parse(raw) as PersistEnvelope;
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** The `state` object of an envelope, or an empty object. */
+function stateOf(envelope: PersistEnvelope | null): Record<string, unknown> {
+  const state = envelope?.state;
+  return state && typeof state === "object" ? state : {};
+}
+
+/**
+ * Structural equality via JSON. NOT canonical — JSON.stringify is key-order
+ * sensitive. This is sufficient here because both operands are produced by the
+ * same build from the same defaults through the same deepMerge, so key order is
+ * stable; a false "changed" would at worst cause one redundant write, never
+ * data loss. It is deliberately not a deep order-independent comparator, which
+ * would cost more on every settings write for no real-world benefit.
+ */
+function sameValue(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Wrap a SYNCHRONOUS StateStorage so each write persists only the top-level
+ * sections this window changed, merged onto the key's current contents.
+ */
+export function createSectionMergingStorage(base: StateStorage): StateStorage {
+  /**
+   * State as of this window's last read or write. `null` = never read, so we
+   * cannot tell what we changed — fail open and write in full, matching the
+   * behaviour of an unwrapped storage.
+   */
+  let baseline: Record<string, unknown> | null = null;
+
+  return {
+    getItem: (name) => {
+      const raw = base.getItem(name) as string | null;
+      baseline = stateOf(parseEnvelope(raw));
+      return raw;
+    },
+
+    // Known limitation: the baseline advances after every `base.setItem`,
+    // whether or not it physically persisted. The underlying safe storage
+    // swallows failures (e.g. an origin-wide quota exception — possible even
+    // for this small blob if other origin data is large), so a failed write is
+    // not observable here, and a later unrelated write won't re-include the
+    // unsaved section. This matches the sibling createFieldChangeGatedStorage;
+    // detecting it would require a read-back on every write.
+    setItem: (name, value) => {
+      const outgoing = parseEnvelope(value);
+      // Unparseable outgoing value: not ours to reason about, pass it through.
+      if (!outgoing || baseline === null) {
+        base.setItem(name, value);
+        if (outgoing) baseline = stateOf(outgoing);
+        return;
+      }
+
+      const outgoingState = stateOf(outgoing);
+      const onDisk = parseEnvelope(base.getItem(name) as string | null);
+      // Corrupt or missing disk value — nothing to merge onto; write in full so
+      // the key is repaired rather than left broken.
+      if (!onDisk) {
+        base.setItem(name, value);
+        baseline = outgoingState;
+        return;
+      }
+
+      const diskState = stateOf(onDisk);
+      const changed = Object.keys(outgoingState).filter(
+        (key) =>
+          !sameValue(outgoingState[key], baseline?.[key]) &&
+          !sameValue(outgoingState[key], diskState[key]),
+      );
+
+      if (changed.length === 0) {
+        // Nothing of ours to contribute. Advance the baseline to what we now
+        // hold so a later genuine change is still detected.
+        baseline = outgoingState;
+        return;
+      }
+
+      const merged: Record<string, unknown> = { ...diskState };
+      for (const key of changed) merged[key] = outgoingState[key];
+
+      base.setItem(name, JSON.stringify({ ...outgoing, state: merged }));
+      // Baseline is what THIS window holds in memory — outgoingState — NOT the
+      // merged disk result. Recording `merged` would fold in other windows'
+      // sections (which this window has not adopted into memory), so this
+      // window's still-stale value for such a section would read as "changed"
+      // on the next write and clobber the peer's value (audit High-1).
+      baseline = outgoingState;
+    },
+
+    removeItem: (name) => {
+      base.removeItem(name);
+      baseline = null;
+    },
+  };
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -40,16 +40,13 @@
 
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
-import { deepMerge } from "@/utils/deepMerge";
 import { createSafeStorage } from "@/services/persistence/safeStorage";
+import { createSectionMergingStorage } from "./persistedSectionMerge";
 import { migrateWorkspaceRailModeToGeneral } from "./settingsStore/migrations";
 import { initialState, type ObjectSections } from "./settingsStore/defaults";
-import { clampMergedSettings, clampSettingValue } from "./settingsStore/clamp";
-import {
-  isPlainObject,
-  normalizeBrowserSettings,
-  sanitizePersistedSettings,
-} from "./settingsStore/persistGuards";
+import { clampSettingValue } from "./settingsStore/clamp";
+import { reconcileSettings } from "./settingsStore/reconcile";
+import { isPlainObject } from "./settingsStore/persistGuards";
 import type { SettingsState, SettingsActions } from "./settingsTypes";
 
 // Re-exported for tests + existing callers that import from "@/stores/settingsStore".
@@ -146,8 +143,16 @@ export const useSettingsStore = create<SettingsState & SettingsActions>()(
         }
         return persistedState as SettingsState;
       },
-      // Guard localStorage access for SSR/non-browser environments
-      storage: createJSONStorage(() => createSafeStorage()),
+      // Guard localStorage access for SSR/non-browser environments, and wrap it
+      // so a write carries only the sections THIS window changed. persist
+      // serializes the whole state on every set(), so without this any write —
+      // a view toggle, or the background update-check timestamp — pushes this
+      // window's snapshot over sections another window changed since we last
+      // read. Reproduced in the running app: a terminal font size set in the
+      // Settings window was reverted by an unrelated document-window write.
+      storage: createJSONStorage(() =>
+        createSectionMergingStorage(createSafeStorage()),
+      ),
       // Deep merge to preserve new default properties when loading old localStorage
       merge: (persistedState, currentState) => {
         const rawPersisted = (persistedState ?? {}) as Record<string, unknown>;
@@ -166,34 +171,28 @@ export const useSettingsStore = create<SettingsState & SettingsActions>()(
           delete appearance.paragraphSpacing;
         }
         migrateWorkspaceRailModeToGeneral(rawPersisted);
-        // T4: validate the persisted shape before deep-merging into live state
-        // (zero-trust at the persist boundary). deepMerge overwrites — rather
-        // than recurses — when a persisted group is a non-object, so a corrupt
-        // localStorage blob (`appearance: "evil"`) would otherwise replace a
-        // settings-group object with a primitive and crash consumers.
-        const persisted = sanitizePersistedSettings(
-          rawPersisted,
-          currentState as unknown as Record<string, unknown>
-        );
-        const merged = deepMerge(
+        // T4/D4: the shared trust boundary — shape-sanitize, deep-merge, clamp
+        // bounded numerics, normalize browser posture. The cross-window
+        // storage-event path in useSettingsSync runs this exact function, so
+        // the two routes cannot drift apart again (see reconcile.ts).
+        const merged = reconcileSettings(
           currentState as unknown as Record<string, unknown>,
-          persisted
+          rawPersisted
         ) as unknown as typeof currentState;
         // Union array-typed defaults so new entries (e.g., link protocols) reach
-        // existing users. The persist guards validate that the value IS an array,
-        // not what is in it — drop non-string entries here, or they reach the
-        // link-scheme allowlist and the settings UI as `42` / `null` / `{}`.
+        // existing users. Hydration-only: it exists so a NEW build's defaults
+        // reach an OLD persisted blob, which cannot arise cross-window (both
+        // windows run the same build). reconcileSettings validated that the
+        // value IS an array, not what is in it — drop non-string entries here,
+        // or they reach the link-scheme allowlist and the settings UI as
+        // `42` / `null` / `{}`.
         const defaultProtocols = currentState.advanced.customLinkProtocols;
-        const persistedAdvanced = persisted.advanced as Record<string, unknown> | undefined;
+        const persistedAdvanced = rawPersisted.advanced as Record<string, unknown> | undefined;
         const persistedProtocols = persistedAdvanced?.customLinkProtocols;
         if (Array.isArray(persistedProtocols)) {
           const strings = persistedProtocols.filter((p): p is string => typeof p === "string");
           merged.advanced.customLinkProtocols = [...new Set([...defaultProtocols, ...strings])];
         }
-        // D4: clamp bounded numeric fields so a corrupt persisted value
-        // (e.g. `appearance.fontSize: 999`) can't render the editor broken.
-        clampMergedSettings(merged as unknown as Record<string, unknown>);
-        normalizeBrowserSettings(merged.browser as unknown as Record<string, unknown>);
         return merged;
       },
     }

--- a/src/stores/settingsStore/reconcile.ts
+++ b/src/stores/settingsStore/reconcile.ts
@@ -1,0 +1,78 @@
+/**
+ * reconcile — the single settings trust boundary.
+ *
+ * Purpose: settings arrive from outside this window's typed store by exactly
+ * two routes — hydration from localStorage, and a cross-window `storage` event
+ * carrying another window's blob. Both are untrusted (a corrupt or
+ * hand-edited localStorage value; a blob from a different build). They must
+ * therefore pass the SAME guards.
+ *
+ * They previously did not: hydration ran sanitize → deepMerge → clamp →
+ * normalizeBrowser, while useSettingsSync did a raw `setState` of whatever it
+ * parsed. That left the D4 defence ("a corrupt persisted value can't render the
+ * editor broken") with a hole exactly one code path wide — `appearance.fontSize:
+ * 9999` was rejected at startup but accepted live from another window. Sharing
+ * one implementation is what stops the two paths drifting again.
+ *
+ * @coordinates-with settingsStore.ts — persist `merge` (hydration route)
+ * @coordinates-with hooks/useSettingsSync.ts — storage-event route
+ * @module stores/settingsStore/reconcile
+ */
+
+import { deepMerge } from "@/utils/deepMerge";
+import { clampMergedSettings } from "./clamp";
+import { normalizeBrowserSettings, sanitizePersistedSettings } from "./persistGuards";
+
+/**
+ * Drop non-string elements from `advanced.customLinkProtocols`. sanitize
+ * validates the field IS an array but not that its ELEMENTS are strings, so a
+ * cross-window `[42, null, {}]` would otherwise reach the link-scheme allowlist
+ * and the settings UI. Hydration filters these separately during its
+ * default-union; doing it here means the storage-event route gets the same
+ * guard (audit Medium-10). Mutates `merged` in place — it is freshly built by
+ * deepMerge, so this touches no shared object.
+ */
+function filterCustomLinkProtocols(merged: Record<string, unknown>): void {
+  const advanced = merged.advanced;
+  if (!advanced || typeof advanced !== "object") return;
+  const protocols = (advanced as Record<string, unknown>).customLinkProtocols;
+  if (!Array.isArray(protocols)) return;
+  const strings = protocols.filter((p): p is string => typeof p === "string");
+  if (strings.length !== protocols.length) {
+    (advanced as Record<string, unknown>).customLinkProtocols = strings;
+  }
+}
+
+/**
+ * Merge an untrusted settings blob onto a trusted base, applying every guard.
+ *
+ * @param base     Trusted current state (live store state, or the defaults).
+ * @param incoming Untrusted partial settings blob.
+ * @returns A NEW top-level object. Sections that came from `incoming` are
+ *          freshly built by deepMerge; sections present only in `base` are
+ *          shared by reference (deepMerge shallow-copies the top level). clamp
+ *          and normalize mutate in place, so `base` must not be frozen — but in
+ *          practice they only alter out-of-range/invalid values, and live
+ *          state is already valid, so no shared `base` section is changed.
+ */
+export function reconcileSettings<T extends Record<string, unknown>>(
+  base: T,
+  incoming: Record<string, unknown>,
+): T {
+  // Shape-validate before merging: deepMerge OVERWRITES rather than recurses
+  // when a value is a non-object, so an unsanitized `appearance: "evil"` would
+  // replace a settings group with a primitive and crash its consumers.
+  const sanitized = sanitizePersistedSettings(incoming, base);
+  const merged = deepMerge(base, sanitized as Partial<T>) as T;
+
+  // Bounded numeric fields, then enum-like browser posture values, then
+  // string-array element hygiene.
+  clampMergedSettings(merged as Record<string, unknown>);
+  const browser = (merged as Record<string, unknown>).browser;
+  if (browser && typeof browser === "object") {
+    normalizeBrowserSettings(browser as Record<string, unknown>);
+  }
+  filterCustomLinkProtocols(merged as Record<string, unknown>);
+
+  return merged;
+}

--- a/src/stores/settingsStore/shortcuts.ts
+++ b/src/stores/settingsStore/shortcuts.ts
@@ -20,6 +20,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { invoke } from "@tauri-apps/api/core";
 import { createSafeStorage } from "@/services/persistence/safeStorage";
+import { createSectionMergingStorage } from "@/stores/persistedSectionMerge";
 import { isMacPlatform } from "@/utils/shortcutMatch";
 import { shortcutsWarn } from "@/utils/debug";
 import { errorMessage } from "@/utils/errorMessage";
@@ -191,7 +192,12 @@ export const useShortcutsStore = create<ShortcutsState & ShortcutsActions>()(
     }),
     {
       name: "vmark-shortcuts",
-      storage: createJSONStorage(() => createSafeStorage()),
+      // Section-merged for the same reason settingsStore is: every window
+      // writes this one key with its whole state, so a blind write would push a
+      // stale customBindings map over another window's rebind.
+      storage: createJSONStorage(() =>
+        createSectionMergingStorage(createSafeStorage()),
+      ),
     }
   )
 );

--- a/src/utils/debug/warn.ts
+++ b/src/utils/debug/warn.ts
@@ -159,6 +159,12 @@ export const menuSyncWarn = createWarnLogger("[MenuSync]");
 /** Warn logger for Update Sync (cross-window state). */
 export const updateSyncWarn = createWarnLogger("[UpdateSync]");
 
+/** Warn logger for Settings Sync (cross-window settings). */
+export const settingsSyncWarn = createWarnLogger("[SettingsSync]");
+
+/** Warn logger for Shortcuts Sync (cross-window shortcut rebinds). */
+export const shortcutsSyncWarn = createWarnLogger("[ShortcutsSync]");
+
 /** Warn logger for Table of Contents. */
 export const tocWarn = createWarnLogger("[TOC]");
 


### PR DESCRIPTION
Fixes a cross-window settings-propagation bug cluster. Each Tauri window (document vs
Settings vs pdf-export) is a **separate JS runtime with its own Zustand store**, so a change
made in the Settings window never reached the document window — e.g. changing the terminal
font size in Settings had no visible effect.

## Changes
- **Settings sync** now covers every section (the sync groups are derived from the store's
  `initialState`, so previously-omitted sections — terminal, large-file, browser — are
  included) and routes through a shared `reconcile` trust boundary (sanitize → deep-merge →
  clamp). A section-merging persisted storage layer means each window's write carries only
  the sections it changed, merged onto current disk contents, so concurrent windows don't
  clobber each other.
- **Shortcuts** propagate across windows (via `storage` events).
- **AI providers** propagate via the Tauri event bridge — **API keys are never broadcast**;
  only a `credentialsRevision` counter is bumped after a keychain write, and peers reload the
  keys from the keychain themselves.
- **Terminal:** resize the PTY on font changes, not just xterm, so a font-size change
  actually reflows the shell (`fitAndResizePty` — a single fit+resize op with per-entry
  debounce, shared by the settings-sync effect, tab-switch, and panel fit).

## Testing
`pnpm check:all` green. Cross-webview `storage`-event propagation was verified empirically on
the live app.
