### PR TITLE
chore(bump): land the version bump via PR and sync Cargo.lock

### DIFF
--- a/.claude/commands/bump.md
+++ b/.claude/commands/bump.md
@@ -1,11 +1,18 @@
 ---
-description: Bump version across all 5 files, commit, tag, and push
+description: Bump version across all 5 files, land it via PR, then tag and push
 argument-hint: "[version | patch | minor | major]"
 ---
 
 # Version Bump
 
-Bump the version number across all 5 required files, commit, tag, and push.
+Bump the version number across all 5 required files, land the commit on `main`
+through a pull request, then tag and push.
+
+**`main` cannot be pushed directly** (since 2026-07-27 — `enforce_admins: true`
+on the `frontend` + `rust` checks, see `.claude/rules/60-ai-governance.md` §10).
+A direct push of the bump commit is rejected, because the required checks cannot
+have run on a commit the remote has never seen. Tag pushes are **not** gated, so
+the release trigger is unchanged.
 
 ## Input
 
@@ -55,26 +62,55 @@ All five files must be updated — see `.claude/rules/40-version-bump.md`.
 
 Use the Edit tool for each file — not sed.
 
+Then sync the **derived** lockfile, which is a sixth file in the commit even
+though nothing edits it by hand:
+
+```bash
+cargo update -p vmark --manifest-path src-tauri/Cargo.toml
+```
+
+`src-tauri/Cargo.lock` carries the `vmark` package's own version. Skip this and
+it stays behind, leaving `origin/main` dirty and breaking any
+`cargo build --locked` / `--frozen` — which is what the release workflow and CI
+run.
+
 ## Phase 4: Verify
 
-Read back all 5 files and confirm the version matches:
+Read back all 5 files, plus the lockfile, and confirm the version matches:
 
 ```bash
 grep '"version"' package.json src-tauri/tauri.conf.json vmark-mcp-server/package.json
 grep '^version' src-tauri/Cargo.toml
 grep 'const VERSION' vmark-mcp-server/src/cli.ts
+git diff --stat src-tauri/Cargo.lock     # must show 1 changed line
 ```
 
 If any mismatch: fix before proceeding.
 
-## Phase 5: Commit, Tag, Push
+## Phase 5: Commit and land via PR
 
 ```bash
+git checkout -b bump-v{version}
 git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml \
+        src-tauri/Cargo.lock \
         vmark-mcp-server/package.json vmark-mcp-server/src/cli.ts
 git commit -m "chore: bump version to {version}"
+git push -u origin bump-v{version}
+gh pr create --fill
+gh pr checks --watch                     # frontend + rust must be green
+gh pr merge --merge --delete-branch
+```
+
+Do **not** tag yet. Wait for the merge.
+
+## Phase 6: Tag the merged commit and push
+
+Tag `main` *after* pulling the merge, so the tag names a commit that is on
+`main` and whose checks actually passed:
+
+```bash
+git checkout main && git pull origin main
 git tag v{version}
-git push origin main
 git push origin v{version}
 ```
 
@@ -84,4 +120,13 @@ origin, each one re-triggering a release run. Push the single new tag
 only. See `.claude/rules/40-version-bump.md` for the full incident
 context.
 
-Report done: `Bumped to {version}, tagged v{version}, pushed.`
+Pushing a `v*` tag still fires the local `pre-push` gate (cross-target compile
+check, `cargo fmt --check`, `cargo clippy -D warnings`, then `pnpm check:all` —
+~3 min) while git holds the SSH connection open. If the push dies with
+**SIGPIPE (exit 141)** right after "quality gate green — push allowed", the SSH
+keepalive is missing: run `node scripts/setup-local-git.mjs`, or retry once with
+`GIT_SSH_COMMAND='ssh -o ServerAliveInterval=20' git push origin v{version}`.
+That is a transport timeout, not a quality failure — `--no-verify` is not the
+fix, and is forbidden without authorization (`60-ai-governance.md` §9).
+
+Report done: `Bumped to {version}, merged via PR #{n}, tagged v{version}, pushed.`

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-# Bump version across all 5 files that must stay in sync.
-# See .claude/rules/40-version-bump.md for details.
+# Bump version across all 5 files that must stay in sync, plus the derived
+# src-tauri/Cargo.lock. See .claude/rules/40-version-bump.md for details.
+#
+# This only edits files. Landing the bump is a separate step and now needs a
+# PR — `main` rejects direct pushes (60-ai-governance.md §10).
 
 VERSION=$1
 
@@ -27,10 +30,24 @@ sed -i '' 's/^version = "[^"]*"/version = "'$VERSION'"/' src-tauri/Cargo.toml
 sed -i '' 's/"version": "[^"]*"/"version": "'$VERSION'"/' vmark-mcp-server/package.json
 sed -i '' "s/const VERSION = '[^']*'/const VERSION = '$VERSION'/" vmark-mcp-server/src/cli.ts
 
+# Derived lockfile: Cargo.lock carries the `vmark` package's own version, so it
+# must move with Cargo.toml. Leaving it behind makes origin/main dirty and
+# breaks `cargo build --locked` / `--frozen` — what CI and the release run.
+cargo update -p vmark --manifest-path src-tauri/Cargo.toml >/dev/null 2>&1 ||
+  echo "WARNING: could not sync src-tauri/Cargo.lock — run cargo update -p vmark manually"
+
 echo ""
 echo "Updated:"
 grep '"version"' package.json src-tauri/tauri.conf.json vmark-mcp-server/package.json
 grep '^version' src-tauri/Cargo.toml
 grep 'const VERSION' vmark-mcp-server/src/cli.ts
+git diff --stat src-tauri/Cargo.lock
 echo ""
-echo "Done! Ready to commit."
+echo "Done. Land it with a PR — main rejects direct pushes:"
+echo "  git checkout -b bump-v$VERSION"
+echo "  git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml \\"
+echo "          src-tauri/Cargo.lock vmark-mcp-server/package.json vmark-mcp-server/src/cli.ts"
+echo "  git commit -m 'chore: bump version to $VERSION'"
+echo "  git push -u origin bump-v$VERSION && gh pr create --fill && gh pr checks --watch"
+echo "  gh pr merge --merge --delete-branch && git checkout main && git pull"
+echo "  git tag v$VERSION && git push origin v$VERSION   # never --tags"


### PR DESCRIPTION
Fixes two defects in the bump tooling, both hit while cutting `v0.9.16`.

## 1. Both told you to push straight to `main`

`/bump` Phase 5 and `scripts/bump-version.sh` ended with `git push origin main`.
That is **rejected** now — `main` requires a PR since `enforce_admins` was
enabled, because the required checks cannot have passed on a commit the remote
has never seen.

The command now branches → PR → `gh pr checks --watch` → merge, and only then
tags. The tag is created **after pulling the merge**, so it names a commit that
is actually on `main` and whose checks passed, rather than the pre-merge branch
commit.

## 2. Neither synced `src-tauri/Cargo.lock`

The lockfile carries the `vmark` package's own version, so it has to move with
`Cargo.toml`. `.claude/rules/40-version-bump.md` lists leaving it behind as a
known mistake — it makes `origin/main` dirty and breaks `cargo build --locked`
/ `--frozen`, which is exactly what CI and the release workflow run.

Despite that, **the automation implementing rule 40 never mentioned the
lockfile at all.** Phase 3 listed five files; the sixth was silently missing. I
only caught it doing the bump by hand.

- The command now runs `cargo update -p vmark` and verifies the lockfile moved.
- The script does the same, and warns rather than failing silently if `cargo`
  isn't on PATH.
- The script's printed next-steps no longer suggest `git add -u`, which would
  sweep in unrelated modifications; it names the six files explicitly.

## Also documented

The `v*` pre-push gate holds the git connection open for several minutes.
A concurrent large download on the same uplink will kill the push **after** the
gate has already printed "quality gate green — push allowed". That is a
transport failure, not a quality one — `--no-verify` is not the fix and remains
forbidden without authorization (`60-ai-governance.md` §9).

## Verification

- `bash -n scripts/bump-version.sh` — clean
- Both guard paths still reject without touching files: no args → usage;
  `0.9.16.1` → semver error
- Docs-only otherwise; no runtime code touched