### PR TITLE
chore: bump version to 0.9.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.16",
+  "version": "0.9.17",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6260,7 +6260,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "base64 0.23.0",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.16"
+version = "0.9.17"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/vmark-mcp-server/package.json
+++ b/vmark-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/vmark-mcp-server/src/cli.ts
+++ b/vmark-mcp-server/src/cli.ts
@@ -18,7 +18,7 @@
  */
 
 // Package version (injected at build time or read from package.json)
-const VERSION = '0.9.16';
+const VERSION = '0.9.17';
 
 /**
  * Handle --version flag.


### PR DESCRIPTION
Ships the native window chrome theming from #1157.

## What's in this release

VMark now matches OS-drawn window chrome to the in-app theme on Windows and
Linux — the title bar, and the menu bar where the OS allows it. Previously Rust
had no theme awareness at all, so a night theme rendered inside a white title
bar.

Those platforms are also narrowed to two themes, **white** and **night**, since
their title bars accept only light or dark; sepia or mint could never have
matching chrome. macOS keeps the full catalog, and a theme synced from macOS
coerces by polarity without overwriting the stored pick.

## Files

All six version sites per `.claude/rules/40-version-bump.md`:

| File | Field |
|---|---|
| `package.json` | `version` |
| `src-tauri/tauri.conf.json` | `version` |
| `src-tauri/Cargo.toml` | `version` |
| `src-tauri/Cargo.lock` | derived `vmark` entry (`cargo update -p vmark`) |
| `vmark-mcp-server/package.json` | `version` |
| `vmark-mcp-server/src/cli.ts` | `VERSION` |

## Verification

`pnpm check:all` → exit 0 on this tree, and #1157 carried it through full CI
including `rust-test (windows-latest)`, which caught and now confirms the fix
for a `STATUS_ENTRYPOINT_NOT_FOUND` regression in the test binary.