### PR TITLE
fix(mutation): completed sweep with findings is the report, not a failure

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -73,7 +73,22 @@ jobs:
 
       - name: Run scoped mutation testing
         # Scope is defined in src-tauri/.cargo/mutants.toml (examine_globs).
-        run: cargo mutants --manifest-path src-tauri/Cargo.toml
+        # Exit-code semantics (first complete sweep, run 30905319861): for a
+        # non-blocking SIGNAL job, surviving mutants (exit 2) and timeouts
+        # (exit 3) ARE the report — the sweep completed and mutants.out holds
+        # the findings. Only real errors fail the job: usage/internal (1) and
+        # a red unmutated baseline (4), which is how this workflow's original
+        # silent death began. See cargo-mutants' documented exit codes.
+        run: |
+          set +e
+          cargo mutants --manifest-path src-tauri/Cargo.toml
+          rc=$?
+          set -e
+          case "$rc" in
+            0) echo "all mutants caught" ;;
+            2|3) echo "sweep completed with findings (exit $rc) — that is the report, not a failure" ;;
+            *) echo "cargo-mutants infrastructure error (exit $rc)"; exit "$rc" ;;
+          esac
 
       - name: Upload mutants report
         if: always()


### PR DESCRIPTION
Closes the last gap in the WI-4 acceptance chain. Run 30905319861: ts-mutants GREEN (first complete Stryker run ever — score 76.32 ≥ break 75, 176 min); Rust sweep COMPLETED (139 mutants: 107 caught / 21 missed / 10 unviable / 1 timeout, 2 h) but exit 3 (timeouts-occurred) failed the step. Exit codes 2/3 = report produced; 1/4 = real failure (kept loud, rolling issue intact). Closes #1210.