### PR TITLE
feat(theme): match native window chrome to the in-app theme on Windows/Linux

### DIFF
--- a/src-tauri/src/command_registry.rs
+++ b/src-tauri/src/command_registry.rs
@@ -59,6 +59,7 @@ macro_rules! all_commands {
             window_manager::open_workspace_in_new_window,
             window_manager::open_workspace_with_files_in_new_window,
             window_manager::open_settings_window,
+            window_manager::set_native_theme,
             window_manager::close_window,
             window_manager::force_quit,
             window_manager::request_quit,

--- a/src-tauri/src/window_manager/document_windows.rs
+++ b/src-tauri/src/window_manager/document_windows.rs
@@ -99,6 +99,9 @@ fn build_document_window(
         .min_inner_size(800.0, 600.0)
         .resizable(true)
         .fullscreen(false)
+        // Match OS-drawn chrome (title bar, and the Windows menu bar) to the
+        // in-app theme from the first frame — see native_theme.rs.
+        .theme(Some(super::current_theme()))
         .focused(true);
 
     if let Some((x, y)) = position {

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -15,6 +15,7 @@
 //! | `path_validation` | Security gates for frontend-supplied paths / workspace roots |
 //! | `commands` | `open_*_in_new_window`, `close_window`, quit commands |
 //! | `settings_window` | Settings window singleton (create / focus / navigate) |
+//! | `native_theme` | Keeps OS-drawn chrome (title bar, Windows menu bar) on the in-app theme |
 //!
 //! Everything is re-exported here so call sites keep using
 //! `crate::window_manager::...` (and `lib.rs`'s `generate_handler!` paths
@@ -30,10 +31,16 @@
 mod commands;
 mod document_windows;
 mod file_open_state;
+mod native_theme;
 mod path_validation;
 mod settings_window;
 
 pub use commands::*;
 pub use document_windows::*;
 pub use file_open_state::*;
+pub use native_theme::*;
 pub use settings_window::*;
+
+#[cfg(test)]
+#[path = "mod.test.rs"]
+mod tests;

--- a/src-tauri/src/window_manager/mod.test.rs
+++ b/src-tauri/src/window_manager/mod.test.rs
@@ -13,25 +13,23 @@
 
 use super::*;
 
-/// Every `#[tauri::command]` in this module that `lib.rs` registers must be
-/// nameable as `crate::window_manager::<name>`. Taking a function pointer is
-/// what forces that resolution — if a submodule stops being re-exported, or a
-/// command is renamed without updating `generate_handler!`, this stops
-/// compiling.
-#[test]
-fn registered_commands_resolve_through_the_facade() {
-    let _open_settings: fn(tauri::AppHandle, Option<String>) -> Result<String, String> =
-        open_settings_window;
-    let _set_theme: fn(tauri::AppHandle, bool) -> Result<(), String> = set_native_theme;
-}
-
-/// The window builders call these unqualified through the facade rather than
-/// reaching into `native_theme::`, so the re-export has to carry them too.
-#[test]
-fn theme_helpers_resolve_through_the_facade() {
-    let _current: fn() -> tauri::Theme = current_theme;
-    let _remember: fn(bool) = remember;
-    let _prefers: fn() -> bool = prefers_dark;
+/// Every `#[tauri::command]` in this module that `lib.rs` registers, plus the
+/// helpers the window builders call unqualified, must be nameable as
+/// `crate::window_manager::<name>`. Importing them is what asserts that: if a
+/// submodule stops being re-exported, or a command is renamed without updating
+/// `generate_handler!`, this module stops compiling.
+///
+/// Deliberately `use` rather than function pointers. Binding a pointer to a
+/// command emits a runtime symbol reference, which drags WebView2 loader
+/// entry points into the lib test binary and makes it fail to start on
+/// Windows with STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139) — the same class
+/// `Cargo.toml` already documents for `tauri::test`. A `use` binds a name at
+/// compile time and emits nothing, so the contract is still checked, and it is
+/// checked on every platform rather than being cfg'd off on the one where it
+/// broke.
+#[allow(unused_imports)]
+mod facade_exports {
+    use super::{current_theme, open_settings_window, prefers_dark, remember, set_native_theme};
 }
 
 /// Guards against the facade re-exporting two different things under one

--- a/src-tauri/src/window_manager/mod.test.rs
+++ b/src-tauri/src/window_manager/mod.test.rs
@@ -1,0 +1,53 @@
+//! Tests for `mod.rs` (included via `#[path]`).
+//!
+//! `mod.rs` declares rather than implements, so there is no behavior of its
+//! own to exercise. What it *does* own is a contract its header states
+//! explicitly: the glob re-exports are what keep `crate::window_manager::…`
+//! paths — including the ones `lib.rs`'s `generate_handler!` names —
+//! resolving after the module was decomposed into submodules.
+//!
+//! That contract has failed silently before: `.claude/rules/60-ai-governance.md`
+//! records paths being moved while the thing depending on them kept compiling
+//! against a stale location. These tests make a broken facade a compile error
+//! here instead of a mystery at the call site.
+
+use super::*;
+
+/// Every `#[tauri::command]` in this module that `lib.rs` registers must be
+/// nameable as `crate::window_manager::<name>`. Taking a function pointer is
+/// what forces that resolution — if a submodule stops being re-exported, or a
+/// command is renamed without updating `generate_handler!`, this stops
+/// compiling.
+#[test]
+fn registered_commands_resolve_through_the_facade() {
+    let _open_settings: fn(tauri::AppHandle, Option<String>) -> Result<String, String> =
+        open_settings_window;
+    let _set_theme: fn(tauri::AppHandle, bool) -> Result<(), String> = set_native_theme;
+}
+
+/// The window builders call these unqualified through the facade rather than
+/// reaching into `native_theme::`, so the re-export has to carry them too.
+#[test]
+fn theme_helpers_resolve_through_the_facade() {
+    let _current: fn() -> tauri::Theme = current_theme;
+    let _remember: fn(bool) = remember;
+    let _prefers: fn() -> bool = prefers_dark;
+}
+
+/// Guards against the facade re-exporting two different things under one
+/// name: `current_theme()` must agree with `prefers_dark()`, since the
+/// builders read the former and `set_native_theme` writes the latter.
+#[test]
+fn facade_theme_view_is_self_consistent() {
+    let previous = prefers_dark();
+
+    remember(true);
+    assert_eq!(current_theme(), tauri::Theme::Dark);
+    assert!(prefers_dark());
+
+    remember(false);
+    assert_eq!(current_theme(), tauri::Theme::Light);
+    assert!(!prefers_dark());
+
+    remember(previous);
+}

--- a/src-tauri/src/window_manager/native_theme.rs
+++ b/src-tauri/src/window_manager/native_theme.rs
@@ -1,0 +1,105 @@
+//! Keeps OS-drawn window chrome in step with VMark's in-app theme.
+//!
+//! Purpose: VMark themes everything it paints itself via CSS, but the title
+//! bar and the Windows menu bar are drawn by the OS and ignore that entirely.
+//! On a light-mode Windows install with VMark's night theme, the Settings
+//! window gets a white title bar around a dark page.
+//!
+//! Pipeline: `useTheme` computes `isDark` → `set_native_theme` → remembered in
+//! a process-global → applied to every open window, and read again by the
+//! window builders so windows opened *later* start with the right chrome.
+//!
+//! Key decisions:
+//!   - macOS is deliberately excluded. Its Settings window uses an overlay
+//!     title bar and its menu lives in the system bar, so it has no symptom;
+//!     `set_theme` there would change NSAppearance app-wide, which is an
+//!     unrequested behavior change on the primary platform.
+//!   - The preference is a process-global rather than Tauri state because the
+//!     window builders need it before any window (and thus any `State`) is
+//!     reachable, and it is a single bool.
+//!
+//! Known limitations:
+//!   - The Windows **menu bar** only follows this on a system already set to
+//!     dark mode. muda gates its dark menu-bar drawing on
+//!     `should_use_dark_mode() = should_apps_use_dark_mode() && !high_contrast
+//!     && is_dark_mode_allowed_for_window()`. This module controls the third
+//!     term; the first is the OS-wide "app dark mode" setting, which an
+//!     application cannot override. The title bar has no such limit —
+//!     `DWMWA_USE_IMMERSIVE_DARK_MODE` is per-window and always honored.
+//!
+//! @coordinates-with hooks/useTheme.ts — reports `isDark` on every change
+//! @coordinates-with settings_window.rs, document_windows.rs — read `current_theme()`
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use tauri::{AppHandle, Theme};
+// Only the non-macOS branch enumerates windows; importing this unconditionally
+// is an unused-import warning on macOS, and clippy runs with `-D warnings`.
+#[cfg(not(target_os = "macos"))]
+use tauri::Manager;
+
+/// Last theme the frontend reported. Defaults to light so a window built
+/// before the frontend has said anything gets a definite theme instead of
+/// inheriting the OS preference.
+static PREFERS_DARK: AtomicBool = AtomicBool::new(false);
+
+/// Map the frontend's `isDark` flag onto a Tauri theme.
+pub fn theme_for(dark: bool) -> Theme {
+    if dark {
+        Theme::Dark
+    } else {
+        Theme::Light
+    }
+}
+
+/// Record the frontend's current theme for windows opened later.
+pub fn remember(dark: bool) {
+    PREFERS_DARK.store(dark, Ordering::Relaxed);
+}
+
+/// Whether the frontend last reported a dark theme.
+pub fn prefers_dark() -> bool {
+    PREFERS_DARK.load(Ordering::Relaxed)
+}
+
+/// The theme a newly built window should start with.
+pub fn current_theme() -> Theme {
+    theme_for(prefers_dark())
+}
+
+/// Push the remembered theme onto every open window.
+///
+/// Applied to all windows rather than just the caller's: the theme is a
+/// single app-wide setting, and Settings is a separate window from the
+/// document window whose UI changed it.
+fn apply_to_all_windows(app: &AppHandle) {
+    // macOS has no symptom and `set_theme` there is app-wide — see header.
+    #[cfg(not(target_os = "macos"))]
+    {
+        let theme = current_theme();
+        log::debug!("[native_theme] applying {theme:?} to open windows");
+        for (label, window) in app.webview_windows() {
+            // Best-effort per window: one failing window (e.g. one closing
+            // mid-iteration) must not stop the rest from being themed.
+            if let Err(e) = window.set_theme(Some(theme)) {
+                log::warn!("[native_theme] could not theme window `{label}`: {e}");
+            }
+        }
+    }
+    #[cfg(target_os = "macos")]
+    let _ = app;
+}
+
+/// Report the in-app theme so native chrome can follow it.
+///
+/// Called by the frontend whenever the resolved theme changes (including at
+/// startup), so this runs often and stays cheap and infallible in practice.
+#[tauri::command]
+pub fn set_native_theme(app: AppHandle, dark: bool) -> Result<(), String> {
+    remember(dark);
+    apply_to_all_windows(&app);
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "native_theme.test.rs"]
+mod tests;

--- a/src-tauri/src/window_manager/native_theme.test.rs
+++ b/src-tauri/src/window_manager/native_theme.test.rs
@@ -1,0 +1,93 @@
+//! Tests for `native_theme.rs` (included via `#[path]`).
+//!
+//! The apply-to-windows half needs a live Tauri runtime, so what is unit
+//! tested here is the part that decides *what* to apply: the dark flag to
+//! `Theme` mapping, and the process-global the window builders read when they
+//! create a window after the user has already picked a theme.
+
+use super::*;
+
+// -- theme_for -------------------------------------------------------------
+
+#[test]
+fn dark_flag_maps_to_dark_theme() {
+    assert_eq!(theme_for(true), Theme::Dark);
+}
+
+#[test]
+fn light_flag_maps_to_light_theme() {
+    assert_eq!(theme_for(false), Theme::Light);
+}
+
+// -- remembered preference -------------------------------------------------
+//
+// These share one process-global, so they run under a mutex and restore the
+// previous value. Cargo runs tests in threads within a single process, so a
+// bare `remember()` in one test is visible to every other.
+
+use std::sync::Mutex;
+static GUARD: Mutex<()> = Mutex::new(());
+
+fn with_saved_preference(body: impl FnOnce()) {
+    // Poisoning is irrelevant here: the guarded state is a single bool that
+    // the closure always overwrites, so a panicking test cannot leave it
+    // inconsistent for the next one.
+    let _lock = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let previous = prefers_dark();
+    body();
+    remember(previous);
+}
+
+#[test]
+fn remember_round_trips_dark() {
+    with_saved_preference(|| {
+        remember(true);
+        assert!(prefers_dark());
+        assert_eq!(current_theme(), Theme::Dark);
+    });
+}
+
+#[test]
+fn remember_round_trips_light() {
+    with_saved_preference(|| {
+        remember(false);
+        assert!(!prefers_dark());
+        assert_eq!(current_theme(), Theme::Light);
+    });
+}
+
+#[test]
+fn remember_is_idempotent() {
+    with_saved_preference(|| {
+        remember(true);
+        remember(true);
+        assert_eq!(current_theme(), Theme::Dark);
+    });
+}
+
+#[test]
+fn later_writes_win() {
+    with_saved_preference(|| {
+        remember(true);
+        remember(false);
+        assert_eq!(
+            current_theme(),
+            Theme::Light,
+            "a theme switch must not be masked by the earlier value"
+        );
+    });
+}
+
+/// A window created before the frontend has ever reported a theme must still
+/// get a definite theme rather than inheriting whatever the OS prefers —
+/// otherwise the very first Settings window on a light-mode OS opens with
+/// light chrome around a dark VMark theme.
+#[test]
+fn default_preference_is_light() {
+    // Not wrapped in `with_saved_preference`: this asserts the *initial*
+    // value of the global, which only holds before any test has written to
+    // it. Re-establish it explicitly so ordering cannot make this flaky.
+    let _lock = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    remember(false);
+    assert_eq!(current_theme(), Theme::Light);
+}

--- a/src-tauri/src/window_manager/settings_window.rs
+++ b/src-tauri/src/window_manager/settings_window.rs
@@ -19,6 +19,17 @@ pub fn open_settings_window(app: AppHandle, section: Option<String>) -> Result<S
         .map_err(|e| e.to_string())
 }
 
+/// Build the Settings window URL for an optional section.
+///
+/// The section is percent-encoded so a value containing reserved characters
+/// (`&`, `?`, `#`) cannot corrupt the query or append a fragment.
+fn settings_url(section: Option<&str>) -> String {
+    match section {
+        Some(s) => format!("/settings?section={}", urlencoding::encode(s)),
+        None => "/settings".to_string(),
+    }
+}
+
 /// Create or focus the settings window, optionally navigating to a specific section.
 /// If settings window exists, focuses it and navigates to the section.
 /// Otherwise creates a new one with the section in the URL.
@@ -54,12 +65,7 @@ pub fn show_settings_window_section(
 
     log::debug!("[window_manager] Creating new settings window");
 
-    // Build URL with optional section query param. Percent-encode the section
-    // so a value containing reserved chars (&, ?, #) can't corrupt the query.
-    let url = match section {
-        Some(s) => format!("/settings?section={}", urlencoding::encode(s)),
-        None => "/settings".to_string(),
-    };
+    let url = settings_url(section);
 
     // Create new settings window.
     //
@@ -74,6 +80,10 @@ pub fn show_settings_window_section(
         .inner_size(SETTINGS_WIDTH, SETTINGS_HEIGHT)
         .min_inner_size(SETTINGS_MIN_WIDTH, SETTINGS_MIN_HEIGHT)
         .resizable(true)
+        // Match the OS-drawn title bar to the in-app theme from the first
+        // frame. Setting it after build would flash a light title bar on a
+        // dark theme; on macOS this is a no-op (overlay title bar).
+        .theme(Some(super::current_theme()))
         .focused(true);
 
     #[cfg(target_os = "macos")]
@@ -107,3 +117,7 @@ pub fn show_settings_window_section(
 
     Ok(SETTINGS_LABEL.to_string())
 }
+
+#[cfg(test)]
+#[path = "settings_window.test.rs"]
+mod tests;

--- a/src-tauri/src/window_manager/settings_window.test.rs
+++ b/src-tauri/src/window_manager/settings_window.test.rs
@@ -1,0 +1,81 @@
+//! Tests for `settings_window.rs` (included via `#[path]`).
+//!
+//! `show_settings_window_section` itself needs a live Tauri runtime, so what
+//! is covered here is the pure part it delegates to: turning an optional
+//! section into the URL the Settings window is built with. That URL is the
+//! one difference between the two Settings entry points (#1141), so it is
+//! worth pinning down exactly.
+
+use super::*;
+
+#[test]
+fn no_section_is_the_bare_route() {
+    assert_eq!(settings_url(None), "/settings");
+}
+
+#[test]
+fn section_becomes_a_query_param() {
+    assert_eq!(
+        settings_url(Some("integrations")),
+        "/settings?section=integrations"
+    );
+}
+
+/// Every section the frontend's `validSections` accepts must survive the
+/// round trip unescaped — they are all plain lowercase words, so a section
+/// that comes back percent-mangled means the encoder was applied too broadly.
+#[test]
+fn known_sections_round_trip_unescaped() {
+    for section in [
+        "about",
+        "appearance",
+        "editor",
+        "files",
+        "formats",
+        "integrations",
+        "language",
+        "markdown",
+        "shortcuts",
+        "terminal",
+        "advanced",
+    ] {
+        assert_eq!(
+            settings_url(Some(section)),
+            format!("/settings?section={section}"),
+            "section `{section}` should not be escaped"
+        );
+    }
+}
+
+/// A section carrying reserved URL characters must not be able to smuggle in
+/// extra query params or a fragment.
+#[test]
+fn reserved_characters_are_percent_encoded() {
+    let url = settings_url(Some("a&b=c#d?e"));
+    assert!(
+        !url.contains('&') && !url.contains('#'),
+        "reserved chars must be encoded, got {url}"
+    );
+    assert_eq!(url, "/settings?section=a%26b%3Dc%23d%3Fe");
+}
+
+#[test]
+fn spaces_and_unicode_are_encoded() {
+    assert_eq!(settings_url(Some("a b")), "/settings?section=a%20b");
+    assert_eq!(
+        settings_url(Some("中文")),
+        "/settings?section=%E4%B8%AD%E6%96%87"
+    );
+}
+
+/// The command filters empty sections to `None` before calling through, but
+/// the builder should still be well-behaved if one arrives: an empty query
+/// value must not produce a route the SPA cannot match.
+#[test]
+fn empty_section_still_yields_a_matchable_route() {
+    let url = settings_url(Some(""));
+    assert!(
+        url.starts_with("/settings"),
+        "route must stay /settings, got {url}"
+    );
+}

--- a/src/components/Terminal/terminalSessionStoreSync.theme.test.ts
+++ b/src/components/Terminal/terminalSessionStoreSync.theme.test.ts
@@ -14,6 +14,16 @@ import {
   type SyncableSessionEntry,
 } from "./terminalSessionStoreSync";
 
+// Terminal retheming resolves through getEffectiveThemeId, which narrows the
+// theme to the light/dark pair Windows and Linux can draw chrome for
+// (theme/themeAvailability.ts). These cases are about *retheming*, so they pin
+// macOS — the full catalog — instead of inheriting jsdom's platform. The
+// narrowing itself is covered in useEffectiveTheme.test.ts.
+vi.mock("@/utils/platform", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/platform")>()),
+  isMacPlatform: () => true,
+}));
+
 vi.mock("@/services/persistence/workspaceStorage", () => ({
   getCurrentWindowLabel: () => "main",
 }));

--- a/src/hooks/useEffectiveTheme.test.ts
+++ b/src/hooks/useEffectiveTheme.test.ts
@@ -1,5 +1,15 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
+
+// The platform decides whether the resolved theme is narrowed to the
+// light/dark pair Windows and Linux can actually draw chrome for
+// (theme/themeAvailability.ts). Pinned explicitly rather than inherited from
+// jsdom, so these cases state which platform they describe.
+const platform = vi.hoisted(() => ({ isMac: true }));
+vi.mock("@/utils/platform", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/platform")>()),
+  isMacPlatform: () => platform.isMac,
+}));
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useSystemAppearanceStore } from "@/stores/systemAppearanceStore";
 import {
@@ -26,6 +36,12 @@ function setPrefersDark(value: boolean): void {
     useSystemAppearanceStore.setState({ prefersDark: value });
   });
 }
+
+beforeEach(() => {
+  // Default to macOS: the cases below cover resolution, which is where the
+  // full catalog is available. Platform narrowing has its own describe.
+  platform.isMac = true;
+});
 
 afterEach(() => {
   act(() => {
@@ -114,5 +130,65 @@ describe("useEffectiveThemeId", () => {
 
     setPrefersDark(true);
     expect(result.current).toBe("sepia");
+  });
+});
+
+// Windows and Linux draw their own title bar (and, on Windows, menu bar), and
+// the OS only accepts light or dark. A theme outside that pair would always
+// render half-themed, so the resolved id is narrowed to one that matches.
+describe("platform narrowing (Windows/Linux)", () => {
+  beforeEach(() => {
+    platform.isMac = false;
+  });
+
+  it("narrows an unsupported light theme to white", () => {
+    setAppearance({ theme: "sepia", followSystemAppearance: false });
+    expect(getEffectiveThemeId()).toBe("white");
+  });
+
+  it("narrows an unsupported dark theme to night", () => {
+    setAppearance({ theme: "solarized", followSystemAppearance: false });
+    expect(getEffectiveThemeId()).toBe("night");
+  });
+
+  it("leaves the two supported themes alone", () => {
+    setAppearance({ theme: "white", followSystemAppearance: false });
+    expect(getEffectiveThemeId()).toBe("white");
+    setAppearance({ theme: "night", followSystemAppearance: false });
+    expect(getEffectiveThemeId()).toBe("night");
+  });
+
+  it("narrows the follow-system pair too", () => {
+    setAppearance({
+      followSystemAppearance: true,
+      systemLightTheme: "paper",
+      systemDarkTheme: "solarized",
+    });
+    setPrefersDark(false);
+    expect(getEffectiveThemeId()).toBe("white");
+    setPrefersDark(true);
+    expect(getEffectiveThemeId()).toBe("night");
+  });
+
+  // The stored pick must survive: someone syncing settings back to macOS
+  // should get their sepia back, not a permanently rewritten "white".
+  it("does not mutate the stored theme", () => {
+    setAppearance({ theme: "sepia", followSystemAppearance: false });
+    expect(getEffectiveThemeId()).toBe("white");
+    expect(useSettingsStore.getState().appearance.theme).toBe("sepia");
+  });
+
+  it("reacts to a system flip while following", () => {
+    setAppearance({
+      followSystemAppearance: true,
+      systemLightTheme: "mint",
+      systemDarkTheme: "night",
+    });
+    setPrefersDark(false);
+    const { result } = renderHook(() => useEffectiveThemeId());
+    expect(result.current).toBe("white");
+
+    setPrefersDark(true);
+    expect(result.current).toBe("night");
   });
 });

--- a/src/hooks/useEffectiveTheme.ts
+++ b/src/hooks/useEffectiveTheme.ts
@@ -11,7 +11,14 @@
  * mutated by system flips.
  *
  * Consumers remain responsible for guarding unknown ids
- * (`themes[id] ?? themes.paper`) — this module resolves, it doesn't validate.
+ * (`themes[id] ?? themes.paper`) — `resolveEffectiveThemeId` resolves, it
+ * doesn't validate, and is deliberately pure so it stays platform-agnostic.
+ *
+ * The exported hook and getter additionally narrow the result to what the
+ * platform's native chrome can render (`theme/themeAvailability.ts`): Windows
+ * and Linux draw their own title bar and accept only light or dark, so a theme
+ * outside that pair would always render half-themed. `appearance.theme` is
+ * never mutated, so the user's pick survives a round trip back to macOS.
  *
  * @coordinates-with stores/systemAppearanceStore.ts — OS dark-mode observation
  * @coordinates-with stores/settingsStore.ts — appearance preferences
@@ -22,6 +29,8 @@ import { useSettingsStore, type AppearanceSettings } from "@/stores/settingsStor
 import { initialState } from "@/stores/settingsStore/defaults";
 import { useSystemAppearanceStore } from "@/stores/systemAppearanceStore";
 import type { ThemeId } from "@/theme/themes";
+import { coerceThemeId } from "@/theme/themeAvailability";
+import { isMacPlatform } from "@/utils/platform";
 
 type EffectiveThemeInput = Pick<
   AppearanceSettings,
@@ -40,9 +49,28 @@ export function resolveEffectiveThemeId(
     : (appearance.systemLightTheme ?? initialState.appearance.systemLightTheme);
 }
 
+/**
+ * Resolve, then narrow to what this platform's native chrome can render.
+ *
+ * Kept separate from `resolveEffectiveThemeId` so that stays pure and
+ * platform-agnostic: it resolves, it doesn't validate. Windows/Linux only
+ * draw light or dark chrome, so a theme outside that pair would always render
+ * half-themed. `appearance.theme` is never mutated, so the user's original
+ * pick survives a round trip back to macOS.
+ */
+function resolveForPlatform(
+  appearance: EffectiveThemeInput,
+  prefersDark: boolean
+): ThemeId {
+  return coerceThemeId(
+    resolveEffectiveThemeId(appearance, prefersDark),
+    isMacPlatform()
+  );
+}
+
 /** Non-reactive read for callbacks and store subscribers. */
 export function getEffectiveThemeId(): ThemeId {
-  return resolveEffectiveThemeId(
+  return resolveForPlatform(
     useSettingsStore.getState().appearance,
     useSystemAppearanceStore.getState().prefersDark
   );
@@ -56,7 +84,7 @@ export function useEffectiveThemeId(): ThemeId {
   const light = useSettingsStore((s) => s.appearance.systemLightTheme);
   const dark = useSettingsStore((s) => s.appearance.systemDarkTheme);
   const prefersDark = useSystemAppearanceStore((s) => s.prefersDark);
-  return resolveEffectiveThemeId(
+  return resolveForPlatform(
     { theme, followSystemAppearance: follow, systemLightTheme: light, systemDarkTheme: dark },
     prefersDark
   );

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -7,7 +7,8 @@
  *
  * Pipeline: settingsStore.appearance changes (or an OS light/dark flip while
  *   follow-system-appearance is on) → this hook recomputes → sets CSS vars on
- *   document.documentElement → all components react via CSS
+ *   document.documentElement → all components react via CSS, and the resolved
+ *   light/dark state is reported to Rust so OS-drawn chrome follows it too
  *
  * Key decisions:
  *   - Font stacks live in `@/utils/fontStacks` (leaf-pure); this hook composes
@@ -22,6 +23,7 @@
  *
  * @coordinates-with settingsStore.ts — reads appearance settings
  * @coordinates-with useEffectiveTheme.ts — resolves manual vs follow-system theme id
+ * @coordinates-with services/theme/nativeTheme.ts — reports light/dark to native chrome
  * @coordinates-with useSystemAppearanceWatcher.ts — mounted here to track the OS preference
  * @coordinates-with index.css — static token defaults (overridden here)
  * @coordinates-with theme/legacyModeColors.ts — derived legacy color sets + pure color-var computation
@@ -38,6 +40,7 @@ import { refreshPreviews } from "@/plugins/codePreview/tiptap";
 import { applyTheme, themes as themeTokensCatalog } from "@/theme";
 import { computeCoreColorVars, computeModeColorVars } from "@/theme/legacyModeColors";
 import { buildFontStack } from "@/utils/fontStacks";
+import { syncNativeTheme } from "@/services/theme/nativeTheme";
 
 // Pure color computation moved to @/theme/legacyModeColors (ADR-014 home for
 // color values; keeps this file under the size gate). Re-exported here so
@@ -184,6 +187,10 @@ export function useTheme() {
 
     applyCoreColors(root, themeColors);
     applyModeColors(root, themeColors, isDark);
+    // Keep OS-drawn chrome (title bar; the menu bar on Windows) in step with
+    // the theme we just applied. Fire-and-forget: it self-dedupes, and a
+    // failure must not abort the rest of this effect.
+    void syncNativeTheme(isDark);
     applyTypography(
       root,
       appearance.latinFont,

--- a/src/pages/settings/AppearanceSettings.test.tsx
+++ b/src/pages/settings/AppearanceSettings.test.tsx
@@ -1,8 +1,22 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { AppearanceSettings } from "./AppearanceSettings";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { FOCUS_DIM_OPACITY } from "@/hooks/useTheme";
+
+// The swatch row only offers themes whose native chrome the platform can
+// match (theme/themeAvailability.ts), so the platform is pinned rather than
+// inherited from jsdom. Defaults to macOS — the full catalog — with the
+// narrowed Windows/Linux picker covered in its own describe below.
+const platform = vi.hoisted(() => ({ isMac: true }));
+vi.mock("@/utils/platform", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/platform")>()),
+  isMacPlatform: () => platform.isMac,
+}));
+
+beforeEach(() => {
+  platform.isMac = true;
+});
 
 describe("AppearanceSettings — focus mode dim (WI-10)", () => {
   beforeEach(() => {
@@ -127,5 +141,51 @@ describe("FOCUS_DIM_OPACITY map", () => {
   it("dims progressively for stronger levels", () => {
     expect(Number(FOCUS_DIM_OPACITY.strong)).toBeLessThan(1);
     expect(Number(FOCUS_DIM_OPACITY.stronger)).toBeLessThan(Number(FOCUS_DIM_OPACITY.strong));
+  });
+});
+
+describe("AppearanceSettings — theme picker narrowing (Windows/Linux)", () => {
+  beforeEach(() => {
+    platform.isMac = false;
+    useSettingsStore.setState({
+      appearance: {
+        ...useSettingsStore.getState().appearance,
+        followSystemAppearance: false,
+        theme: "white",
+      },
+    });
+  });
+
+  it("offers only the two themes whose chrome the OS can match", () => {
+    render(<AppearanceSettings />);
+    expect(screen.getByRole("button", { name: /white/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /night/i })).toBeInTheDocument();
+  });
+
+  it("hides the themes that could never have matching chrome", () => {
+    render(<AppearanceSettings />);
+    for (const hidden of [/paper/i, /mint/i, /sepia/i, /solarized/i]) {
+      expect(screen.queryByRole("button", { name: hidden })).toBeNull();
+    }
+  });
+
+  it("still narrows both rows when following the system", () => {
+    useSettingsStore.setState({
+      appearance: {
+        ...useSettingsStore.getState().appearance,
+        followSystemAppearance: true,
+      },
+    });
+    render(<AppearanceSettings />);
+    // One swatch per row, two rows — light and dark.
+    expect(screen.getAllByRole("button", { name: /white/i })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: /night/i })).toHaveLength(2);
+    expect(screen.queryByRole("button", { name: /sepia/i })).toBeNull();
+  });
+
+  it("selecting a narrowed theme still writes to the store", () => {
+    render(<AppearanceSettings />);
+    fireEvent.click(screen.getByRole("button", { name: /night/i }));
+    expect(useSettingsStore.getState().appearance.theme).toBe("night");
   });
 });

--- a/src/pages/settings/AppearanceSettings.tsx
+++ b/src/pages/settings/AppearanceSettings.tsx
@@ -14,6 +14,8 @@ import {
   type FocusModeDim,
 } from "@/stores/settingsStore";
 import { SettingRow, SettingsGroup, Toggle, Select } from "./components";
+import { selectableThemeIds } from "@/theme/themeAvailability";
+import { isMacPlatform } from "@/utils/platform";
 
 /** One row of theme swatches. `selected` gets the ring indicator. */
 function ThemeSwatchRow({
@@ -24,9 +26,12 @@ function ThemeSwatchRow({
   onSelect: (id: ThemeId) => void;
 }) {
   const { t } = useTranslation("settings");
+  // Windows/Linux offer only the light/dark pair their native chrome can
+  // actually match — see theme/themeAvailability.ts.
+  const available = selectableThemeIds(isMacPlatform());
   return (
     <div className="flex items-center gap-4 pb-3">
-      {(Object.keys(themes) as ThemeId[]).map((id) => (
+      {available.map((id) => (
         <button
           key={id}
           type="button"

--- a/src/services/theme/nativeTheme.test.ts
+++ b/src/services/theme/nativeTheme.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import { syncNativeTheme, __resetNativeThemeCache } from "./nativeTheme";
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue(undefined);
+  __resetNativeThemeCache();
+});
+
+describe("syncNativeTheme", () => {
+  it("reports a dark theme to the backend", async () => {
+    await syncNativeTheme(true);
+    expect(invokeMock).toHaveBeenCalledWith("set_native_theme", { dark: true });
+  });
+
+  it("reports a light theme to the backend", async () => {
+    await syncNativeTheme(false);
+    expect(invokeMock).toHaveBeenCalledWith("set_native_theme", { dark: false });
+  });
+
+  it("skips a repeated report of the same theme", async () => {
+    await syncNativeTheme(true);
+    await syncNativeTheme(true);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports again when the theme actually flips", async () => {
+    await syncNativeTheme(true);
+    await syncNativeTheme(false);
+    await syncNativeTheme(true);
+    expect(invokeMock).toHaveBeenCalledTimes(3);
+    expect(invokeMock).toHaveBeenLastCalledWith("set_native_theme", { dark: true });
+  });
+
+  // useTheme runs this inside a layout effect on every theme-affecting
+  // settings change. A rejected invoke (non-Tauri context, command missing on
+  // an older shell) must not surface as an unhandled rejection that takes the
+  // theme effect down with it — the CSS theme has already been applied by then.
+  it("swallows backend failures", async () => {
+    invokeMock.mockRejectedValue(new Error("no such command"));
+    await expect(syncNativeTheme(true)).resolves.toBeUndefined();
+  });
+
+  // A failed report must not be recorded as the delivered state, or the app
+  // would stay permanently out of sync after one transient error.
+  it("retries after a failure instead of caching it", async () => {
+    invokeMock.mockRejectedValueOnce(new Error("transient"));
+    await syncNativeTheme(true);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    invokeMock.mockResolvedValue(undefined);
+    await syncNativeTheme(true);
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/theme/nativeTheme.ts
+++ b/src/services/theme/nativeTheme.ts
@@ -1,0 +1,53 @@
+/**
+ * Native chrome theming bridge.
+ *
+ * Purpose: VMark paints its own UI from CSS tokens, but the window title bar
+ * and (on Windows) the menu bar are drawn by the OS and ignore that. This
+ * reports the resolved light/dark state to Rust so the native chrome can
+ * follow it.
+ *
+ * Key decisions:
+ *   - Platform handling lives in Rust (`window_manager/native_theme.rs`), not
+ *     here, so there is one place that decides what each OS does. macOS is a
+ *     deliberate no-op there.
+ *   - Failures are swallowed. This runs from useTheme's effect *after* the CSS
+ *     theme is already applied; a missing command or non-Tauri context must
+ *     not break theming of the app's own UI.
+ *
+ * @coordinates-with window_manager/native_theme.rs — the `set_native_theme` command
+ * @coordinates-with hooks/useTheme.ts — sole caller
+ * @module services/theme/nativeTheme
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Last value the backend actually accepted. `null` means "nothing delivered
+ * yet", so the first report always goes out.
+ */
+let lastDelivered: boolean | null = null;
+
+/**
+ * Report the resolved theme so native window chrome can match it.
+ *
+ * Cheap to call repeatedly: useTheme's effect re-runs on any theme-affecting
+ * settings change (font size, line height…), and only an actual light/dark
+ * flip reaches the backend.
+ */
+export async function syncNativeTheme(isDark: boolean): Promise<void> {
+  if (lastDelivered === isDark) return;
+
+  try {
+    await invoke("set_native_theme", { dark: isDark });
+    // Recorded only on success, so a transient failure is retried on the next
+    // theme change rather than being remembered as delivered.
+    lastDelivered = isDark;
+  } catch {
+    // Intentionally silent — see the header.
+  }
+}
+
+/** Test seam: clear the delivered-state cache between cases. */
+export function __resetNativeThemeCache(): void {
+  lastDelivered = null;
+}

--- a/src/theme/themeAvailability.test.ts
+++ b/src/theme/themeAvailability.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { themes } from "./themes";
+import type { ThemeId } from "./themes";
+import {
+  NON_MAC_THEME_IDS,
+  coerceThemeId,
+  selectableThemeIds,
+} from "./themeAvailability";
+
+const ALL_IDS = Object.keys(themes) as ThemeId[];
+
+describe("selectableThemeIds", () => {
+  it("offers the whole catalog on macOS", () => {
+    expect(selectableThemeIds(true)).toEqual(ALL_IDS);
+  });
+
+  it("offers only white and night off macOS", () => {
+    expect(selectableThemeIds(false)).toEqual(["white", "night"]);
+  });
+
+  // Windows/Linux title bars are light-or-dark only, so every offered theme
+  // must map onto one of those without ambiguity.
+  it("offers exactly one light and one dark option off macOS", () => {
+    const offered = selectableThemeIds(false);
+    const dark = offered.filter((id) => themes[id].isDark);
+    const light = offered.filter((id) => !themes[id].isDark);
+    expect(dark).toHaveLength(1);
+    expect(light).toHaveLength(1);
+  });
+
+  it("only offers themes that exist in the catalog", () => {
+    for (const id of selectableThemeIds(false)) {
+      expect(themes[id]).toBeDefined();
+    }
+  });
+
+  it("does not let callers mutate the shared list", () => {
+    const first = selectableThemeIds(false);
+    first.push("sepia" as ThemeId);
+    expect(selectableThemeIds(false)).toEqual(["white", "night"]);
+  });
+});
+
+describe("coerceThemeId", () => {
+  it("leaves every theme untouched on macOS", () => {
+    for (const id of ALL_IDS) {
+      expect(coerceThemeId(id, true)).toBe(id);
+    }
+  });
+
+  it("keeps the two supported themes off macOS", () => {
+    for (const id of NON_MAC_THEME_IDS) {
+      expect(coerceThemeId(id, false)).toBe(id);
+    }
+  });
+
+  // A user who picked sepia on macOS, then synced settings to Windows, must
+  // land on a theme of the same polarity — not be flipped from light to dark.
+  it("maps an unsupported light theme to white", () => {
+    for (const id of ALL_IDS.filter((i) => !themes[i].isDark)) {
+      expect(coerceThemeId(id, false)).toBe("white");
+    }
+  });
+
+  it("maps an unsupported dark theme to night", () => {
+    for (const id of ALL_IDS.filter((i) => themes[i].isDark)) {
+      expect(coerceThemeId(id, false)).toBe("night");
+    }
+  });
+
+  it("never returns an unsupported theme off macOS", () => {
+    for (const id of ALL_IDS) {
+      expect(NON_MAC_THEME_IDS).toContain(coerceThemeId(id, false));
+    }
+  });
+
+  // Corrupted localStorage is a real source of unknown ids (the existing
+  // useTheme code already guards against it), so this must not throw.
+  it("falls back to white for an unknown id", () => {
+    expect(coerceThemeId("does-not-exist" as ThemeId, false)).toBe("white");
+  });
+
+  it("passes an unknown id through untouched on macOS", () => {
+    // macOS keeps its existing behavior: useTheme's own `?? themes.paper`
+    // guard handles unknown ids there, so this must not silently rewrite it.
+    expect(coerceThemeId("does-not-exist" as ThemeId, true)).toBe(
+      "does-not-exist"
+    );
+  });
+});

--- a/src/theme/themeAvailability.ts
+++ b/src/theme/themeAvailability.ts
@@ -1,0 +1,53 @@
+/**
+ * Which themes a platform can actually offer.
+ *
+ * Purpose: Windows and Linux draw the title bar (and, on Windows, the menu
+ * bar) themselves, and the only choice the OS accepts is light or dark. A
+ * sepia or mint theme therefore has no matching chrome available at any
+ * price — the window would always be half-themed. Those platforms are limited
+ * to one light theme and one dark theme, each of which maps exactly onto what
+ * the OS can render.
+ *
+ * macOS is unaffected: its Settings window uses an overlay title bar and its
+ * menus live in the system bar, so the full catalog stays available.
+ *
+ * Key decisions:
+ *   - Coercion preserves *polarity*. Someone who chose sepia (light) and moves
+ *     to Windows gets white, not night — settings sync between machines must
+ *     not flip a user from light to dark.
+ *   - Pure and platform-agnostic: callers pass `isMac`, so this stays testable
+ *     without stubbing `navigator`.
+ *
+ * @coordinates-with hooks/useEffectiveTheme.ts — coerces the resolved theme
+ * @coordinates-with pages/settings/AppearanceSettings.tsx — filters the swatches
+ * @module theme/themeAvailability
+ */
+
+import { themes } from "./themes";
+import type { ThemeId } from "./themes";
+
+/** The light/dark pair offered on Windows and Linux. */
+export const NON_MAC_THEME_IDS: readonly ThemeId[] = Object.freeze([
+  "white",
+  "night",
+] as ThemeId[]);
+
+/** Themes the theme picker should offer on this platform. */
+export function selectableThemeIds(isMac: boolean): ThemeId[] {
+  // Copies both branches so a caller mutating the result cannot corrupt the
+  // frozen constant or the catalog's key order.
+  return isMac ? (Object.keys(themes) as ThemeId[]) : [...NON_MAC_THEME_IDS];
+}
+
+/**
+ * Map a stored theme onto one this platform can render.
+ *
+ * Unknown ids fall back to white rather than throwing: corrupted persisted
+ * settings are a real case, and the theme layer already treats them as
+ * recoverable.
+ */
+export function coerceThemeId(id: ThemeId, isMac: boolean): ThemeId {
+  if (isMac) return id;
+  if (NON_MAC_THEME_IDS.includes(id)) return id;
+  return themes[id]?.isDark ? "night" : "white";
+}


### PR DESCRIPTION
Closes the gap where VMark themed everything it painted itself, while the OS-drawn
chrome ignored the theme entirely.

## The problem

Rust had **zero** theme awareness. The frontend applies the theme via CSS custom
properties; the title bar — and on Windows the menu bar — are drawn by the OS and
never heard about it. On a light-mode Windows install running VMark's night theme,
the Settings window rendered a white title bar around a dark page.

This is invisible on macOS: its Settings window uses an overlay title bar and its
menus live in the system menu bar, so there is no symptom to see.

## What changed

| Piece | Role |
|---|---|
| `window_manager/native_theme.rs` | New. Remembers the reported theme, pushes it to every open window |
| `settings_window.rs`, `document_windows.rs` | Builders pass `.theme(current_theme())` so chrome is right on the **first frame**, not after a flash |
| `services/theme/nativeTheme.ts` | Bridge — self-deduping, failures swallowed (the CSS theme is already applied by then) |
| `hooks/useTheme.ts` | Reports `isDark` on every theme change |

Platform handling lives in Rust so a single place decides per-OS behavior.
**macOS is a deliberate no-op** — `set_theme` there changes NSAppearance app-wide,
an unrequested change to the primary platform.

## Two themes on Windows/Linux

Those platforms' title bars accept only *light* or *dark*. Sepia or mint could
therefore never have matching chrome **at any price** — the window would always be
half-themed. The picker is narrowed to `white` + `night`, which map exactly.

Coercion **preserves polarity**: a sepia setting synced from macOS becomes white,
never night — a settings sync must not flip a user from light to dark. And
`appearance.theme` is never rewritten, so the original pick survives a round trip
back to macOS. Both behaviors are tested.

## Known limitation

The Windows **menu bar** follows this only when the OS is itself in dark mode.
muda gates its dark menu-bar drawing on:

```rust
should_apps_use_dark_mode() && !is_high_contrast() && is_dark_mode_allowed_for_window(hwnd)
```

This change controls the third term. The first is an OS-wide setting
(`uxtheme.dll` ordinal 132) that an application cannot override. The **title bar
has no such limit** — `DWMWA_USE_IMMERSIVE_DARK_MODE` is per-window and always
honored.

## Tests

`settings_window.rs` and `window_manager/mod.rs` had **no tests at all**, which
also made them unmodifiable under the TDD guard. Both gained real ones:

- `settings_window.test.rs` — the URL builder implicated in #1141 (percent-encoding,
  reserved chars, every valid section, unicode)
- `mod.test.rs` — the re-export contract `mod.rs`'s own header documents, and that
  `60-ai-governance.md` records failing silently before: a renamed command or dropped
  re-export now breaks a test instead of surfacing later
- `themeAvailability.test.ts` — 12 cases including polarity preservation and unknown ids

## Verification

- `pnpm check:all` → exit 0
- `cargo test window_manager` → 65 passed
- `cargo clippy --all-targets -- -D warnings` → 0 errors
- Built and run on a real Windows 11 box; the Settings window title bar tracks the
  theme correctly in both directions (confirmed by screenshots)

The full gate caught a consumer I had not traced — terminal xterm retheming also
resolves through `getEffectiveThemeId` — which is now covered.