### PR TITLE
fix: Windows sidecar staging path + v0.9.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.19",
+  "version": "0.9.20",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/__tests__/buildSidecarCore.test.ts
+++ b/server/mcp/__tests__/buildSidecarCore.test.ts
@@ -151,6 +151,22 @@ describe("buildForTarget", () => {
     expect(await buildForTarget("darwin-arm64", deps)).toBe(false);
   });
 
+  it("keeps the .exe extension TERMINAL on the Windows staging path", async () => {
+    // pkg appends .exe to extensionless Windows outputs; a suffix after the
+    // extension made pkg write a different file than verify checked.
+    const { deps } = makeDeps();
+    expect(await buildForTarget("win32-x64", deps)).toBe(true);
+    const pkgArgs = (deps.runTool as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => (c[0] as string[])[0] === "@yao-pkg/pkg"
+    )?.[0] as string[];
+    const out = pkgArgs[pkgArgs.indexOf("--output") + 1];
+    expect(out).toMatch(/vmark-mcp-server-x86_64-pc-windows-msvc\.staging-[^.]+\.exe$/);
+    expect(deps.rename).toHaveBeenCalledWith(
+      expect.stringMatching(/\.staging-[^.]+\.exe$/),
+      expect.stringMatching(/vmark-mcp-server-x86_64-pc-windows-msvc\.exe$/)
+    );
+  });
+
   it("returns false when the artifact is missing after pkg", async () => {
     const { deps } = makeDeps({
       access: vi.fn(async () => {

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/scripts/build-sidecar-core.mjs
+++ b/server/mcp/scripts/build-sidecar-core.mjs
@@ -210,7 +210,14 @@ export async function buildForTarget(targetKey, deps) {
   const ext = target.ext || '';
   const outputName = `vmark-mcp-server-${target.triple}${ext}`;
   const outputPath = join(deps.binariesDir, outputName);
-  const stagingPath = `${outputPath}.staging-${deps.runId ?? 'local'}`;
+  // The staging suffix goes BEFORE the extension: pkg normalizes Windows
+  // output to end in `.exe`, so `foo.exe.staging-N` would be written as
+  // `foo.exe.staging-N.exe` and the verify/rename step would miss it
+  // (v0.9.19 release failure, windows-latest).
+  const stagingPath = join(
+    deps.binariesDir,
+    `vmark-mcp-server-${target.triple}.staging-${deps.runId ?? 'local'}${ext}`
+  );
 
   deps.log(`Building for ${targetKey} -> ${outputName}`);
 

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.19';
+const VERSION = '0.9.20';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6262,7 +6262,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "base64 0.23.0",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.19"
+version = "0.9.20"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/hooks/mcpBridge/v2/__tests__/browserNavigation.test.ts
+++ b/src/hooks/mcpBridge/v2/__tests__/browserNavigation.test.ts
@@ -225,6 +225,22 @@ describe("navigate", () => {
     expect(mocks.invoke).not.toHaveBeenCalledWith("browser_ai_navigate", expect.anything());
   });
 
+  it("responds queue-full (NOT needsApproval) when the approval queue is at capacity", async () => {
+    const { MAX_PENDING_APPROVALS } = await import("@/stores/browserApprovalStore");
+    const tabId = seed("ai-shared");
+    const store = useBrowserApprovalStore.getState();
+    for (let i = 0; i < MAX_PENDING_APPROVALS; i++) {
+      store.requestApproval(`fill-${i}`, URL, "click", { role: "button", name: `b${i}` } as never, tabId, 1);
+    }
+    mocks.ensureNative.mockRejectedValueOnce("APPROVAL_REQUIRED");
+
+    await handleBrowserNavigate("nav-full", { tabId, url: URL });
+
+    const res = lastResponse();
+    expect(String(res.error)).toContain("approval queue is full");
+    expect((res.data as { needsApproval?: boolean } | undefined)?.needsApproval).toBeUndefined();
+  });
+
   it("queues approval when Rust rejects the destination", async () => {
     const tabId = seed("ai-shared");
     mocks.ensureNative.mockRejectedValueOnce("APPROVAL_REQUIRED");

--- a/src/hooks/mcpBridge/v2/__tests__/browserReadClass.test.ts
+++ b/src/hooks/mcpBridge/v2/__tests__/browserReadClass.test.ts
@@ -56,6 +56,20 @@ describe("requireHumanAttachment", () => {
     expect(useBrowserApprovalStore.getState().pending[0]).toMatchObject({ operation: "attach", tabId: id });
   });
 
+  it("responds queue-full (NOT needsApproval) when the attach queue is at capacity", async () => {
+    const { MAX_PENDING_APPROVALS } = await import("@/stores/browserApprovalStore");
+    const id = seed("human");
+    const store = useBrowserApprovalStore.getState();
+    for (let i = 0; i < MAX_PENDING_APPROVALS; i++) {
+      store.requestApproval(`fill-${i}`, SITE, "click", { role: "button", name: `b${i}` } as never, id, 1);
+    }
+    const tab = resolveBrowserTab(id);
+    expect(await requireHumanAttachment("r-full", tab)).toBe(false);
+    const res = lastResponse();
+    expect(String(res.error)).toContain("approval queue is full");
+    expect((res.data as { needsApproval?: boolean } | undefined)?.needsApproval).toBeUndefined();
+  });
+
   it("allows an attached human tab", async () => {
     const id = seed("human");
     useBrowserApprovalStore.setState({

--- a/src/hooks/mcpBridge/v2/__tests__/browserSession.test.ts
+++ b/src/hooks/mcpBridge/v2/__tests__/browserSession.test.ts
@@ -44,6 +44,20 @@ describe("handleBrowserSessionSave (op=session, never grantable)", () => {
     void id;
   });
 
+  it("responds queue-full (NOT needsApproval) when the approval queue is at capacity", async () => {
+    const { MAX_PENDING_APPROVALS } = await import("@/stores/browserApprovalStore");
+    const id = seed();
+    const store = useBrowserApprovalStore.getState();
+    for (let i = 0; i < MAX_PENDING_APPROVALS; i++) {
+      store.requestApproval(`fill-${i}`, "https://blog.example.com/", "click", { role: "button", name: `b${i}` } as never, id, 1);
+    }
+    await handleBrowserSessionSave("sv-full", { tabId: id, handle: "work_login" });
+    expect(invoke).not.toHaveBeenCalled();
+    const res = lastResponse();
+    expect(String(res.error)).toContain("approval queue is full");
+    expect((res.data as { needsApproval?: boolean } | undefined)?.needsApproval).toBeUndefined();
+  });
+
   it("raises approval, then saves and returns a handle + summary (no values)", async () => {
     const id = seed();
     await handleBrowserSessionSave("sv-a", { tabId: id, handle: "work_login" });


### PR DESCRIPTION
The v0.9.19 release failed on windows-latest: pkg normalizes extensionless Windows outputs to `.exe`, so the per-run staging suffix appended AFTER the extension made pkg write `…staging-N.exe` while verify/rename looked for `…exe.staging-N`. The suffix now goes before the extension (regression test added; macOS sidecar build re-verified).

Second commit bumps to **0.9.20** (all five files + lockfile). The failed v0.9.19 tag/draft will be retired — it was never published.