### PR TITLE
fix(diagrams): defer pan-zoom setup until the preview widget is attached

### DIFF
--- a/src/plugins/codePreview/renderers/renderGraphvizPreview.test.ts
+++ b/src/plugins/codePreview/renderers/renderGraphvizPreview.test.ts
@@ -120,8 +120,72 @@ describe("createGraphvizPreviewWidget", () => {
 
     expect(element.textContent).toContain("result");
     expect(cache.get("key")).toEqual({ rendered: "<svg>result</svg>" });
-    expect(setupMermaidPanZoom).toHaveBeenCalledWith(element);
-    expect(setupGraphvizExport).toHaveBeenCalledWith(element, "digraph { a -> b }");
+  });
+
+  // Same defect as the Mermaid renderer — see issue #1200. Panzoom throws on
+  // detached elements and ProseMirror attaches the widget only after the
+  // factory returns.
+  it("defers pan-zoom and export setup until after an animation frame", async () => {
+    vi.mocked(renderGraphviz).mockResolvedValueOnce("<svg>result</svg>");
+    const frames: FrameRequestCallback[] = [];
+    const rafSpy = vi
+      .spyOn(globalThis, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        frames.push(cb);
+        return frames.length;
+      });
+
+    try {
+      const cache = new Map();
+      createGraphvizPreviewWidget(10, "digraph { a -> b }", "key", cache, vi.fn());
+      const element = capturedFactory!(null);
+
+      await vi.waitFor(() => {
+        expect(element.className).toBe("code-block-preview graphviz-preview");
+      });
+
+      expect(element.textContent).toContain("result");
+      expect(setupMermaidPanZoom).not.toHaveBeenCalled();
+      expect(setupGraphvizExport).not.toHaveBeenCalled();
+
+      document.body.appendChild(element);
+      expect(frames).toHaveLength(1);
+      frames[0]!(0);
+
+      expect(setupMermaidPanZoom).toHaveBeenCalledWith(element);
+      expect(setupGraphvizExport).toHaveBeenCalledWith(element, "digraph { a -> b }");
+      element.remove();
+    } finally {
+      rafSpy.mockRestore();
+    }
+  });
+
+  it("skips enhancement when the element was detached before the frame ran", async () => {
+    vi.mocked(renderGraphviz).mockResolvedValueOnce("<svg>result</svg>");
+    const frames: FrameRequestCallback[] = [];
+    const rafSpy = vi
+      .spyOn(globalThis, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        frames.push(cb);
+        return frames.length;
+      });
+
+    try {
+      const cache = new Map();
+      createGraphvizPreviewWidget(10, "digraph { a -> b }", "key", cache, vi.fn());
+      const element = capturedFactory!(null);
+
+      await vi.waitFor(() => {
+        expect(element.className).toBe("code-block-preview graphviz-preview");
+      });
+
+      expect(frames).toHaveLength(1);
+      expect(() => frames[0]!(0)).not.toThrow();
+      expect(setupMermaidPanZoom).not.toHaveBeenCalled();
+      expect(setupGraphvizExport).not.toHaveBeenCalled();
+    } finally {
+      rafSpy.mockRestore();
+    }
   });
 
   it("shows error state when renderGraphviz returns null", async () => {

--- a/src/plugins/codePreview/renderers/renderGraphvizPreview.ts
+++ b/src/plugins/codePreview/renderers/renderGraphvizPreview.ts
@@ -108,8 +108,15 @@ export function createGraphvizPreviewWidget(
           previewCache.set(cacheKey, { rendered: svg });
           placeholder.className = "code-block-preview graphviz-preview";
           placeholder.innerHTML = sanitizeSvg(svg);
-          setupMermaidPanZoom(placeholder);
-          setupGraphvizExport(placeholder, content);
+          // Defer enhancement: Panzoom throws on elements that are not
+          // attached to the DOM, and ProseMirror attaches the widget only
+          // after this factory returns. The isConnected guard matters because
+          // a throw inside the frame callback escapes the promise chain below.
+          requestAnimationFrame(() => {
+            if (!placeholder.isConnected) return;
+            setupMermaidPanZoom(placeholder);
+            setupGraphvizExport(placeholder, content);
+          });
         })
         .catch((error: unknown) => {
           diagramWarn("Graphviz preview render failed:", errorMessage(error));

--- a/src/plugins/codePreview/renderers/renderMermaidPreview.test.ts
+++ b/src/plugins/codePreview/renderers/renderMermaidPreview.test.ts
@@ -127,8 +127,79 @@ describe("createMermaidPreviewWidget", () => {
 
     expect(element.textContent).toContain("result");
     expect(cache.get("key")).toEqual({ rendered: "<svg>result</svg>" });
-    expect(setupMermaidPanZoom).toHaveBeenCalledWith(element);
-    expect(setupMermaidExport).toHaveBeenCalledWith(element, "graph TD; A-->B");
+  });
+
+  // Panzoom throws on elements that are not attached to the DOM, and
+  // ProseMirror attaches a widget only AFTER its factory returns. The
+  // cache-hit path (previewHelpers.createPreviewElement) already defers for
+  // this reason; this path did not — see issue #1200.
+  it("defers pan-zoom and export setup until after an animation frame", async () => {
+    vi.mocked(renderMermaid).mockResolvedValueOnce("<svg>result</svg>");
+    const frames: FrameRequestCallback[] = [];
+    const rafSpy = vi
+      .spyOn(globalThis, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        frames.push(cb);
+        return frames.length;
+      });
+
+    try {
+      const cache = new Map();
+      createMermaidPreviewWidget(10, "graph TD; A-->B", "key", cache, vi.fn());
+      const element = capturedFactory!(null);
+
+      await vi.waitFor(() => {
+        expect(element.className).toBe("code-block-preview mermaid-preview");
+      });
+
+      // The SVG is painted immediately; only the enhancement is deferred.
+      expect(element.textContent).toContain("result");
+      expect(setupMermaidPanZoom).not.toHaveBeenCalled();
+      expect(setupMermaidExport).not.toHaveBeenCalled();
+
+      // ProseMirror attaches the widget, then the frame runs.
+      document.body.appendChild(element);
+      expect(frames).toHaveLength(1);
+      frames[0]!(0);
+
+      expect(setupMermaidPanZoom).toHaveBeenCalledWith(element);
+      expect(setupMermaidExport).toHaveBeenCalledWith(element, "graph TD; A-->B");
+      element.remove();
+    } finally {
+      rafSpy.mockRestore();
+    }
+  });
+
+  // A widget can be replaced before its render promise settles. Calling
+  // Panzoom on the orphan would throw inside the frame callback, where the
+  // promise's .catch() can no longer see it — an unhandled error.
+  it("skips enhancement when the element was detached before the frame ran", async () => {
+    vi.mocked(renderMermaid).mockResolvedValueOnce("<svg>result</svg>");
+    const frames: FrameRequestCallback[] = [];
+    const rafSpy = vi
+      .spyOn(globalThis, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        frames.push(cb);
+        return frames.length;
+      });
+
+    try {
+      const cache = new Map();
+      createMermaidPreviewWidget(10, "graph TD; A-->B", "key", cache, vi.fn());
+      const element = capturedFactory!(null);
+
+      await vi.waitFor(() => {
+        expect(element.className).toBe("code-block-preview mermaid-preview");
+      });
+
+      // Never attached — the frame must be a no-op rather than throwing.
+      expect(frames).toHaveLength(1);
+      expect(() => frames[0]!(0)).not.toThrow();
+      expect(setupMermaidPanZoom).not.toHaveBeenCalled();
+      expect(setupMermaidExport).not.toHaveBeenCalled();
+    } finally {
+      rafSpy.mockRestore();
+    }
   });
 
   it("shows error state when renderMermaid returns null", async () => {

--- a/src/plugins/codePreview/renderers/renderMermaidPreview.ts
+++ b/src/plugins/codePreview/renderers/renderMermaidPreview.ts
@@ -60,8 +60,17 @@ export function createMermaidPreviewWidget(
           previewCache.set(cacheKey, { rendered: svg });
           placeholder.className = "code-block-preview mermaid-preview";
           placeholder.innerHTML = sanitizeSvg(svg);
-          setupMermaidPanZoom(placeholder);
-          setupMermaidExport(placeholder, content);
+          // Defer enhancement: Panzoom throws on elements that are not
+          // attached to the DOM, and ProseMirror attaches the widget only
+          // after this factory returns. The cache-hit path in
+          // previewHelpers.createPreviewElement defers for the same reason.
+          // The isConnected guard matters because a throw inside the frame
+          // callback escapes the promise chain below.
+          requestAnimationFrame(() => {
+            if (!placeholder.isConnected) return;
+            setupMermaidPanZoom(placeholder);
+            setupMermaidExport(placeholder, content);
+          });
         } else {
           placeholder.className = "code-block-preview mermaid-error";
           placeholder.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg> Failed to render diagram`;


### PR DESCRIPTION
Fixes a real defect surfaced by #1200, but deliberately does **not** close it.

## The defect

The Mermaid and Graphviz cache-miss renderers called `setupMermaidPanZoom`
synchronously inside the render promise. ProseMirror attaches a widget only
*after* its decoration factory returns, and Panzoom throws on detached
elements — producing exactly the error the reporter captured:

    [Diagram] Mermaid preview render failed: Panzoom should be called on
    elements that have been attached to the DOM

`9bf29864` fixed this class of bug for the cache-hit path
(`previewHelpers.createPreviewElement`) and for Markmap. These two renderers
were missed — including the path that runs immediately after leaving the block
editor, which deletes the cache entry (`editMode.ts:200`) and so forces a
cache miss.

## The fix

Both now defer to `requestAnimationFrame`, guarded by `isConnected`.

The guard is load-bearing rather than defensive: a throw inside a frame
callback escapes the promise chain below it, so an unguarded deferral would
convert a caught warning into an unhandled error.

## Why this does not close #1200

The reporter describes an empty **gray** placeholder. The failure path fixed
here renders a **red** error box reading "Failed to render diagram". Those are
different artifacts, so the reported symptom has a separate cause that is still
under investigation — I have asked the reporter for detail that discriminates
between the remaining hypotheses.

## Tests

Test-first: RED verified before implementing (two failures per renderer, each
for the expected reason), then GREEN.

- `defers pan-zoom and export setup until after an animation frame`
- `skips enhancement when the element was detached before the frame ran`

`pnpm check:all` is green.

These tests pin the *contract* — enhancement is deferred, detached nodes are
skipped — not the underlying race. jsdom cannot reproduce a real-WebKit timing
race between promise resolution and widget attachment.

## Follow-ups not in this PR

- `previewHelpers.ts:121` has the same unguarded-throw-inside-`rAF` shape.
  Pre-existing and not implicated in #1200, so left alone to keep this diff
  focused.
- `${language}:${content}` is not a unique widget identity
  (`previewDecorations.ts:104`), so two identical diagram blocks in one
  document collide on a single key. Real, but it cannot explain the
  single-block reproduction in #1200.
