### PR TITLE
test(codePreview): de-flake the markmap render test

### DIFF
--- a/src/plugins/codePreview/tiptap.test.ts
+++ b/src/plugins/codePreview/tiptap.test.ts
@@ -1720,7 +1720,16 @@ describe("codePreview widget factory invocation — covers lines 263-354", () =>
 
     useBlockMathEditingStore.getState().exitEditing();
     viewResult.destroy!();
-  });
+    // Explicit timeout: this is the one markmap test that reaches the render
+    // path, so it pays for `Promise.all([import("markmap-lib"),
+    // import("markmap-view")])` (plugins/markmap/plugin.ts) — two d3-backed
+    // libraries, lazily loaded and NOT mocked here, because sibling tests in
+    // this file spy on the real `@/plugins/markmap`. `runAllTimersAsync` awaits
+    // that real settlement, and under full-suite parallel load the transform +
+    // eval exceeds the 5s default. It passes in isolation; it reddened the
+    // v0.9.16 pre-push gate. Same root cause and same remedy as the
+    // WorkflowCanvas lazy-chunk bump in df896e22.
+  }, 20_000);
 
   it("live preview: updateLivePreview token cancellation — rapid calls only execute last (line 104)", async () => {
     const { useBlockMathEditingStore } = await import("@/stores/blockMathEditingStore");


### PR DESCRIPTION
Unblocks the `v0.9.16` tag push.

## What happened

The pre-push gate refused the release tag: `pnpm check:all` failed with 1 test
out of 24,777. The gate did its job — **the tag never reached origin**, so no
release was cut from an unverified state.

## Root cause

`src/plugins/codePreview/tiptap.test.ts:1679` is the one markmap test that
reaches the render path, so it triggers `plugins/markmap/plugin.ts:65-66`:

```ts
Promise.all([import("markmap-lib"), import("markmap-view")])
```

Two d3-backed libraries, lazily loaded and deliberately **not** mocked in this
file — sibling tests at :2310 and :2334 spy on the real `@/plugins/markmap`, so
a file-level mock would break them. `await vi.runAllTimersAsync()` waits on that
real settlement, and under full-suite parallel load the Vite transform + eval
exceeds the 5s default timeout.

The sibling markmap test at :1173 only asserts that a dispatch happened and
never triggers the loader — which is why exactly one of the two flaked.

## Evidence

| Run | Result |
|---|---|
| Pre-push gate (full suite) | FAIL — `Test timed out in 5000ms` |
| Full suite, unchanged tree | PASS |
| Full suite, unchanged tree | FAIL — same test |
| File in isolation | PASS (116/116), every time |
| CI on the same commit (#1154) | all 9 checks green |

2 of 3 full runs red on an unchanged tree — too flaky to retry-and-hope.

## Fix

An explicit 20s timeout on that single test, with a comment recording the
mechanism. **No assertion is relaxed**; the timeout covers only genuine
module-load I/O. This is the same root cause and the same remedy as the
WorkflowCanvas lazy-chunk bump in `df896e22`, whose rule was "fixed at the root,
not by loosening" — a real deadline on real I/O is not a loosened assertion.

## Verification

- File in isolation: 116/116 pass
- Full suite under parallel load: **24,767 passed**, 0 failed, 10 skipped

Once this merges, `v0.9.16` is re-tagged on the merged commit and pushed.