### PR TITLE
chore: bump version to 0.9.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.15",
+  "version": "0.9.16",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6260,7 +6260,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "base64 0.23.0",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.15"
+version = "0.9.16"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/vmark-mcp-server/package.json
+++ b/vmark-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/vmark-mcp-server/src/cli.ts
+++ b/vmark-mcp-server/src/cli.ts
@@ -18,7 +18,7 @@
  */
 
 // Package version (injected at build time or read from package.json)
-const VERSION = '0.9.15';
+const VERSION = '0.9.16';
 
 /**
  * Handle --version flag.


### PR DESCRIPTION
Re-cuts the release from a commit whose CI is green.

`v0.9.15` shipped successfully, but it was tagged from a commit where
`rust-test (windows-latest)` was red — a hardcoded POSIX path separator in a
Rust test assertion. That was fixed in #1153. Nothing in the shipped binaries
was affected (the failure was a test assertion, not product behavior), but the
tag pointing at red CI is not a state worth keeping.

0.9.16 is that same code with the fix in history and every check green.

## Files

All six version sites, per `.claude/rules/40-version-bump.md`:

| File | Field |
|---|---|
| `package.json` | `version` |
| `src-tauri/tauri.conf.json` | `version` |
| `src-tauri/Cargo.toml` | `version` |
| `src-tauri/Cargo.lock` | derived `vmark` entry (`cargo update -p vmark`) |
| `vmark-mcp-server/package.json` | `version` |
| `vmark-mcp-server/src/cli.ts` | `VERSION` |

## Verification

Local gate, run with 0.9.16 applied:

- `pnpm check:all` → exit 0
- `cargo test` → 1499 passed, 0 failed
- `cargo fmt --check` → clean
- `cargo clippy --all-targets -- -D warnings` → 0 errors

## Note

Second exercise of the PR path that `enforce_admins` now requires. Tags remain
ungated, so `v0.9.16` is pushed directly after this merges.