### PR TITLE
docs(terminal): say what #1176 coverage actually proves, and what it does not

### DIFF
--- a/src/components/Terminal/imeAsciiHandoff.test.ts
+++ b/src/components/Terminal/imeAsciiHandoff.test.ts
@@ -97,7 +97,15 @@ function typeWithIme(textarea: HTMLTextAreaElement, char: string) {
   textarea.dispatchEvent(new KeyboardEvent("keyup", { key: char, keyCode: 229, bubbles: true }));
 }
 
-/** Enter IME mode: the gate learns it from any keyCode-229 keydown. */
+/**
+ * Dispatch a keyCode-229 keydown ahead of the run.
+ *
+ * NOT "the gate learns IME mode from it" — the gate registers only
+ * `compositionstart`/`compositionend`/`input` listeners, its keydown listener
+ * having been deleted when ownership moved to accepted writes (57c53aed).
+ * This is here because the REAL key handler is wired in these tests and must
+ * see the same keydown a live IME would send; the gate itself ignores it.
+ */
 function enterImeMode(textarea: HTMLTextAreaElement) {
   textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "a", keyCode: 229, bubbles: true }));
 }
@@ -141,10 +149,13 @@ describe("terminal ASCII reaches the PTY exactly once (#1176)", () => {
     (char) => {
       enterImeMode(w.textarea);
       typeWithIme(w.textarea, char);
-      // Before the fix this was "" — T2 ate the keydown and, for these keys, a
-      // live Shuangpin trace shows no input event follows at all. Now xterm's
-      // keydown path writes it. The trailing input event in this harness is the
-      // belt-and-braces case: some IME might emit one, and it must not double.
+      // Before the fix this was "": T2 ate the keydown, and the gate dropped
+      // the insert because it assumed xterm's keydown path had already
+      // written it. Now the GATE writes it — xterm's keydown path cannot,
+      // because the handler consumes every keyCode-229 keydown
+      // (terminalKeyHandler.ts, T2). `typeWithIme` dispatches the insert
+      // BEFORE the keydown, which is the order the live trace recorded, so
+      // the gate is the only writer in play here.
       expect(w.ptyWrites.join("")).toBe(char);
     },
   );

--- a/src/components/Terminal/terminalKeyHandler.ime.test.ts
+++ b/src/components/Terminal/terminalKeyHandler.ime.test.ts
@@ -12,13 +12,26 @@
  *
  * An earlier draft of this suite asserted the opposite — that the handler
  * writes `/`, the digits and their shifted punctuation itself. That was a
- * candidate design for #1176 which was not the one adopted, and the
- * assertions were committed without an implementation, so they described
- * behaviour no code had. They are removed rather than skipped: a test for a
- * rejected design is not pending work, it is a false description of the
- * system. The real-IME behaviour is covered where it can actually be
- * observed — `setupImeCompositionGate.webkit.test.ts` against a real xterm,
- * and the opt-in `pnpm e2e:ime` lane driving the OS input method.
+ * candidate design for #1176 which was not the one adopted (the fix,
+ * 271c044d, changed this file by one blank comment line; its ~84 real lines
+ * went into the GATE), so the assertions described behaviour no code had.
+ * They are removed rather than skipped: a test for a rejected design is not
+ * pending work, it is a false description of the system.
+ *
+ * WHERE #1176 IS ACTUALLY COVERED, and where it is NOT:
+ *   - `imeAsciiHandoff.test.ts` wires the REAL handler to the REAL gate and
+ *     replays the RECORDED event order (insert before its own keydown),
+ *     asserting the slash, the digits and shifted punctuation each reach the
+ *     PTY exactly once. That is the delivery proof.
+ *   - No tier drives a real OS IME in the TERMINAL. The WebKit tier says so
+ *     itself — it can drive ASCII and direct non-ASCII insertion, not a
+ *     macOS Pinyin candidate cycle — and `pnpm e2e:ime` focuses
+ *     `.ProseMirror`, never the terminal. So every check above is synthetic
+ *     in its event shape. If an affected IME emits no `input` event at all,
+ *     the key is still lost by construction and nothing here would notice.
+ *     Stating that plainly is the point: an earlier version of this comment
+ *     claimed those two tiers covered it, which is the same false
+ *     description the deleted tests were removed for.
  *
  * Split from terminalKeyHandler.test.ts, which is at its frozen size baseline.
  */
@@ -88,12 +101,16 @@ describe("createTerminalKeyHandler — keys the IME passed through (#1176)", () 
     },
   );
 
-  it("does not write when the PTY is gone", () => {
+  it("still consumes the keydown when the PTY is gone", () => {
+    // Asserting only "does not throw" was vacuous: the 229 branch returns
+    // before it ever consults `ptyRef`, so it passed with a live PTY too.
+    // The property that matters is that a dead PTY does not change the
+    // channel decision — xterm must still not see the keydown.
     const handler = createTerminalKeyHandler(makeTerm(), { current: null }, {
       onSearch: vi.fn(),
       isComposing: () => false,
     });
-    expect(() => handler(imeKeydown("/"))).not.toThrow();
+    expect(handler(imeKeydown("/"))).toBe(false);
   });
 
   it.each(["a", "n", "z"])("consumes the letter %s WITHOUT writing (it starts a composition)", (key) => {


### PR DESCRIPTION
## Why

A prior merge removed 24 assertions in `terminalKeyHandler.ime.test.ts` that said the key handler writes `/`, the digits and shifted punctuation to the PTY itself under a Chinese IME. An independent review (Codex) confirmed that removal was correct — but flagged that the comment replacing them overclaimed, which is the same defect the deleted tests had.

## What the investigation established

`#1176` is closed by `271c044d`. That commit changed `terminalKeyHandler.ts` by **one blank comment line**; its ~84 real lines went into the composition gate. The shipped design is therefore: the handler consumes every keyCode-229 keydown (T2), and the **gate** delivers the character. `git blame` shows the consume rule predates the fix, and the handler-write assertions were added afterwards — they described a design that had already been rejected.

The mechanism was later refined (`57c53aed`) from keydown-shaped ownership to accepted-writes, with the state machine extracted to `imeGateMachine.ts`. Superseded, not reverted. Delivery chain in current main: handler consumes → gate receives `input` → machine commits the unclaimed insert → session wiring writes to the PTY.

Real coverage is `imeAsciiHandoff.test.ts` (37 tests, real handler wired to real gate, replaying the recorded insert-before-keydown order). No keystroke class from the issue was uniquely covered by what was deleted.

## What this PR fixes

- **The header's false coverage claim.** It cited the WebKit tier and `pnpm e2e:ime`. Neither covers this: the WebKit suite says outright it cannot drive a macOS Pinyin candidate cycle, and the e2e lane focuses `.ProseMirror` and never opens the terminal.
- **Two stale comments in `imeAsciiHandoff.test.ts`** asserting the opposite of what its own harness proves — the likeliest reason the rejected design got written up as tests.
- **A vacuous null-PTY assertion** that only checked "does not throw", which the 229 branch satisfies before consulting `ptyRef`.

## The residual risk, stated in the code

`#1176` is fixed in code but has **never been proven against a real OS IME in the terminal** — every check is synthetic in its event shape. If an affected IME emits no `input` event at all, the key is still lost by construction and no current test would notice. Closing that needs a recorded human trace replayed in the terminal (plan WI-0.3).

## Verification

`pnpm check:all` — exit 0, unpiped: 35,253 + 500 + 159 tests. No production code changed.
