### PR TITLE
fix: Windows rcfile assertions, and enforce main's required checks on admins

### DIFF
--- a/.claude/rules/40-version-bump.md
+++ b/.claude/rules/40-version-bump.md
@@ -68,10 +68,18 @@ any `cargo build --locked` / `--frozen` (release + CI).
    git commit -m "chore: bump version to 0.4.0"
    ```
 
-4. **Tag and push**:
+4. **Open a PR, then tag** (`main` requires one since 2026-07-27 — see
+   `60-ai-governance.md` §10; a direct push of a new commit is rejected because
+   the required checks cannot have run on it yet):
    ```bash
+   git checkout -b bump-v0.4.0        # from the bump commit
+   git push origin bump-v0.4.0
+   gh pr create --fill
+   gh pr checks --watch               # frontend + rust must be green
+   gh pr merge --merge                # or --squash
+   git checkout main && git pull
    git tag v0.4.0
-   git push origin main v0.4.0
+   git push origin v0.4.0             # tags are NOT gated by branch protection
    ```
 
    **CRITICAL: Never use `git push --tags`** — it pushes ALL local tags, including

--- a/.claude/rules/60-ai-governance.md
+++ b/.claude/rules/60-ai-governance.md
@@ -143,9 +143,30 @@ The hook is enabled by `git config core.hooksPath .githooks`, which the root
 `package.json` `prepare` script applies on `pnpm install` (no husky
 dependency). Overriding it (`git push --no-verify`) falls under §9.
 
-**Residual control (owner-only, GitHub settings — not enforceable from the
-repo):** to close the bypass entirely, enable branch protection on `main`
-with *Require a pull request before merging*, *Require status checks to pass*
-(`frontend`, `rust`), and *Do not allow bypassing the above settings* / no
-direct-push allowance for admins. Until that is set, the `pre-push` hook is
-the only thing standing between a red local gate and `origin/main`.
+**Residual control — ENABLED 2026-07-27.** The hook was never the whole story:
+`main` had required status checks (`frontend`, `rust`) but `enforce_admins:
+false`, so an owner push sailed past them with
+`remote: Bypassed rule violations for refs/heads/main`. The v0.9.15 push did
+exactly that, and CI then went red on a Windows-only test assertion the local
+gate cannot see (`check-cross-target.sh` COMPILES for Windows; it does not run
+the suite there).
+
+`main` now carries:
+- required status checks `frontend` + `rust`,
+- `enforce_admins: true` — admins are subject to them,
+- a pull request required before merging, with
+  `required_approving_review_count: 0` so a solo maintainer can self-merge once
+  the checks are green,
+- deletions blocked, and force-push blocked by the separate `main-no-force-push`
+  ruleset (`bypass_actors: []`, `current_user_can_bypass: "never"`).
+
+**Consequence for releases:** a direct `git push origin main` of a new commit is
+now REJECTED — required checks cannot have passed on a commit the remote has
+never seen. The bump must go through a PR; see `40-version-bump.md`. Tag pushes
+are unaffected, so the release trigger is unchanged.
+
+To inspect or revert:
+```bash
+gh api repos/xiaolai/vmark/branches/main/protection
+gh api -X DELETE repos/xiaolai/vmark/branches/main/protection   # removes it entirely
+```

--- a/src-tauri/src/shell_integration.test.rs
+++ b/src-tauri/src/shell_integration.test.rs
@@ -75,10 +75,18 @@ fn bash_script_preserves_existing_prompt_command() {
 fn bash_env_returns_rcfile_arg() {
     let dir = Path::new("/vmark/bash");
     let integration = build_integration(ShellKind::Bash, dir, None);
-    assert_eq!(
-        integration.args,
-        vec!["--rcfile".to_string(), "/vmark/bash/vmark.bash".to_string()]
-    );
+
+    // Asserted as a PATH, not as a literal string: `Path::join` uses `\` on
+    // Windows, so comparing against "/vmark/bash/vmark.bash" fails there even
+    // though the behavior is correct. (Windows never reaches this code —
+    // `bash.exe` does not match the `bash` basename — but the builder is
+    // compiled and tested on every platform.)
+    assert_eq!(integration.args.len(), 2);
+    assert_eq!(integration.args[0], "--rcfile");
+    let rc = Path::new(&integration.args[1]);
+    assert_eq!(rc.file_name().and_then(|s| s.to_str()), Some("vmark.bash"));
+    assert_eq!(rc.parent(), Some(dir));
+
     // bash is hooked entirely through the arg — no env override at all.
     assert!(integration.env.is_empty());
 }
@@ -107,10 +115,14 @@ fn shell_integration_serializes_env_and_args() {
     ))
     .unwrap();
     assert!(json.get("env").is_some(), "env key missing: {json}");
-    assert!(json.get("args").is_some(), "args key missing: {json}");
+    let args = json.get("args").expect("args key missing: {json}");
+    // Separator-agnostic (see bash_env_returns_rcfile_arg): the point is that
+    // both fields survive serialization with the flag and rc path intact.
+    assert_eq!(args[0], serde_json::json!("--rcfile"));
+    let rc = args[1].as_str().expect("rcfile path should be a string");
     assert_eq!(
-        json["args"],
-        serde_json::json!(["--rcfile", "/vmark/bash/vmark.bash"])
+        Path::new(rc).file_name().and_then(|s| s.to_str()),
+        Some("vmark.bash")
     );
 }
 


### PR DESCRIPTION
## Why

Two things, both surfaced by the v0.9.15 release push.

**1. CI went red on `main`.** `rust-test (windows-latest)` failed:

```
left:  ["--rcfile", "/vmark/bash\vmark.bash"]
right: ["--rcfile", "/vmark/bash/vmark.bash"]
```

`Path::join` uses a backslash on Windows, and the test hardcoded a POSIX
separator. It is a **test-only** defect — Windows never reaches that code, since
`bash.exe` does not match the `bash` basename and shell integration stays off —
but `build_integration` is compiled and tested on every platform. Both
assertions now go through `Path::file_name()` / `parent()`, which is what the
contract actually is.

The local pre-push gate could not have caught it: `check-cross-target.sh`
*compiles* for the Windows target, it does not run the suite there.

**2. That push bypassed branch protection.** GitHub reported:

```
remote: Bypassed rule violations for refs/heads/main:
remote: - 2 of 2 required status checks are expected.
```

`main` had required checks (`frontend`, `rust`) but `enforce_admins: false`, so
they were advisory for the owner. Rule 60 §10 predicted exactly this and named
the fix as an unset owner-only control. It is now set:

- `enforce_admins: true`
- PR required, `required_approving_review_count: 0` (solo maintainer can
  self-merge once green)
- deletions blocked; force-push already blocked by the `main-no-force-push`
  ruleset with `bypass_actors: []`

## Consequence

A direct `git push origin main` of a new commit is now rejected — required
checks cannot have passed on a commit the remote has not seen. Rule 40's
release procedure is updated to bump via a PR. **Tag pushes are unaffected**, so
the release trigger is unchanged.

This PR is itself the first exercise of that path.

## Verification

- `cargo test … shell_integration` → 23 passed locally
- The Windows assertions are now separator-agnostic; `file_name()` returns
  `vmark.bash` and `parent()` returns the dir under either separator
- CI on this PR is the real check