### PR TITLE
fix(explorer): remove the file tree's phantom second scrollbar

### DIFF
--- a/src/components/Sidebar/FileExplorer/FileExplorer.css
+++ b/src/components/Sidebar/FileExplorer/FileExplorer.css
@@ -65,9 +65,15 @@
   border-radius: 1px;
 }
 
+/* Sizing frame only — react-window (`.file-explorer-scroller`, inside) is the
+ * one scroll container. This element must NOT scroll: it used to say
+ * `overflow-y: auto`, and since the measured height handed to <Tree> was the
+ * border box while the tree is laid out in the content box, it overflowed
+ * itself by exactly its own vertical padding and rendered a second, redundant
+ * scrollbar. `hidden` keeps that class of mismatch from ever being visible. */
 .file-explorer-tree {
   flex: 1;
-  overflow-y: auto;
+  overflow: hidden;
   padding: var(--space-1) var(--space-2) var(--space-1) 0;
 }
 

--- a/src/components/Sidebar/FileExplorer/FileExplorer.tsx
+++ b/src/components/Sidebar/FileExplorer/FileExplorer.tsx
@@ -19,8 +19,9 @@
  *     collapseAll / expandAll to the Sidebar header buttons.
  *   - File tree is workspace-only — no inferred root from file path (single-file mode
  *     has no explorer).
- *   - Tree height is measured dynamically via ResizeObserver because react-arborist
- *     (react-window) requires an explicit numeric pixel height.
+ *   - Tree height is measured dynamically via ResizeObserver (react-window needs an
+ *     explicit pixel height) and is the CONTENT box; react-window's outer div
+ *     (`scrollerClassName`) is the ONE scroller. See useObservedHeight.ts.
  *   - After create operations, a small timeout allows the tree to refresh before
  *     auto-entering edit mode on the new node.
  *   - Folders default to collapsed (openByDefault=false). Open/closed state is persisted
@@ -28,7 +29,7 @@
  *     snapshots uiStore at mount and mirrors toggles back.
  *   - Root element is a `navigation` ARIA landmark (labelled `aria.fileExplorer`).
  *
- * @coordinates-with useTreeWiring.tsx — identity-stable Tree children/ref + measured height
+ * @coordinates-with useTreeWiring.tsx — identity-stable Tree children/ref, measured height, scroller class
  * @coordinates-with useFileTree.ts — loads directory tree and watches for fs changes
  * @coordinates-with useExplorerOperations.ts — CRUD operations on files and folders
  * @coordinates-with useFileExplorerOpenState.ts — persists folder open state across remounts
@@ -120,9 +121,8 @@ export const FileExplorer = forwardRef<FileExplorerHandle, FileExplorerProps>(
 
   // WI-9.2: with the rail on, folder/scroll state is per workspace instance.
   const workspaceInstanceId = useExplorerWorkspaceInstance(windowLabel);
-  const treeElRef = useRef<HTMLDivElement | null>(null);
   // Identity-stable Tree wiring — see useTreeWiring's header (#1187).
-  const { setTreeContainer, renderNode, treeHeight } = useTreeWiring(currentFilePath, treeElRef);
+  const { setTreeContainer, renderNode, treeHeight, scrollerClassName, treeElRef } = useTreeWiring(currentFilePath);
 
   // Persisted folder open state — preserved across sidebar view-mode switches
   // (react-arborist unmounts on viewMode change, losing internal state otherwise).
@@ -351,7 +351,6 @@ export const FileExplorer = forwardRef<FileExplorerHandle, FileExplorerProps>(
     [moveItem, rootPath]
   );
 
-
   // Expose methods to parent via ref
   useImperativeHandle(ref, () => ({
     createNewFile: () => handleNewFile(),
@@ -386,6 +385,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, FileExplorerProps>(
         <Tree<FileNodeType>
           key={workspaceInstanceId ?? "window"}
           ref={treeRef}
+          className={scrollerClassName}
           data={tree}
           openByDefault={false}
           initialOpenState={initialOpenState}

--- a/src/components/Sidebar/FileExplorer/types.ts
+++ b/src/components/Sidebar/FileExplorer/types.ts
@@ -6,6 +6,18 @@ export interface FileNode {
   children?: FileNode[];
 }
 
+/**
+ * Class applied to react-window's outer element — the file tree's ONE real
+ * scroll container. Passed to `<Tree className>`, which react-arborist forwards
+ * to the virtualized list's outer div.
+ *
+ * It exists because that element ships with neither a class nor a role, so the
+ * only way to reach it was to guess. Two places guessed `[role="tree"]` and both
+ * were wrong: that is a non-scrolling wrapper one level up, which made scroll
+ * restore a silent no-op and left a `::-webkit-scrollbar` rule styling nothing.
+ */
+export const FILE_TREE_SCROLLER_CLASS = "file-explorer-scroller";
+
 /** Raw directory entry returned by the Tauri filesystem command. */
 export interface DirectoryEntry {
   name: string;

--- a/src/components/Sidebar/FileExplorer/useFileExplorerOpenState.test.ts
+++ b/src/components/Sidebar/FileExplorer/useFileExplorerOpenState.test.ts
@@ -6,7 +6,7 @@ import type { TreeApi } from "react-arborist";
 import { useFileExplorerOpenState, __ARBORIST_ROOT_ID } from "./useFileExplorerOpenState";
 import { useUIStore } from "@/stores/uiStore";
 import { useWorkspaceInstanceUiStore } from "@/stores/workspaceInstanceUiStore";
-import type { FileNode as FileNodeType } from "./types";
+import { FILE_TREE_SCROLLER_CLASS, type FileNode as FileNodeType } from "./types";
 
 /** Minimal TreeApi stand-in — only the surface the hook actually calls. */
 interface TreeStub {
@@ -320,7 +320,29 @@ describe("useFileExplorerOpenState per-instance (WI-9.2)", () => {
     }
   });
 
-  it("restoreScroll sets scrollTop on the tree's scroller element", () => {
+  /**
+   * The DOM react-arborist actually renders. `role="tree"` is a plain wrapper
+   * with `overflow: visible`; the scroller is react-window's outer element
+   * NESTED INSIDE it, which carries the `className` passed to <Tree>.
+   *
+   * Measured in the running app: writing scrollTop to the `role="tree"` wrapper
+   * reads back 0, so restoring an instance's file-tree scroll silently did
+   * nothing. The previous version of this test built a fake DOM in which
+   * `role="tree"` WAS the scroller, so it passed against broken production code.
+   */
+  function makeArboristDom(): { container: HTMLElement; wrapper: HTMLElement; scroller: HTMLElement } {
+    const container = document.createElement("div");
+    container.className = "file-explorer-tree";
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("role", "tree");
+    const scroller = document.createElement("div");
+    scroller.className = FILE_TREE_SCROLLER_CLASS;
+    wrapper.appendChild(scroller);
+    container.appendChild(wrapper);
+    return { container, wrapper, scroller };
+  }
+
+  it("restoreScroll sets scrollTop on react-window's scroller, not the role=tree wrapper", () => {
     useWorkspaceInstanceUiStore.getState().updateInstanceUiState("wsi-a", {
       fileTreeScrollOffset: 77,
     });
@@ -328,14 +350,12 @@ describe("useFileExplorerOpenState per-instance (WI-9.2)", () => {
       useFileExplorerOpenState(makeRef(makeTreeStub()), "wsi-a"),
     );
 
-    const container = document.createElement("div");
-    const scroller = document.createElement("div");
-    scroller.setAttribute("role", "tree");
-    container.appendChild(scroller);
+    const { container, wrapper, scroller } = makeArboristDom();
 
     act(() => result.current.restoreScroll(container));
 
     expect(scroller.scrollTop).toBe(77);
+    expect(wrapper.scrollTop).toBe(0);
   });
 
   it("restoreScroll is a no-op with no offset or no scroller", () => {

--- a/src/components/Sidebar/FileExplorer/useFileExplorerOpenState.ts
+++ b/src/components/Sidebar/FileExplorer/useFileExplorerOpenState.ts
@@ -26,6 +26,9 @@
  *   - Scroll capture is DOM-based (container capture phase), not arborist-API
  *     based, so it survives arborist internals changing; writes are trailing-
  *     throttled to one per SCROLL_THROTTLE_MS.
+ *   - Restoring that offset needs the ONE element that actually scrolls, which
+ *     arborist ships with no class and no role. We give it one via
+ *     FILE_TREE_SCROLLER_CLASS rather than guessing at its DOM position.
  *
  * @coordinates-with FileExplorer.tsx — owns the treeRef and passes handlers to Tree
  * @coordinates-with uiStore.ts — window-global fileExplorerOpenState (rail off)
@@ -42,7 +45,7 @@ import {
   selectActiveWorkspaceInstance,
   useWorkspaceInstancesStore,
 } from "@/stores/workspaceInstancesStore";
-import type { FileNode as FileNodeType } from "./types";
+import { FILE_TREE_SCROLLER_CLASS, type FileNode as FileNodeType } from "./types";
 
 /**
  * The workspace instance whose file-tree state the explorer should show:
@@ -189,8 +192,11 @@ export function useFileExplorerOpenState(
         .getState()
         .getInstanceUiState(workspaceInstanceId).fileTreeScrollOffset;
       if (offset === null || !Number.isFinite(offset)) return;
-      // Arborist marks its virtualized scroller with role="tree".
-      const scroller = container.querySelector<HTMLElement>('[role="tree"]');
+      // NOT `[role="tree"]` — that is react-arborist's outer wrapper, and it has
+      // `overflow: visible`, so writing scrollTop to it reads back 0 and the
+      // restore silently does nothing. The scroller is react-window's outer
+      // element nested inside it, tagged by the className we pass to <Tree>.
+      const scroller = container.querySelector<HTMLElement>(`.${FILE_TREE_SCROLLER_CLASS}`);
       if (!scroller) return;
       scroller.scrollTop = offset;
     },

--- a/src/components/Sidebar/FileExplorer/useObservedHeight.test.ts
+++ b/src/components/Sidebar/FileExplorer/useObservedHeight.test.ts
@@ -1,7 +1,10 @@
 /**
- * The measured height must not oscillate between two boxes.
+ * The measured height must not oscillate between two boxes, AND it must be the
+ * box the measured element's child is actually laid out into — its CONTENT box.
  *
- * Regression guard for the file explorer's dead mouse clicks (issue #1187, and
+ * Two bugs meet in this hook, and fixing only the first caused the second.
+ *
+ * (1) Regression guard for the file explorer's dead mouse clicks (issue #1187, and
  * "clicking a file doesn't open it"). `.file-explorer-tree` has 4px vertical
  * padding with box-sizing: border-box, and this hook measured TWO DIFFERENT
  * boxes:
@@ -19,6 +22,17 @@
  * row that receives mousedown is destroyed before mouseup, so WebKit never
  * synthesises a click. Automated tests never caught it because a synthetic
  * element.click() does not need the press and release to share a node.
+ *
+ * (2) Converging BOTH paths on the border box stopped the oscillation but left
+ * the value 8px too large, because the number is handed to <Tree height> and
+ * react-arborist stamps it onto a child of the measured element — a child that
+ * lives in the CONTENT box. An 885px child inside an 877px content box made
+ * `.file-explorer-tree` itself scrollable by exactly its 8px of padding, so the
+ * file explorer rendered a SECOND vertical scrollbar beside react-window's real
+ * one. Measured in the running app: clientHeight 885, scrollHeight 893.
+ *
+ * So the invariant is two-sided: both paths must agree (or #1187 returns), and
+ * they must agree on the CONTENT box (or the phantom scrollbar returns).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
@@ -26,6 +40,7 @@ import { useObservedHeight } from "./useObservedHeight";
 
 const BORDER_BOX = 909;
 const CONTENT_BOX = 901; // 909 - 4px padding-top - 4px padding-bottom
+const VERTICAL_PADDING = "4px";
 
 let roCallbacks: ResizeObserverCallback[] = [];
 
@@ -40,8 +55,15 @@ class MockResizeObserver {
   unobserve() {}
 }
 
+/**
+ * A `.file-explorer-tree` stand-in: box-sizing border-box, no border, 4px of
+ * vertical padding. With no border, clientHeight == the border box; the content
+ * box is that minus the padding.
+ */
 function makeElement(): HTMLElement {
   const el = document.createElement("div");
+  el.style.paddingTop = VERTICAL_PADDING;
+  el.style.paddingBottom = VERTICAL_PADDING;
   el.getBoundingClientRect = () =>
     ({ height: BORDER_BOX, width: 200, top: 0, left: 0, right: 200, bottom: BORDER_BOX, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
   Object.defineProperty(el, "clientHeight", { value: BORDER_BOX, configurable: true });
@@ -69,11 +91,23 @@ afterEach(() => {
 });
 
 describe("useObservedHeight", () => {
-  it("reports the element height on attach", () => {
+  it("reports the CONTENT box on attach — the box a child is laid out into", () => {
     const { result } = renderHook(() => useObservedHeight<HTMLElement>());
     const el = makeElement();
     act(() => result.current[0](el));
-    expect(result.current[1]).toBe(BORDER_BOX);
+    // Border box would be 909, which is 8px taller than the box the child
+    // occupies — that surplus is what rendered a second scrollbar.
+    expect(result.current[1]).toBe(CONTENT_BOX);
+  });
+
+  it("a child sized to the reported height does not overflow the measured element", () => {
+    const { result } = renderHook(() => useObservedHeight<HTMLElement>());
+    const el = makeElement();
+    act(() => result.current[0](el));
+    act(() => roCallbacks[0]([resizeEntryFor(el)], {} as ResizeObserver));
+
+    const contentBoxHeight = BORDER_BOX - 2 * parseFloat(VERTICAL_PADDING);
+    expect(result.current[1]).toBeLessThanOrEqual(contentBoxHeight);
   });
 
   it("does not change the height when the observer reports the same element", () => {
@@ -100,7 +134,7 @@ describe("useObservedHeight", () => {
       act(() => roCallbacks[roCallbacks.length - 1]([resizeEntryFor(el)], {} as ResizeObserver));
     }
 
-    expect(result.current[1]).toBe(BORDER_BOX);
+    expect(result.current[1]).toBe(CONTENT_BOX);
   });
 
   it("still tracks a genuine resize", () => {
@@ -116,7 +150,7 @@ describe("useObservedHeight", () => {
     } as unknown as ResizeObserverEntry;
     act(() => roCallbacks[0]([grown], {} as ResizeObserver));
 
-    expect(result.current[1]).toBe(500);
+    expect(result.current[1]).toBe(492);
   });
 
   it("clamps to at least 1 — react-window breaks on height 0", () => {

--- a/src/components/Sidebar/FileExplorer/useObservedHeight.ts
+++ b/src/components/Sidebar/FileExplorer/useObservedHeight.ts
@@ -8,8 +8,20 @@ function clampHeight(rawHeight: number): number {
 }
 
 /**
- * The BORDER-box height of a resize entry — the same box
- * `getBoundingClientRect().height` reports.
+ * The CONTENT-box height of an element, derived from `clientHeight` (which
+ * excludes borders and scrollbars but INCLUDES padding).
+ */
+function contentBoxHeightOf(el: HTMLElement): number {
+  const style = getComputedStyle(el);
+  const padding =
+    (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
+  return el.clientHeight - padding;
+}
+
+/**
+ * The CONTENT-box height of a resize entry.
+ *
+ * Two constraints, and missing either one has already shipped a bug.
  *
  * Both measurement paths MUST agree. They used to disagree: the ref path read
  * the border box while this path read `contentRect`, which is the CONTENT box.
@@ -20,16 +32,25 @@ function clampHeight(rawHeight: number): number {
  * was destroyed before its mouseup, so no click event was ever synthesised
  * (issue #1187).
  *
- * `borderBoxSize` is preferred because it needs no forced layout; older WebKit
+ * They must also agree on the CONTENT box specifically. The caller feeds this
+ * number to `<Tree height>`, and react-arborist stamps it onto an element
+ * nested INSIDE the measured one — which is laid out in its content box, not
+ * its border box. Converging both paths on the border box therefore made every
+ * measurement 8px too tall, so `.file-explorer-tree` overflowed itself by
+ * exactly its own padding and grew a second, redundant vertical scrollbar next
+ * to react-window's real one.
+ *
+ * `contentBoxSize` is preferred because it needs no forced layout; older WebKit
  * exposes it as a bare object rather than the spec's array.
  */
-function borderBoxHeightOf(entry: ResizeObserverEntry, el: HTMLElement): number {
-  const raw = entry.borderBoxSize as
+function measuredHeightOf(entry: ResizeObserverEntry, el: HTMLElement): number {
+  const raw = entry.contentBoxSize as
     | readonly ResizeObserverSize[]
     | ResizeObserverSize
     | undefined;
   const size = Array.isArray(raw) ? raw[0] : (raw as ResizeObserverSize | undefined);
-  return size?.blockSize ?? el.getBoundingClientRect().height;
+  if (size) return size.blockSize;
+  return entry.contentRect?.height ?? contentBoxHeightOf(el);
 }
 
 /** Hook that tracks an element's height via ResizeObserver, returning a callback ref and the measured height. */
@@ -49,9 +70,8 @@ export function useObservedHeight<T extends HTMLElement>(): [CallbackRef<T>, num
     if (!el) return;
 
     // Initialize synchronously to avoid flash before ResizeObserver fires.
-    const initialRectHeight = el.getBoundingClientRect().height;
-    const initialHeight = initialRectHeight > 0 ? initialRectHeight : el.clientHeight;
-    setHeight(clampHeight(initialHeight));
+    // Must read the same box the observer path reports — see measuredHeightOf.
+    setHeight(clampHeight(contentBoxHeightOf(el)));
 
     if (typeof ResizeObserver === "undefined") {
       // jsdom/older WebKit: best-effort measurement without observation.
@@ -63,10 +83,8 @@ export function useObservedHeight<T extends HTMLElement>(): [CallbackRef<T>, num
 
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
-      const rectHeight = entry
-        ? borderBoxHeightOf(entry, el)
-        : el.getBoundingClientRect().height;
-      setHeight(clampHeight(rectHeight));
+      const height = entry ? measuredHeightOf(entry, el) : contentBoxHeightOf(el);
+      setHeight(clampHeight(height));
     });
 
     observer.observe(el);

--- a/src/components/Sidebar/FileExplorer/useTreeWiring.tsx
+++ b/src/components/Sidebar/FileExplorer/useTreeWiring.tsx
@@ -1,10 +1,14 @@
 /**
  * useTreeWiring
  *
- * Purpose: the two react-arborist props whose IDENTITY must stay stable across
- * renders, plus the measured tree height they depend on.
+ * Purpose: everything FileExplorer needs to hand react-arborist a correctly
+ * wired <Tree> — the two props whose IDENTITY must stay stable across renders
+ * (`children` and the container callback ref), the measured height they depend
+ * on, the class that names the real scroll container, and the container element
+ * itself for callers that need to query into the rendered tree.
  *
- * Key decision: both of these were inline in FileExplorer's JSX, and that made
+ * Key decision: the two identity-stable props were inline in FileExplorer's JSX,
+ * and that made
  * every click in the file explorer impossible (#1187). react-arborist uses the
  * `children` value as the row COMPONENT, so a new arrow function per render is
  * a new component type and React remounts every row; an inline callback ref is
@@ -15,29 +19,32 @@
  *
  * @coordinates-with FileExplorer.tsx — sole consumer
  * @coordinates-with useObservedHeight.ts — supplies the height, must not be re-created per render
+ * @coordinates-with types.ts — FILE_TREE_SCROLLER_CLASS, the real scroller's name
  * @module components/Sidebar/FileExplorer/useTreeWiring
  */
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import type { MutableRefObject } from "react";
 import type { NodeRendererProps } from "react-arborist";
 import { FileNode } from "./FileNode";
 import { useObservedHeight } from "./useObservedHeight";
-import type { FileNode as FileNodeType } from "./types";
+import { FILE_TREE_SCROLLER_CLASS, type FileNode as FileNodeType } from "./types";
 
 export interface TreeWiring {
-  /** Stable callback ref for the scroll container (also mirrors it into `treeElRef`). */
+  /** Stable callback ref for the sizing frame (also mirrors it into `treeElRef`). */
   setTreeContainer: (el: HTMLDivElement | null) => void;
   /** Stable row renderer passed as react-arborist's children. */
   renderNode: (props: NodeRendererProps<FileNodeType>) => React.ReactElement;
-  /** Measured container height — react-arborist needs an explicit pixel height. */
+  /** Measured CONTENT-box height — react-arborist needs an explicit pixel height. */
   treeHeight: number;
+  /** Class for `<Tree className>`, landing on react-window's real scroll container. */
+  scrollerClassName: string;
+  /** The sizing frame element, for callers that need to query into the tree. */
+  treeElRef: MutableRefObject<HTMLDivElement | null>;
 }
 
 /** Owns the identity-stable Tree wiring; see the module header for why it matters. */
-export function useTreeWiring(
-  currentFilePath: string | null,
-  treeElRef: MutableRefObject<HTMLDivElement | null>,
-): TreeWiring {
+export function useTreeWiring(currentFilePath: string | null): TreeWiring {
+  const treeElRef = useRef<HTMLDivElement | null>(null);
   const [treeContainerRef, treeHeight] = useObservedHeight<HTMLDivElement>();
 
   const setTreeContainer = useCallback(
@@ -45,7 +52,7 @@ export function useTreeWiring(
       treeContainerRef(el);
       treeElRef.current = el;
     },
-    [treeContainerRef, treeElRef],
+    [treeContainerRef],
   );
 
   const renderNode = useCallback(
@@ -55,5 +62,11 @@ export function useTreeWiring(
     [currentFilePath],
   );
 
-  return { setTreeContainer, renderNode, treeHeight };
+  return {
+    setTreeContainer,
+    renderNode,
+    treeHeight,
+    scrollerClassName: FILE_TREE_SCROLLER_CLASS,
+    treeElRef,
+  };
 }

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -100,19 +100,22 @@
   flex-shrink: 0;
 }
 
-/* Thin scrollbar - 2px, theme-aware color */
-.sidebar-content::-webkit-scrollbar,
-.sidebar [role="tree"]::-webkit-scrollbar {
+/* Thin scrollbar - 2px, theme-aware color.
+ *
+ * `.sidebar [role="tree"]` used to be listed here too and styled nothing: in
+ * BOTH sidebar trees that element has `overflow: visible` and never scrolls.
+ * The file tree's real scroller is react-window's outer div
+ * (`.file-explorer-scroller`); the outline's is `.sidebar-content` itself.
+ * Left as-is, the file tree fell through to the global 10px scrollbar. */
+.sidebar-content::-webkit-scrollbar {
   width: 2px;
 }
 
-.sidebar-content::-webkit-scrollbar-track,
-.sidebar [role="tree"]::-webkit-scrollbar-track {
+.sidebar-content::-webkit-scrollbar-track {
   background: transparent;
 }
 
-.sidebar-content::-webkit-scrollbar-thumb,
-.sidebar [role="tree"]::-webkit-scrollbar-thumb {
+.sidebar-content::-webkit-scrollbar-thumb {
   background: var(--border-color);
   border-radius: 1px;
 }


### PR DESCRIPTION
## The bug

The file explorer rendered **two vertical scrollbars side by side**.

Both trace to one wrong belief about react-arborist's DOM: that `[role="tree"]` is its virtualized scroller. It is not — it is a non-scrolling wrapper, and the real scroller is react-window's outer div nested inside it, shipping with **neither a class nor a role**. Three places in this codebase guessed at it, and all three were wrong.

## Why a second bar appeared

A second-order effect. `useObservedHeight` measured `.file-explorer-tree`'s **border box** and handed that number to `<Tree height>`, which stamps it onto a child laid out in the **content box** — 8px smaller. The tree overflowed its own parent by exactly the parent's vertical padding (`4px` top + `4px` bottom), and the parent's `overflow-y: auto` turned that into a scrollbar.

Measured in a running debug build: `clientHeight 885`, `scrollHeight 893`.

The sharpest demonstration: with folders collapsed (22 rows, 572px of content in an 875px viewport) the *real* scroller had **zero** scroll range while the wrapper still showed its 10px bar — a scrollbar on a pane with nothing to scroll.

The border-box measurement was not arbitrary. It was the fix for the #1187 render loop, where the two measurement paths disagreed and tore down every tree row ~60 times a second, making mouse clicks impossible. Converging them stopped the loop but converged on the wrong box. So the invariant is two-sided: **both paths must agree, and they must agree on the content box.**

## Two more bugs from the same wrong belief

- **`restoreScroll` had never worked.** It wrote `scrollTop` to `[role="tree"]`, which computes `overflow: visible`. Writing `500` reads back `0`. Per-workspace-instance file-tree scroll restore (WI-9.2) was a silent no-op.
- **`.sidebar [role="tree"]::-webkit-scrollbar` styled nothing** — in *both* sidebar trees that element never scrolls. The file tree fell through to the global 10px scrollbar instead of the intended 2px one.

## The fix

Rather than guess at the scroller's DOM position a fourth time, give it a name. `FILE_TREE_SCROLLER_CLASS` goes through `<Tree className>`, which react-arborist forwards to the list's outer element — public API, not a structural guess.

| File | Change |
|---|---|
| `useObservedHeight.ts` | Measure the content box in both paths (`contentBoxSize`; sync path via `clientHeight` − padding) |
| `FileExplorer.css` | `.file-explorer-tree`: `overflow-y: auto` → `overflow: hidden` |
| `types.ts` | New `FILE_TREE_SCROLLER_CLASS` |
| `useTreeWiring.tsx` | Surfaces `scrollerClassName`; now owns `treeElRef` rather than taking it as a parameter |
| `FileExplorer.tsx` | `<Tree className={scrollerClassName}>` |
| `useFileExplorerOpenState.ts` | `restoreScroll` targets the real scroller |
| `Sidebar.css` | Dropped the dead `[role="tree"]` scrollbar selectors |

## Verified live in a running debug build

| | before | after |
|---|---|---|
| `.file-explorer-tree` scroll range | 8px, 10px bar | **0, no bar** |
| `[role="tree"]` height | 885 (overflowing) | **877** (fits content box) |
| real scroller | 12281px range | 12289px range, sole bar |
| `restoreScroll` write → read | 500 → **0** | 500 → **500** |

## Note on tests

The old `restoreScroll` test **passed against the broken code** — it built a fake DOM in which `[role="tree"]` *was* the scroller, encoding the same wrong assumption as production. It now builds the real nesting and asserts the wrapper stays at `0`.

`useObservedHeight`'s tests asserted the border box, which was the bug; they now assert the content box, plus a new test that a child sized to the reported height cannot overflow the measured element.

## Gate

`pnpm check:all` green (`GATE_EXIT=0`). `FileExplorer.tsx` stays at its 419-line baseline — no baseline raised.

Worth flagging for follow-up: that file now sits exactly at its ceiling against a ~300-line guideline, so the next change there will need a real extraction (`openFileByType` or the context-menu block are the clean candidates).
