### PR TITLE
Release v0.9.25 — file explorer clicks work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.24",
+  "version": "0.9.25",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.24';
+const VERSION = '0.9.25';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6280,7 +6280,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.24"
+version = "0.9.25"
 dependencies = [
  "base64 0.23.0",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.24"
+version = "0.9.25"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump only; the fixes landed in #1192.

v0.9.24 shipped two real fixes but neither addressed the reported symptom. The
actual cause — a 60fps render loop that made every mouse click in the file
explorer impossible — is fixed in #1187 / #1192 and reaches users only with
this tag.

## What v0.9.25 contains beyond v0.9.24

- **fix(explorer)**: the file tree re-rendered ~60 times a second, rebuilding
  every row each frame. A `click` needs `mousedown` and `mouseup` on the same
  DOM node, and rows were replaced 4 times during a single 68ms press — so
  folder chevrons never toggled and clicking a file never opened it. Two causes:
  `useObservedHeight` measured the border box in one path and the content box in
  the other (909 vs 901, an 8px padding difference) so each measurement
  re-triggered the other; and inline closures for react-arborist's row renderer
  and the container ref remounted every row on each render. Verified with real
  CGEvent clicks: idle DOM churn 19,584 nodes/20s → **0**, chevron expands, file
  opens.
- **style(workspace)**: the open-folder consent dialog now uses the canonical
  `.vm-btn` instead of hand-rolled buttons that had drifted from the primitive.
- **chore(lint)**: the bespoke-button gate now also counts by USAGE, so a button
  class can no longer evade it by being named something without "btn" in it.

`pnpm check:all` green (25,693 tests). All five version files plus the derived
`src-tauri/Cargo.lock` are at 0.9.25.