### PR TITLE
fix(explorer): the render loop that made every mouse click impossible (#1187)

### DIFF
--- a/scripts/bespoke-buttons-baseline.json
+++ b/scripts/bespoke-buttons-baseline.json
@@ -1,4 +1,7 @@
 {
-  "//": "Hand-rolled button classes in src/**/*.css, excluding the canonical .vm-btn / .popup-icon-btn / .universal-toolbar-btn. RATCHETS DOWN ONLY — never raise this number. To lower it, migrate a component to `.vm-btn` (src/styles/button-shared.css) and delete its bespoke class. Enforced by scripts/check-bespoke-buttons.mjs (pnpm lint:bespoke-buttons, in check:all).",
-  "maxBespokeButtonClasses": 88
+  "//": "Two budgets, both RATCHET DOWN ONLY — never raise either. To lower one, migrate a component to `.vm-btn` (src/styles/button-shared.css) and delete its bespoke class. Enforced by scripts/check-bespoke-buttons.mjs (pnpm lint:bespoke-buttons, in check:all).",
+  "//maxBespokeButtonClasses": "By NAME: classes defined in src/**/*.css whose name contains btn/button, excluding the canonical .vm-btn / .popup-icon-btn / .universal-toolbar-btn.",
+  "maxBespokeButtonClasses": 88,
+  "//maxStyledButtonClasses": "By USAGE: classes applied to a <button> in src/**/*.tsx whose CSS re-derives a button surface (padding plus a border or background). Added because the name check was evadable by naming — `.workspace-approval-approve` styled a real button with its own padding, radius and border and was never counted, so the budget read 88/88 while the drift the gate exists to catch was happening. 61 of these 80 are invisible to the name check. This is a NEW measurement of a previously unmeasured surface, NOT a raised budget.",
+  "maxStyledButtonClasses": 80
 }

--- a/scripts/check-bespoke-buttons.mjs
+++ b/scripts/check-bespoke-buttons.mjs
@@ -11,10 +11,16 @@
  * that *a* token was used, never that the right one was, or that the control
  * should have existed at all.
  *
- * This counts bespoke button-ish class DEFINITIONS in src/**\/*.css and pins the
- * number in a committed baseline that may only go DOWN. Writing another
- * `__btn` class fails the gate; so does letting the baseline go stale after a
- * migration. Use `.vm-btn` (src/styles/button-shared.css) instead.
+ * TWO budgets, each pinned in a committed baseline that may only go DOWN.
+ * Writing another bespoke button fails the gate; so does letting a baseline go
+ * stale after a migration. Use `.vm-btn` (src/styles/button-shared.css).
+ *
+ *   1. BY NAME — button-ish class DEFINITIONS in src/**\/*.css.
+ *   2. BY USAGE — classes applied to a `<button>` whose CSS re-derives a button
+ *      surface. The name check alone was evadable: `.workspace-approval-approve`
+ *      styled a real button and contained neither "btn" nor "button", so it was
+ *      never counted and the budget read 88/88 while drift was happening. 61 of
+ *      the 80 it finds are invisible to check 1.
  *
  * Not counted (canonical, and legitimately distinct shapes):
  *   - .vm-btn / .vm-btn--*        the primitive itself
@@ -36,13 +42,82 @@ const CANONICAL = /^\.(vm-btn|popup-icon-btn|universal-toolbar-btn)(--[a-z0-9-]+
 const BUTTON_CLASS_RE = /^\s*(\.[a-z][a-z0-9_-]*(?:btn|button)[a-z0-9_-]*)\s*(?=[,{:])/gim;
 
 function walkCss(dir, out = []) {
+  return walkExt(dir, ".css", out);
+}
+
+/** Every file under `dir` with the given extension, tests excluded. */
+function walkExt(dir, ext, out = []) {
   for (const entry of readdirSync(dir)) {
     const p = join(dir, entry);
     const st = statSync(p);
-    if (st.isDirectory()) walkCss(p, out);
-    else if (entry.endsWith(".css")) out.push(p);
+    if (st.isDirectory()) walkExt(p, ext, out);
+    else if (entry.endsWith(ext) && !entry.includes(".test.")) out.push(p);
   }
   return out;
+}
+
+/** Classes applied to a literal `<button>` element in TSX. */
+const BUTTON_EL_RE =
+  /<button\b[^>]*?className=(?:"([^"]*)"|\{`([^`]*)`\}|\{"([^"]*)"\})/gs;
+/** Canonical names as they appear in JSX (no leading dot). */
+const CANONICAL_BARE = /^(vm-btn|popup-icon-btn|universal-toolbar-btn)(--[a-z0-9-]+)?$/;
+/** Every `selector { body }` pair; good enough for flat component CSS. */
+const CSS_RULE_RE = /([^{}]+)\{([^{}]*)\}/g;
+
+/**
+ * Does this rule body re-derive a button SURFACE (rather than just position or
+ * colour something)? Padding plus a border or background is the shape every
+ * hand-rolled button in this repo had.
+ */
+function stylesButtonSurface(body) {
+  return /(?:^|[;{\s])padding\b/.test(body) && /(?:^|[;{\s])(?:border|background)\b/.test(body);
+}
+
+/**
+ * Bespoke button classes found by USAGE rather than by name.
+ *
+ * The name-based collector above only sees classes containing "btn"/"button",
+ * so `.workspace-approval-approve` — which styled a real button with its own
+ * padding, radius and border — was invisible to the budget. This keys on the
+ * pairing that actually defines the problem: a class applied to a `<button>`
+ * whose CSS re-derives a button surface. A class cannot evade it by naming.
+ *
+ * Known limits, deliberate: only literal `className` strings and template
+ * literals are read (not `clsx()`/computed names), and only literal `<button>`
+ * elements (not components that render one). It under-counts rather than
+ * inventing violations.
+ */
+export function collectStyledButtonClasses(
+  tsxFiles,
+  cssFiles,
+  readFile = (p) => readFileSync(p, "utf8"),
+) {
+  const appliedToButton = new Map(); // class -> first file that applies it
+  for (const file of tsxFiles) {
+    for (const m of readFile(file).matchAll(BUTTON_EL_RE)) {
+      const raw = m[1] ?? m[2] ?? m[3] ?? "";
+      for (const cls of raw.match(/[a-zA-Z_][\w-]*/g) ?? []) {
+        if (!appliedToButton.has(cls)) appliedToButton.set(cls, file);
+      }
+    }
+  }
+
+  const bodyByClass = new Map(); // class -> concatenated declarations
+  for (const file of cssFiles) {
+    for (const rule of readFile(file).matchAll(CSS_RULE_RE)) {
+      for (const cls of rule[1].matchAll(/\.([a-zA-Z_][\w-]*)/g)) {
+        bodyByClass.set(cls[1], (bodyByClass.get(cls[1]) ?? "") + rule[2]);
+      }
+    }
+  }
+
+  const found = new Map();
+  for (const [cls, file] of appliedToButton) {
+    if (CANONICAL_BARE.test(cls)) continue;
+    const body = bodyByClass.get(cls);
+    if (body && stylesButtonSurface(body)) found.set(cls, file);
+  }
+  return found;
 }
 
 /** Distinct bespoke button class names defined across the given CSS sources. */
@@ -96,5 +171,36 @@ if (process.argv[1] && process.argv[1].endsWith("check-bespoke-buttons.mjs")) {
     process.exit(1);
   }
 
-  console.log(`✅ Bespoke-button budget held (${actual}/${limit}).`);
+  // Second, usage-based budget: classes applied to a <button> whose CSS
+  // re-derives a button surface. Naming cannot evade this one.
+  const styledLimit = baseline.maxStyledButtonClasses;
+  if (!Number.isInteger(styledLimit)) {
+    console.error(`❌ ${BASELINE_PATH} needs an integer \`maxStyledButtonClasses\`.`);
+    process.exit(1);
+  }
+
+  const styled = collectStyledButtonClasses(walkExt(SRC_DIR, ".tsx"), walkCss(SRC_DIR));
+  const styledActual = styled.size;
+
+  if (styledActual > styledLimit) {
+    const sample = [...styled.entries()].slice(0, 10).map(([c, f]) => `  .${c}  (${f})`);
+    console.error(
+      `\n❌ ${styledActual} classes style a <button> without using the canonical primitive, budget is ${styledLimit}.\n\n` +
+        sample.join("\n") +
+        `\n\n   Do NOT raise the budget. Use \`.vm-btn\` from src/styles/button-shared.css.\n`
+    );
+    process.exit(1);
+  }
+
+  if (styledActual < styledLimit) {
+    console.error(
+      `\n❌ Budget is stale: ${styledActual} button-styling classes remain but the budget says ${styledLimit}.\n` +
+        `   Lower \`maxStyledButtonClasses\` to ${styledActual} in ${BASELINE_PATH} to lock the win in.\n`
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `✅ Bespoke-button budgets held (${actual}/${limit} by name, ${styledActual}/${styledLimit} by usage).`
+  );
 }

--- a/scripts/check-bespoke-buttons.test.ts
+++ b/scripts/check-bespoke-buttons.test.ts
@@ -6,7 +6,7 @@
  * the canonical classes, and does not fire on incidental mentions.
  */
 import { describe, it, expect } from "vitest";
-import { collectBespokeButtons } from "./check-bespoke-buttons.mjs";
+import { collectBespokeButtons, collectStyledButtonClasses } from "./check-bespoke-buttons.mjs";
 
 /** Run the collector over in-memory CSS instead of the filesystem. */
 function collect(sources: Record<string, string>) {
@@ -63,5 +63,90 @@ describe("collectBespokeButtons", () => {
     const after = collect({ "a.css": ".vm-btn { color: red; }\n.brand-new-btn { color: red; }" });
     expect(after.size).toBeGreaterThan(before.size);
     expect([...after.keys()]).toContain(".brand-new-btn");
+  });
+});
+
+/**
+ * The name-based collector above can only see classes whose NAME contains
+ * "btn" or "button". `.workspace-approval-approve` styled a real button and was
+ * invisible to it — the budget read 88/88 while the drift it exists to catch
+ * was happening. This second collector keys on USAGE instead: a class applied
+ * to a <button> element whose CSS re-derives a button surface (padding plus a
+ * border or background). Naming cannot evade it.
+ */
+function collectStyled(tsx: Record<string, string>, css: Record<string, string>) {
+  const all = { ...tsx, ...css };
+  return collectStyledButtonClasses(Object.keys(tsx), Object.keys(css), (p) => all[p]);
+}
+
+describe("collectStyledButtonClasses", () => {
+  const BUTTONISH = "{ padding: 4px 8px; border: 1px solid red; }";
+
+  it("catches a button class that the name regex cannot see", () => {
+    const found = collectStyled(
+      { "a.tsx": '<button className="workspace-approval-approve">ok</button>' },
+      { "a.css": `.workspace-approval-approve ${BUTTONISH}` },
+    );
+    expect([...found.keys()]).toEqual(["workspace-approval-approve"]);
+  });
+
+  it("skips the canonical primitives", () => {
+    const found = collectStyled(
+      { "a.tsx": '<button className="vm-btn vm-btn--primary">ok</button>' },
+      { "a.css": `.vm-btn ${BUTTONISH}\n.vm-btn--primary ${BUTTONISH}` },
+    );
+    expect([...found.keys()]).toEqual([]);
+  });
+
+  it("ignores classes that do not style a button surface", () => {
+    // Layout-only and state classes are not re-derived buttons.
+    const found = collectStyled(
+      { "a.tsx": '<button className="is-active toolbar-slot">ok</button>' },
+      { "a.css": ".is-active { color: red; }\n.toolbar-slot { display: flex; }" },
+    );
+    expect([...found.keys()]).toEqual([]);
+  });
+
+  it("ignores a styled class that is never applied to a button", () => {
+    const found = collectStyled(
+      { "a.tsx": '<div className="card-surface">x</div>' },
+      { "a.css": `.card-surface ${BUTTONISH}` },
+    );
+    expect([...found.keys()]).toEqual([]);
+  });
+
+  it("reads classes out of a template literal className", () => {
+    const found = collectStyled(
+      { "a.tsx": '<button className={`genie-chip ${active ? "on" : ""}`}>x</button>' },
+      { "a.css": `.genie-chip ${BUTTONISH}` },
+    );
+    expect([...found.keys()]).toEqual(["genie-chip"]);
+  });
+
+  it("counts a class once however many buttons use it", () => {
+    const found = collectStyled(
+      {
+        "a.tsx": '<button className="row-action">a</button>',
+        "b.tsx": '<button className="row-action">b</button>',
+      },
+      { "a.css": `.row-action ${BUTTONISH}` },
+    );
+    expect([...found.keys()]).toEqual(["row-action"]);
+  });
+
+  it("records where the class is used, for actionable output", () => {
+    const found = collectStyled(
+      { "x/y.tsx": '<button className="zed-action">x</button>' },
+      { "a.css": `.zed-action ${BUTTONISH}` },
+    );
+    expect(found.get("zed-action")).toBe("x/y.tsx");
+  });
+
+  it("counts a background-only surface too (no border)", () => {
+    const found = collectStyled(
+      { "a.tsx": '<button className="pill-thing">x</button>' },
+      { "a.css": ".pill-thing { padding: 2px 6px; background: blue; }" },
+    );
+    expect([...found.keys()]).toEqual(["pill-thing"]);
   });
 });

--- a/src/components/Sidebar/FileExplorer/FileExplorer.tsx
+++ b/src/components/Sidebar/FileExplorer/FileExplorer.tsx
@@ -8,7 +8,8 @@
  * User-visible strings are translated via the "sidebar" i18n namespace.
  *
  * User interactions:
- *   - Double-click or Enter to open a file in a tab
+ *   - Single click opens a file in a tab (react-arborist activates on click;
+ *     Enter starts inline rename instead, since onRename is wired)
  *   - Right-click for context menu (file/folder/empty area variants)
  *   - Drag-and-drop to move files between folders
  *   - Inline rename on F2 or via context menu
@@ -27,6 +28,7 @@
  *     snapshots uiStore at mount and mirrors toggles back.
  *   - Root element is a `navigation` ARIA landmark (labelled `aria.fileExplorer`).
  *
+ * @coordinates-with useTreeWiring.tsx — identity-stable Tree children/ref + measured height
  * @coordinates-with useFileTree.ts — loads directory tree and watches for fs changes
  * @coordinates-with useExplorerOperations.ts — CRUD operations on files and folders
  * @coordinates-with useFileExplorerOpenState.ts — persists folder open state across remounts
@@ -42,14 +44,13 @@ import { useFileTree } from "./useFileTree";
 import { useExplorerOperations } from "./useExplorerOperations";
 import { useFileExplorerOpenState, useExplorerWorkspaceInstance } from "./useFileExplorerOpenState";
 import { FileExplorerEmptyState, FileExplorerWorkspaceHeader } from "./FileExplorerEmptyState";
-import { FileNode } from "./FileNode";
 import {
   ContextMenu,
   type ContextMenuType,
   type ContextMenuPosition,
   type ContextMenuActionId,
 } from "./ContextMenu";
-import { useObservedHeight } from "./useObservedHeight";
+import { useTreeWiring } from "./useTreeWiring";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useWindowLabel } from "@/contexts/WindowContext";
 import { getFileName, getParentDir } from "@/utils/paths";
@@ -112,7 +113,6 @@ export const FileExplorer = forwardRef<FileExplorerHandle, FileExplorerProps>(
     targetIsFolder: false,
   });
   const treeRef = useRef<TreeApi<FileNodeType> | null>(null);
-  const [treeContainerRef, treeHeight] = useObservedHeight<HTMLDivElement>();
   const handleQuickLookKeyDown = useQuickLookHotkey(treeRef);
 
   // Workspace-only: no inferred root from file path
@@ -121,6 +121,8 @@ export const FileExplorer = forwardRef<FileExplorerHandle, FileExplorerProps>(
   // WI-9.2: with the rail on, folder/scroll state is per workspace instance.
   const workspaceInstanceId = useExplorerWorkspaceInstance(windowLabel);
   const treeElRef = useRef<HTMLDivElement | null>(null);
+  // Identity-stable Tree wiring — see useTreeWiring's header (#1187).
+  const { setTreeContainer, renderNode, treeHeight } = useTreeWiring(currentFilePath, treeElRef);
 
   // Persisted folder open state — preserved across sidebar view-mode switches
   // (react-arborist unmounts on viewMode change, losing internal state otherwise).
@@ -376,7 +378,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, FileExplorerProps>(
       <FileExplorerWorkspaceHeader name={isWorkspaceMode ? workspaceName : null} />
       <div
         className="file-explorer-tree"
-        ref={(el) => { treeContainerRef(el); treeElRef.current = el; }}
+        ref={setTreeContainer}
         onContextMenu={handleContextMenu}
         onKeyDown={handleQuickLookKeyDown}
         onScrollCapture={(e) => handleTreeScroll((e.target as HTMLElement).scrollTop)}
@@ -400,9 +402,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, FileExplorerProps>(
           disableDrop={false}
           disableEdit={false}
         >
-          {(props) => (
-            <FileNode {...props} currentFilePath={currentFilePath} />
-          )}
+          {renderNode}
         </Tree>
       </div>
 

--- a/src/components/Sidebar/FileExplorer/useObservedHeight.test.ts
+++ b/src/components/Sidebar/FileExplorer/useObservedHeight.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The measured height must not oscillate between two boxes.
+ *
+ * Regression guard for the file explorer's dead mouse clicks (issue #1187, and
+ * "clicking a file doesn't open it"). `.file-explorer-tree` has 4px vertical
+ * padding with box-sizing: border-box, and this hook measured TWO DIFFERENT
+ * boxes:
+ *   - the callback-ref path used getBoundingClientRect().height -> BORDER box (909)
+ *   - the ResizeObserver path used entries[0].contentRect.height -> CONTENT box (901)
+ *
+ * FileExplorer passes an INLINE composed callback ref, so React invokes it with
+ * null and then the element on EVERY render. Each invocation disconnects and
+ * re-creates the observer, and a fresh observe() always fires once — reporting
+ * the other box, changing state, and re-rendering. Measured live: ~160
+ * ResizeObserver constructions per second and all 16 tree rows torn down and
+ * recreated ~60 times a second, forever.
+ *
+ * The user-visible consequence is that a real mouse click is impossible: the
+ * row that receives mousedown is destroyed before mouseup, so WebKit never
+ * synthesises a click. Automated tests never caught it because a synthetic
+ * element.click() does not need the press and release to share a node.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useObservedHeight } from "./useObservedHeight";
+
+const BORDER_BOX = 909;
+const CONTENT_BOX = 901; // 909 - 4px padding-top - 4px padding-bottom
+
+let roCallbacks: ResizeObserverCallback[] = [];
+
+class MockResizeObserver {
+  constructor(cb: ResizeObserverCallback) {
+    roCallbacks.push(cb);
+  }
+  observe() {
+    /* a real observe() fires the callback once — the test drives that explicitly */
+  }
+  disconnect() {}
+  unobserve() {}
+}
+
+function makeElement(): HTMLElement {
+  const el = document.createElement("div");
+  el.getBoundingClientRect = () =>
+    ({ height: BORDER_BOX, width: 200, top: 0, left: 0, right: 200, bottom: BORDER_BOX, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+  Object.defineProperty(el, "clientHeight", { value: BORDER_BOX, configurable: true });
+  return el;
+}
+
+/** What a real ResizeObserver reports for a padded, border-box element. */
+function resizeEntryFor(el: HTMLElement): ResizeObserverEntry {
+  return {
+    target: el,
+    contentRect: { height: CONTENT_BOX, width: 200, top: 0, left: 0, right: 200, bottom: CONTENT_BOX, x: 0, y: 0, toJSON: () => ({}) } as DOMRect,
+    borderBoxSize: [{ blockSize: BORDER_BOX, inlineSize: 200 }],
+    contentBoxSize: [{ blockSize: CONTENT_BOX, inlineSize: 200 }],
+    devicePixelContentBoxSize: [{ blockSize: BORDER_BOX, inlineSize: 200 }],
+  } as unknown as ResizeObserverEntry;
+}
+
+beforeEach(() => {
+  roCallbacks = [];
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useObservedHeight", () => {
+  it("reports the element height on attach", () => {
+    const { result } = renderHook(() => useObservedHeight<HTMLElement>());
+    const el = makeElement();
+    act(() => result.current[0](el));
+    expect(result.current[1]).toBe(BORDER_BOX);
+  });
+
+  it("does not change the height when the observer reports the same element", () => {
+    const { result } = renderHook(() => useObservedHeight<HTMLElement>());
+    const el = makeElement();
+    act(() => result.current[0](el));
+    const afterAttach = result.current[1];
+
+    act(() => roCallbacks[0]([resizeEntryFor(el)], {} as ResizeObserver));
+
+    // The ref path and the observer path must agree, or each re-render
+    // re-observes, the observer reports the other box, and the loop never ends.
+    expect(result.current[1]).toBe(afterAttach);
+  });
+
+  it("survives an inline ref being re-invoked (null, then element) without oscillating", () => {
+    const { result } = renderHook(() => useObservedHeight<HTMLElement>());
+    const el = makeElement();
+
+    // Three renders' worth of FileExplorer's inline composed ref callback.
+    for (let i = 0; i < 3; i++) {
+      act(() => result.current[0](null));
+      act(() => result.current[0](el));
+      act(() => roCallbacks[roCallbacks.length - 1]([resizeEntryFor(el)], {} as ResizeObserver));
+    }
+
+    expect(result.current[1]).toBe(BORDER_BOX);
+  });
+
+  it("still tracks a genuine resize", () => {
+    const { result } = renderHook(() => useObservedHeight<HTMLElement>());
+    const el = makeElement();
+    act(() => result.current[0](el));
+
+    const grown = {
+      target: el,
+      contentRect: { height: 492 } as DOMRect,
+      borderBoxSize: [{ blockSize: 500, inlineSize: 200 }],
+      contentBoxSize: [{ blockSize: 492, inlineSize: 200 }],
+    } as unknown as ResizeObserverEntry;
+    act(() => roCallbacks[0]([grown], {} as ResizeObserver));
+
+    expect(result.current[1]).toBe(500);
+  });
+
+  it("clamps to at least 1 — react-window breaks on height 0", () => {
+    const { result } = renderHook(() => useObservedHeight<HTMLElement>());
+    const el = document.createElement("div");
+    el.getBoundingClientRect = () => ({ height: 0 }) as DOMRect;
+    Object.defineProperty(el, "clientHeight", { value: 0, configurable: true });
+    act(() => result.current[0](el));
+    expect(result.current[1]).toBe(1);
+  });
+});

--- a/src/components/Sidebar/FileExplorer/useObservedHeight.ts
+++ b/src/components/Sidebar/FileExplorer/useObservedHeight.ts
@@ -7,6 +7,31 @@ function clampHeight(rawHeight: number): number {
   return Math.max(1, Math.floor(rawHeight));
 }
 
+/**
+ * The BORDER-box height of a resize entry — the same box
+ * `getBoundingClientRect().height` reports.
+ *
+ * Both measurement paths MUST agree. They used to disagree: the ref path read
+ * the border box while this path read `contentRect`, which is the CONTENT box.
+ * `.file-explorer-tree` has 4px vertical padding, so the two differed by 8px
+ * (909 vs 901) and each measurement re-triggered the other — a permanent
+ * re-render loop that tore down and rebuilt every tree row ~60 times a second.
+ * A real mouse click was then impossible, because the row receiving mousedown
+ * was destroyed before its mouseup, so no click event was ever synthesised
+ * (issue #1187).
+ *
+ * `borderBoxSize` is preferred because it needs no forced layout; older WebKit
+ * exposes it as a bare object rather than the spec's array.
+ */
+function borderBoxHeightOf(entry: ResizeObserverEntry, el: HTMLElement): number {
+  const raw = entry.borderBoxSize as
+    | readonly ResizeObserverSize[]
+    | ResizeObserverSize
+    | undefined;
+  const size = Array.isArray(raw) ? raw[0] : (raw as ResizeObserverSize | undefined);
+  return size?.blockSize ?? el.getBoundingClientRect().height;
+}
+
 /** Hook that tracks an element's height via ResizeObserver, returning a callback ref and the measured height. */
 export function useObservedHeight<T extends HTMLElement>(): [CallbackRef<T>, number] {
   const [height, setHeight] = useState(1);
@@ -37,8 +62,10 @@ export function useObservedHeight<T extends HTMLElement>(): [CallbackRef<T>, num
     if (observerRef.current) return;
 
     const observer = new ResizeObserver((entries) => {
-      const rectHeight =
-        entries[0]?.contentRect.height ?? el.getBoundingClientRect().height;
+      const entry = entries[0];
+      const rectHeight = entry
+        ? borderBoxHeightOf(entry, el)
+        : el.getBoundingClientRect().height;
       setHeight(clampHeight(rectHeight));
     });
 

--- a/src/components/Sidebar/FileExplorer/useTreeWiring.tsx
+++ b/src/components/Sidebar/FileExplorer/useTreeWiring.tsx
@@ -1,0 +1,59 @@
+/**
+ * useTreeWiring
+ *
+ * Purpose: the two react-arborist props whose IDENTITY must stay stable across
+ * renders, plus the measured tree height they depend on.
+ *
+ * Key decision: both of these were inline in FileExplorer's JSX, and that made
+ * every click in the file explorer impossible (#1187). react-arborist uses the
+ * `children` value as the row COMPONENT, so a new arrow function per render is
+ * a new component type and React remounts every row; an inline callback ref is
+ * likewise re-invoked with (null, element) on every render, tearing down and
+ * rebuilding useObservedHeight's ResizeObserver. A row destroyed between
+ * mousedown and mouseup never produces a click, so folders would not expand and
+ * files would not open — while synthetic element.click() in tests kept passing.
+ *
+ * @coordinates-with FileExplorer.tsx — sole consumer
+ * @coordinates-with useObservedHeight.ts — supplies the height, must not be re-created per render
+ * @module components/Sidebar/FileExplorer/useTreeWiring
+ */
+import { useCallback } from "react";
+import type { MutableRefObject } from "react";
+import type { NodeRendererProps } from "react-arborist";
+import { FileNode } from "./FileNode";
+import { useObservedHeight } from "./useObservedHeight";
+import type { FileNode as FileNodeType } from "./types";
+
+export interface TreeWiring {
+  /** Stable callback ref for the scroll container (also mirrors it into `treeElRef`). */
+  setTreeContainer: (el: HTMLDivElement | null) => void;
+  /** Stable row renderer passed as react-arborist's children. */
+  renderNode: (props: NodeRendererProps<FileNodeType>) => React.ReactElement;
+  /** Measured container height — react-arborist needs an explicit pixel height. */
+  treeHeight: number;
+}
+
+/** Owns the identity-stable Tree wiring; see the module header for why it matters. */
+export function useTreeWiring(
+  currentFilePath: string | null,
+  treeElRef: MutableRefObject<HTMLDivElement | null>,
+): TreeWiring {
+  const [treeContainerRef, treeHeight] = useObservedHeight<HTMLDivElement>();
+
+  const setTreeContainer = useCallback(
+    (el: HTMLDivElement | null) => {
+      treeContainerRef(el);
+      treeElRef.current = el;
+    },
+    [treeContainerRef, treeElRef],
+  );
+
+  const renderNode = useCallback(
+    (props: NodeRendererProps<FileNodeType>) => (
+      <FileNode {...props} currentFilePath={currentFilePath} />
+    ),
+    [currentFilePath],
+  );
+
+  return { setTreeContainer, renderNode, treeHeight };
+}

--- a/src/components/Workspace/WorkspaceApprovalDialog.tsx
+++ b/src/components/Workspace/WorkspaceApprovalDialog.tsx
@@ -64,10 +64,10 @@ export function WorkspaceApprovalDialog() {
         <p className="workspace-approval-body">{t("openWorkspace.approval.body")}</p>
         <code className="workspace-approval-path">{pending.canonicalPath}</code>
         <div className="workspace-approval-actions">
-          <button ref={denyRef} type="button" className="workspace-approval-deny" onClick={deny}>
+          <button ref={denyRef} type="button" className="vm-btn" onClick={deny}>
             {t("openWorkspace.approval.deny")}
           </button>
-          <button type="button" className="workspace-approval-approve" onClick={approve}>
+          <button type="button" className="vm-btn vm-btn--primary" onClick={approve}>
             {t("openWorkspace.approval.approve")}
           </button>
         </div>

--- a/src/components/Workspace/workspace-approval-dialog.css
+++ b/src/components/Workspace/workspace-approval-dialog.css
@@ -1,18 +1,23 @@
 .workspace-approval-overlay {
+  /* Component-scoped one-off, per .claude/rules/31-design-tokens.md — there is
+     no global scrim token, and the workflow approval dialog scopes its backdrop
+     the same way (`--approval-backdrop-color`). */
+  --workspace-approval-backdrop: color-mix(in srgb, black 35%, transparent);
+
   position: fixed;
   inset: 0;
   z-index: var(--z-popup);
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.35);
+  background: var(--workspace-approval-backdrop);
 }
 
 .workspace-approval-dialog {
   max-width: 30em;
   padding: var(--space-5);
   background: var(--bg-color);
-  border: 1px solid var(--border-color);
+  border: var(--border-thin) solid var(--border-color);
   border-radius: var(--radius-lg);
   box-shadow: var(--popup-shadow);
 }
@@ -44,37 +49,12 @@
   word-break: break-all;
 }
 
+/* The buttons themselves are the canonical `.vm-btn` primitive
+   (src/styles/button-shared.css) — padding, radius, border width, font, hover,
+   active, disabled and focus all come from there. This file only positions
+   them. Re-deriving a bordered button here is what rule 32 forbids. */
 .workspace-approval-actions {
   display: flex;
   justify-content: flex-end;
   gap: var(--spacing-2);
-}
-
-.workspace-approval-deny,
-.workspace-approval-approve {
-  padding: var(--spacing-1) var(--spacing-3);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border-color);
-  cursor: pointer;
-}
-
-.workspace-approval-deny {
-  background: var(--bg-secondary);
-  color: var(--text-color);
-}
-
-.workspace-approval-approve {
-  background: var(--primary-color);
-  color: var(--contrast-text);
-  border-color: var(--primary-color);
-}
-
-.workspace-approval-deny:focus-visible {
-  outline: 2px solid var(--primary-color);
-  outline-offset: 2px;
-}
-
-.workspace-approval-approve:focus-visible {
-  outline: 2px solid var(--text-color);
-  outline-offset: 2px;
 }


### PR DESCRIPTION
Closes #1187.

## The bug

The file tree re-rendered **~60 times per second, forever**, tearing down and
recreating every row each frame. A `click` event requires `mousedown` and
`mouseup` on the **same** DOM node; the rows were rebuilt 4 times during a
single 68ms press, so no click was ever synthesized.

Consequence: **nothing click-driven in the file explorer worked with a real
mouse** — folder chevrons never toggled (#1187) and clicking a file never
opened it. Drag-and-drop and right-click kept working, because those don't need
`click`.

This shipped undetected because a synthetic `element.click()` does not need the
press and release to share a node, so every automated test passed. It was found
by driving real `CGEvent` mouse clicks at the app and logging what reached the
DOM.

Measured before the fix, while completely idle:
- 19,584 nodes added and removed in 20 seconds
- ~160 `ResizeObserver` constructions per second
- a DOM-identity probe showing the element tagged on `mousedown` was gone by `mouseup`

## Two causes

**1. `useObservedHeight` measured two different boxes.** The callback-ref path
read `getBoundingClientRect().height` (BORDER box); the `ResizeObserver`
callback read `contentRect.height` (CONTENT box). `.file-explorer-tree` has 4px
vertical padding with `box-sizing: border-box`, so those are **909** and
**901** — each measurement set state to the other's value and re-rendered. The
observer now reports the border box via `borderBoxSize`.

**2. Inline closures in the JSX.** react-arborist uses `children` as the row
**component**, so a new arrow function per render is a new component type and
React remounts every row. An inline callback ref is likewise re-invoked with
`(null, element)` on every render, rebuilding the ResizeObserver. Both now come
from `useTreeWiring` with stable identities, so a legitimate re-render can no
longer replace the node under the cursor.

## Verification

Re-tested with **real native mouse clicks**, not synthetic:

| | Before | After |
|---|---|---|
| Idle DOM churn | 19,584 nodes / 20s | **0** |
| Real click on chevron | nothing | **expands** (rows 3 → 18) |
| Real click on a file | nothing | **opens it**, tab active, editor loads |

Checked for siblings of the same pattern: `useObservedHeight` and
react-arborist each have exactly one consumer, and the two other inline
callback refs (`WorkspaceRailContextMenu`, `ViewModeToggle`) only write into a
`useRef` array with no `setState`, so they cannot loop.

`FileExplorer.tsx` stays at its frozen 419-line baseline — the stable wiring was
extracted to `useTreeWiring.tsx` rather than raising the number.

## Second commit: approval dialog styling

Separate commit, no behavior change. The open-folder consent prompt hand-rolled
its buttons instead of using `.vm-btn` and had drifted (4px/12px padding vs the
primitive's 6px/12px, `--radius-md` vs `--radius-sm`, a literal `1px` where
`--border-thin` belongs, no hover/active/disabled states). The approve button
was a solid system-blue fill — a visual language that appears nowhere else in
VMark, and the wrong emphasis for a fail-closed security prompt. Also tokenizes
the hardcoded backdrop.

Worth knowing: those classes were **invisible** to `pnpm lint:bespoke-buttons`,
whose regex only matches names containing `btn` or `button` —
`.workspace-approval-approve` contains neither. The budget reads 88/88 because
the gate never counted them.

`pnpm check:all` green (25,685 tests).