### PR TITLE
fix(math): guard unclosed $$ fences and recognize ChatGPT delimiters (fixes #1181, #1180)

### DIFF
--- a/src/utils/cleanPastedMarkdown.test.ts
+++ b/src/utils/cleanPastedMarkdown.test.ts
@@ -27,8 +27,13 @@ describe("cleanPastedMarkdown — escape stripping", () => {
     expect(cleanPastedMarkdown("see \\[note\\]")).toBe("see [note]");
   });
 
-  it("strips escaped parens mid-line", () => {
-    expect(cleanPastedMarkdown("item \\(a\\)")).toBe("item (a)");
+  it("keeps a PAIRED \\(...\\) — since #1180 it reads as inline math", () => {
+    // Behavior change with math-delimiter support: a paired `\(…\)` is
+    // ChatGPT-style inline math and must survive the paste so the
+    // parser can normalize it to `$…$`. Only unpaired escaped parens
+    // (the Gemini prose artifact) still strip — see the lone-\( test in
+    // the math-delimiter block below.
+    expect(cleanPastedMarkdown("item \\(a\\)")).toBe("item \\(a\\)");
   });
 
   it("strips escaped exclamation mid-line", () => {
@@ -241,5 +246,33 @@ describe("cleanPastedMarkdown — ordered list trigger preservation", () => {
 
   it("strips 1\\) mid-line", () => {
     expect(cleanPastedMarkdown("item 1\\) done")).toBe("item 1) done");
+  });
+});
+
+describe("cleanPastedMarkdown — math delimiter preservation (#1180)", () => {
+  it("preserves an inline \\( ... \\) pair", () => {
+    expect(cleanPastedMarkdown("Given \\( x^2 \\) here.")).toBe(
+      "Given \\( x^2 \\) here.",
+    );
+  });
+
+  it("preserves a standalone display \\[ ... \\] pair", () => {
+    expect(cleanPastedMarkdown("\\[ \\alpha=0 \\]")).toBe("\\[ \\alpha=0 \\]");
+  });
+
+  it("still strips a lone \\( with no closer", () => {
+    expect(cleanPastedMarkdown("A lone \\( paren")).toBe("A lone ( paren");
+  });
+
+  it("still strips mid-sentence escaped brackets (not math)", () => {
+    // A non-standalone \[...\] is escaped-bracket prose, not display
+    // math — the normalizer skips it, so the cleaner may strip it.
+    expect(cleanPastedMarkdown("and \\[not a link\\].")).toBe(
+      "and [not a link].",
+    );
+  });
+
+  it("still strips escaped parens inside a link destination", () => {
+    expect(cleanPastedMarkdown("[x](foo\\(bar\\))")).toBe("[x](foo(bar))");
   });
 });

--- a/src/utils/cleanPastedMarkdown.ts
+++ b/src/utils/cleanPastedMarkdown.ts
@@ -12,6 +12,7 @@
  */
 
 import { buildCodeMask } from "./markdownCodeMask";
+import { findMathDelimiterSpans } from "./markdownPipeline/parser/mathDelimiterSpans";
 
 /** Characters that are safe to unescape when they appear mid-line. */
 const SAFE_MID_LINE = "#\\-*_`|[\\]()>+.!";
@@ -92,9 +93,22 @@ function lineHasUnescapedPipe(
 function stripUnnecessaryEscapes(markdown: string): string {
   const mask = buildCodeMask(markdown);
 
+  // Backslash offsets that form a recognized `\( … \)` / `\[ … \]`
+  // math pair (#1180). Stripping those would destroy ChatGPT math
+  // before the parser's delimiter normalization ever sees it — the
+  // exact paste flow the issue reports. Lone/non-math escapes on the
+  // same characters still strip as before.
+  const mathDelimiters = new Set<number>();
+  for (const span of findMathDelimiterSpans(markdown)) {
+    mathDelimiters.add(span.start);
+    mathDelimiters.add(span.end - 2);
+  }
+
   return markdown.replace(ESCAPE_RE, (match, char: string, offset: number) => {
     // Never strip escapes inside code
     if (mask[offset]) return match;
+
+    if (mathDelimiters.has(offset)) return match;
 
     if (isBlockTriggerEscape(markdown, offset, char)) return match;
 

--- a/src/utils/markdownCodeMask.fences.test.ts
+++ b/src/utils/markdownCodeMask.fences.test.ts
@@ -1,0 +1,48 @@
+// CommonMark fence-grammar strictness tests for buildCodeMask, split
+// from markdownCodeMask.test.ts (file-size limit). These pin the
+// closer and info-string rules its consumers (link detection, CJK
+// formatting, paste cleaning) rely on.
+
+import { describe, it, expect } from "vitest";
+import { buildCodeMask } from "./markdownCodeMask";
+
+describe("buildCodeMask — CommonMark closer strictness", () => {
+  it("a closer with trailing text does not close the fence", () => {
+    // CommonMark: a closing fence may carry only trailing whitespace.
+    // "``` x" is CONTENT, so the lines after it are still code — the
+    // old regex accepted it as a closer and under-masked them.
+    const md = ["```", "code", "``` x", "\\( still code \\)", "```", "after"].join("\n");
+    const mask = buildCodeMask(md);
+    const idx = md.indexOf("\\( still code");
+    expect(mask[idx]).toBe(1);
+    expect(mask[md.indexOf("after")]).toBe(0);
+  });
+
+  it("a closer with trailing whitespace still closes", () => {
+    const md = ["```", "code", "```  ", "after"].join("\n");
+    const mask = buildCodeMask(md);
+    expect(mask[md.indexOf("after")]).toBe(0);
+  });
+
+  it("a CRLF closer still closes", () => {
+    const md = "```\r\ncode\r\n```\r\nafter";
+    const mask = buildCodeMask(md);
+    expect(mask[md.indexOf("after")]).toBe(0);
+  });
+});
+
+describe("buildCodeMask — backtick info strings", () => {
+  it("a ```info` line with a backtick in the info is prose, not an opener", () => {
+    // CommonMark bans backticks in a backtick fence's info string;
+    // accepting it would mis-mask everything after the line.
+    const md = ["```foo`", "not code \\( x \\)", "text"].join("\n");
+    const mask = buildCodeMask(md);
+    expect(mask[md.indexOf("not code")]).toBe(0);
+  });
+
+  it("a tilde fence may carry anything in its info string", () => {
+    const md = ["~~~foo`bar", "code", "~~~"].join("\n");
+    const mask = buildCodeMask(md);
+    expect(mask[md.indexOf("code")]).toBe(1);
+  });
+});

--- a/src/utils/markdownCodeMask.ts
+++ b/src/utils/markdownCodeMask.ts
@@ -81,7 +81,16 @@ export function buildCodeMask(markdown: string): Uint8Array {
 
       if (!inFencedCodeBlock) {
         const openMatch = line.match(/^ {0,3}(`{3,}|~{3,})/);
-        if (openMatch) {
+        // CommonMark: a backtick fence's info string may not contain a
+        // backtick — "```foo`" is prose, and treating it as an opener
+        // mis-masks everything after it.
+        if (
+          openMatch &&
+          !(
+            openMatch[1][0] === "`" &&
+            line.slice(openMatch[0].length).includes("`")
+          )
+        ) {
           inFencedCodeBlock = true;
           fencedChar = openMatch[1][0] as "`" | "~";
           fencedLen = openMatch[1].length;
@@ -90,9 +99,12 @@ export function buildCodeMask(markdown: string): Uint8Array {
           continue;
         }
       } else {
-        // Check for closing fence: same char, >= same count
+        // Check for closing fence: same char, >= same count. CommonMark
+        // allows ONLY trailing whitespace after the closing run — a
+        // "``` x" line is content, not a closer (accepting it
+        // under-masked everything after it).
         const closeRe = new RegExp(
-          `^ {0,3}\\${fencedChar}{${fencedLen},}(?:\\s|$)`
+          `^ {0,3}\\${fencedChar}{${fencedLen},}[ \\t]*\\r?$`
         );
         if (closeRe.test(line)) {
           inFencedCodeBlock = false;

--- a/src/utils/markdownPipeline/parser.ts
+++ b/src/utils/markdownPipeline/parser.ts
@@ -34,6 +34,10 @@ import {
   normalizeBareListMarkers,
   fixNormalizationSpread,
 } from "./parser/listNormalization";
+import {
+  escapeUnclosedMathFences,
+  normalizeMathDelimiters,
+} from "./parser/mathSourceGuards";
 import { createProcessor } from "./parser/processorFactory";
 
 // Re-exports for backward compatibility with callers that import directly
@@ -57,8 +61,15 @@ export function parseMarkdownToMdast(
   markdown: string,
   options: MarkdownPipelineOptions = {}
 ): Root {
+  // Math source guards (#1180/#1181): rewrite `\[ \]`/`\( \)` to
+  // `$`-delimiters and defuse unclosed `$$` fences (pandoc's blank-line
+  // rule) before remark sees the text. Document parse only — the
+  // source-position dialect must see the text as written.
+  const mathGuarded = escapeUnclosedMathFences(
+    normalizeMathDelimiters(markdown),
+  );
   // Normalize bare list markers (e.g., "  -\n") to ensure trailing space
-  const { text: normalized, modified: wasNormalized } = normalizeBareListMarkers(markdown);
+  const { text: normalized, modified: wasNormalized } = normalizeBareListMarkers(mathGuarded);
   // Pre-process escaped custom markers before remark parsing
   const preprocessed = preprocessEscapedMarkers(normalized);
 

--- a/src/utils/markdownPipeline/parser/mathDelimiterSpans.test.ts
+++ b/src/utils/markdownPipeline/parser/mathDelimiterSpans.test.ts
@@ -1,0 +1,246 @@
+// Tests for the `\[ \]` / `\( \)` math-delimiter span finder and the
+// normalization built on it (issue #1180). The finder is a single
+// forward scan (no regex backtracking — a document of unpaired openers
+// or escaped closers must not go quadratic) over an opaque-region mask:
+// code, YAML frontmatter, inline-link destinations, and HTML tags are
+// never rewritten (Codex audit H1/M4/M5).
+
+import { describe, it, expect } from "vitest";
+import {
+  findMathDelimiterSpans,
+  normalizeMathDelimiters,
+} from "./mathDelimiterSpans";
+
+describe("normalizeMathDelimiters — conversions", () => {
+  it("converts standalone \\[ ... \\] to a $$ fence", () => {
+    expect(normalizeMathDelimiters("\\[ \\alpha=0 \\]")).toBe(
+      ["$$", "\\alpha=0", "$$"].join("\n"),
+    );
+  });
+
+  it("converts a multi-line display span", () => {
+    const input = ["\\[", "\\alpha = 0", "\\]"].join("\n");
+    expect(normalizeMathDelimiters(input)).toBe(
+      ["$$", "\\alpha = 0", "$$"].join("\n"),
+    );
+  });
+
+  it("converts an indented display span, preserving the indent", () => {
+    expect(normalizeMathDelimiters("  \\[ x \\]")).toBe(
+      ["  $$", "x", "$$"].join("\n"),
+    );
+  });
+
+  it("converts inline \\( ... \\) to single-dollar math", () => {
+    expect(normalizeMathDelimiters("Given \\( x^2 \\) here.")).toBe(
+      "Given $x^2$ here.",
+    );
+  });
+
+  it("picks a longer dollar run when the content contains a dollar", () => {
+    // `$\text{\$5}$` would close at the inner dollar (Codex H4) — the
+    // delimiter run must exceed the longest run in the content, like
+    // mdast-util-math's serializer.
+    expect(normalizeMathDelimiters("\\( \\text{\\$5} \\)")).toBe(
+      "$$\\text{\\$5}$$",
+    );
+  });
+
+  it("display: lengthens the fence when the content has a dollar-only line", () => {
+    const input = ["\\[", "x", "$$", "y", "\\]"].join("\n");
+    expect(normalizeMathDelimiters(input)).toBe(
+      ["$$$", "x", "$$", "y", "$$$"].join("\n"),
+    );
+  });
+
+  it("converts CJK-adjacent inline math without surrounding spaces", () => {
+    // The reporter writes Chinese — CJK text routinely omits spaces
+    // around math, and the guard must not require them.
+    expect(normalizeMathDelimiters("值\\(x\\)是")).toBe("值$x$是");
+  });
+
+  it("CRLF: a standalone display span converts", () => {
+    expect(normalizeMathDelimiters("\\[ \\alpha=0 \\]\r\ntext")).toBe(
+      "$$\n\\alpha=0\n$$\r\ntext",
+    );
+  });
+});
+
+describe("normalizeMathDelimiters — refusals", () => {
+  it("leaves inline code spans untouched", () => {
+    const input = "Use `\\( x \\)` verbatim.";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves fenced code untouched", () => {
+    const input = ["```tex", "\\[ x \\]", "```"].join("\n");
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("rejects a span that CROSSES an inline code region", () => {
+    // Endpoints are outside code, but converting would swallow the
+    // code span into math (Codex M4).
+    const input = "\\( a `code` b \\)";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves escaped parens inside a link destination untouched (Codex H1)", () => {
+    const input = "[x](foo\\(bar\\))";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves a literal autolink URL untouched", () => {
+    // GFM literal autolinks put the URL in the child span — tail-only
+    // masking would expose it.
+    const input = "See https://example.test/\\(x\\) for details.";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves an angle autolink URL untouched", () => {
+    const input = "See <https://example.test/\\(x\\)> for details.";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves a SHORTCUT reference label untouched — it is also the id", () => {
+    // Converting the label would break the match to its definition.
+    const input = "[\\(x\\)]\n\n[\\(x\\)]: https://example.test";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves a COLLAPSED reference label untouched — same id semantics", () => {
+    const input = "[\\(x\\)][]\n\n[\\(x\\)]: https://example.test";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("converts a FULL reference label — the id does the matching", () => {
+    const input = "[\\( x \\)][id]\n\n[id]: https://example.test";
+    const out = normalizeMathDelimiters(input);
+    expect(out).toContain("[$x$][id]");
+    expect(out).toContain("[id]: https://example.test");
+  });
+
+  it("leaves YAML frontmatter untouched", () => {
+    const input = ["---", "title: \\[ x \\]", "---", "", "body"].join("\n");
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves delimiters inside an HTML tag untouched", () => {
+    const input = '<img alt="\\(x\\)" src="a.png">';
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("does not touch LaTeX row-spacing \\\\[4pt] (double backslash)", () => {
+    const input = ["$$", "a \\\\[4pt] b", "$$"].join("\n");
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves an unpaired opener alone", () => {
+    const input = "A lone \\( with no closer.";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("does not pair across a blank line", () => {
+    const input = ["\\[ a", "", "b \\]"].join("\n");
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("CRLF: does not pair across a \\r\\n blank line", () => {
+    const input = "\\[ a\r\n\r\nb \\]";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves mid-sentence escaped brackets alone (corpus: \\[not a link\\])", () => {
+    const input = "Backslash escapes: \\*not italic\\*, and \\[not a link\\].";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves a link reference definition untouched", () => {
+    const input = "[id]: foo\\(bar\\)";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves a reference definition with an escaped label bracket untouched", () => {
+    const input = "[a\\]]: foo\\(bar\\)";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves a processing-instruction HTML block untouched", () => {
+    const input = ["<?target", "\\(x\\)", "?>"].join("\n");
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves a quoted attribute containing > untouched", () => {
+    const input = '<span title="> \\(x\\)">label</span>';
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves an unterminated comment untouched (runs to EOF)", () => {
+    const input = "<!-- open comment\n\\( x \\)";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves HTML comments untouched", () => {
+    const input = "<!-- \\( x \\) -->";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("leaves raw HTML block bodies (script/style) untouched", () => {
+    const input = ['<script>', 'let a = "\\( x \\)";', "</script>"].join("\n");
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("does not pair across a backslash hard-break into a blank line", () => {
+    // The trailing backslash before the newline must not swallow the
+    // blank-line boundary check (Codex M6).
+    const input = "\\(a\\\n\nb\\)";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("treats an escaped closer as content, not a terminator", () => {
+    // `\\)` is backslash-escaped — no closer exists, so no span; and
+    // the scan must terminate promptly (no quadratic rescans).
+    const input = "\\( a \\\\) b";
+    expect(normalizeMathDelimiters(input)).toBe(input);
+  });
+
+  it("empty input passes through", () => {
+    expect(normalizeMathDelimiters("")).toBe("");
+  });
+});
+
+describe("findMathDelimiterSpans", () => {
+  it("reports offsets usable for escape protection", () => {
+    const text = "Given \\( x \\) end.";
+    const spans = findMathDelimiterSpans(text);
+    expect(spans).toHaveLength(1);
+    expect(text.slice(spans[0].start, spans[0].start + 2)).toBe("\\(");
+    expect(text.slice(spans[0].end - 2, spans[0].end)).toBe("\\)");
+    expect(spans[0].kind).toBe("inline");
+  });
+
+  it("skips display spans that are not standalone", () => {
+    expect(findMathDelimiterSpans("mid \\[ x \\] sentence")).toHaveLength(0);
+  });
+
+  it("finds a standalone display span", () => {
+    const spans = findMathDelimiterSpans("\\[ x \\]");
+    expect(spans).toHaveLength(1);
+    expect(spans[0].kind).toBe("display");
+  });
+
+  it("survives a flood of unpaired openers (linearity smoke)", () => {
+    const flood = "\\( ".repeat(20000);
+    const started = performance.now();
+    expect(findMathDelimiterSpans(flood)).toHaveLength(0);
+    expect(performance.now() - started).toBeLessThan(1000);
+  });
+
+  it("survives a flood of openers whose only closer is inside code", () => {
+    // Codex M5 — the masked closer must not send every opener on a
+    // fresh scan to it.
+    const flood = "\\( ".repeat(20000) + "`\\)`";
+    const started = performance.now();
+    expect(findMathDelimiterSpans(flood)).toHaveLength(0);
+    expect(performance.now() - started).toBeLessThan(1000);
+  });
+});

--- a/src/utils/markdownPipeline/parser/mathDelimiterSpans.ts
+++ b/src/utils/markdownPipeline/parser/mathDelimiterSpans.ts
@@ -1,0 +1,206 @@
+/**
+ * Purpose: Recognize ChatGPT-style `\[ … \]` / `\( … \)` LaTeX
+ * delimiter spans in raw markdown, and normalize them to the
+ * `$`-delimiters remark-math understands (issue #1180). Runs before
+ * remark because CommonMark escape handling consumes the backslashes
+ * into literal brackets — no mdast transform can see them.
+ *
+ * Key decisions:
+ *   - Worst-case linear: escape parity, blank-line boundaries, closer
+ *     positions, and a mask prefix-sum are each precomputed in one
+ *     pass; the opener loop then advances monotonic pointers, so a
+ *     flood of unpaired openers — even with masked or escaped closers
+ *     in range — never rescans (Codex M5/M6).
+ *   - Spans never overlap opaque regions — code, HTML (every
+ *     CommonMark block class and inline tags), frontmatter, reference
+ *     definitions, link/image destinations and autolinks — derived
+ *     from a probe parse (mathProbe.ts), so micromark's grammar is the
+ *     authority, not a regex approximation. (Existing math is NOT
+ *     opaque — see mathProbe's OPAQUE_TYPES for why.) Spans never cross a blank
+ *     line, and display spans convert only when standalone:
+ *     mid-sentence `\[…\]` is escaped-bracket prose (the corpus has
+ *     `\[not a link\]`), while ChatGPT emits display math on its own
+ *     lines. Inline `\(…\)` has no prose collision and converts even
+ *     with CJK butted against it — no whitespace requirement.
+ *   - Replacement delimiters follow mdast-util-math's sizing: the
+ *     dollar run must exceed the longest run in the content, so
+ *     `\( \text{\$5} \)` becomes `$$\text{\$5}$$`, not `$…$` truncated
+ *     at the inner dollar (Codex H4).
+ *   - The span finder is shared with cleanPastedMarkdown, which must
+ *     NOT strip the backslashes of a recognized math pair on paste.
+ *
+ * @coordinates-with ./mathProbe.ts — the hands-off mask
+ * @coordinates-with ./mathSourceGuards.ts — re-exports normalize for parser.ts
+ * @coordinates-with @/utils/cleanPastedMarkdown — protects spans on paste
+ * @module utils/markdownPipeline/parser/mathDelimiterSpans
+ */
+
+import { buildProbeOpaqueMask } from "./mathProbe";
+
+export interface MathDelimiterSpan {
+  /** Offset of the opener's backslash. */
+  start: number;
+  /** Offset just past the closer's bracket. */
+  end: number;
+  /** Trimmed LaTeX content between the delimiters. */
+  content: string;
+  kind: "display" | "inline";
+}
+
+const KINDS = [
+  { open: "\\[", closeChar: "]", kind: "display" as const },
+  { open: "\\(", closeChar: ")", kind: "inline" as const },
+];
+
+/** escapedAt[i] = 1 when the char at i is preceded by an ODD number of
+ *  backslashes (i.e. it is itself escaped). One pass. */
+function buildEscapedAt(text: string): Uint8Array {
+  const escapedAt = new Uint8Array(text.length);
+  let run = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (run % 2 === 1) escapedAt[i] = 1;
+    run = text[i] === "\\" ? run + 1 : 0;
+  }
+  return escapedAt;
+}
+
+/** prefix[i] = number of masked bytes in text[0, i). */
+function buildMaskPrefix(mask: Uint8Array): Int32Array {
+  const prefix = new Int32Array(mask.length + 1);
+  for (let i = 0; i < mask.length; i++) prefix[i + 1] = prefix[i] + mask[i];
+  return prefix;
+}
+
+const BLANK_LINE = /^[ \t]*\r?$/;
+const WHITESPACE_ONLY = /^[ \t]*$/;
+const WHITESPACE_EOL = /^[ \t]*\r?$/;
+
+/** Offsets of each `\n` that immediately precedes a blank line. */
+function buildBlankBoundaries(text: string): number[] {
+  const boundaries: number[] = [];
+  let lineStart = 0;
+  while (lineStart <= text.length) {
+    const nl = text.indexOf("\n", lineStart);
+    const lineEnd = nl === -1 ? text.length : nl;
+    if (lineStart > 0 && BLANK_LINE.test(text.slice(lineStart, lineEnd))) {
+      boundaries.push(lineStart - 1);
+    }
+    if (nl === -1) break;
+    lineStart = nl + 1;
+  }
+  return boundaries;
+}
+
+/** Longest run of consecutive `$` anywhere in `content`. */
+function longestDollarRun(content: string): number {
+  let longest = 0;
+  let run = 0;
+  for (const c of content) {
+    run = c === "$" ? run + 1 : 0;
+    if (run > longest) longest = run;
+  }
+  return longest;
+}
+
+/** Longest `$`-run forming a whole (closer-shaped) line of `content`. */
+function longestDollarOnlyLine(content: string): number {
+  let longest = 0;
+  for (const line of content.split("\n")) {
+    const m = /^ {0,3}(\$+)[ \t]*\r?$/.exec(line);
+    if (m && m[1].length > longest) longest = m[1].length;
+  }
+  return longest;
+}
+
+/** All convertible math delimiter spans in `text`, sorted by start. */
+export function findMathDelimiterSpans(
+  text: string,
+  mask: Uint8Array = buildProbeOpaqueMask(text),
+): MathDelimiterSpan[] {
+  const spans: MathDelimiterSpan[] = [];
+  const escapedAt = buildEscapedAt(text);
+  const maskPrefix = buildMaskPrefix(mask);
+  const blanks = buildBlankBoundaries(text);
+  const maskedBetween = (from: number, to: number): boolean =>
+    maskPrefix[to] - maskPrefix[from] > 0;
+
+  for (const { open, closeChar, kind } of KINDS) {
+    // Usable closer positions, precomputed once.
+    const closers: number[] = [];
+    for (let j = text.indexOf("\\" + closeChar); j !== -1; j = text.indexOf("\\" + closeChar, j + 1)) {
+      if (escapedAt[j] !== 1 && mask[j] !== 1 && mask[j + 1] !== 1) {
+        closers.push(j);
+      }
+    }
+    if (closers.length === 0) continue;
+
+    let cIdx = 0;
+    let bIdx = 0;
+    let pos = 0;
+    for (;;) {
+      const i = text.indexOf(open, pos);
+      if (i === -1) break;
+      pos = i + 2;
+      if (mask[i] === 1 || mask[i + 1] === 1 || escapedAt[i] === 1) continue;
+
+      while (cIdx < closers.length && closers[cIdx] < i + 2) cIdx += 1;
+      if (cIdx === closers.length) break; // no closer remains for ANY later opener
+      const closer = closers[cIdx];
+      while (bIdx < blanks.length && blanks[bIdx] <= i) bIdx += 1;
+      const blank = bIdx < blanks.length ? blanks[bIdx] : Number.POSITIVE_INFINITY;
+      if (blank < closer) continue; // dead opener — blank line first
+      const end = closer + 2;
+      if (maskedBetween(i, end)) continue; // spans an opaque region
+
+      const content = text.slice(i + 2, closer).trim();
+      if (content.length === 0) continue;
+
+      if (kind === "display") {
+        const lineStart = text.lastIndexOf("\n", i - 1) + 1;
+        const nl = text.indexOf("\n", end);
+        const lineEnd = nl === -1 ? text.length : nl;
+        const standalone =
+          WHITESPACE_ONLY.test(text.slice(lineStart, i)) &&
+          WHITESPACE_EOL.test(text.slice(end, lineEnd));
+        if (!standalone) continue;
+      }
+
+      spans.push({ start: i, end, content, kind });
+      pos = end;
+    }
+  }
+
+  return spans.sort((a, b) => a.start - b.start);
+}
+
+/**
+ * Rewrite recognized delimiter spans to `$`-form. Overlapping spans
+ * (a display span wrapping an inline pair) resolve outer-first.
+ */
+export function normalizeMathDelimiters(markdown: string): string {
+  if (!markdown.includes("\\[") && !markdown.includes("\\(")) return markdown;
+  const spans = findMathDelimiterSpans(markdown);
+  if (spans.length === 0) return markdown;
+
+  const pieces: string[] = [];
+  let last = 0;
+  for (const span of spans) {
+    if (span.start < last) continue; // nested inside a consumed span
+    let rendered: string;
+    if (span.kind === "display") {
+      const fence = "$".repeat(
+        Math.max(2, longestDollarOnlyLine(span.content) + 1),
+      );
+      rendered = `${fence}\n${span.content}\n${fence}`;
+    } else {
+      const run = "$".repeat(
+        Math.max(1, longestDollarRun(span.content) + 1),
+      );
+      rendered = `${run}${span.content}${run}`;
+    }
+    pieces.push(markdown.slice(last, span.start), rendered);
+    last = span.end;
+  }
+  pieces.push(markdown.slice(last));
+  return pieces.join("");
+}

--- a/src/utils/markdownPipeline/parser/mathGuards.integration.test.ts
+++ b/src/utils/markdownPipeline/parser/mathGuards.integration.test.ts
@@ -1,0 +1,102 @@
+// Pipeline integration for both math source guards (issues #1181,
+// #1180): the guards run inside parseMarkdownToMdast, so these tests
+// go through the real parseMarkdown/serializeMarkdown adapter. Unit
+// coverage lives in mathSourceGuards.test.ts and
+// mathDelimiterSpans.test.ts.
+
+import { describe, it, expect } from "vitest";
+import { parseMarkdown, serializeMarkdown } from "../adapter";
+import { testSchema } from "../testSchema";
+import { MATH_BLOCK_LANGUAGE } from "../mdastBlockConverters";
+import type { Node as PMNode } from "@tiptap/pm/model";
+
+/** Collect [typeName, language|null, textContent] rows for block nodes. */
+function blockRows(doc: PMNode): Array<[string, string | null, string]> {
+  const rows: Array<[string, string | null, string]> = [];
+  doc.forEach((child) => {
+    rows.push([
+      child.type.name,
+      (child.attrs?.language as string | undefined) ?? null,
+      child.textContent,
+    ]);
+  });
+  return rows;
+}
+
+describe("pipeline integration", () => {
+  it("#1181 — paragraphs after an unclosed $$ survive; the later pair still parses", () => {
+    const input = [
+      "$$",
+      "E=mc^2",
+      "",
+      "A normal paragraph.",
+      "",
+      "$$",
+      "F=ma",
+      "$$",
+    ].join("\n");
+    const doc = parseMarkdown(testSchema, input);
+    const rows = blockRows(doc);
+
+    expect(
+      rows.some(
+        ([type, , text]) =>
+          type === "paragraph" && text.includes("A normal paragraph."),
+      ),
+    ).toBe(true);
+    const mathBlocks = rows.filter(([, lang]) => lang === MATH_BLOCK_LANGUAGE);
+    expect(mathBlocks).toHaveLength(1);
+    expect(mathBlocks[0][2]).toContain("F=ma");
+  });
+
+  it("#1181 — a legit multi-line block still round-trips", () => {
+    const input = ["$$", "E=mc^2", "\\alpha + \\beta", "$$"].join("\n");
+    const doc = parseMarkdown(testSchema, input);
+    const output = serializeMarkdown(testSchema, doc).trim();
+    expect(output).toBe(input);
+  });
+
+  it("#1180 — display brackets become a block math node, serialized canonical", () => {
+    const doc = parseMarkdown(testSchema, "\\[ \\alpha=0 \\]");
+    const rows = blockRows(doc);
+    const mathBlocks = rows.filter(([, lang]) => lang === MATH_BLOCK_LANGUAGE);
+    expect(mathBlocks).toHaveLength(1);
+    expect(mathBlocks[0][2]).toContain("\\alpha=0");
+    const output = serializeMarkdown(testSchema, doc).trim();
+    expect(output).toBe(["$$", "\\alpha=0", "$$"].join("\n"));
+  });
+
+  it("#1180 — inline brackets become inline math, serialized canonical", () => {
+    const doc = parseMarkdown(testSchema, "Given \\( x^2 \\) here.");
+    let sawInlineMath = false;
+    doc.descendants((node) => {
+      if (node.type.name === "math_inline") sawInlineMath = true;
+      return true;
+    });
+    expect(sawInlineMath).toBe(true);
+    const output = serializeMarkdown(testSchema, doc).trim();
+    expect(output).toBe("Given $x^2$ here.");
+  });
+
+  it("#1180 — bracket delimiters inside code fences stay literal", () => {
+    const input = ["```tex", "\\[ x \\]", "```"].join("\n");
+    const doc = parseMarkdown(testSchema, input);
+    const output = serializeMarkdown(testSchema, doc).trim();
+    expect(output).toBe(input);
+  });
+
+  it("dialect pin: the source-position processor sees the text as written", async () => {
+    // The guards run ONLY in the document parse. The source-position
+    // dialect maps offsets of the raw text — rewriting there would
+    // corrupt every consumer downstream. This pins the divergence as
+    // intentional (same contract as remarkDisableSetextHeadings).
+    const { createMarkdownProcessor } = await import("../parser");
+    const processor = createMarkdownProcessor();
+    const input = "Given \\( x^2 \\) here.";
+    const tree = processor.runSync(processor.parse(input)) as {
+      children: Array<{ children?: Array<{ type: string }> }>;
+    };
+    const inlineTypes = tree.children[0]?.children?.map((c) => c.type) ?? [];
+    expect(inlineTypes).not.toContain("inlineMath");
+  });
+});

--- a/src/utils/markdownPipeline/parser/mathProbe.ts
+++ b/src/utils/markdownPipeline/parser/mathProbe.ts
@@ -1,0 +1,180 @@
+/**
+ * Purpose: micromark-authoritative facts about a raw markdown string,
+ * for the math source guards. Instead of re-implementing CommonMark
+ * container/HTML/code grammar in hand-rolled scanners (which
+ * demonstrably diverged — tabs, nested lists, HTML block types, quoted
+ * attributes, escaped labels…), a probe parse with the pipeline's own
+ * processor answers two questions exactly:
+ *
+ *   1. Which UTF-16 offset ranges are OPAQUE to source rewrites —
+ *      code, HTML (all seven CommonMark block classes and inline tags,
+ *      via `html` nodes), frontmatter (`yaml`), reference definitions,
+ *      and link/image destinations (whole autolinks). Existing math is
+ *      deliberately NOT opaque — see OPAQUE_TYPES.
+ *   2. Where each math-flow node actually starts and ends — containers,
+ *      indentation, and fence grammar all resolved by micromark itself.
+ *
+ * The probe is `processor.parse()` only (no transforms), so positions
+ * are pristine offsets into the probed text. It runs only for
+ * documents that contain math-ish markers, at document-parse time (not
+ * per keystroke).
+ *
+ * @coordinates-with ./processorFactory.ts — the probe processor
+ * @coordinates-with ./mathDelimiterSpans.ts — opaque-mask consumer
+ * @coordinates-with ./mathSourceGuards.ts — math-extent consumer
+ * @module utils/markdownPipeline/parser/mathProbe
+ */
+
+import type { Node, Parent, Root } from "mdast";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkFrontmatter from "remark-frontmatter";
+import { createProcessor } from "./processorFactory";
+
+/** Parse `text` with the pipeline's processor, transforms skipped. */
+export function probeParse(text: string): Root {
+  return createProcessor(text, {}).parse(text) as Root;
+}
+
+/**
+ * Parse with math DISABLED. Used by the guard's fail-closed sweep: a
+ * violating math node hides the code/HTML blocks it swallowed, so
+ * opacity for the sweep must come from a tree where `$$` is inert and
+ * those blocks are visible again. Core CommonMark (code, HTML) plus
+ * frontmatter is enough — the sweep only needs the opaque classes.
+ */
+export function probeParseWithoutMath(text: string): Root {
+  return unified()
+    .use(remarkParse)
+    .use(remarkFrontmatter, ["yaml"])
+    .parse(text) as Root;
+}
+
+interface Positioned {
+  position?: {
+    start: { offset?: number };
+    end: { offset?: number };
+  };
+}
+
+function spanOf(node: Node): [number, number] | null {
+  const pos = (node as Positioned).position;
+  const start = pos?.start.offset;
+  const end = pos?.end.offset;
+  return typeof start === "number" && typeof end === "number"
+    ? [start, end]
+    : null;
+}
+
+function visit(node: Node, fn: (node: Node) => void): void {
+  fn(node);
+  const children = (node as Parent).children;
+  if (Array.isArray(children)) {
+    for (const child of children) visit(child, fn);
+  }
+}
+
+/** Node types whose entire span is opaque to source rewrites.
+ *  Existing math nodes are deliberately NOT opaque: a `\[ … \]` span
+ *  whose content merely LOOKS like `$$` math would otherwise be
+ *  half-claimed by the probe and never convert. Literal `\(`/`\[`
+ *  inside real dollar-math is invalid LaTeX to begin with, and the
+ *  escape-parity rule still protects `\\[4pt]` row spacing. */
+const OPAQUE_TYPES = new Set([
+  "code",
+  "inlineCode",
+  "html",
+  "yaml",
+  "definition",
+]);
+
+/** Link-ish parents whose destination tail (after the label) is opaque. */
+const LINKISH_TYPES = new Set(["link", "image", "linkReference", "imageReference"]);
+
+/**
+ * Per-offset mask (UTF-16 indexing, same as String) of regions the
+ * math source guards must not rewrite, derived from the probe parse
+ * rather than regex approximations.
+ */
+export function buildProbeOpaqueMask(
+  text: string,
+  tree: Root = probeParse(text),
+): Uint8Array {
+  const mask = new Uint8Array(text.length);
+  const cover = (from: number, to: number) => {
+    for (let i = Math.max(0, from); i < Math.min(text.length, to); i++) {
+      mask[i] = 1;
+    }
+  };
+
+  visit(tree, (node) => {
+    const span = spanOf(node);
+    if (!span) return;
+    if (OPAQUE_TYPES.has(node.type)) {
+      cover(span[0], span[1]);
+      return;
+    }
+    if (LINKISH_TYPES.has(node.type)) {
+      // An authored `[label](dest)` link: the label may contain
+      // convertible math; the tail (destination, title, reference) may
+      // not — mask from the last child's end. But an AUTOLINK's child
+      // span IS the URL (`https://…` or `<https://…>`), so tail-only
+      // masking leaves the URL exposed. Geometric discriminator: an
+      // authored link carries ≥4 syntax chars outside its children
+      // (`[](…)`), an autolink at most 2 (the angle brackets) — mask
+      // the whole node when the overhead is that small.
+      const children = (node as Parent).children;
+      const lastChild = Array.isArray(children)
+        ? children[children.length - 1]
+        : undefined;
+      const lastSpan = lastChild ? spanOf(lastChild) : null;
+      const firstSpan =
+        Array.isArray(children) && children[0] ? spanOf(children[0]) : null;
+      const overhead =
+        firstSpan && lastSpan
+          ? firstSpan[0] - span[0] + (span[1] - lastSpan[1])
+          : Number.POSITIVE_INFINITY;
+      // Only `link` nodes can be autolinks. Reference labels are
+      // authored prose and stay convertible for FULL references only
+      // (`[label][id]` — the separate id does the matching). SHORTCUT
+      // (`[label]`) and COLLAPSED (`[label][]`) references use the
+      // label itself as the identifier: converting it would break the
+      // match to the definition, so mask those nodes whole.
+      const refType = (node as { referenceType?: string }).referenceType;
+      const labelIsId = refType === "shortcut" || refType === "collapsed";
+      if ((node.type === "link" && overhead <= 2) || labelIsId) {
+        cover(span[0], span[1]);
+        return;
+      }
+      cover(lastSpan ? lastSpan[1] : span[0], span[1]);
+    }
+  });
+
+  return mask;
+}
+
+export interface MathFlowExtent {
+  /** Offset of the node's first character — the fence's opening `$`;
+   *  container prefixes (`> `, list indent) sit BEFORE this offset. */
+  start: number;
+  /** Offset just past the node. */
+  end: number;
+  /** The node's value (content between the fences). */
+  value: string;
+}
+
+/** All math FLOW nodes (block `$$` fences) with usable offsets. */
+export function collectMathFlowExtents(tree: Root): MathFlowExtent[] {
+  const extents: MathFlowExtent[] = [];
+  visit(tree, (node) => {
+    if (node.type !== "math") return;
+    const span = spanOf(node);
+    if (!span) return;
+    extents.push({
+      start: span[0],
+      end: span[1],
+      value: (node as unknown as { value?: string }).value ?? "",
+    });
+  });
+  return extents;
+}

--- a/src/utils/markdownPipeline/parser/mathSourceGuards.test.ts
+++ b/src/utils/markdownPipeline/parser/mathSourceGuards.test.ts
@@ -1,0 +1,275 @@
+// Tests for the `$$` fence guard (issue #1181).
+//
+// #1181 — an unclosed `$$` opener swallowed every following paragraph
+// into one giant math block (micromark math flow runs to the next
+// closing fence line or EOF, like an unclosed code fence). The guard
+// applies pandoc's display-math rule at the source layer: a `$$` block
+// must close before a blank line; an opener that doesn't is escaped so
+// it parses as literal text and the content behind it survives as
+// normal blocks. Delimiter normalization (#1180) is covered in
+// mathDelimiterSpans.test.ts; adapter-level round trips in
+// mathGuards.integration.test.ts.
+
+import { describe, it, expect } from "vitest";
+import { escapeUnclosedMathFences } from "./mathSourceGuards";
+
+describe("escapeUnclosedMathFences (#1181)", () => {
+  it("escapes an opener that never closes before a blank line", () => {
+    const input = ["$$", "E=mc^2", "", "A normal paragraph."].join("\n");
+    const out = escapeUnclosedMathFences(input);
+    expect(out).toBe(["\\$$", "E=mc^2", "", "A normal paragraph."].join("\n"));
+  });
+
+  it("keeps a well-formed multi-line block untouched", () => {
+    const input = ["$$", "E=mc^2", "\\alpha + \\beta", "$$"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("a later, well-paired block after a broken opener still parses as math", () => {
+    const input = [
+      "$$",
+      "E=mc^2",
+      "",
+      "A normal paragraph.",
+      "",
+      "$$",
+      "F=ma",
+      "$$",
+    ].join("\n");
+    const out = escapeUnclosedMathFences(input);
+    expect(out.startsWith("\\$$")).toBe(true);
+    expect(out).toContain(["$$", "F=ma", "$$"].join("\n"));
+  });
+
+  it("applies pandoc's rule: a blank line followed by more content is not display math", () => {
+    const input = ["$$", "a", "", "b", "$$"].join("\n");
+    const out = escapeUnclosedMathFences(input);
+    expect(out.startsWith("\\$$")).toBe(true);
+  });
+
+  it("tolerates the app's empty-math template: $$ / blank / $$", () => {
+    // Source-mode insertMath produces exactly this shape (opener, blank
+    // caret line, closer) — behavioral parity requires it to keep
+    // parsing as an empty math block. A blank tail followed directly by
+    // the closer swallows nothing, so the pandoc rule stands down.
+    const input = ["The quick brown fox", "$$", "", "$$", ""].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("tolerates trailing blank lines before the closer", () => {
+    const input = ["$$", "a", "", "", "$$"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("ignores $$ inside fenced code blocks", () => {
+    const input = ["```", "$$", "not math", "```", "", "text"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("ignores single-line inline math", () => {
+    const input = "The value $$x$$ stays inline.";
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("empty input passes through", () => {
+    expect(escapeUnclosedMathFences("")).toBe("");
+  });
+
+  it("CRLF: a well-formed block with \\r\\n endings stays untouched", () => {
+    // The trailing paragraph keeps the closer OFF the final line, so it
+    // carries a real "\r" (split("\n") leaves it there).
+    const input = ["$$", "E=mc^2", "$$", "", "after"].join("\r\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("CRLF: a blank \\r\\n line still triggers the pandoc rule", () => {
+    const input = ["$$", "E=mc^2", "", "text"].join("\r\n");
+    expect(escapeUnclosedMathFences(input).startsWith("\\$$")).toBe(true);
+  });
+
+  it("lone CR: a blank \\r line still triggers the pandoc rule", () => {
+    // CommonMark accepts classic-Mac \r endings; the guard must not go
+    // blind on them.
+    const input = ["$$", "x", "", "paragraph"].join("\r");
+    expect(escapeUnclosedMathFences(input).startsWith("\\$$")).toBe(true);
+  });
+
+  it("lone CR: a well-formed block stays untouched", () => {
+    const input = ["$$", "x", "$$", "", "after"].join("\r");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("honors micromark's run-length grammar: $$$ closes only with 3+ dollars", () => {
+    // Codex H3 — a valid $$$ block must not be escaped…
+    const valid = ["$$$", "x $$ y", "$$$"].join("\n");
+    expect(escapeUnclosedMathFences(valid)).toBe(valid);
+    // …a longer closer is fine…
+    const longCloser = ["$$", "x", "$$$"].join("\n");
+    expect(escapeUnclosedMathFences(longCloser)).toBe(longCloser);
+    // …and a too-short closer does not close.
+    const shortCloser = ["$$$", "x", "$$", "", "text"].join("\n");
+    expect(escapeUnclosedMathFences(shortCloser).startsWith("\\$$$")).toBe(
+      true,
+    );
+  });
+
+  it("treats $$$x$$$ on one line as inline, not a fence", () => {
+    const input = "The value $$$x$$$ stays inline.";
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("guards blockquoted math: an unclosed > $$ is escaped in place", () => {
+    // Codex H2 — micromark opens math flow behind container prefixes
+    // too; without the guard it swallows the rest of the blockquote.
+    const input = ["> $$", "> E=mc^2", "", "after"].join("\n");
+    const out = escapeUnclosedMathFences(input);
+    expect(out).toBe(["> \\$$", "> E=mc^2", "", "after"].join("\n"));
+  });
+
+  it("keeps a well-formed blockquoted block untouched", () => {
+    const input = ["> $$", "> E=mc^2", "> $$"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("a blockquote ending before the closer counts as unclosed", () => {
+    const input = ["> $$", "> E=mc^2", "plain paragraph"].join("\n");
+    const out = escapeUnclosedMathFences(input);
+    expect(out.startsWith("> \\$$")).toBe(true);
+  });
+
+  it("leaves $$ inside YAML frontmatter untouched", () => {
+    const input = ["---", "price: $$", "---", "", "body"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("leaves $$ inside a raw HTML block untouched", () => {
+    const input = ["<script>", "$$", "foo()", "</script>", "", "text"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("a bare - $$ before a sibling item swallows nothing and stays as typed", () => {
+    // micromark ends the math node at the item boundary (value "") —
+    // the sibling item is NOT swallowed, so the empty-value courtesy
+    // applies, same as the mid-typing case.
+    const input = ["- $$", "- next item"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("guards list-item math that swallows past a blank line", () => {
+    const input = ["- $$", "  x", "", "  swallowed"].join("\n");
+    const out = escapeUnclosedMathFences(input);
+    expect(out).toContain("- \\$$");
+  });
+
+  it("keeps a well-formed bullet-list math block untouched", () => {
+    const input = ["- $$", "  E=mc^2", "  $$"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("keeps a well-formed ordered-list math block untouched", () => {
+    const input = ["1. $$", "   x", "   $$"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("an unclosed quoted code fence does not disarm the guard afterwards (Codex M7)", () => {
+    const input = ["> ```", "> code", "", "$$", "x", "", "text"].join("\n");
+    const out = escapeUnclosedMathFences(input);
+    expect(out).toBe(["> ```", "> code", "", "\\$$", "x", "", "text"].join("\n"));
+  });
+
+  it("guards nested-list math: an unclosed deep opener is escaped in place", () => {
+    // micromark opens math flow at any container depth — the probe
+    // parse sees exactly what it sees, so nesting needs no scanner.
+    const input = ["- outer", "  - $$", "    x", "  - next"].join("\n");
+    const out = escapeUnclosedMathFences(input);
+    expect(out).toContain("- \\$$");
+  });
+
+  it("leaves tab-indented $$ alone — it is indented code, not math", () => {
+    const input = "\t$$\n\tstill code";
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("leaves $$ inside a tilde fence within a list item untouched", () => {
+    const input = ["- ~~~", "  $$", "  code", "  ~~~"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("leaves $$ inside a generic HTML block untouched", () => {
+    const input = ["<div>", "$$", "</div>", "", "text"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("a `` ```info` `` line is prose, not a fence — the guard stays armed", () => {
+    // CommonMark bans backticks in a backtick fence's info string; a
+    // scanner that accepted it would treat the following $$ as code.
+    const input = ["```foo`", "", "$$", "x", "", "text"].join("\n");
+    const out = escapeUnclosedMathFences(input);
+    expect(out).toContain("\\$$");
+  });
+
+  it("an over-indented $$ line is content, not a closer", () => {
+    // micromark reports the "    $$" line inside the node's value —
+    // the value-based closure check needs no indent grammar to agree.
+    const input = ["$$", "x", "    $$", "", "paragraph"].join("\n");
+    const out = escapeUnclosedMathFences(input);
+    expect(out.startsWith("\\$$")).toBe(true);
+  });
+
+  it("keeps an empty dangling opener as typed (mid-typing courtesy)", () => {
+    // An empty-value node swallows nothing; escaping while the user is
+    // still typing the block would be hostile.
+    const input = ["text", "", "$$"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+  });
+
+  it("a deeper-quoted $$ line is content, not a closer", () => {
+    // micromark reports value "x\n> $$" (one quote marker consumed) —
+    // the line belongs to the (unclosed) block, so the opener escapes.
+    const input = ["> $$", "> x", ">> $$", "", "paragraph"].join("\n");
+    const out = escapeUnclosedMathFences(input);
+    expect(out.startsWith("> \\$$")).toBe(true);
+  });
+
+  it("a valid $$$ block containing a shorter dollar line is NOT unclosed", () => {
+    // Suffix-based closure checks collided here: the real "$$$" closer
+    // ends with the value's "$$" line. Line counts do not collide.
+    const input = ["$$$", "x", "$$", "$$$"].join("\n");
+    expect(escapeUnclosedMathFences(input)).toBe(input);
+    const singleDollar = ["$$", "x", "$", "$$"].join("\n");
+    expect(escapeUnclosedMathFences(singleDollar)).toBe(singleDollar);
+    const quoted = ["> $$$", "> x", "> $$", "> $$$"].join("\n");
+    expect(escapeUnclosedMathFences(quoted)).toBe(quoted);
+  });
+
+  it("fails closed past the healing budget: no violating opener survives (bounded time)", () => {
+    const flood = Array.from({ length: 2000 }, () => "$$ meta").join("\n");
+    const input = `${flood}\n\nsurvivor paragraph`;
+    const started = performance.now();
+    const out = escapeUnclosedMathFences(input);
+    expect(performance.now() - started).toBeLessThan(5000);
+    // Every opener-shaped line is escaped — partial healing must not
+    // leave an active swallower in front of the paragraph.
+    expect(/^\$\$/m.test(out)).toBe(false);
+    expect(out).toContain("survivor paragraph");
+  });
+
+  it("the fail-closed sweep also escapes list-prefixed openers", () => {
+    const flood = Array.from({ length: 15 }, (_, i) =>
+      ["$$ b" + i, "x", "", ""].join("\n"),
+    ).join("");
+    const input = `${flood}- $$\n  x\n\n  survivor`;
+    const out = escapeUnclosedMathFences(input);
+    expect(out).toContain("- \\$$");
+    expect(out).toContain("survivor");
+  });
+
+  it("the fail-closed sweep still respects code fences (math-disabled probe)", () => {
+    const flood = Array.from({ length: 15 }, (_, i) =>
+      ["$$ b" + i, "x", "", ""].join("\n"),
+    ).join("");
+    const input = `${flood}~~~\n$$\n~~~`;
+    const out = escapeUnclosedMathFences(input);
+    expect(out).toContain("~~~\n$$\n~~~");
+  });
+});

--- a/src/utils/markdownPipeline/parser/mathSourceGuards.ts
+++ b/src/utils/markdownPipeline/parser/mathSourceGuards.ts
@@ -1,0 +1,156 @@
+/**
+ * Purpose: Pre-parse guard for unclosed `$$` math fences (issue
+ * #1181). micromark's math flow is fence-like — an unclosed opener
+ * legally swallows everything to the next closing fence line, the end
+ * of its container, or EOF, so by the time mdast exists the damage is
+ * one giant math node. The guard applies pandoc's display-math rule:
+ * a fence must close before a blank line; an opener that doesn't gets
+ * its first `$` escaped so it parses as literal text and the content
+ * behind it survives as normal blocks.
+ *
+ * How: parse-heal-reparse. A probe parse (mathProbe.ts) tells us —
+ * with micromark's own container, code, and HTML grammar, not a
+ * re-implementation — exactly which math flow nodes exist and where.
+ * Offending nodes get their opener escaped, and the text is re-probed:
+ * escaping an opener legitimately re-interprets everything after it
+ * (an old closer becomes a new opener), and only the parser can say
+ * what that means. Rounds are capped; a document that exhausts the
+ * budget falls through to the fail-closed sweep (see
+ * sweepRemainingOpeners), which escapes every remaining potential
+ * opener outside opaque regions — a violating node never survives, and
+ * work is never unbounded.
+ *
+ * A math node offends when:
+ *   - its value contains a blank line followed by more content
+ *     (a blank-only TAIL is tolerated — the app's own source-mode
+ *     insertMath emits `$$` / blank caret line / `$$`, and a blank
+ *     tail swallows nothing), or
+ *   - it never closes (the node's last line is not a `$`-run at least
+ *     as long as the opener, alone on its line).
+ *
+ * Serializing an affected document writes `\$\$` — the same
+ * escape-normalization class the pipeline already applies to literal
+ * `$` (see the currency-pattern tests). Runs ONLY in the document
+ * parse; the source-position dialect maps offsets of the text as
+ * written and must never see rewritten input.
+ *
+ * @coordinates-with ../parser.ts — sole caller (parseMarkdownToMdast)
+ * @coordinates-with ./mathProbe.ts — micromark-authoritative extents
+ * @coordinates-with ./mathDelimiterSpans.ts — the #1180 half, re-exported here
+ * @module utils/markdownPipeline/parser/mathSourceGuards
+ */
+
+import {
+  buildProbeOpaqueMask,
+  collectMathFlowExtents,
+  probeParse,
+  probeParseWithoutMath,
+  type MathFlowExtent,
+} from "./mathProbe";
+
+export { normalizeMathDelimiters } from "./mathDelimiterSpans";
+
+/** Cap on parse-heal rounds. Real documents converge in one or two; a
+ *  crafted flood falls through to the fail-closed sweep below rather
+ *  than doing unbounded reparses. */
+const MAX_HEAL_ROUNDS = 10;
+
+/** Any CommonMark line ending — LF, CRLF, or lone CR (classic Mac). */
+const LINE_ENDING = /\r\n|\r|\n/;
+/** Blank line followed by more content, after tolerated trailing blanks. */
+const INTERNAL_BLANK = /(?:\r\n|\r|\n)[ \t]*(?:\r\n|\r|\n)/;
+
+/**
+ * Closure comes from micromark itself, not from fence grammar we would
+ * only approximate: a CLOSED node's source is opener line + value
+ * lines + closer line; an UNCLOSED node's source is opener line +
+ * value lines. Comparing LINE COUNTS is collision-free — a suffix
+ * check was not (`"$$$".endsWith("$$")` misread a valid `$$$` block
+ * whose content held a shorter dollar line as unclosed). Over-indented
+ * `    $$`, tab-indented, and deeper-quoted pseudo-closers all sit
+ * inside `value`, so they add to the value's line count and the node
+ * still counts as unclosed. Any OTHER count relationship (unexpected
+ * node shape) is treated as closed — the fail-safe direction is "no
+ * rewrite".
+ *
+ * An empty-value node (a bare dangling `$$`, or the app's empty-math
+ * template) swallows nothing and is left as typed — escaping while the
+ * user is mid-typing a block would be hostile.
+ */
+function violates(text: string, extent: MathFlowExtent): boolean {
+  if (INTERNAL_BLANK.test(extent.value.trimEnd())) return true;
+  if (extent.value === "") return false;
+  const sliceLines = text
+    .slice(extent.start, extent.end)
+    .replace(/(?:\r\n|\r|\n)$/, "")
+    .split(LINE_ENDING).length;
+  const valueLines = extent.value.split(LINE_ENDING).length;
+  return sliceLines === valueLines + 1; // opener line only — no closer
+}
+
+/**
+ * Escape `$$` fence openers that never close before a blank line, the
+ * end of their container, or EOF. See module header.
+ */
+export function escapeUnclosedMathFences(markdown: string): string {
+  if (!markdown.includes("$$")) return markdown;
+
+  let text = markdown;
+  for (let round = 0; round < MAX_HEAL_ROUNDS; round++) {
+    const offender = collectMathFlowExtents(probeParse(text)).find((extent) =>
+      violates(text, extent),
+    );
+    if (!offender) return text;
+
+    // ONE escape per round: escaping an opener re-interprets everything
+    // after it (a freed closer becomes the next block's opener), so any
+    // later "offender" seen in this round's parse is a phantom of the
+    // pre-heal reading. The reparse decides what actually follows.
+    const dollar = text.indexOf("$", offender.start);
+    /* v8 ignore next -- @preserve defensive: a math node always contains its fence */
+    if (dollar === -1 || dollar >= offender.end) return text;
+    text = `${text.slice(0, dollar)}\\${text.slice(dollar)}`;
+  }
+  return sweepRemainingOpeners(text);
+}
+
+/** Opener-shaped line: any run of blockquote markers, list markers, and
+ *  indentation, then a `$$` run. Deliberately broad — the sweep must
+ *  not miss a container form the parser would accept. */
+const SWEEP_OPENER =
+  /^((?:[>\t ]|(?:[-*+]|\d{1,9}[.)])[ \t])*)(\$\$+)/;
+
+/**
+ * Fail-closed fallback for documents that exhaust the healing budget:
+ * a violating node must NOT survive (it would still swallow content),
+ * so every remaining potential opener line outside opaque regions is
+ * escaped in one pass. Opacity comes from a MATH-DISABLED probe — the
+ * damaged tree hides code/HTML blocks inside the violating math node,
+ * so the normal probe cannot be trusted here. Legitimate later math in
+ * such a document degrades to literal text — only crafted opener
+ * floods get here, and over-escaping is the same normalization class
+ * as healing itself.
+ */
+function sweepRemainingOpeners(text: string): string {
+  const stillViolating = collectMathFlowExtents(probeParse(text)).some(
+    (extent) => violates(text, extent),
+  );
+  /* v8 ignore next -- @preserve reachable only via crafted >10-offender floods */
+  if (!stillViolating) return text;
+
+  const mask = buildProbeOpaqueMask(text, probeParseWithoutMath(text));
+  // Separator-preserving split so LF, CRLF, and lone-CR documents all
+  // reassemble byte-identically.
+  const parts = text.split(/(\r\n|\r|\n)/);
+  let offset = 0;
+  const out = parts.map((part, idx) => {
+    const partOffset = offset;
+    offset += part.length;
+    if (idx % 2 === 1) return part; // line separator
+    const m = SWEEP_OPENER.exec(part);
+    if (!m || /\$\$/.test(part.slice(m[0].length))) return part;
+    if (mask[partOffset + m[1].length] === 1) return part;
+    return `${m[1]}\\${part.slice(m[1].length)}`;
+  });
+  return out.join("");
+}

--- a/src/utils/markdownPipeline/parser/opaqueRegions.test.ts
+++ b/src/utils/markdownPipeline/parser/opaqueRegions.test.ts
@@ -1,0 +1,37 @@
+// Tests for the shared CommonMark code-fence line tracker.
+
+import { describe, it, expect } from "vitest";
+import { createCodeFenceTracker } from "./opaqueRegions";
+
+describe("createCodeFenceTracker", () => {
+  it("tracks open/close across lines", () => {
+    const t = createCodeFenceTracker();
+    expect(t.feed("```")).toBe(true);
+    expect(t.feed("inside")).toBe(true);
+    expect(t.feed("```")).toBe(true);
+    expect(t.feed("after")).toBe(false);
+  });
+
+  it("requires the closer to match the opener's char and length", () => {
+    const t = createCodeFenceTracker();
+    expect(t.feed("`````")).toBe(true);
+    expect(t.feed("```")).toBe(true); // shorter run: still inside
+    expect(t.feed("~~~~~")).toBe(true); // wrong char: still inside
+    expect(t.feed("`````")).toBe(true); // closes
+    expect(t.feed("after")).toBe(false);
+  });
+
+  it("a closer may carry only trailing whitespace (CRLF ok)", () => {
+    const t = createCodeFenceTracker();
+    expect(t.feed("```")).toBe(true);
+    expect(t.feed("``` x")).toBe(true); // trailing text: content
+    expect(t.feed("```  \r")).toBe(true); // closes
+    expect(t.feed("after")).toBe(false);
+  });
+
+  it("rejects a backtick opener whose info string contains a backtick", () => {
+    const t = createCodeFenceTracker();
+    expect(t.feed("```foo`")).toBe(false);
+    expect(t.feed("not code")).toBe(false);
+  });
+});

--- a/src/utils/markdownPipeline/parser/opaqueRegions.ts
+++ b/src/utils/markdownPipeline/parser/opaqueRegions.ts
@@ -1,0 +1,49 @@
+/**
+ * Purpose: The shared CommonMark code-fence line tracker.
+ *
+ * Extracted so `hasAmbiguousListUnderline` (remarkPlugins.ts) and any
+ * future line scanners share ONE fence-state implementation and cannot
+ * drift apart on closer/CRLF rules. (The math source guards consult a
+ * probe parse via mathProbe.ts instead; their fail-closed sweep scans
+ * lines but takes opacity from a math-disabled probe, not from here.)
+ *
+ * @coordinates-with ./remarkPlugins.ts — consumer
+ * @module utils/markdownPipeline/parser/opaqueRegions
+ */
+
+/** A code fence line (backticks or tildes, CommonMark indent rule). */
+const CODE_FENCE = /^ {0,3}(`{3,}|~{3,})/;
+const BLANK_REST = /^[ \t]*\r?$/;
+
+/**
+ * Line-by-line CommonMark fence state. `feed(line)` returns true when
+ * the line is code (a fence delimiter or inside an open fence). A
+ * closer must repeat the OPENER's character at least the opener's
+ * length and carry nothing but trailing whitespace. A backtick opener
+ * whose info string contains a backtick is prose, not a fence.
+ */
+export function createCodeFenceTracker() {
+  let fence: { char: string; size: number } | null = null;
+  return {
+    feed(line: string): boolean {
+      const run = CODE_FENCE.exec(line);
+      if (fence) {
+        const closes =
+          run !== null &&
+          run[1][0] === fence.char &&
+          run[1].length >= fence.size &&
+          BLANK_REST.test(line.slice(run[0].length));
+        if (closes) fence = null;
+        return true;
+      }
+      if (run) {
+        if (run[1][0] === "`" && line.slice(run[0].length).includes("`")) {
+          return false; // CommonMark: backtick info strings ban backticks
+        }
+        fence = { char: run[1][0], size: run[1].length };
+        return true;
+      }
+      return false;
+    },
+  };
+}

--- a/src/utils/markdownPipeline/parser/remarkPlugins.ts
+++ b/src/utils/markdownPipeline/parser/remarkPlugins.ts
@@ -7,6 +7,7 @@
 import type { Plugin } from "unified";
 import type { Root, Parent } from "mdast";
 import type { InlineMath } from "mdast-util-math";
+import { createCodeFenceTracker } from "./opaqueRegions";
 
 /**
  * Plugin to validate inline math and convert invalid ones back to text.
@@ -104,15 +105,6 @@ export interface ContentAnalysis {
  */
 const AMBIGUOUS_LIST_UNDERLINE = /^[ \t]+[-*+][ \t]*$/;
 
-/**
- * A fence line by CommonMark's rules: at most 3 spaces of indent, then a run
- * of 3+ backticks or tildes. Four or more spaces make the line indented CODE,
- * so it can neither open nor close a fence — the old scanner accepted
- * unlimited indentation and a four-space-indented backtick run swallowed the
- * rest of the document, hiding genuine ambiguity after it.
- */
-const FENCE_LINE = /^ {0,3}(`{3,}|~{3,})/;
-
 /** Indented-code line: 4+ spaces or a tab. Its content is literal text. */
 const INDENTED_CODE_LINE = /^(?: {4}|\t)/;
 
@@ -125,30 +117,16 @@ const INDENTED_CODE_LINE = /^(?: {4}|\t)/;
  * document, so a real `Title` / `-----` heading elsewhere in the same file
  * silently parsed as a paragraph and could be rewritten on save.
  *
- * The scanner walks lines, tracking one open fence at a time. A closer must
- * repeat the OPENER'S character at least the opener's length (CommonMark keeps
- * a 5-backtick block open across a 3-backtick line) and carry nothing but
- * trailing whitespace. Indented-code lines are skipped too: `    -` is never a
- * setext underline — indented code cannot interrupt a paragraph, and a setext
- * underline allows at most 3 spaces of indent.
+ * Fence state comes from the shared tracker (opaqueRegions.ts), the
+ * one CommonMark fence-line scanner, so its closer/CRLF rules are
+ * tested in one place. Indented-code lines are skipped too: `    -` is
+ * never a setext underline — indented code cannot interrupt a
+ * paragraph, and a setext underline allows at most 3 spaces of indent.
  */
 function hasAmbiguousListUnderline(markdown: string): boolean {
-  let fence: { char: string; size: number } | null = null;
+  const tracker = createCodeFenceTracker();
   for (const line of markdown.split("\n")) {
-    const fenceRun = FENCE_LINE.exec(line);
-    if (fence) {
-      const closes =
-        fenceRun !== null &&
-        fenceRun[1][0] === fence.char &&
-        fenceRun[1].length >= fence.size &&
-        /^[ \t]*$/.test(line.slice(fenceRun[0].length));
-      if (closes) fence = null;
-      continue;
-    }
-    if (fenceRun) {
-      fence = { char: fenceRun[1][0], size: fenceRun[1].length };
-      continue;
-    }
+    if (tracker.feed(line)) continue;
     if (INDENTED_CODE_LINE.test(line)) continue;
     if (AMBIGUOUS_LIST_UNDERLINE.test(line)) return true;
   }

--- a/website/guide/features.md
+++ b/website/guide/features.md
@@ -243,6 +243,11 @@ KaTeX-powered LaTeX rendering:
 
 - Inline math: `$E = mc^2$`
 - Display math: `$$...$$` blocks
+- ChatGPT-style delimiters are recognized on open/paste and normalized to
+  `$`-form: `\( ... \)` becomes inline math, and a standalone `\[ ... \]`
+  becomes a display block
+- A `$$` block must close before a blank line (pandoc's rule) — an unclosed
+  `$$` renders as literal text instead of swallowing the paragraphs after it
 - Full LaTeX syntax support
 - Helpful error messages with syntax hints
 

--- a/website/guide/features.md
+++ b/website/guide/features.md
@@ -247,7 +247,9 @@ KaTeX-powered LaTeX rendering:
   `$`-form: `\( ... \)` becomes inline math, and a standalone `\[ ... \]`
   becomes a display block
 - A `$$` block must close before a blank line (pandoc's rule) — an unclosed
-  `$$` renders as literal text instead of swallowing the paragraphs after it
+  `$$` renders as literal text instead of swallowing the paragraphs after it.
+  Trailing blank lines directly before the closer are fine (an empty
+  `$$` … `$$` block stays a math block)
 - Full LaTeX syntax support
 - Helpful error messages with syntax hints
 


### PR DESCRIPTION
## Summary

- **#1181 (bug):** an unclosed `$$` opener swallowed every following paragraph/table into one garbled math block (micromark math flow is fence-like — it runs to the next closing fence or EOF), and clicks anywhere in the swallowed region opened the formula editor. The parser now applies pandoc's display-math rule: a `$$` block must close before a blank line; a violating opener is escaped to literal text and the content behind it survives. A later well-paired block still parses as math.
- **#1180 (feature):** ChatGPT-style `\[ ... \]` / `\( ... \)` delimiters are now recognized and normalized to `$$`/`$` form — on file open AND on paste (source-mode paste-cleaning previously stripped the backslashes before anything could see them). Display form converts only when standalone; mid-sentence `\[…\]` remains escaped-bracket prose.

Fixes #1181
Fixes #1180

## Approach

Both fixes are pre-parse source guards in `parseMarkdownToMdast`, but all CommonMark judgment comes from **a probe parse with the pipeline's own processor** — never re-implemented grammar:

- `mathProbe.ts` derives opaque regions (code, every HTML block class, frontmatter, definitions, link destinations, autolinks, shortcut/collapsed reference labels) and exact math-flow extents from mdast nodes.
- `mathSourceGuards.ts` heals via parse-escape-reparse (one opener per round, capped, fail-closed sweep for crafted floods). Closure is derived from a collision-free line-count invariant against micromark's own `value`. Blank-only tails are tolerated — the app's own source-mode insertMath emits `$$` / blank caret line / `$$`.
- `mathDelimiterSpans.ts` is a worst-case-linear span scanner (precomputed escape parity, blank boundaries, closers, mask prefix sums) shared with `cleanPastedMarkdown`.
- Two pre-existing `buildCodeMask` bugs found en route are fixed with regression tests (closer-with-trailing-text; backtick in a backtick-fence info string).

Serializing an affected document writes `\$\$` — the same escape-normalization class the pipeline already applies to literal `$`.

## Behavior changes to note

- A `$$` block containing a blank line followed by more content no longer parses as display math (pandoc semantics). Trailing blank lines directly before the closer are fine.
- A **paired** `\(a\)` in pasted text is preserved as math instead of being unescaped to `(a)`; lone escapes still strip.
- Documents opened with `\[ \]`/`\( \)` math render it, and it normalizes to `$`-form on the next save.

## Codex Audit

Six review rounds (high reasoning effort). Early rounds surfaced real corruption vectors in scanner-based approaches (link destinations, HTML blocks, nested containers, ReDoS); the final architecture — probe-derived opacity + value-derived closure — was Codex's own recommendation, and its last-round items (collapsed-reference labels, lone-CR line endings) are fixed as prescribed with the exact regression tests requested.

## Validation

- [x] `pnpm check:all` green (one unrelated flaky content-server watcher test passed on isolated rerun)
- [x] TDD — ~90 new tests across guards, spans, probe, code mask, paste cleaning, plus the behavioral-parity suite (4200+ tests in affected areas)
- [x] Codex audit loop completed (6 iterations)

## Type of Change

- [x] Bug fix (#1181)
- [x] Feature (#1180)