### PR TITLE
Release v0.9.24 — file explorer and silent-rewrite fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.23",
+  "version": "0.9.24",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.23';
+const VERSION = '0.9.24';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6280,7 +6280,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.23"
+version = "0.9.24"
 dependencies = [
  "base64 0.23.0",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.23"
+version = "0.9.24"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/Editor/useTiptapFlush.test.ts
+++ b/src/components/Editor/useTiptapFlush.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The flush must tell the store whether a USER edit is behind it.
+ *
+ * Auto-save calls `flushActiveWysiwygNow()` on every tick BEFORE it reads
+ * `isDirty`. If that flush claimed to be a user edit, the serializer's
+ * canonical output (which is not byte-identical to arbitrary on-disk markdown)
+ * would dirty a document nobody touched and auto-save would rewrite the file —
+ * the "opening a file rewrites it" bug.
+ *
+ * `scheduleFlush` is the only user-edit signal available: the editor's
+ * `onUpdate` is its sole caller and already drops programmatic transactions.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { Editor as TiptapEditor } from "@tiptap/core";
+
+vi.mock("@/utils/markdownPipeline", () => ({
+  serializeMarkdown: vi.fn(() => "SERIALIZED"),
+}));
+
+vi.mock("@/stores/settingsStore", () => ({
+  useSettingsStore: { getState: () => ({ markdown: { preserveBlankLines: false } }) },
+}));
+
+vi.mock("@/stores/tabStore", () => ({
+  useTabStore: { getState: () => ({ activeTabId: { main: "tab-1" } }) },
+}));
+
+vi.mock("@/stores/documentStore", () => ({
+  useDocumentStore: { getState: () => ({ getDocument: () => ({ hardBreakStyle: "unknown" }) }) },
+}));
+
+import { useTiptapFlush } from "./useTiptapFlush";
+
+/** Minimal editor stand-in — the flush only reads schema/state.doc. */
+const editor = {
+  schema: {},
+  state: { doc: { content: { size: 10 } } },
+} as unknown as TiptapEditor;
+
+function setup(setContent: (md: string, opts?: { fromUserEdit?: boolean }) => void) {
+  return renderHook(() =>
+    useTiptapFlush({
+      activeTabId: "tab-1",
+      windowLabel: "main",
+      setContent,
+      preserveLineBreaksRef: { current: false },
+      hardBreakStyleOnSaveRef: { current: "preserve" },
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("requestAnimationFrame", vi.fn(() => 1));
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+});
+
+describe("flushToStore user-edit reporting", () => {
+  it("reports fromUserEdit: false when no edit preceded it (the auto-save tick)", () => {
+    const setContent = vi.fn();
+    const { result } = setup(setContent);
+
+    result.current.flushToStore(editor);
+
+    expect(setContent).toHaveBeenCalledWith("SERIALIZED", { fromUserEdit: false });
+  });
+
+  it("reports fromUserEdit: true after the editor scheduled a flush (a real edit)", () => {
+    const setContent = vi.fn();
+    const { result } = setup(setContent);
+
+    result.current.scheduleFlush(editor); // onUpdate — user typed
+    result.current.flushToStore(editor);
+
+    expect(setContent).toHaveBeenCalledWith("SERIALIZED", { fromUserEdit: true });
+  });
+
+  it("consumes the signal — a later sync flush no longer claims a user edit", () => {
+    const setContent = vi.fn();
+    const { result } = setup(setContent);
+
+    result.current.scheduleFlush(editor);
+    result.current.flushToStore(editor);
+    result.current.flushToStore(editor); // next auto-save tick, no new edit
+
+    expect(setContent).toHaveBeenNthCalledWith(1, "SERIALIZED", { fromUserEdit: true });
+    expect(setContent).toHaveBeenNthCalledWith(2, "SERIALIZED", { fromUserEdit: false });
+  });
+
+  it("does not lose an edit whose debounce has not fired yet", () => {
+    const setContent = vi.fn();
+    const { result } = setup(setContent);
+
+    // User types (flush scheduled, still pending) and auto-save flushes first.
+    result.current.scheduleFlush(editor);
+    result.current.flushToStore(editor);
+
+    expect(setContent).toHaveBeenCalledWith("SERIALIZED", { fromUserEdit: true });
+  });
+
+  it("repeated sync flushes never claim a user edit", () => {
+    const setContent = vi.fn();
+    const { result } = setup(setContent);
+
+    for (let i = 0; i < 3; i++) result.current.flushToStore(editor);
+
+    for (const call of setContent.mock.calls) {
+      expect(call[1]).toEqual({ fromUserEdit: false });
+    }
+  });
+});

--- a/src/components/Editor/useTiptapFlush.ts
+++ b/src/components/Editor/useTiptapFlush.ts
@@ -16,6 +16,11 @@
  *     hasn't run yet (#755).
  *   - scheduleFlush uses RAF for small docs (≤100ms tier) and a debounced
  *     timeout for large docs — see getAdaptiveDebounceDelay.
+ *   - Every flush reports whether a USER edit is behind it (userEditPending,
+ *     set by scheduleFlush). Auto-save and Save All flush before reading
+ *     isDirty, so a flush that claimed to be an edit would dirty a document
+ *     nobody touched and rewrite the file — see documentStore's
+ *     SetContentOptions.
  *
  * @coordinates-with components/Editor/TiptapEditor.tsx — sole consumer
  * @coordinates-with hooks/useTiptapUnmountFlush.ts — consumes the pending-timer refs
@@ -36,7 +41,7 @@ interface TiptapFlushOptions {
   /** Tab this editor is pinned to (#1081) — store writes target this tab. */
   activeTabId: string | undefined;
   windowLabel: string;
-  setContent: (markdown: string) => void;
+  setContent: (markdown: string, options?: { fromUserEdit?: boolean }) => void;
   preserveLineBreaksRef: MutableRefObject<boolean>;
   hardBreakStyleOnSaveRef: MutableRefObject<HardBreakStyleOnSave>;
 }
@@ -67,6 +72,17 @@ export function useTiptapFlush(options: TiptapFlushOptions): TiptapFlushHandle {
   const pendingDebounceTimeout = useRef<number | null>(null);
   const internalChangeRaf = useRef<number | null>(null);
   const flushToStoreRef = useRef<((editor: TiptapEditor) => void) | null>(null);
+  /**
+   * A genuine user edit is waiting to be written to the store.
+   *
+   * `scheduleFlush` is called from exactly one place — the editor's `onUpdate`,
+   * which already drops programmatic transactions (`preventUpdate`) — so this
+   * is set only by real edits. The pending RAF/timeout refs cannot serve as
+   * this signal: they are cleared inside their own callbacks BEFORE the flush
+   * runs, and a flush requested by auto-save or Save All has no pending timer
+   * at all.
+   */
+  const userEditPending = useRef(false);
 
   const flushToStore = useCallback(
     (editor: TiptapEditor) => {
@@ -92,7 +108,12 @@ export function useTiptapFlush(options: TiptapFlushOptions): TiptapFlushHandle {
 
       isInternalChange.current = true;
       lastExternalContent.current = markdown;
-      setContent(markdown);
+      // Consume the edit signal: a flush with no user edit behind it is pure
+      // re-serialization and must not dirty the document (auto-save flushes
+      // every tick before it reads isDirty).
+      const fromUserEdit = userEditPending.current;
+      userEditPending.current = false;
+      setContent(markdown, { fromUserEdit });
 
       // Cancel previous RAF if pending, then schedule reset
       if (internalChangeRaf.current) {
@@ -108,6 +129,10 @@ export function useTiptapFlush(options: TiptapFlushOptions): TiptapFlushHandle {
 
   const scheduleFlush = useCallback(
     (editor: TiptapEditor) => {
+      // Only onUpdate schedules a flush, and it has already filtered out
+      // programmatic transactions — so reaching here means the user edited.
+      userEditPending.current = true;
+
       // Cancel any pending flush
       if (pendingRaf.current) {
         cancelAnimationFrame(pendingRaf.current);

--- a/src/hooks/useDocumentState.ts
+++ b/src/hooks/useDocumentState.ts
@@ -28,6 +28,7 @@ import {
   useDocumentStore,
   type CursorInfo,
   type DocumentState,
+  type SetContentOptions,
 } from "../stores/documentStore";
 import { useTabStore } from "../stores/tabStore";
 
@@ -138,10 +139,10 @@ export function useDocumentActions(ownTabId?: string | null) {
   }, [getActiveTabId]);
 
   const setContent = useCallback(
-    (content: string) => {
+    (content: string, options?: SetContentOptions) => {
       const tabId = getActiveTabId();
       if (tabId) {
-        useDocumentStore.getState().setContent(tabId, content);
+        useDocumentStore.getState().setContent(tabId, content, options);
       }
     },
     [getActiveTabId]

--- a/src/services/workspaces/workspaceSession.test.ts
+++ b/src/services/workspaces/workspaceSession.test.ts
@@ -399,4 +399,78 @@ describe("persistWorkspaceSession — rail mode (WI-6R)", () => {
       "/repo-a/two.md", // the second instance's tab is not lost
     ]);
   });
+
+  // #1187 — this writer is the ONLY one that mints a config without going
+  // through the store's normalizer, so it is the only place an
+  // excludeFolders-less config could ever reach disk.
+  describe("exclude-folder defaults for a root with no config on disk", () => {
+    function diskReturns(value: WorkspaceConfig | null): void {
+      invokeMock.mockImplementation(async (cmd: string) => {
+        if (cmd === "read_workspace_config") return value;
+        return undefined;
+      });
+    }
+
+    beforeEach(() => {
+      useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+      addWorkspace("wsi-new", "/fresh-repo");
+      useWorkspaceInstancesStore.getState().activateWorkspaceInstance(WINDOW_LABEL, "wsi-new");
+      useTabStore.getState().createTab(WINDOW_LABEL, "/fresh-repo/one.md");
+    });
+
+    it("mints the default excludes — never an empty list", async () => {
+      diskReturns(null);
+
+      await persistWorkspaceSession(WINDOW_LABEL);
+
+      const write = writesOf().find((w) => w.rootPath === "/fresh-repo")!;
+      expect(write.config.excludeFolders).toEqual([".git", "node_modules"]);
+    });
+
+    it("repairs a config a previous build auto-created with empty excludes", async () => {
+      diskReturns({
+        version: 1,
+        excludeFolders: [],
+        lastOpenTabs: [],
+        showHiddenFiles: false,
+        showAllFiles: false,
+      } as WorkspaceConfig);
+
+      await persistWorkspaceSession(WINDOW_LABEL);
+
+      const write = writesOf().find((w) => w.rootPath === "/fresh-repo")!;
+      expect(write.config.excludeFolders).toEqual([".git", "node_modules"]);
+    });
+
+    it("keeps an empty list the user cleared deliberately (identity present)", async () => {
+      diskReturns({
+        version: 1,
+        excludeFolders: [],
+        lastOpenTabs: [],
+        showHiddenFiles: false,
+        showAllFiles: false,
+        identity: { id: "disk-id", createdAt: 1, trustLevel: "untrusted", trustedAt: null },
+      } as WorkspaceConfig);
+
+      await persistWorkspaceSession(WINDOW_LABEL);
+
+      const write = writesOf().find((w) => w.rootPath === "/fresh-repo")!;
+      expect(write.config.excludeFolders).toEqual([]);
+    });
+
+    it("leaves a configured exclude list alone", async () => {
+      diskReturns({
+        version: 1,
+        excludeFolders: ["dist"],
+        lastOpenTabs: [],
+        showHiddenFiles: false,
+        showAllFiles: false,
+      } as WorkspaceConfig);
+
+      await persistWorkspaceSession(WINDOW_LABEL);
+
+      const write = writesOf().find((w) => w.rootPath === "/fresh-repo")!;
+      expect(write.config.excludeFolders).toEqual(["dist"]);
+    });
+  });
 });

--- a/src/services/workspaces/workspaceSession.ts
+++ b/src/services/workspaces/workspaceSession.ts
@@ -16,6 +16,12 @@
  * Split layouts (WI-10.3): the ACTIVE instance persists its live split; a
  * HIDDEN instance persists its stashed snapshot — each keyed by its own root.
  *
+ * Exclude defaults (#1187): this is the only config writer that does NOT go
+ * through the store's normalizer, so the config it mints for a root with none
+ * on disk — and the on-disk one it rewrites — run through
+ * repairAutoCreatedExcludeFolders here, or nothing ever restores them.
+ *
+ * @coordinates-with stores/workspaceConfigDefaults.ts — the exclude-defaults repair
  * @coordinates-with workspaceStore.ts — reads rootPath and config (rail off)
  * @coordinates-with useWindowClose.ts — calls persistWorkspaceSession before close
  * @coordinates-with services/persistence/splitLayoutPersistence.ts — saves split layout
@@ -25,6 +31,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { workspaceError } from "@/utils/debug";
 import { useWorkspaceStore, type WorkspaceConfig } from "@/stores/workspaceStore";
+import { repairAutoCreatedExcludeFolders } from "@/stores/workspaceConfigDefaults";
 import { useTabStore, type Tab } from "@/stores/tabStore";
 import { tabFilePath } from "@/stores/tabStoreTypes";
 import { usePaneStore, type WindowSplit } from "@/stores/paneStore";
@@ -114,13 +121,19 @@ async function persistRailWorkspaceSessions(windowLabel: string): Promise<void> 
         workspaceError("Malformed on-disk config; skipping session write for", rootPath);
         continue;
       }
-      const base: WorkspaceConfig = disk ?? {
-        version: 1,
-        excludeFolders: [],
-        lastOpenTabs: [],
-        showHiddenFiles: false,
-        showAllFiles: false,
-      };
+      // This is the one config writer that does NOT go through the store's
+      // normalizer, so both the minted shape and the on-disk one it rewrites
+      // need the exclude defaults applied here or nothing ever restores them
+      // (#1187).
+      const base: WorkspaceConfig = repairAutoCreatedExcludeFolders(
+        disk ?? {
+          version: 1,
+          excludeFolders: [],
+          lastOpenTabs: [],
+          showHiddenFiles: false,
+          showAllFiles: false,
+        },
+      );
       await invoke("write_workspace_config", {
         rootPath,
         config: {

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -36,6 +36,7 @@ export {
   setTabExistenceGuard,
   type DocumentState,
   type CursorInfo,
+  type SetContentOptions,
 } from "./documentStore/document";
 export { useFileLoadStore } from "./documentStore/fileLoad";
 export { useLargeFileSessionStore } from "./documentStore/largeFileSession";

--- a/src/stores/documentStore/__tests__/serializationSyncDirty.test.ts
+++ b/src/stores/documentStore/__tests__/serializationSyncDirty.test.ts
@@ -1,0 +1,112 @@
+/**
+ * A serialization sync must never manufacture dirty state.
+ *
+ * Regression guard for the "opening a file rewrites it" bug: auto-save calls
+ * `flushActiveWysiwygNow()` BEFORE testing `isDirty`, and that flush
+ * re-serializes the live ProseMirror doc into the store. Because the
+ * serializer's canonical output is not byte-identical to arbitrary on-disk
+ * markdown (blank-line runs collapse when `preserveBlankLines` is off, HTML
+ * blocks gain surrounding blank lines, a trailing newline is appended), the
+ * flush made `content !== savedContent` and `setContent` marked the document
+ * dirty. Auto-save then saved a file the user had only ever OPENED — verified
+ * live: a fresh file was rewritten ~6s after opening, with no edit and with no
+ * dirty indicator ever shown.
+ *
+ * The fix separates the two meanings `isDirty` had been carrying — "the user
+ * changed this document" vs. "the serialized bytes differ from disk". A flush
+ * that is not driven by a user edit reports `fromUserEdit: false` and may
+ * neither create nor clear dirt.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { useDocumentStore } from "../document";
+import { useRevisionStore } from "../revision";
+
+const TAB = "tab-serialization-sync";
+
+/** What the file holds on disk. */
+const DISK = "# Title\n\n\n\nBody.\n\n<!-- marker -->\nRef\n<!-- /marker -->\n\nEnd.";
+/** What the WYSIWYG serializer emits for that same document, unedited. */
+const NORMALIZED = "# Title\n\nBody.\n\n<!-- marker -->\n\nRef\n\n<!-- /marker -->\n\nEnd.\n";
+
+function doc() {
+  return useDocumentStore.getState().documents[TAB];
+}
+
+beforeEach(() => {
+  useDocumentStore.setState({ documents: {} });
+});
+
+describe("serialization sync (fromUserEdit: false)", () => {
+  it("does not dirty a document the user never edited", () => {
+    useDocumentStore.getState().initDocument(TAB, DISK, "/a.md");
+    expect(doc().isDirty).toBe(false);
+
+    useDocumentStore.getState().setContent(TAB, NORMALIZED, { fromUserEdit: false });
+
+    expect(doc().isDirty).toBe(false);
+    expect(doc().content).toBe(NORMALIZED);
+  });
+
+  it("still records the serialized content so a later save writes the live doc", () => {
+    useDocumentStore.getState().initDocument(TAB, DISK, "/a.md");
+    useDocumentStore.getState().setContent(TAB, NORMALIZED, { fromUserEdit: false });
+    expect(doc().content).toBe(NORMALIZED);
+  });
+
+  it("does not CLEAR dirt on a document the user did edit", () => {
+    useDocumentStore.getState().initDocument(TAB, DISK, "/a.md");
+    useDocumentStore.getState().setContent(TAB, `${DISK} edited`);
+    expect(doc().isDirty).toBe(true);
+
+    // Auto-save's flush lands after a real edit — the dirt must survive it,
+    // otherwise the edit would never be written.
+    useDocumentStore.getState().setContent(TAB, `${NORMALIZED} edited`, { fromUserEdit: false });
+
+    expect(doc().isDirty).toBe(true);
+  });
+
+  it("does not bump the revision — a sync is not a document change", () => {
+    useDocumentStore.getState().initDocument(TAB, DISK, "/a.md");
+    const before = useRevisionStore.getState().getRevision(TAB);
+
+    useDocumentStore.getState().setContent(TAB, NORMALIZED, { fromUserEdit: false });
+
+    expect(useRevisionStore.getState().getRevision(TAB)).toBe(before);
+  });
+
+  it("is idempotent across repeated auto-save cycles", () => {
+    useDocumentStore.getState().initDocument(TAB, DISK, "/a.md");
+    for (let i = 0; i < 5; i++) {
+      useDocumentStore.getState().setContent(TAB, NORMALIZED, { fromUserEdit: false });
+    }
+    expect(doc().isDirty).toBe(false);
+  });
+});
+
+describe("user edits (default) keep their existing behavior", () => {
+  it("dirties when content differs from the saved bytes", () => {
+    useDocumentStore.getState().initDocument(TAB, DISK, "/a.md");
+    useDocumentStore.getState().setContent(TAB, `${DISK}!`);
+    expect(doc().isDirty).toBe(true);
+  });
+
+  it("an explicit fromUserEdit: true dirties even from the normalized form", () => {
+    useDocumentStore.getState().initDocument(TAB, DISK, "/a.md");
+    useDocumentStore.getState().setContent(TAB, NORMALIZED, { fromUserEdit: true });
+    expect(doc().isDirty).toBe(true);
+  });
+
+  it("returns to clean when the user restores the saved content", () => {
+    useDocumentStore.getState().initDocument(TAB, DISK, "/a.md");
+    useDocumentStore.getState().setContent(TAB, `${DISK}!`);
+    useDocumentStore.getState().setContent(TAB, DISK);
+    expect(doc().isDirty).toBe(false);
+  });
+
+  it("bumps the revision", () => {
+    useDocumentStore.getState().initDocument(TAB, DISK, "/a.md");
+    const before = useRevisionStore.getState().getRevision(TAB);
+    useDocumentStore.getState().setContent(TAB, `${DISK}!`);
+    expect(useRevisionStore.getState().getRevision(TAB)).not.toBe(before);
+  });
+});

--- a/src/stores/documentStore/document.ts
+++ b/src/stores/documentStore/document.ts
@@ -28,13 +28,27 @@ import { useRevisionStore } from "./revision";
 export type { CursorInfo } from "@/types/cursorSync";
 export type { DocumentState } from "./documentState";
 
+/** Options for {@link DocumentStore.setContent}. */
+export interface SetContentOptions {
+  /**
+   * Whether this write carries a change the USER made. Default true.
+   *
+   * The WYSIWYG flush passes `false` when it is only re-serializing a document
+   * nobody edited. That distinction is load-bearing: the serializer's canonical
+   * output is not byte-identical to arbitrary on-disk markdown, so treating
+   * such a flush as an edit made auto-save (which flushes BEFORE testing
+   * `isDirty`) rewrite files the user had merely opened.
+   */
+  fromUserEdit?: boolean;
+}
+
 interface DocumentStore {
   // Documents keyed by tab ID (changed from window label)
   documents: Record<string, DocumentState>;
 
   // Actions - now take tabId instead of windowLabel
   initDocument: (tabId: string, content?: string, filePath?: string | null, savedContent?: string) => void;
-  setContent: (tabId: string, content: string) => void;
+  setContent: (tabId: string, content: string, options?: SetContentOptions) => void;
   loadContent: (
     tabId: string,
     content: string,
@@ -145,15 +159,21 @@ export const useDocumentStore = create<DocumentStore>((set, get) => ({
     }));
   },
 
-  setContent: (tabId, content) => {
+  setContent: (tabId, content, options) => {
+    const fromUserEdit = options?.fromUserEdit ?? true;
     const previous = get().documents[tabId]?.content;
     set((state) =>
       updateDoc(state, tabId, (doc) => ({
         content,
-        isDirty: doc.savedContent !== content,
+        // A serialization sync is not a change: it may neither create dirt on a
+        // document nobody edited nor clear dirt on one that was edited (an
+        // auto-save flush can land before the debounced edit-flush).
+        isDirty: fromUserEdit ? doc.savedContent !== content : doc.isDirty,
       }))
     );
-    bumpRevisionIfContentChanged(tabId, previous, content);
+    // Same reasoning for the revision token: a re-serialization is not an edit,
+    // so it must not make an MCP client's held revision look STALE.
+    if (fromUserEdit) bumpRevisionIfContentChanged(tabId, previous, content);
   },
 
   loadContent: (tabId, content, filePath, meta) => {

--- a/src/stores/workspaceConfigDefaults.test.ts
+++ b/src/stores/workspaceConfigDefaults.test.ts
@@ -1,0 +1,130 @@
+// Regression cover for #1187 — a brand-new workspace's config was minted with
+// an EMPTY excludeFolders, so the file explorer walked node_modules/.git.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  DEFAULT_EXCLUDED_FOLDERS,
+  normalizeWorkspaceConfig,
+  repairAutoCreatedExcludeFolders,
+} from "./workspaceConfigDefaults";
+import type { WorkspaceConfig } from "./workspaceStore";
+
+vi.mock("@/utils/workspaceIdentity", () => ({
+  createWorkspaceIdentity: vi.fn(() => ({
+    id: "mock-uuid-1234",
+    createdAt: 1700000000000,
+    trustLevel: "untrusted",
+    trustedAt: null,
+  })),
+}));
+
+const IDENTITY = {
+  id: "disk-id",
+  createdAt: 1,
+  trustLevel: "untrusted" as const,
+  trustedAt: null,
+};
+
+function config(overrides: Partial<WorkspaceConfig> = {}): WorkspaceConfig {
+  return {
+    version: 1,
+    excludeFolders: [],
+    lastOpenTabs: [],
+    showHiddenFiles: false,
+    showAllFiles: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("repairAutoCreatedExcludeFolders", () => {
+  it("restores the defaults for an identity-less empty exclude list", () => {
+    const repaired = repairAutoCreatedExcludeFolders(config());
+    expect(repaired.excludeFolders).toEqual(DEFAULT_EXCLUDED_FOLDERS);
+  });
+
+  it("leaves an empty list the user cleared deliberately (identity present)", () => {
+    const repaired = repairAutoCreatedExcludeFolders(config({ identity: IDENTITY }));
+    expect(repaired.excludeFolders).toEqual([]);
+  });
+
+  it("never overwrites a non-empty exclude list", () => {
+    expect(
+      repairAutoCreatedExcludeFolders(config({ excludeFolders: ["dist"] })).excludeFolders,
+    ).toEqual(["dist"]);
+    expect(
+      repairAutoCreatedExcludeFolders(
+        config({ excludeFolders: ["dist"], identity: IDENTITY }),
+      ).excludeFolders,
+    ).toEqual(["dist"]);
+  });
+
+  it("preserves every other field untouched", () => {
+    const input = config({ showHiddenFiles: true, lastOpenTabs: ["/a.md"] });
+    const repaired = repairAutoCreatedExcludeFolders(input);
+    expect(repaired.showHiddenFiles).toBe(true);
+    expect(repaired.lastOpenTabs).toEqual(["/a.md"]);
+    expect(repaired.version).toBe(1);
+  });
+
+  it("does not mint an identity — that stays normalizeWorkspaceConfig's job", () => {
+    expect(repairAutoCreatedExcludeFolders(config()).identity).toBeUndefined();
+  });
+
+  it("is idempotent: a repaired config is no longer a repair candidate", () => {
+    const once = repairAutoCreatedExcludeFolders(config());
+    const twice = repairAutoCreatedExcludeFolders(once);
+    expect(twice.excludeFolders).toEqual(DEFAULT_EXCLUDED_FOLDERS);
+  });
+
+  it("does not hand back the shared DEFAULT_EXCLUDED_FOLDERS array", () => {
+    const repaired = repairAutoCreatedExcludeFolders(config());
+    expect(repaired.excludeFolders).not.toBe(DEFAULT_EXCLUDED_FOLDERS);
+    repaired.excludeFolders.push("mutated");
+    expect(DEFAULT_EXCLUDED_FOLDERS).not.toContain("mutated");
+  });
+
+  it("does not mutate the caller's config", () => {
+    const input = config();
+    repairAutoCreatedExcludeFolders(input);
+    expect(input.excludeFolders).toEqual([]);
+  });
+});
+
+describe("normalizeWorkspaceConfig", () => {
+  it("uses the defaults when there is no config at all", () => {
+    expect(normalizeWorkspaceConfig(null).excludeFolders).toEqual(DEFAULT_EXCLUDED_FOLDERS);
+    expect(normalizeWorkspaceConfig().excludeFolders).toEqual(DEFAULT_EXCLUDED_FOLDERS);
+  });
+
+  it("repairs an auto-created empty exclude list", () => {
+    expect(normalizeWorkspaceConfig(config()).excludeFolders).toEqual(DEFAULT_EXCLUDED_FOLDERS);
+  });
+
+  it("keeps a deliberately cleared list", () => {
+    expect(normalizeWorkspaceConfig(config({ identity: IDENTITY })).excludeFolders).toEqual([]);
+  });
+
+  it("keeps a custom exclude list", () => {
+    expect(normalizeWorkspaceConfig(config({ excludeFolders: ["custom"] })).excludeFolders).toEqual([
+      "custom",
+    ]);
+  });
+
+  it("mints an identity when the config has none", () => {
+    expect(normalizeWorkspaceConfig(config()).identity?.id).toBe("mock-uuid-1234");
+  });
+
+  it("preserves an existing identity", () => {
+    expect(normalizeWorkspaceConfig(config({ identity: IDENTITY })).identity?.id).toBe("disk-id");
+  });
+
+  it("never aliases the module default or the caller's arrays", () => {
+    const callerOwned = ["dist"];
+    const normalized = normalizeWorkspaceConfig(config({ excludeFolders: callerOwned }));
+    expect(normalized.excludeFolders).not.toBe(callerOwned);
+    expect(normalizeWorkspaceConfig(null).excludeFolders).not.toBe(DEFAULT_EXCLUDED_FOLDERS);
+  });
+});

--- a/src/stores/workspaceConfigDefaults.ts
+++ b/src/stores/workspaceConfigDefaults.ts
@@ -1,0 +1,84 @@
+/**
+ * Workspace config shape, defaults, and the auto-created-config repair.
+ *
+ * Purpose: one normalizer every entry point runs, so a config reaching live
+ * state always has defaults filled in, an identity present (trust gating reads
+ * it), and no array aliased with the module defaults or the caller.
+ *
+ * Key decisions:
+ *   - Extracted from workspaceStore.ts so the store file holds state only.
+ *   - `excludeFolders: []` from an app-minted config is repaired, not honored.
+ *     See repairAutoCreatedExcludeFolders for why that is safe.
+ *
+ * @coordinates-with workspaceStore.ts — runs this on openWorkspace/bootstrapConfig
+ * @coordinates-with services/workspaces/workspaceSession.ts — repairs the on-disk config it rewrites
+ * @module stores/workspaceConfigDefaults
+ */
+import { createWorkspaceIdentity, type WorkspaceIdentity } from "@/utils/workspaceIdentity";
+import type { SessionTabsV1 } from "@/services/persistence/sessionTabs";
+
+/** Workspace configuration — excluded folders, session restore tabs, file visibility, and trust identity. */
+export interface WorkspaceConfig {
+  version: 1;
+  excludeFolders: string[];
+  lastOpenTabs: string[]; // Doc paths for session restore (legacy; kept for older builds)
+  /** WI-1.1 — full ordered tab list (documents + browser tabs). Written by
+   *  workspaceSession.ts, read back by sessionTabs.ts; the Rust side keeps it
+   *  as an opaque JSON value, so the schema lives on this side. */
+  sessionTabs?: SessionTabsV1;
+  showHiddenFiles: boolean;
+  showAllFiles: boolean; // Show non-markdown files in the file explorer
+  ai?: Record<string, unknown>; // Future AI settings
+  identity?: WorkspaceIdentity; // Workspace identity and trust info
+}
+
+export const DEFAULT_EXCLUDED_FOLDERS = [".git", "node_modules"];
+
+/**
+ * Restore the default excludes on a config the APP minted without any (#1187).
+ *
+ * v0.9.21–v0.9.23 let workspaceSession mint a brand-new workspace's config with
+ * an empty `excludeFolders`, and nothing healed it afterwards: the store's
+ * `?? DEFAULT_EXCLUDED_FOLDERS` only fires when the field is nullish, and `[]`
+ * is not. The file explorer then walked `node_modules` and `.git` on every load
+ * and every fs event — 4055 directories instead of 65 in the workspace that
+ * surfaced this — leaving the tree stale or empty, so folders would not expand
+ * and files would not open.
+ *
+ * A user who deliberately clears the list is left alone: every user-initiated
+ * write goes through the store, which mints an identity into each config it
+ * normalizes, so "empty AND identity-less" matches only the app-minted shape.
+ * Repairing is idempotent — the result is non-empty and no longer a candidate.
+ */
+export function repairAutoCreatedExcludeFolders(config: WorkspaceConfig): WorkspaceConfig {
+  const wasAutoCreated = config.identity === undefined && config.excludeFolders.length === 0;
+  if (!wasAutoCreated) return config;
+  return { ...config, excludeFolders: [...DEFAULT_EXCLUDED_FOLDERS] };
+}
+
+/**
+ * Bring any config (from disk, from a caller, or none at all) to the shape the
+ * store guarantees: defaults filled in, an identity present, and no array
+ * shared with the module defaults or the caller — live state that aliases
+ * `DEFAULT_EXCLUDED_FOLDERS` would let one in-place mutation corrupt every
+ * future workspace.
+ *
+ * Both entry points (openWorkspace, bootstrapConfig) run this, so a
+ * bootstrapped workspace can't end up without the identity an opened one
+ * always gets.
+ */
+export function normalizeWorkspaceConfig(config?: WorkspaceConfig | null): WorkspaceConfig {
+  const source: Partial<WorkspaceConfig> = config ?? {};
+  const merged: WorkspaceConfig = {
+    version: 1,
+    showHiddenFiles: false,
+    showAllFiles: false,
+    ...source,
+    excludeFolders: [...(source.excludeFolders ?? DEFAULT_EXCLUDED_FOLDERS)],
+    lastOpenTabs: [...(source.lastOpenTabs ?? [])],
+  };
+  // Repair BEFORE minting the identity below — that mint would otherwise mask
+  // the very absence that identifies an app-created config.
+  const repaired = repairAutoCreatedExcludeFolders(merged);
+  return { ...repaired, identity: repaired.identity ?? createWorkspaceIdentity() };
+}

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -10,16 +10,18 @@
  *     calls setCurrentWindowLabel() then rehydrate() at mount time.
  *   - Workspace identity (UUID + trust) enables future features like
  *     workspace-scoped AI settings and security gating.
- *   - Default excluded folders (.git, node_modules) are merged on open
- *     to ensure new defaults propagate to existing workspaces. openWorkspace
- *     and bootstrapConfig share ONE normalizer (defaults, identity, array
- *     copies), so a disk config lands in the same shape as a caller's.
+ *   - The config shape, its defaults and the normalizer live in
+ *     workspaceConfigDefaults.ts. openWorkspace and bootstrapConfig share that
+ *     ONE normalizer (defaults, identity, array copies, and the #1187 repair
+ *     of app-created empty excludes), so a disk config lands in the same
+ *     shape as a caller's.
  *
  * Known limitations:
  *   - Config is stored in localStorage (via windowScopedStorage), not on
  *     disk — workspace settings don't transfer between machines.
  *   - No workspace indexing or search — only folder exclusion.
  *
+ * @coordinates-with workspaceConfigDefaults.ts — config shape, defaults, normalizer
  * @coordinates-with tabStore.ts — lastOpenTabs drives session restore
  * @coordinates-with useWorkspaceBootstrap.ts — loads config from Tauri on startup
  * @coordinates-with recentsStore.ts — recent files/workspaces (re-exported here)
@@ -34,25 +36,15 @@ import {
   grantTrust,
   revokeTrust,
   isTrusted,
-  type WorkspaceIdentity,
 } from "@/utils/workspaceIdentity";
 import { windowScopedStorage } from "@/services/persistence/workspaceStorage";
-import type { SessionTabsV1 } from "@/services/persistence/sessionTabs";
+import {
+  DEFAULT_EXCLUDED_FOLDERS,
+  normalizeWorkspaceConfig,
+  type WorkspaceConfig,
+} from "./workspaceConfigDefaults";
 
-/** Workspace configuration — excluded folders, session restore tabs, file visibility, and trust identity. */
-export interface WorkspaceConfig {
-  version: 1;
-  excludeFolders: string[];
-  lastOpenTabs: string[]; // Doc paths for session restore (legacy; kept for older builds)
-  /** WI-1.1 — full ordered tab list (documents + browser tabs). Written by
-   *  workspaceSession.ts, read back by sessionTabs.ts; the Rust side keeps it
-   *  as an opaque JSON value, so the schema lives on this side. */
-  sessionTabs?: SessionTabsV1;
-  showHiddenFiles: boolean;
-  showAllFiles: boolean; // Show non-markdown files in the file explorer
-  ai?: Record<string, unknown>; // Future AI settings
-  identity?: WorkspaceIdentity; // Workspace identity and trust info
-}
+export type { WorkspaceConfig };
 
 // Runtime workspace state
 interface WorkspaceState {
@@ -83,31 +75,6 @@ interface WorkspaceActions {
   isPathExcluded: (path: string) => boolean;
   isWorkspaceTrusted: () => boolean;
   getWorkspaceId: () => string | null;
-}
-
-const DEFAULT_EXCLUDED_FOLDERS = [".git", "node_modules"];
-
-/**
- * Bring any config (from disk, from a caller, or none at all) to the shape the
- * store guarantees: defaults filled in, an identity present (trust gating reads
- * it), and no array shared with the module defaults or the caller — live state
- * that aliases `DEFAULT_EXCLUDED_FOLDERS` would let one in-place mutation
- * corrupt every future workspace.
- *
- * Both entry points (openWorkspace, bootstrapConfig) run this, so a bootstrapped
- * workspace can't end up without the identity an opened one always gets.
- */
-function normalizeWorkspaceConfig(config?: WorkspaceConfig | null): WorkspaceConfig {
-  const source: Partial<WorkspaceConfig> = config ?? {};
-  return {
-    version: 1,
-    showHiddenFiles: false,
-    showAllFiles: false,
-    ...source,
-    excludeFolders: [...(source.excludeFolders ?? DEFAULT_EXCLUDED_FOLDERS)],
-    lastOpenTabs: [...(source.lastOpenTabs ?? [])],
-    identity: source.identity ?? createWorkspaceIdentity(),
-  };
 }
 
 /** Manages workspace folder state — open/close, config, excluded folders, and trust. Use selectors, not destructuring. */


### PR DESCRIPTION
Patch release. Two data-integrity fixes plus the version bump.

## fix(workspace): restore default excludeFolders on app-created configs

Closes #1187.

A workspace opened for the first time got its config minted by the rail session
writer, whose literal set `excludeFolders: []`, and nothing healed it afterwards
— the store's `?? DEFAULT_EXCLUDED_FOLDERS` only fires when the field is
nullish, and `[]` is not. The file explorer then walked `node_modules` and
`.git` on every load and every fs event: 4055 directories instead of 65
(1254ms vs 30ms) in the workspace that surfaced this, leaving the tree stale or
empty, so folders would not expand and files would not open.

The session writer is the only config writer that bypasses the store's
normalizer, so both the shape it mints and the on-disk config it rewrites now
run through the repair. Existing broken configs heal lazily — in memory on the
next open, on disk at the next session write. A deliberately cleared list is
preserved: user-initiated writes go through the store, which mints an identity
into every config it normalizes, so "empty AND identity-less" matches only the
app-minted shape.

## fix(save): a serialization sync must not dirty an unedited document

Opening a file and touching nothing rewrote it on disk. Auto-save calls
`flushActiveWysiwygNow()` **before** it reads `isDirty`, and that flush
re-serializes the live ProseMirror doc into the store. The serializer's
canonical output is never byte-identical to arbitrary on-disk markdown, so
`setContent` marked the document dirty and auto-save saved a file the user had
only opened.

`isDirty` was carrying two meanings — "the user changed this" and "the bytes
differ from disk". Only the first may authorize a write. `setContent` now takes
`fromUserEdit` (default `true`, so every existing caller is unchanged); the
flush learns which it is from `scheduleFlush`, whose sole caller is the editor's
`onUpdate`. A sync cannot *clear* dirt either, so an edit whose debounce has not
fired when auto-save flushes is still saved.

## Verification

`pnpm check:all` green (25,680 tests). Both fixes verified live against the
reproductions:

| Check | Before | After |
|---|---|---|
| Open a file, touch nothing | rewritten in 6-8s | unchanged after 75s (2+ auto-save cycles) |
| Make a real edit | saved | saved in 3s, dirty flag and revision correct |
| Open affected workspace | tree stale/empty, folders dead | tree loads, folders expand, `node_modules`/`.git` excluded |