### PR TITLE
test(ci): fix the two flake classes behind red main pushes #1241/#1244

### DIFF
--- a/src/plugins/toolbarActions/__tests__/parity/behavioralParity.test.ts
+++ b/src/plugins/toolbarActions/__tests__/parity/behavioralParity.test.ts
@@ -30,8 +30,20 @@
  * @coordinates-with @/utils/markdownPipeline/__tests__/fidelity/docFingerprint — equivalence
  * @module plugins/toolbarActions/__tests__/parity/behavioralParity.test
  */
-import { describe, it, expect, afterAll } from "vitest";
+import { describe, it, expect, afterAll, vi } from "vitest";
 import { parseMarkdown } from "@/utils/markdownPipeline";
+
+// One exception to "nothing here is mocked": the debug loggers. The real
+// surfaces mount the mermaid plugin, whose async render failures log via
+// debug.ts AFTER this synchronous suite has finished — console writes
+// racing worker teardown produced CI-only EnvironmentTeardownError
+// flakes ("Closing rpc while onUserConsoleLog was pending", main run
+// #1244). The loggers are no-ops in production builds, so no-oping them
+// here mirrors production, and no parity assertion reads them.
+vi.mock("@/utils/debug", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return Object.fromEntries(Object.keys(actual).map((k) => [k, () => {}]));
+});
 import { stripBlockMarkup } from "@/plugins/shared/lineContent";
 import { getProductionSchema } from "@/test/productionSchema";
 import { docFingerprint } from "@/utils/markdownPipeline/__tests__/fidelity/docFingerprint";

--- a/src/utils/markdownPipeline/parser/mathDelimiterSpans.test.ts
+++ b/src/utils/markdownPipeline/parser/mathDelimiterSpans.test.ts
@@ -232,7 +232,7 @@ describe("findMathDelimiterSpans", () => {
     const flood = "\\( ".repeat(20000);
     const started = performance.now();
     expect(findMathDelimiterSpans(flood)).toHaveLength(0);
-    expect(performance.now() - started).toBeLessThan(1000);
+    expect(performance.now() - started).toBeLessThan(5000);
   });
 
   it("survives a flood of openers whose only closer is inside code", () => {
@@ -241,6 +241,6 @@ describe("findMathDelimiterSpans", () => {
     const flood = "\\( ".repeat(20000) + "`\\)`";
     const started = performance.now();
     expect(findMathDelimiterSpans(flood)).toHaveLength(0);
-    expect(performance.now() - started).toBeLessThan(1000);
+    expect(performance.now() - started).toBeLessThan(5000);
   });
 });


### PR DESCRIPTION
## Why main went red twice post-merge

Both failures were in the \`on: push\` runs (the combination no PR gate sees — governance §10 territory), and neither was a product bug:

- **Run #1241**: the 20k-opener linearity smoke tests assert wall-clock time; CI hardware took 1025ms against a 1000ms budget with every test passing. The assertion's purpose is catching quadratic blowup (minutes, not milliseconds) — budget raised to 5000ms, matching the guard-side flood test.
- **Run #1244**: all 28,717 tests passed, all coverage floors cleared — vitest exited 1 on two \`EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending\`, originating in the behavioral-parity suite. The real surfaces mount the mermaid plugin, whose async render failures log through \`debug.ts\` after the synchronous suite ends; those late console writes race vitest's worker teardown. The parity suite now no-ops the debug loggers — mirroring their production no-op behavior; no parity assertion reads them (documented as the one exception to the suite's nothing-mocked rule).

Test-only changes; #1244's rerun was also kicked to confirm green on the existing tree.