### PR TITLE
fix: close five open issues (#1204, #1207, #1208, #1209, #1215)

### DIFF
--- a/.claude/rules/32-component-patterns.md
+++ b/.claude/rules/32-component-patterns.md
@@ -7,9 +7,19 @@ Standard patterns for UI components. Follow these for consistency.
 | Need | Use | Defined in |
 |---|---|---|
 | Text button (start, stop, confirm, cancel) | `.vm-btn` (+ `--primary`, `--danger`) | `src/styles/button-shared.css` |
+| Dropdown / `<select>` | `.vm-select` inside a `.vm-select-field` wrapper | `src/styles/select-shared.css` |
 | Icon-only square button inside a popup | `.popup-icon-btn` (+ `--primary`, `--danger`) | `src/styles/popup-shared.css` |
 | Editor toolbar button | `.universal-toolbar-btn` | `universal-toolbar.css` |
 | Popup surface | `.popup-container` | `src/styles/popup-shared.css` |
+
+A bare `<select>` keeps `appearance: auto`, so WebKit draws its own control —
+native bezel, native chevron, 5px pill radius — and author styling only partly
+applies. A fully tokenised stylesheet still renders as macOS chrome; text
+inputs beside it look correct, which is why the drift survives review. Reach
+for `.vm-select`, and note the wrapper is load-bearing: `select` cannot host a
+reliable `::after`, so the chevron lives on `.vm-select-field` and is drawn
+with `mask-image` + `currentColor` rather than a `background-image` data URI,
+which would bake in a colour that no theme token can reach.
 
 Writing a new `*-btn` class is a **gate failure** — `pnpm lint:bespoke-buttons`
 (`scripts/check-bespoke-buttons.mjs`) ratchets the bespoke count down only.

--- a/scripts/knip-baseline.json
+++ b/scripts/knip-baseline.json
@@ -2,7 +2,7 @@
   "//": "Warn-tier knip findings, frozen. These six families run at `warn` in knip.json, so knip exits 0 and 78 findings were printing inside a green check:all with nothing stopping a 79th. Ratchets DOWN only \u2014 see scripts/check-knip-baseline.mjs. Delete dead code and lower the number; never raise it.",
   "exports": 16,
   "nsExports": 0,
-  "types": 60,
+  "types": 59,
   "nsTypes": 0,
   "duplicates": 0,
   "enumMembers": 0

--- a/server/mcp/src/tools/session.ts
+++ b/server/mcp/src/tools/session.ts
@@ -35,7 +35,8 @@ export function registerSessionTool(server: VMarkMcpServer): void {
       description:
         'One-shot session orientation — discover every open window, every tab, and the server\'s capabilities in a single call. Use this first to learn what is available; subsequent tool calls reference tabs by their `id`.\n\n' +
         'Action:\n' +
-        '- get_state: Return windows[], capabilities. Document tabs carry {id, filePath, title, dirty, revision, kind} where `kind` is `"markdown"` or `"yaml-workflow"` (use `document.write` or `workflow.apply_patch` respectively). Browser tabs carry {id, kind:"browser", title, url, active, loading, automationMode} — act on those with the `browser.*` tools.\n\n' +
+        '- get_state: Return windows[], capabilities. Document tabs carry {id, filePath, title, dirty, revision, kind, active, visible} where `kind` is `"markdown"` or `"yaml-workflow"` (use `document.write` or `workflow.apply_patch` respectively). Browser tabs carry {id, kind:"browser", title, url, active, loading, automationMode} — act on those with the `browser.*` tools.\n\n' +
+        'Reading what is ON SCREEN: a tab can exist and be activatable without being shown. `active` marks its window\'s current tab; `visible` is false when the tab belongs to a workspace instance the window is not currently showing (`window.activeWorkspaceInstanceId` names the one it is). `window.focused` marks the window the USER is looking at, which need not be the window a request was routed to — so after activating a tab, confirm with get_state rather than trusting the activation result alone.\n\n' +
         'Returns: {windows, capabilities}.',
       inputSchema: {
         action: z.enum(['get_state']).describe('The action to perform'),

--- a/server/mcp/src/tools/session.ts
+++ b/server/mcp/src/tools/session.ts
@@ -57,7 +57,7 @@ export function registerSessionTool(server: VMarkMcpServer): void {
         windows: z
           .array(z.unknown())
           .optional()
-          .describe('Open windows, each {label, focused, tabs[]}.'),
+          .describe('Open windows, each {label, focused, activeWorkspaceInstanceId, tabs[]}.'),
         capabilities: z
           .unknown()
           .optional()

--- a/src-tauri/locales/de.yml
+++ b/src-tauri/locales/de.yml
@@ -171,6 +171,7 @@ menu:
   view.zoomIn: "Vergrößern"
   view.zoomOut: "Verkleinern"
   view.wordWrap: "Zeilenumbruch umschalten"
+  view.universalToolbar: "Universelle Symbolleiste anzeigen"
   view.lineNumbers: "Zeilennummern umschalten"
   view.diagramPreview: "Diagramm-Vorschau umschalten"
   view.fitTables: "Tabellen an Breite anpassen"

--- a/src-tauri/locales/en.yml
+++ b/src-tauri/locales/en.yml
@@ -171,6 +171,7 @@ menu:
   view.zoomIn: "Zoom In"
   view.zoomOut: "Zoom Out"
   view.wordWrap: "Toggle Word Wrap"
+  view.universalToolbar: "Show Universal Toolbar"
   view.lineNumbers: "Toggle Line Numbers"
   view.diagramPreview: "Toggle Diagram Preview"
   view.fitTables: "Fit Tables to Width"

--- a/src-tauri/locales/es.yml
+++ b/src-tauri/locales/es.yml
@@ -171,6 +171,7 @@ menu:
   view.zoomIn: "Acercar"
   view.zoomOut: "Alejar"
   view.wordWrap: "Alternar ajuste de línea"
+  view.universalToolbar: "Mostrar barra de herramientas universal"
   view.lineNumbers: "Alternar números de línea"
   view.diagramPreview: "Alternar vista previa de diagramas"
   view.fitTables: "Ajustar tablas al ancho"

--- a/src-tauri/locales/fr.yml
+++ b/src-tauri/locales/fr.yml
@@ -171,6 +171,7 @@ menu:
   view.zoomIn: "Zoom avant"
   view.zoomOut: "Zoom arrière"
   view.wordWrap: "Activer/désactiver le retour à la ligne"
+  view.universalToolbar: "Afficher la barre d'outils universelle"
   view.lineNumbers: "Afficher/masquer les numéros de ligne"
   view.diagramPreview: "Afficher/masquer l'aperçu des diagrammes"
   view.fitTables: "Ajuster les tableaux à la largeur"

--- a/src-tauri/locales/it.yml
+++ b/src-tauri/locales/it.yml
@@ -171,6 +171,7 @@ menu:
   view.zoomIn: "Ingrandisci"
   view.zoomOut: "Riduci"
   view.wordWrap: "Attiva/disattiva a capo automatico"
+  view.universalToolbar: "Mostra barra strumenti universale"
   view.lineNumbers: "Mostra/Nascondi numeri riga"
   view.diagramPreview: "Mostra/Nascondi anteprima diagramma"
   view.fitTables: "Adatta tabelle alla larghezza"

--- a/src-tauri/locales/ja.yml
+++ b/src-tauri/locales/ja.yml
@@ -171,6 +171,7 @@ menu:
   view.zoomIn: "拡大"
   view.zoomOut: "縮小"
   view.wordWrap: "折り返しの切り替え"
+  view.universalToolbar: "ユニバーサルツールバーを表示"
   view.lineNumbers: "行番号の表示切替"
   view.diagramPreview: "ダイアグラムプレビューの切り替え"
   view.fitTables: "テーブルを幅に合わせる"

--- a/src-tauri/locales/ko.yml
+++ b/src-tauri/locales/ko.yml
@@ -171,6 +171,7 @@ menu:
   view.zoomIn: "확대"
   view.zoomOut: "축소"
   view.wordWrap: "자동 줄 바꿈 전환"
+  view.universalToolbar: "유니버설 도구 모음 표시"
   view.lineNumbers: "줄 번호 전환"
   view.diagramPreview: "다이어그램 미리 보기 전환"
   view.fitTables: "표를 너비에 맞추기"

--- a/src-tauri/locales/pt-BR.yml
+++ b/src-tauri/locales/pt-BR.yml
@@ -171,6 +171,7 @@ menu:
   view.zoomIn: "Ampliar"
   view.zoomOut: "Reduzir"
   view.wordWrap: "Alternar quebra de linha"
+  view.universalToolbar: "Mostrar barra de ferramentas universal"
   view.lineNumbers: "Alternar números de linha"
   view.diagramPreview: "Alternar pré-visualização de diagrama"
   view.fitTables: "Ajustar tabelas à largura"

--- a/src-tauri/locales/zh-CN.yml
+++ b/src-tauri/locales/zh-CN.yml
@@ -171,6 +171,7 @@ menu:
   view.zoomIn: "放大"
   view.zoomOut: "缩小"
   view.wordWrap: "切换自动换行"
+  view.universalToolbar: "显示通用工具栏"
   view.lineNumbers: "切换行号"
   view.diagramPreview: "切换图表预览"
   view.fitTables: "表格适应宽度"

--- a/src-tauri/locales/zh-TW.yml
+++ b/src-tauri/locales/zh-TW.yml
@@ -171,6 +171,7 @@ menu:
   view.zoomIn: "放大"
   view.zoomOut: "縮小"
   view.wordWrap: "切換自動換行"
+  view.universalToolbar: "顯示通用工具列"
   view.lineNumbers: "切換行號"
   view.diagramPreview: "切換圖表預覽"
   view.fitTables: "表格配合寬度"

--- a/src-tauri/src/coherence/gitops.rs
+++ b/src-tauri/src/coherence/gitops.rs
@@ -41,9 +41,20 @@ pub enum GitClass {
     },
     /// Mid-conflict merge: defer reconciliation until it concludes.
     MergeInProgress,
-    /// Observation gap (repo appeared/disappeared, unreadable HEAD):
+    /// Observation gap (repo appeared/disappeared, unborn HEAD):
     /// fall back to observed-external handling — honest, never guessed.
     ExternalUnknown,
+    /// The observation itself cannot be trusted: a repository that HAD a
+    /// resolvable HEAD now reports none. Commits do not vanish, so this is a
+    /// failed `git` read (a subprocess that could not spawn or exited
+    /// non-zero — `git_output` reports both as `None`), not a state change.
+    ///
+    /// Treating it as `ExternalUnknown` reclassified a git mutation as an
+    /// external edit and minted a spurious revision (#1207). Defer instead:
+    /// the next scan re-observes against the SAME baseline and reconciles
+    /// normally, so a transient failure costs one cycle rather than
+    /// corrupting history.
+    ObservationUnreliable,
 }
 
 fn git_output(root: &Path, args: &[&str]) -> Option<String> {
@@ -119,7 +130,13 @@ pub fn classify(before: Option<&GitObservation>, after: Option<&GitObservation>)
         (Some(b), Some(a)) => (b, a),
     };
     let Some(head) = &a.head_sha else {
-        return GitClass::ExternalUnknown;
+        // A repo that HAD a HEAD cannot stop having one; that read failed.
+        // An unborn repo (never had one) keeps its existing handling.
+        return if b.head_sha.is_some() {
+            GitClass::ObservationUnreliable
+        } else {
+            GitClass::ExternalUnknown
+        };
     };
     let new_shas: Vec<String> = {
         let mut v: Vec<String> = a.known_shas.difference(&b.known_shas).cloned().collect();

--- a/src-tauri/src/coherence/gitops.test.rs
+++ b/src-tauri/src/coherence/gitops.test.rs
@@ -123,16 +123,12 @@ fn fetch_only_new_shas_without_head_move_is_noop() {
     assert_eq!(classify(Some(&b), Some(&a)), GitClass::NoOp);
 }
 
-#[test]
-fn unknown_head_is_external_unknown() {
-    let b = obs("main", "s1", &["s1"], false);
-    let mut a = obs("main", "s1", &["s1"], false);
-    a.head_sha = None;
-    assert!(matches!(
-        classify(Some(&b), Some(&a)),
-        GitClass::ExternalUnknown
-    ));
-}
+// `unknown_head_is_external_unknown` used to assert that an unreadable HEAD
+// falls back to ExternalUnknown. That was the defect, not the contract: the
+// fallback MINTS an external-edit revision, which is itself a guess about what
+// the user did. Superseded by
+// `unreadable_head_after_a_known_one_is_unreliable_not_external` (defer) and
+// `unborn_head_is_still_external_unknown` (genuinely no HEAD — unchanged).
 
 // ── integration: real repos in temp dirs ────────────────────────────────
 
@@ -216,5 +212,62 @@ fn observe_includes_unreachable_detached_head_sha() {
     assert!(
         o.known_shas.contains(&head),
         "unreachable detached HEAD {head} must be in known_shas"
+    );
+}
+
+/// A repository whose HEAD suddenly reads as absent has NOT lost its commits —
+/// `git rev-parse HEAD` failed. Under a loaded full-suite run a git subprocess
+/// can fail transiently, and treating that as a real observation reclassified a
+/// git mutation as an external edit, minting a spurious revision (#1207).
+#[test]
+fn unreadable_head_after_a_known_one_is_unreliable_not_external() {
+    let before = obs("main", "aaa", &["aaa"], false);
+    let after = GitObservation {
+        head_ref: "main".to_string(),
+        head_sha: None, // rev-parse failed — commits cannot vanish
+        known_shas: HashSet::new(),
+        merge_in_progress: false,
+    };
+    assert_eq!(
+        classify(Some(&before), Some(&after)),
+        GitClass::ObservationUnreliable
+    );
+}
+
+/// An UNBORN repository legitimately has no HEAD, and never had one. That is a
+/// real state, not a failed read, so it must keep its existing handling.
+#[test]
+fn unborn_head_is_still_external_unknown() {
+    let before = GitObservation {
+        head_ref: "main".to_string(),
+        head_sha: None,
+        known_shas: HashSet::new(),
+        merge_in_progress: false,
+    };
+    let after = GitObservation {
+        head_ref: "main".to_string(),
+        head_sha: None,
+        known_shas: HashSet::new(),
+        merge_in_progress: false,
+    };
+    assert_eq!(
+        classify(Some(&before), Some(&after)),
+        GitClass::ExternalUnknown
+    );
+}
+
+/// A merge in progress still wins: it is checked before anything else.
+#[test]
+fn unreliable_observation_does_not_mask_a_merge() {
+    let before = obs("main", "aaa", &["aaa"], false);
+    let after = GitObservation {
+        head_ref: "main".to_string(),
+        head_sha: None,
+        known_shas: HashSet::new(),
+        merge_in_progress: true,
+    };
+    assert_eq!(
+        classify(Some(&before), Some(&after)),
+        GitClass::MergeInProgress
     );
 }

--- a/src-tauri/src/coherence/scan.rs
+++ b/src-tauri/src/coherence/scan.rs
@@ -52,6 +52,9 @@ pub struct ScanReport {
     pub navigations: usize,
     pub git_mutations: usize,
     pub external_edits: usize,
+    /// Set when the git observation could not be trusted and reconciliation
+    /// was deferred to the next scan (#1207).
+    pub git_observation_unreliable: bool,
     pub adopted: usize,
     pub absent_marked: usize,
     pub diagnostics: usize,
@@ -90,6 +93,16 @@ pub fn scan_workspace(kernel: &mut WorkspaceKernel) -> Result<ScanReport, String
         // Defer: reconcile once the merge concludes.
         kernel.last_git = current_git;
         report.merge_deferred = true;
+        return Ok(report);
+    }
+    if class == GitClass::ObservationUnreliable {
+        // A repository that HAD a resolvable HEAD now reports none, so the
+        // `git` read failed rather than the repo changing. Reconciling on it
+        // would mint a spurious external-edit revision for what is really a
+        // git mutation (#1207). Return WITHOUT storing the bad observation,
+        // so the next scan compares against the same good baseline and
+        // reconciles normally — a transient failure costs one cycle.
+        report.git_observation_unreliable = true;
         return Ok(report);
     }
     if let GitClass::Navigation { op, from, to } = &class {

--- a/src-tauri/src/macos_menu_icons.rs
+++ b/src-tauri/src/macos_menu_icons.rs
@@ -165,6 +165,7 @@ pub(crate) const MENU_ICONS: &[(&str, &str)] = &[
     ("zoom-actual", "1.magnifyingglass"),
     ("zoom-in", "plus.magnifyingglass"),
     ("zoom-out", "minus.magnifyingglass"),
+    ("universal-toolbar", "textformat"),
     ("word-wrap", "arrow.right.to.line"),
     ("line-numbers", "number"),
     ("diagram-preview", "eye.square"),

--- a/src-tauri/src/menu/localized.test.rs
+++ b/src-tauri/src/menu/localized.test.rs
@@ -150,6 +150,7 @@ const DEFAULT_ACCELERATORS: &[(&str, &str)] = &[
     ("typewriter-mode", "F9"),
     ("underline", "CmdOrCtrl+U"),
     ("undo", "CmdOrCtrl+Z"),
+    ("universal-toolbar", "CmdOrCtrl+Shift+B"),
     ("unordered-list", "Alt+CmdOrCtrl+U"),
     ("use-selection-find", "CmdOrCtrl+E"),
     ("video", ""),

--- a/src-tauri/src/menu/localized/view_menu.rs
+++ b/src-tauri/src/menu/localized/view_menu.rs
@@ -5,6 +5,10 @@
 //! gate. The mode items (`wysiwyg-mode`, `source-mode`, `markdown-split`)
 //! are `CheckMenuItem`s whose checkmarks are kept in sync by
 //! `menu::menu_state`.
+//!
+//! `universal-toolbar` is deliberately a plain `MenuItem`: invoking it while
+//! the toolbar is already visible moves focus rather than hiding it (Esc
+//! dismisses), so a checkmark would advertise a state the click cannot clear.
 
 use rust_i18n::t;
 use tauri::menu::{CheckMenuItem, MenuItem, PredefinedMenuItem, Submenu};

--- a/src-tauri/src/menu/localized/view_menu.rs
+++ b/src-tauri/src/menu/localized/view_menu.rs
@@ -90,6 +90,13 @@ pub(super) fn build(app: &tauri::AppHandle, accel: &AccelFn) -> tauri::Result<Su
             )?,
             &MenuItem::with_id(
                 app,
+                "universal-toolbar",
+                &t!("menu.view.universalToolbar"),
+                true,
+                accel("universal-toolbar", "CmdOrCtrl+Shift+B"),
+            )?,
+            &MenuItem::with_id(
+                app,
                 "line-numbers",
                 &t!("menu.view.lineNumbers"),
                 true,

--- a/src/components/Editor/WorkflowEditor/PermissionsForm.tsx
+++ b/src/components/Editor/WorkflowEditor/PermissionsForm.tsx
@@ -9,7 +9,12 @@
  *   panel for the most common scopes. Power users (rare scope edits)
  *   continue to drop to source.
  *
+ *   Selects use the canonical `.vm-select` primitive inside a
+ *   `.vm-select-field` wrapper (rule 32); a bare `<select>` renders native
+ *   macOS chrome that ignores the design tokens.
+ *
  * @coordinates-with src/lib/ghaWorkflow/save/mutators.ts — workflow.permissions.set patch
+ * @coordinates-with src/styles/select-shared.css — the select primitive
  * @module components/Editor/WorkflowEditor/PermissionsForm
  */
 

--- a/src/components/Editor/WorkflowEditor/PermissionsForm.tsx
+++ b/src/components/Editor/WorkflowEditor/PermissionsForm.tsx
@@ -109,8 +109,9 @@ export function PermissionsForm({
         </span>
       </header>
       <label className="workflow-form__field">
+        <span className="vm-select-field">
         <select
-          className="workflow-form__input"
+          className="vm-select"
           value={mode}
           onChange={(e) => onModeChange(e.target.value as PresetMode)}
         >
@@ -126,6 +127,7 @@ export function PermissionsForm({
             })}
           </option>
         </select>
+        </span>
       </label>
       {mode === "custom" && (
         <div className="workflow-form__permissions-scopes">
@@ -134,8 +136,9 @@ export function PermissionsForm({
               <span className="workflow-form__permissions-scope-name">
                 <code>{scope}</code>
               </span>
+              <span className="vm-select-field">
               <select
-                className="workflow-form__input"
+                className="vm-select"
                 value={customMap[scope] ?? ""}
                 onChange={(e) =>
                   onScopeChange(scope, e.target.value as PermLevel | "")
@@ -148,6 +151,7 @@ export function PermissionsForm({
                 <option value="write">write</option>
                 <option value="none">none</option>
               </select>
+              </span>
             </label>
           ))}
         </div>

--- a/src/components/Editor/WorkflowEditor/__tests__/PermissionsForm.test.tsx
+++ b/src/components/Editor/WorkflowEditor/__tests__/PermissionsForm.test.tsx
@@ -52,8 +52,10 @@ describe("PermissionsForm", () => {
     render(<PermissionsForm permissions={{ contents: "read" }} />);
     const allSelects = screen.getAllByRole("combobox");
     const issuesScope = allSelects.find((s) =>
-      // The select for 'issues' starts empty.
-      (s.parentElement?.textContent ?? "").includes("issues"),
+      // Walk to the labelled ROW rather than the immediate parent: the select
+      // sits inside a `.vm-select-field` wrapper that owns the chevron, so
+      // `parentElement` is that wrapper and carries no scope name.
+      (s.closest("label")?.textContent ?? "").includes("issues"),
     );
     fireEvent.change(issuesScope!, { target: { value: "write" } });
     const patches = useWorkflowStore.getState().edit.pendingPatches;

--- a/src/hooks/useCommandBootstrap.ts
+++ b/src/hooks/useCommandBootstrap.ts
@@ -96,6 +96,7 @@ const VIEW_BINDINGS: MenuCommandBinding[] = [
   { menuEvent: "menu:breakdown", commandId: "view.toggleBreakdown" },
   { menuEvent: "menu:word-wrap", commandId: "view.toggleWordWrap" },
   { menuEvent: "menu:line-numbers", commandId: "view.toggleLineNumbers" },
+  { menuEvent: "menu:universal-toolbar", commandId: "view.toggleUniversalToolbar" },
   { menuEvent: "menu:diagram-preview", commandId: "view.toggleDiagramPreview" },
   { menuEvent: "menu:fit-tables", commandId: "view.toggleFitTables" },
   { menuEvent: "menu:read-only", commandId: "view.toggleReadOnly" },

--- a/src/hooks/useUniversalToolbar.ts
+++ b/src/hooks/useUniversalToolbar.ts
@@ -12,6 +12,7 @@ import { useEffect, useCallback } from "react";
 import { useUIStore } from "@/stores/uiStore";
 import { useShortcutsStore } from "@/stores/settingsStore";
 import { matchesShortcutEvent } from "@/utils/shortcutMatch";
+import { toggleUniversalToolbar } from "@/services/editor/universalToolbarToggle";
 
 /**
  * Hook to handle the universal toolbar toggle shortcut.
@@ -25,15 +26,9 @@ import { matchesShortcutEvent } from "@/utils/shortcutMatch";
  * }
  */
 export function useUniversalToolbar(): void {
-  const toggleToolbar = useCallback(() => {
-    const ui = useUIStore.getState();
-    if (!ui.universalToolbarVisible) {
-      // Opening UniversalToolbar: displace StatusBar and close FindBar
-      ui.displaceStatusBar();
-      useUIStore.getState().searchClose();
-    }
-    ui.toggleUniversalToolbar();
-  }, []);
+  // Shared with the View-menu command so the two entry points cannot drift
+  // (services/editor/universalToolbarToggle).
+  const toggleToolbar = useCallback(() => toggleUniversalToolbar(), []);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/src/hooks/useUniversalToolbar.ts
+++ b/src/hooks/useUniversalToolbar.ts
@@ -1,10 +1,17 @@
 /**
  * Universal Toolbar Toggle Hook
  *
- * Purpose: Listens for the configurable keyboard shortcut to toggle the
- *   universal toolbar visibility — works in both WYSIWYG and Source modes.
+ * Purpose: Listens for the configurable keyboard shortcut to summon the
+ *   universal toolbar — works in both WYSIWYG and Source modes — and owns the
+ *   Escape cascade that dismisses it.
  *
- * @coordinates-with uiStore.ts — toggles toolbar visibility
+ *   The summon itself is delegated to `services/editor/universalToolbarToggle`,
+ *   shared with the View-menu command so the keyboard and the menu item cannot
+ *   drift. This hook keeps the key matching and the Escape handling, which have
+ *   no menu counterpart.
+ *
+ * @coordinates-with services/editor/universalToolbarToggle.ts — the shared summon
+ * @coordinates-with uiStore.ts — Escape cascade (dropdown → toolbar → StatusBar)
  * @coordinates-with shortcutsStore.ts — reads configurable shortcut binding
  * @module hooks/useUniversalToolbar
  */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import "./styles/index.css";
 // Canonical `.vm-btn` text button. Global so any surface can use it instead of
 // hand-rolling another bespoke `__btn` class (see the file header).
 import "./styles/button-shared.css";
+import "./styles/select-shared.css";
 // Shared syntax-highlight palette (source-syntax.css + json-view-theme.css
 // both consume these vars). Global so the vars resolve wherever either renders.
 import "./styles/syntax-palette.css";

--- a/src/plugins/mermaid/ensureSvgSize.test.ts
+++ b/src/plugins/mermaid/ensureSvgSize.test.ts
@@ -1,0 +1,94 @@
+/**
+ * #1215 / #1200 — mermaid SVGs must carry a resolvable height.
+ *
+ * Mermaid's `calculateSvgSizeAttrs` emits `width="100%"` + `style="max-width:
+ * Npx"` and NO height whenever `useMaxWidth` is on, which is its default for
+ * every diagram type. VMark styles that SVG `height: auto` inside a
+ * `display:flex; align-items:center` container, so it is a non-stretched flex
+ * item with a percentage width and no intrinsic height — a shape some engines
+ * resolve to zero, leaving an invisible diagram inside a `min-height:100px`
+ * grey container. No error, no log, just a grey box.
+ */
+import { describe, it, expect } from "vitest";
+import { ensureSvgSize } from "./ensureSvgSize";
+
+const mermaidLike = (attrs: string) =>
+  `<svg id="m1" ${attrs} viewBox="0 0 340 130" xmlns="http://www.w3.org/2000/svg"><g/></svg>`;
+
+describe("ensureSvgSize", () => {
+  it("adds an aspect-ratio derived from the viewBox", () => {
+    const out = ensureSvgSize(mermaidLike('width="100%" style="max-width: 340px;"'));
+    expect(out).toContain("aspect-ratio: 340 / 130");
+  });
+
+  it("leaves width alone, so diagrams still fill the editor as before", () => {
+    // Replacing width with pixels would shrink every working diagram — a
+    // visible change for everyone to fix a bug only some see.
+    const out = ensureSvgSize(mermaidLike('width="100%" style="max-width: 340px;"'));
+    expect(out).toContain('width="100%"');
+    expect(out).toContain("max-width: 340px");
+  });
+
+  it("appends to an existing style without dropping it", () => {
+    const out = ensureSvgSize(mermaidLike('width="100%" style="max-width: 340px;"'));
+    expect(out).toMatch(/style="max-width: 340px; aspect-ratio: 340 \/ 130;"/);
+  });
+
+  it("adds a style attribute when the SVG has none", () => {
+    const out = ensureSvgSize(`<svg width="100%" viewBox="0 0 10 20"><g/></svg>`);
+    expect(out).toContain('style="aspect-ratio: 10 / 20;"');
+  });
+
+  it("handles a style without a trailing semicolon", () => {
+    const out = ensureSvgSize(`<svg width="100%" style="color: red" viewBox="0 0 4 2"/>`);
+    expect(out).toContain("color: red; aspect-ratio: 4 / 2;");
+  });
+
+  it("leaves an SVG that already has a height alone", () => {
+    const svg = mermaidLike('width="340" height="130"');
+    expect(ensureSvgSize(svg)).toBe(svg);
+  });
+
+  it("is idempotent — a second pass adds nothing", () => {
+    const once = ensureSvgSize(mermaidLike('width="100%" style="max-width: 340px;"'));
+    expect(ensureSvgSize(once)).toBe(once);
+  });
+
+  it("handles a fractional viewBox", () => {
+    const out = ensureSvgSize(`<svg width="100%" viewBox="0 0 1166 1654.5"><g/></svg>`);
+    expect(out).toContain("aspect-ratio: 1166 / 1654.5");
+  });
+
+  it("handles a viewBox with a non-zero origin", () => {
+    const out = ensureSvgSize(`<svg width="100%" viewBox="-8 -8 200 90"><g/></svg>`);
+    expect(out).toContain("aspect-ratio: 200 / 90");
+  });
+
+  it("tolerates comma-separated viewBox values", () => {
+    const out = ensureSvgSize(`<svg width="100%" viewBox="0,0,50,25"><g/></svg>`);
+    expect(out).toContain("aspect-ratio: 50 / 25");
+  });
+
+  it("leaves an SVG with no viewBox untouched — nothing to derive from", () => {
+    const svg = `<svg width="100%"><g/></svg>`;
+    expect(ensureSvgSize(svg)).toBe(svg);
+  });
+
+  it("ignores a degenerate viewBox rather than pinning the diagram flat", () => {
+    const svg = `<svg width="100%" viewBox="0 0 0 0"><g/></svg>`;
+    expect(ensureSvgSize(svg)).toBe(svg);
+  });
+
+  it("only rewrites the ROOT svg, not a nested icon", () => {
+    const out = ensureSvgSize(
+      `<svg width="100%" viewBox="0 0 10 20"><svg width="100%" viewBox="0 0 4 4"/></svg>`,
+    );
+    expect(out).toContain("aspect-ratio: 10 / 20");
+    expect(out).not.toContain("aspect-ratio: 4 / 4");
+  });
+
+  it("returns non-SVG input unchanged", () => {
+    expect(ensureSvgSize("")).toBe("");
+    expect(ensureSvgSize("<div>nope</div>")).toBe("<div>nope</div>");
+  });
+});

--- a/src/plugins/mermaid/ensureSvgSize.ts
+++ b/src/plugins/mermaid/ensureSvgSize.ts
@@ -1,0 +1,75 @@
+/**
+ * Give a mermaid SVG a resolvable height (#1200, #1215).
+ *
+ * Mermaid's `calculateSvgSizeAttrs` emits, when `useMaxWidth` is on:
+ *
+ *     width="100%"  style="max-width: <W>px;"      // and NO height
+ *
+ * and that is the default for every diagram type, so overriding it in config
+ * would mean enumerating each type and re-doing so whenever mermaid adds one.
+ * Normalising the emitted markup covers them all at once.
+ *
+ * Why it matters: VMark renders that SVG as a non-stretched flex item
+ * (`display:flex; align-items:center`) styled `height: auto`. A replaced
+ * element with a percentage width and no intrinsic height must derive its
+ * height from the viewBox ratio, and where an engine resolves that to zero the
+ * diagram is invisible — inside a `min-height:100px` container with a grey
+ * background, which is exactly the "empty grey placeholder" both issues
+ * describe: no error box, no log line, nothing to grep for. Markmap never hit
+ * it because it sets an explicit `height`.
+ *
+ * The fix adds `aspect-ratio` rather than a `height` attribute, for two
+ * reasons:
+ *   - a `height` ATTRIBUTE is a presentation hint, so the stylesheet's
+ *     `height: auto` outranks it and the element stays indefinite;
+ *   - replacing `width="100%"` with pixels would shrink every diagram that
+ *     currently fills the editor width — a visible change for everyone, to
+ *     fix a bug only some see.
+ * `aspect-ratio` leaves the width behaviour alone and lets `height: auto`
+ * resolve deterministically from an explicit ratio instead of an inferred one.
+ *
+ * @coordinates-with plugin.ts — applied to every rendered diagram
+ * @coordinates-with mermaid.css — the `max-width: 100%; height: auto` rules
+ * @module plugins/mermaid/ensureSvgSize
+ */
+
+/** `viewBox="minX minY W H"`, space- or comma-separated. */
+const VIEWBOX_RE = /\bviewBox\s*=\s*"\s*([-\d.eE]+)[\s,]+([-\d.eE]+)[\s,]+([-\d.eE]+)[\s,]+([-\d.eE]+)\s*"/;
+
+/** The opening tag of the ROOT `<svg>` element. */
+const ROOT_SVG_TAG_RE = /^(\s*)(<svg\b[^>]*>)/;
+
+/**
+ * Add an explicit `aspect-ratio` derived from the viewBox so `height: auto`
+ * always resolves. Input without a root `<svg>`, without a usable viewBox,
+ * already carrying a height or an aspect-ratio, is returned unchanged.
+ */
+export function ensureSvgSize(svg: string): string {
+  const tagMatch = ROOT_SVG_TAG_RE.exec(svg);
+  if (!tagMatch) return svg;
+
+  const [, leading, openTag] = tagMatch;
+  // An explicit height, or a ratio someone already set, resolves on its own.
+  if (/\bheight\s*=/.test(openTag) || /aspect-ratio\s*:/.test(openTag)) return svg;
+
+  const viewBox = VIEWBOX_RE.exec(openTag);
+  if (!viewBox) return svg;
+
+  const width = Number(viewBox[3]);
+  const height = Number(viewBox[4]);
+  // A degenerate viewBox would pin the diagram flat — worse than leaving the
+  // engine to guess.
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return svg;
+  }
+
+  const ratio = `aspect-ratio: ${width} / ${height};`;
+  const styled = /\bstyle\s*=\s*"/.test(openTag)
+    ? openTag.replace(/\bstyle\s*=\s*"([^"]*)"/, (_m, css: string) => {
+        const sep = css.trim().endsWith(";") || css.trim() === "" ? "" : ";";
+        return `style="${css}${sep} ${ratio}"`;
+      })
+    : openTag.replace(/^<svg\b/, `<svg style="${ratio}"`);
+
+  return leading + styled + svg.slice(tagMatch[0].length);
+}

--- a/src/plugins/mermaid/plugin.ts
+++ b/src/plugins/mermaid/plugin.ts
@@ -14,6 +14,7 @@ import {
 } from "@/plugins/shared/diagramThemeTokens";
 import { buildMermaidThemeVariables, exportThemeVariables } from "./themeConfig";
 import { cleanupMermaidContainer, getMonoFontSize } from "./renderDomUtils";
+import { ensureSvgSize } from "./ensureSvgSize";
 
 // Lazy-loaded mermaid instance
 let mermaidModule: typeof import("mermaid") | null = null;
@@ -185,7 +186,10 @@ export async function renderMermaid(
       }
       // mermaidModule is guaranteed non-null after initMermaid()
       const { svg } = await mermaidModule!.default.render(diagramId, content);
-      return svg;
+      // mermaid emits width="100%" and NO height under useMaxWidth (its
+      // default), which can collapse to zero height in the preview's flex
+      // container — an invisible diagram in a grey box (#1200, #1215).
+      return ensureSvgSize(svg);
     } catch (error) {
       diagramWarn("Failed to render diagram:", error);
       return null;
@@ -233,7 +237,7 @@ export async function renderMermaidForExport(
         themeVariables: themeVars,
       });
       const { svg } = await mermaidModule!.default.render(diagramId, content);
-      return svg;
+      return ensureSvgSize(svg);
     } catch (error) {
       diagramWarn("Failed to render export diagram:", error);
       return null;

--- a/src/services/commands/lintCommands.test.ts
+++ b/src/services/commands/lintCommands.test.ts
@@ -1,0 +1,118 @@
+// Behaviour of the `lint.*` command set after its extraction from
+// viewCommands.ts. `lint.next` / `lint.prev` previously had no behavioural
+// test — only their presence in the id list — so a move that swapped the two
+// directions, or dropped the scroll-to-diagnostic call, would have gone
+// unnoticed. The lint store runs for real (three seeded diagnostics), so these
+// assert the selection actually moves, including the wrap at each end.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { scrollToSelectedDiagnostic, runActiveLint, getActiveTabId } = vi.hoisted(() => ({
+  scrollToSelectedDiagnostic: vi.fn(),
+  runActiveLint: vi.fn(),
+  getActiveTabId: vi.fn(),
+}));
+
+vi.mock("@/services/lint/lintNavigation", () => ({ scrollToSelectedDiagnostic }));
+vi.mock("@/services/lint/runActiveLint", () => ({ runActiveLint }));
+vi.mock("@/services/navigation/activeDocument", () => ({ getActiveTabId }));
+
+import { registerLintCommands, __resetLintCommandsRegistration } from "./lintCommands";
+import { executeCommand, getCommand, _resetCommandBus } from "./CommandBus";
+import { useLintStore } from "@/stores/documentStore";
+
+const TAB = "tab-1";
+
+/** Index the commands are expected to move. */
+function selected(tabId = TAB): number | undefined {
+  return useLintStore.getState().selectedIndexByTab[tabId];
+}
+
+function seedDiagnostics(count: number, tabId = TAB): void {
+  useLintStore.setState({
+    diagnosticsByTab: {
+      [tabId]: Array.from({ length: count }, (_, i) => ({
+        line: i + 1,
+        column: 1,
+        rule: `MD00${i + 1}`,
+        message: `problem ${i + 1}`,
+        severity: "warning" as const,
+      })),
+    },
+    selectedIndexByTab: { [tabId]: 0 },
+  });
+}
+
+beforeEach(() => {
+  _resetCommandBus();
+  __resetLintCommandsRegistration();
+  registerLintCommands();
+  vi.clearAllMocks();
+  useLintStore.setState({ diagnosticsByTab: {}, selectedIndexByTab: {} });
+  getActiveTabId.mockReturnValue(TAB);
+});
+
+describe("registerLintCommands", () => {
+  it("registers the three lint commands under the lint category", () => {
+    for (const id of ["lint.check", "lint.next", "lint.prev"]) {
+      expect(getCommand(id)?.category).toBe("lint");
+    }
+  });
+
+  it("is idempotent — a second call does not throw on duplicate ids", () => {
+    expect(() => registerLintCommands()).not.toThrow();
+  });
+});
+
+describe("lint.check", () => {
+  it("runs the active linter for the calling window", async () => {
+    await executeCommand("lint.check", undefined, { windowLabel: "w2" });
+    expect(runActiveLint).toHaveBeenCalledWith("w2");
+  });
+
+  it("falls back to the main window when no label is supplied", async () => {
+    await executeCommand("lint.check", undefined, {});
+    expect(runActiveLint).toHaveBeenCalledWith("main");
+  });
+});
+
+describe("lint.next / lint.prev", () => {
+  beforeEach(() => seedDiagnostics(3));
+
+  it("lint.next advances the selection and scrolls to it", async () => {
+    await executeCommand("lint.next", undefined, { windowLabel: "main" });
+    expect(selected()).toBe(1);
+    expect(scrollToSelectedDiagnostic).toHaveBeenCalledWith(TAB);
+  });
+
+  it("lint.prev moves the selection BACKWARD, wrapping to the last", async () => {
+    await executeCommand("lint.prev", undefined, { windowLabel: "main" });
+    expect(selected()).toBe(2);
+    expect(scrollToSelectedDiagnostic).toHaveBeenCalledWith(TAB);
+  });
+
+  it("lint.next wraps around at the end", async () => {
+    for (let i = 0; i < 3; i++) {
+      await executeCommand("lint.next", undefined, { windowLabel: "main" });
+    }
+    expect(selected()).toBe(0);
+  });
+
+  it("resolves the tab from the calling window, not a hardcoded one", async () => {
+    await executeCommand("lint.next", undefined, { windowLabel: "w3" });
+    expect(getActiveTabId).toHaveBeenCalledWith("w3");
+  });
+
+  it("does nothing when the window has no active tab", async () => {
+    getActiveTabId.mockReturnValue(undefined);
+    await executeCommand("lint.next", undefined, { windowLabel: "main" });
+    await executeCommand("lint.prev", undefined, { windowLabel: "main" });
+    expect(selected()).toBe(0);
+    expect(scrollToSelectedDiagnostic).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the tab has no diagnostics", async () => {
+    useLintStore.setState({ diagnosticsByTab: {}, selectedIndexByTab: {} });
+    await executeCommand("lint.next", undefined, { windowLabel: "main" });
+    expect(selected()).toBeUndefined();
+  });
+});

--- a/src/services/commands/lintCommands.ts
+++ b/src/services/commands/lintCommands.ts
@@ -1,0 +1,60 @@
+/**
+ * Lint commands — the markdown-lint command set, split out of viewCommands.ts
+ * for the file-size gate. These are `lint.*`, a namespace of their own rather
+ * than a corner of `view.*`, so they were the natural seam. Registered by
+ * `registerViewCommands()`, so callers and tests keep a single entry point.
+ */
+
+import { hasCommand, registerCommand } from "./CommandBus";
+import { useLintStore } from "@/stores/documentStore";
+import { getActiveTabId } from "@/services/navigation/activeDocument";
+import { scrollToSelectedDiagnostic } from "@/services/lint/lintNavigation";
+import { runActiveLint } from "@/services/lint/runActiveLint";
+import i18n from "@/i18n";
+
+type Ctx = { windowLabel?: string };
+
+/** Move the lint selection and scroll the editor to whatever is now selected. */
+function step(windowLabel: string, direction: "next" | "prev"): void {
+  const tabId = getActiveTabId(windowLabel);
+  if (!tabId) return;
+  const lint = useLintStore.getState();
+  if (direction === "next") lint.selectNext(tabId);
+  else lint.selectPrev(tabId);
+  scrollToSelectedDiagnostic(tabId);
+}
+
+let registered = false;
+export function registerLintCommands(): void {
+  if (registered || hasCommand("lint.check")) return; // HMR: module-local flag resets on reload; the bus registry survives
+
+  registerCommand({
+    id: "lint.check",
+    title: () => i18n.t("commands:lint.check"),
+    category: "lint",
+    run: (_args, ctx: Ctx) => {
+      runActiveLint(ctx.windowLabel ?? "main");
+    },
+  });
+
+  registerCommand({
+    id: "lint.next",
+    title: () => i18n.t("commands:lint.next"),
+    category: "lint",
+    run: (_args, ctx: Ctx) => step(ctx.windowLabel ?? "main", "next"),
+  });
+
+  registerCommand({
+    id: "lint.prev",
+    title: () => i18n.t("commands:lint.prev"),
+    category: "lint",
+    run: (_args, ctx: Ctx) => step(ctx.windowLabel ?? "main", "prev"),
+  });
+
+  registered = true;
+}
+
+/** Test-only: reset the module registration guard so a fresh CommandBus can be repopulated. */
+export function __resetLintCommandsRegistration(): void {
+  registered = false;
+}

--- a/src/services/commands/viewCommands.test.ts
+++ b/src/services/commands/viewCommands.test.ts
@@ -108,7 +108,7 @@ describe("registerViewCommands — full command set", () => {
     expect(getCommand("view.toggleSourceMode")).toBeDefined();
   });
 
-  it("registers all 32 view/lint commands", () => {
+  it("registers all 33 view/lint commands", () => {
     const ids = listCommands().map((c) => c.id);
     expect(ids).toContain("view.toggleSidebar");
     expect(ids).toContain("view.toggleSourceMode");
@@ -122,7 +122,8 @@ describe("registerViewCommands — full command set", () => {
     expect(ids).toContain("view.contentSearch");
     expect(ids).toContain("explorer.toggleHiddenFiles");
     expect(ids).toContain("explorer.toggleAllFiles");
-    expect(ids.length).toBe(32);
+    expect(ids).toContain("view.toggleUniversalToolbar");
+    expect(ids.length).toBe(33);
   });
 
   it("every command resolves a non-empty title and executes without throwing", async () => {

--- a/src/services/commands/viewCommands.ts
+++ b/src/services/commands/viewCommands.ts
@@ -1,31 +1,31 @@
 /**
  * View commands — ADR-012 migration of useViewMenuEvents.
  *
- * 28 commands covering source/focus/typewriter modes, sidebar views and
- * panels (knowledge base, window status, breakdown), word wrap, line
- * numbers, diagram preview, fit tables, read-only, terminal toggle, zoom,
- * and lint check/navigation. The split-document pane commands live in
- * paneCommands.ts (registered from here).
+ * Commands covering source/focus/typewriter modes, the universal toolbar,
+ * sidebar views and panels (knowledge base, window status, breakdown), word
+ * wrap, line numbers, diagram preview, fit tables, read-only, terminal
+ * toggle, and zoom. Two sibling sets are registered from here so callers
+ * keep one entry point: the split-document pane commands
+ * (paneCommands.ts) and the markdown-lint commands (lintCommands.ts).
  */
 
 import { hasCommand, registerCommand } from "./CommandBus";
 import { registerPaneCommands, __resetPaneCommandsRegistration } from "./paneCommands";
+import { registerLintCommands, __resetLintCommandsRegistration } from "./lintCommands";
 import { useUIStore } from "@/stores/uiStore";
 import { toggleShowHiddenFiles, toggleShowAllFiles } from "@/services/workspaces/workspaceConfig";
 import { useContentServerStore } from "@/stores/contentServerStore";
 import { useWindowStatusStore } from "@/stores/windowStatusStore";
 import { useBreakdownStore } from "@/stores/breakdownStore";
 import { useSettingsStore } from "@/stores/settingsStore";
-import { useLintStore } from "@/stores/documentStore";
 import { requestToggleTerminal } from "@/services/terminal/terminalGate";
 import { cleanupBeforeModeSwitch } from "@/services/assembly/modeSwitchCleanup";
 import { toggleSourceModeWithCheckpoint } from "@/services/history/unifiedHistory";
 import { toggleMarkdownSplitWithCheckpoint } from "@/services/editor/markdownSplitToggle";
 import { getActiveTabId } from "@/services/navigation/activeDocument";
 import { toggleDocumentReadOnlyWithOwnership } from "@/services/workspaces/fileOwnership";
-import { scrollToSelectedDiagnostic } from "@/services/lint/lintNavigation";
-import { runActiveLint } from "@/services/lint/runActiveLint";
 import i18n from "@/i18n";
+import { toggleUniversalToolbar } from "@/services/editor/universalToolbarToggle";
 
 const DEFAULT_FONT_SIZE = 18;
 const MIN_FONT_SIZE = 12;
@@ -47,6 +47,13 @@ export function registerViewCommands(): void {
       cleanupBeforeModeSwitch();
       toggleSourceModeWithCheckpoint(windowLabel);
     },
+  });
+
+  registerCommand({
+    id: "view.toggleUniversalToolbar",
+    title: () => i18n.t("commands:view.toggleUniversalToolbar"),
+    category: "view",
+    run: () => toggleUniversalToolbar(),
   });
 
   registerCommand({
@@ -247,44 +254,8 @@ export function registerViewCommands(): void {
     },
   });
 
-  registerCommand({
-    id: "lint.check",
-    title: () => i18n.t("commands:lint.check"),
-    category: "lint",
-    run: (_args, ctx: Ctx) => {
-      runActiveLint(ctx.windowLabel ?? "main");
-    },
-  });
-
-  registerCommand({
-    id: "lint.next",
-    title: () => i18n.t("commands:lint.next"),
-    category: "lint",
-    run: (_args, ctx: Ctx) => {
-      const windowLabel = ctx.windowLabel ?? "main";
-      const tabId = getActiveTabId(windowLabel);
-      if (tabId) {
-        useLintStore.getState().selectNext(tabId);
-        scrollToSelectedDiagnostic(tabId);
-      }
-    },
-  });
-
-  registerCommand({
-    id: "lint.prev",
-    title: () => i18n.t("commands:lint.prev"),
-    category: "lint",
-    run: (_args, ctx: Ctx) => {
-      const windowLabel = ctx.windowLabel ?? "main";
-      const tabId = getActiveTabId(windowLabel);
-      if (tabId) {
-        useLintStore.getState().selectPrev(tabId);
-        scrollToSelectedDiagnostic(tabId);
-      }
-    },
-  });
-
   registerPaneCommands();
+  registerLintCommands();
 
   registered = true;
 }
@@ -293,4 +264,5 @@ export function registerViewCommands(): void {
 export function __resetViewCommandsRegistration(): void {
   registered = false;
   __resetPaneCommandsRegistration();
+  __resetLintCommandsRegistration();
 }

--- a/src/services/editor/universalToolbarToggle.test.ts
+++ b/src/services/editor/universalToolbarToggle.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { toggleUniversalToolbar } from "./universalToolbarToggle";
+import { useUIStore } from "@/stores/uiStore";
+
+describe("toggleUniversalToolbar", () => {
+  beforeEach(() => {
+    useUIStore.getState().clearToolbarSession();
+    useUIStore.getState().setStatusBarVisible(true);
+    useUIStore.getState().searchClose();
+  });
+
+  it("summons the toolbar when hidden", () => {
+    toggleUniversalToolbar();
+    expect(useUIStore.getState().universalToolbarVisible).toBe(true);
+    expect(useUIStore.getState().universalToolbarHasFocus).toBe(true);
+  });
+
+  it("moves FOCUS rather than hiding when already visible", () => {
+    // The shortcut summons and re-focuses; dismissal is Esc. A menu item
+    // carrying the same accelerator must behave identically, or clicking
+    // the item and pressing the key would diverge while macOS advertises
+    // them as the same action.
+    toggleUniversalToolbar();
+    toggleUniversalToolbar();
+    expect(useUIStore.getState().universalToolbarVisible).toBe(true);
+    expect(useUIStore.getState().universalToolbarHasFocus).toBe(false);
+  });
+
+  it("displaces the StatusBar when summoning — they share the strip", () => {
+    expect(useUIStore.getState().statusBarVisible).toBe(true);
+    toggleUniversalToolbar();
+    expect(useUIStore.getState().statusBarVisible).toBe(false);
+  });
+
+  it("closes an open search when summoning", () => {
+    useUIStore.getState().searchOpen();
+    expect(useUIStore.getState().search.isOpen).toBe(true);
+    toggleUniversalToolbar();
+    expect(useUIStore.getState().search.isOpen).toBe(false);
+  });
+
+  it("does not touch the StatusBar again once the toolbar is up", () => {
+    toggleUniversalToolbar();
+    useUIStore.getState().setStatusBarVisible(true);
+    toggleUniversalToolbar();
+    expect(useUIStore.getState().statusBarVisible).toBe(true);
+  });
+});

--- a/src/services/editor/universalToolbarToggle.ts
+++ b/src/services/editor/universalToolbarToggle.ts
@@ -1,0 +1,31 @@
+/**
+ * The one way to toggle the Universal Toolbar (#1204).
+ *
+ * Showing the toolbar is not a single flag flip: it displaces the StatusBar
+ * and closes the FindBar first, because all three compete for the same strip
+ * at the bottom of the window. That sequence used to live inside
+ * `useUniversalToolbar`'s keydown handler, which was fine while the shortcut
+ * was the only entry point. Adding a View-menu item gives it a second caller,
+ * and a copy of the sequence in the command would drift from the copy in the
+ * hook — the toolbar would open over a still-visible StatusBar from one path
+ * and not the other.
+ *
+ * @coordinates-with hooks/useUniversalToolbar.ts — the keyboard entry point
+ * @coordinates-with services/commands/viewCommands.ts — the menu entry point
+ * @module services/editor/universalToolbarToggle
+ */
+import { useUIStore } from "@/stores/uiStore";
+
+/**
+ * Show the toolbar (displacing the StatusBar and closing search) or hide it
+ * again. Safe to call from any surface — it reads current state itself.
+ */
+export function toggleUniversalToolbar(): void {
+  const ui = useUIStore.getState();
+  if (!ui.universalToolbarVisible) {
+    // Opening: the StatusBar and FindBar share this strip, so they yield.
+    ui.displaceStatusBar();
+    useUIStore.getState().searchClose();
+  }
+  ui.toggleUniversalToolbar();
+}

--- a/src/services/keybinding/keybindingManifest.ts
+++ b/src/services/keybinding/keybindingManifest.ts
@@ -128,6 +128,7 @@ export const KEYBINDING_MANIFEST: readonly KeybindingManifestEntry[] = [
   { id: "markdownSplit", defaultKey: "Shift-F6", menuId: "markdown-split" },
   { id: "focusMode", defaultKey: "F8", menuId: "focus-mode" },
   { id: "typewriterMode", defaultKey: "F9", menuId: "typewriter-mode" },
+  { id: "formatToolbar", defaultKey: "Mod-Shift-b", menuId: "universal-toolbar" },
   { id: "wordWrap", defaultKey: "Alt-z", menuId: "word-wrap" },
   { id: "lineNumbers", defaultKey: "Alt-Mod-l", menuId: "line-numbers" },
   { id: "toggleTerminal", defaultKey: "Ctrl-`", menuId: "toggle-terminal" },

--- a/src/services/mcpBridge/focusedWindow.test.ts
+++ b/src/services/mcpBridge/focusedWindow.test.ts
@@ -1,0 +1,54 @@
+// #1208 — resolving which window the USER is looking at, as opposed to which
+// window happens to be answering an MCP request. The distinction only exists
+// in a multi-window session, which is why the bug hid for so long.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { getAllWebviewWindows } = vi.hoisted(() => ({ getAllWebviewWindows: vi.fn() }));
+vi.mock("@tauri-apps/api/webviewWindow", () => ({ getAllWebviewWindows }));
+
+import { resolveFocusedWindowLabel } from "./focusedWindow";
+
+function win(label: string, focused: boolean | Error) {
+  return {
+    label,
+    isFocused: () => (focused instanceof Error ? Promise.reject(focused) : Promise.resolve(focused)),
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("resolveFocusedWindowLabel", () => {
+  it("returns the label of the focused window", async () => {
+    getAllWebviewWindows.mockResolvedValue([win("main", false), win("doc-1", true)]);
+    await expect(resolveFocusedWindowLabel()).resolves.toBe("doc-1");
+  });
+
+  it("returns null when no window holds focus — the app is in the background", async () => {
+    getAllWebviewWindows.mockResolvedValue([win("main", false), win("doc-1", false)]);
+    await expect(resolveFocusedWindowLabel()).resolves.toBeNull();
+  });
+
+  it("returns null for an empty window list", async () => {
+    getAllWebviewWindows.mockResolvedValue([]);
+    await expect(resolveFocusedWindowLabel()).resolves.toBeNull();
+  });
+
+  it("returns undefined — UNKNOWN, not 'none' — when the platform API fails", async () => {
+    // The caller must be able to tell "nobody is focused" from "I could not
+    // find out", because only the second one may fall back to a guess.
+    getAllWebviewWindows.mockRejectedValue(new Error("no tauri"));
+    await expect(resolveFocusedWindowLabel()).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when a per-window focus probe throws", async () => {
+    getAllWebviewWindows.mockResolvedValue([win("main", new Error("gone"))]);
+    await expect(resolveFocusedWindowLabel()).resolves.toBeUndefined();
+  });
+
+  it("takes the first focused window when the platform reports more than one", async () => {
+    // Not reachable on a sane platform; pinned so the answer stays a single
+    // label rather than becoming order-dependent noise.
+    getAllWebviewWindows.mockResolvedValue([win("main", true), win("doc-1", true)]);
+    await expect(resolveFocusedWindowLabel()).resolves.toBe("main");
+  });
+});

--- a/src/services/mcpBridge/focusedWindow.ts
+++ b/src/services/mcpBridge/focusedWindow.ts
@@ -1,0 +1,37 @@
+/**
+ * Which window the USER is looking at (#1208).
+ *
+ * Purpose: the bridge routes a request to whichever window owns the relevant
+ * workspace, so the webview answering an MCP call is frequently NOT the window
+ * on screen. `session.get_state` used to derive its `focused` flag from its own
+ * label, which made the payload assert that the responding window was the
+ * focused one — true in a single-window session, a lie in a restored
+ * multi-window one, and precisely why "MCP reports success but the UI never
+ * follows" was undiagnosable from the client side.
+ *
+ * The three-valued return is the point: a label, `null` for "resolved: no VMark
+ * window holds focus", and `undefined` for "could not find out". Only the last
+ * one may fall back to a guess.
+ *
+ * @coordinates-with services/mcpBridge/v2/session.ts — the sole consumer
+ * @module services/mcpBridge/focusedWindow
+ */
+import { getAllWebviewWindows } from "@tauri-apps/api/webviewWindow";
+
+/**
+ * The focused window's label, `null` when none is focused, or `undefined` when
+ * the platform could not answer.
+ */
+export async function resolveFocusedWindowLabel(): Promise<string | null | undefined> {
+  try {
+    const windows = await getAllWebviewWindows();
+    for (const window of windows) {
+      if (await window.isFocused()) return window.label;
+    }
+    return null;
+  } catch {
+    // Never throw from a status query: an unresolvable focus degrades the
+    // payload's precision, it does not fail the request.
+    return undefined;
+  }
+}

--- a/src/services/mcpBridge/v2/__tests__/sessionVisibility.test.ts
+++ b/src/services/mcpBridge/v2/__tests__/sessionVisibility.test.ts
@@ -1,0 +1,199 @@
+// #1208 — `session.get_state` must describe what is ON SCREEN, not merely what
+// exists in the stores.
+//
+// The reported symptom was "MCP reports success but the UI never follows": an
+// AI client opened a tab, switched to it, got `{activated: true}` back, and
+// nothing moved. The payload gave it no way to notice, because:
+//   - document tabs carried no `active` flag at all (only browser tabs did), so
+//     "which tab is showing?" was unanswerable;
+//   - every tab of a window was listed flat, with no indication that a tab
+//     belongs to a workspace instance that is not the visible one — the exact
+//     state the issue hit, where get_state listed 4 tabs and the strip showed 1;
+//   - `focused` was computed as "the window label of the webview answering this
+//     request", which is whatever window the Rust router picked, NOT the window
+//     the user is looking at. In a single-window session those coincide, which
+//     is why it went unnoticed; in a restored multi-window session it is a lie.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useTabStore } from "@/stores/tabStore";
+import { useDocumentStore } from "@/stores/documentStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { buildSessionState, handleSessionGetState } from "@/services/mcpBridge/v2/session";
+import type { DocumentSessionTab } from "@/services/mcpBridge/v2/types";
+import { createWorkspaceInstance, createWorkspaceRootIdentity } from "@/utils/workspaceIdentity";
+
+const { respond, resolveFocusedWindowLabel } = vi.hoisted(() => ({
+  respond: vi.fn(),
+  resolveFocusedWindowLabel: vi.fn(),
+}));
+vi.mock("@/services/mcpBridge/utils", () => ({ respond }));
+vi.mock("@/services/mcpBridge/focusedWindow", () => ({ resolveFocusedWindowLabel }));
+vi.mock("@/services/persistence/workspaceStorage", () => ({
+  getCurrentWindowLabel: () => "main",
+}));
+
+function docTabs(label: string, state = buildSessionState("0.0.0")): DocumentSessionTab[] {
+  const win = state.windows.find((w) => w.label === label);
+  return (win?.tabs ?? []).filter((t): t is DocumentSessionTab => t.kind !== "browser");
+}
+
+/** A real workspace instance rooted at `rootPath`, owned by `main`. */
+function seedInstance(id: string, rootPath: string): void {
+  const root = createWorkspaceRootIdentity(rootPath, { displayName: id, platform: "macos" });
+  if (!root.ok) throw new Error(`test root should be valid: ${rootPath}`);
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: id,
+      root: root.root,
+      ownerWindowLabel: "main",
+      createdFrom: "open",
+    }),
+  );
+}
+
+function seedTab(windowLabel: string, id: string, filePath: string | null): void {
+  useTabStore.setState((s) => ({
+    tabs: {
+      ...s.tabs,
+      [windowLabel]: [
+        ...(s.tabs[windowLabel] ?? []),
+        { id, title: id, filePath, kind: "document" as const },
+      ],
+    },
+  }));
+  useDocumentStore.setState((s) => ({
+    documents: { ...s.documents, [id]: { content: "", isDirty: false } },
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useTabStore.setState({ tabs: {}, activeTabId: {}, untitledCounter: 0, closedTabs: {} });
+  useDocumentStore.setState({ documents: {} });
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  useSettingsStore.setState((s) => ({ general: { ...s.general, workspaceRailMode: false } }));
+});
+
+describe("document tabs carry an active flag", () => {
+  it("marks exactly the window's active tab", () => {
+    seedTab("main", "t1", "/a.md");
+    seedTab("main", "t2", "/b.md");
+    useTabStore.setState({ activeTabId: { main: "t2" } });
+
+    const tabs = docTabs("main");
+    expect(tabs.map((t) => [t.id, t.active])).toEqual([
+      ["t1", false],
+      ["t2", true],
+    ]);
+  });
+
+  it("marks none active when the window has no active tab", () => {
+    seedTab("main", "t1", "/a.md");
+    expect(docTabs("main").every((t) => !t.active)).toBe(true);
+  });
+});
+
+describe("visibility under the workspace rail", () => {
+  it("is true for every tab when the rail is off", () => {
+    seedTab("main", "t1", "/a.md");
+    seedTab("main", "t2", "/b.md");
+    expect(docTabs("main").every((t) => t.visible)).toBe(true);
+  });
+
+  it("is false for a tab owned by a workspace instance that is not showing", () => {
+    // The #1208 shape: two instances, one visible. Both tabs exist and are
+    // activatable; only one is on screen.
+    useSettingsStore.setState((s) => ({ general: { ...s.general, workspaceRailMode: true } }));
+    seedTab("main", "t-a", "/Users/x/root-a/a.md");
+    seedTab("main", "t-b", "/Users/x/root-b/b.md");
+    seedInstance("wsi-a", "/Users/x/root-a");
+    seedInstance("wsi-b", "/Users/x/root-b");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance("main", "wsi-a");
+
+    const byId = Object.fromEntries(docTabs("main").map((t) => [t.id, t.visible]));
+    expect(byId["t-a"]).toBe(true);
+    expect(byId["t-b"]).toBe(false);
+  });
+
+  it("reports which workspace instance the window is showing", () => {
+    useSettingsStore.setState((s) => ({ general: { ...s.general, workspaceRailMode: true } }));
+    seedTab("main", "t-a", "/Users/x/root-a/a.md");
+    seedInstance("wsi-a", "/Users/x/root-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance("main", "wsi-a");
+
+    const win = buildSessionState("0.0.0").windows.find((w) => w.label === "main");
+    expect(win?.activeWorkspaceInstanceId).toBe("wsi-a");
+  });
+
+  it("reports a null instance when the rail is off", () => {
+    seedTab("main", "t1", "/a.md");
+    const win = buildSessionState("0.0.0").windows.find((w) => w.label === "main");
+    expect(win?.activeWorkspaceInstanceId).toBeNull();
+  });
+});
+
+describe("focused reflects the real focused window, not the responding one", () => {
+  it("marks the window the caller says is focused", () => {
+    seedTab("main", "t1", "/a.md");
+    seedTab("doc-1", "t2", "/b.md");
+
+    const state = buildSessionState("0.0.0", undefined, "doc-1");
+    expect(state.windows.find((w) => w.label === "doc-1")?.focused).toBe(true);
+    expect(state.windows.find((w) => w.label === "main")?.focused).toBe(false);
+  });
+
+  it("marks NO window focused when the real focused window is not one of ours", () => {
+    // A settings window, a browser panel, or another app holds focus. Claiming
+    // a document window has it is the lie #1208 was built on.
+    seedTab("main", "t1", "/a.md");
+    const state = buildSessionState("0.0.0", undefined, "settings");
+    expect(state.windows.every((w) => !w.focused)).toBe(true);
+  });
+
+  it("falls back to the responding window when the focus is UNKNOWN", () => {
+    // Degrades to the historical behaviour rather than reporting nothing —
+    // an unresolvable focus must not blind a single-window client.
+    seedTab("main", "t1", "/a.md");
+    const state = buildSessionState("0.0.0", undefined, undefined);
+    expect(state.windows.find((w) => w.label === "main")?.focused).toBe(true);
+  });
+
+  it("marks NO window focused when the app itself is in the background", () => {
+    // `null` is a RESOLVED answer — no VMark window holds focus — and must not
+    // collapse into the unknown-focus fallback, or a backgrounded app would
+    // still claim the user is looking at one of its windows.
+    seedTab("main", "t1", "/a.md");
+    const state = buildSessionState("0.0.0", undefined, null);
+    expect(state.windows.every((w) => !w.focused)).toBe(true);
+  });
+});
+
+describe("the handler asks the platform, not itself", () => {
+  it("passes the resolved focused window through to the payload", async () => {
+    // The whole fix hinges on this one wiring: if the handler stops consulting
+    // the resolver, `focused` silently reverts to "the window that answered".
+    resolveFocusedWindowLabel.mockResolvedValue("doc-1");
+    seedTab("main", "t1", "/a.md");
+    seedTab("doc-1", "t2", "/b.md");
+
+    await handleSessionGetState("req-1", "0.0.0");
+
+    const data = vi.mocked(respond).mock.calls.at(-1)?.[0]?.data as
+      | { windows: { label: string; focused: boolean }[] }
+      | undefined;
+    expect(data?.windows.find((w) => w.label === "doc-1")?.focused).toBe(true);
+    expect(data?.windows.find((w) => w.label === "main")?.focused).toBe(false);
+  });
+
+  it("degrades to the responding window when the platform cannot answer", async () => {
+    resolveFocusedWindowLabel.mockResolvedValue(undefined);
+    seedTab("main", "t1", "/a.md");
+
+    await handleSessionGetState("req-2", "0.0.0");
+
+    const data = vi.mocked(respond).mock.calls.at(-1)?.[0]?.data as
+      | { windows: { label: string; focused: boolean }[] }
+      | undefined;
+    expect(data?.windows.find((w) => w.label === "main")?.focused).toBe(true);
+  });
+});

--- a/src/services/mcpBridge/v2/__tests__/workspaceSwitchTabVerify.test.ts
+++ b/src/services/mcpBridge/v2/__tests__/workspaceSwitchTabVerify.test.ts
@@ -1,0 +1,120 @@
+// #1208 — `workspace.switch_tab` must report the state it can OBSERVE, not the
+// state it intended.
+//
+// The handler used to pass `activated` / `workspaceSwitched` /
+// `workspaceInstanceId` straight through from the coordinator's return value
+// and only read `activeTabId` back from the store. So a switch that was written
+// and a switch that silently no-opped produced byte-identical `{activated:
+// true, workspaceSwitched: true}` payloads, which is what the issue reported
+// seeing while the window never moved.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { activateTabWithWorkspaceContext } = vi.hoisted(() => ({
+  activateTabWithWorkspaceContext: vi.fn(),
+}));
+vi.mock("@/services/workspaces/activateTabWithWorkspaceContext", () => ({
+  activateTabWithWorkspaceContext,
+}));
+vi.mock("@/services/mcpBridge/utils", () => ({ respond: vi.fn() }));
+
+import { handleWorkspaceSwitchTab } from "@/services/mcpBridge/v2/workspace";
+import { respond } from "@/services/mcpBridge/utils";
+import { useTabStore } from "@/stores/tabStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+
+const TAB = "t-b";
+
+function payload(): Record<string, unknown> {
+  const call = vi.mocked(respond).mock.calls.at(-1)?.[0] as
+    | { data?: Record<string, unknown> }
+    | undefined;
+  return call?.data ?? {};
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useTabStore.setState({
+    tabs: { main: [{ id: TAB, title: "b", filePath: "/b.md", kind: "document" }] },
+    activeTabId: {},
+    untitledCounter: 0,
+    closedTabs: {},
+  });
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+});
+
+describe("workspace.switch_tab reports observed state", () => {
+  it("reports the instance the window is ACTUALLY showing, not the requested one", async () => {
+    // The coordinator claims it switched to wsi-b; the store says otherwise.
+    // The payload must side with the store.
+    activateTabWithWorkspaceContext.mockReturnValue({
+      activated: true,
+      workspaceSwitched: true,
+      workspaceInstanceId: "wsi-b",
+    });
+
+    await handleWorkspaceSwitchTab("1", { tabId: TAB });
+
+    expect(payload().workspaceInstanceId).toBeNull();
+    expect(payload().workspaceSwitched).toBe(false);
+  });
+
+  it("confirms a switch that really landed", async () => {
+    useWorkspaceInstancesStore.setState({
+      windows: {
+        main: {
+          windowLabel: "main",
+          workspaceInstanceIds: ["wsi-b"],
+          activeWorkspaceInstanceId: "wsi-b",
+        },
+      },
+    });
+    activateTabWithWorkspaceContext.mockReturnValue({
+      activated: true,
+      workspaceSwitched: true,
+      workspaceInstanceId: "wsi-b",
+    });
+
+    await handleWorkspaceSwitchTab("1", { tabId: TAB });
+
+    expect(payload().workspaceInstanceId).toBe("wsi-b");
+    expect(payload().workspaceSwitched).toBe(true);
+  });
+
+  it("reports activated only when the tab is the window's active tab afterwards", async () => {
+    activateTabWithWorkspaceContext.mockReturnValue({
+      activated: true,
+      workspaceSwitched: false,
+      workspaceInstanceId: null,
+    });
+
+    await handleWorkspaceSwitchTab("1", { tabId: TAB });
+
+    // The coordinator said yes; the store never took the activation.
+    expect(payload().activated).toBe(false);
+    expect(payload().activeTabId).toBeNull();
+  });
+
+  it("agrees with the coordinator when the activation did land", async () => {
+    activateTabWithWorkspaceContext.mockImplementation(() => {
+      useTabStore.setState({ activeTabId: { main: TAB } });
+      return { activated: true, workspaceSwitched: false, workspaceInstanceId: null };
+    });
+
+    await handleWorkspaceSwitchTab("1", { tabId: TAB });
+
+    expect(payload().activated).toBe(true);
+    expect(payload().activeTabId).toBe(TAB);
+  });
+
+  it("stays false when the coordinator itself refused", async () => {
+    activateTabWithWorkspaceContext.mockReturnValue({
+      activated: false,
+      workspaceSwitched: false,
+      workspaceInstanceId: null,
+    });
+
+    await handleWorkspaceSwitchTab("1", { tabId: TAB });
+
+    expect(payload().activated).toBe(false);
+  });
+});

--- a/src/services/mcpBridge/v2/session.ts
+++ b/src/services/mcpBridge/v2/session.ts
@@ -13,11 +13,21 @@
  *     is validated against the correct document.
  *   - `kind` is computed by sniffing filePath + content via the existing
  *     workflow detection helpers — the AI shouldn't reimplement it.
+ *   - The payload describes what is ON SCREEN, not just what exists (#1208).
+ *     Document tabs carry `active` and `visible`, and each window reports the
+ *     workspace instance it is showing, because a window holds tabs from
+ *     several instances and renders only one instance's. Without those the
+ *     client cannot tell a successful activation from one that landed in a
+ *     hidden instance.
+ *   - `focused` comes from the PLATFORM, not from this webview's own label.
+ *     The bridge routes a request to whichever window owns the workspace, so
+ *     the responding window is frequently not the one the user is looking at.
  *
  * @coordinates-with stores/tabStore.ts — open tabs per window
  * @coordinates-with stores/documentStore.ts — filePath, dirty, content
  * @coordinates-with stores/revisionStore.ts — revision token
- * @coordinates-with stores/windowStore.ts — focused window resolution
+ * @coordinates-with services/mcpBridge/focusedWindow.ts — real focused window
+ * @coordinates-with services/tabs/visibleWindowTabs.ts — the on-screen projection
  * @coordinates-with lib/ghaWorkflow/detection.ts — kind discrimination
  * @module services/mcpBridge/v2/session
  */
@@ -26,6 +36,9 @@ import { useTabStore } from "@/stores/tabStore";
 import { useDocumentStore } from "@/stores/documentStore";
 import { useRevisionStore } from "@/stores/documentStore";
 import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
+import { visibleWindowTabs } from "@/services/tabs/visibleWindowTabs";
+import { resolveFocusedWindowLabel } from "@/services/mcpBridge/focusedWindow";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
 import {
   isWorkflowYaml,
   looksLikeWorkflowPath,
@@ -93,15 +106,27 @@ function detectKind(
  * Pure function over store state — exported for unit testing without
  * the bridge `respond` round-trip.
  */
-export function buildSessionState(appVersion: string, clientProtocol?: string): SessionState {
+export function buildSessionState(
+  appVersion: string,
+  clientProtocol?: string,
+  osFocusedLabel?: string | null,
+): SessionState {
   const includeBrowserTabs = clientSupportsBrowserTabs(clientProtocol);
   const tabState = useTabStore.getState();
   const docState = useDocumentStore.getState();
   const revisionStore = useRevisionStore.getState();
-  const focusedLabel = getCurrentWindowLabel();
+  // The window the USER is looking at. `undefined` means the caller could not
+  // resolve it, and we fall back to the responding window — historical
+  // behaviour, so an unresolvable focus degrades rather than blinding a
+  // single-window client. `null` is a RESOLVED answer meaning no VMark window
+  // holds focus, and must not be flattened into that fallback.
+  const focusedLabel =
+    osFocusedLabel === undefined ? getCurrentWindowLabel() : osFocusedLabel;
 
   const windowLabels = Object.keys(tabState.tabs);
   const windows: SessionWindow[] = windowLabels.map((label) => {
+    const visibleIds = new Set(visibleWindowTabs(label).map((t) => t.id));
+    const activeTabId = tabState.activeTabId[label] ?? null;
     const sessionTabs: SessionTab[] = (tabState.tabs[label] ?? [])
       .filter((tab) => includeBrowserTabs || tab.kind !== "browser")
       .map((tab) => {
@@ -128,11 +153,15 @@ export function buildSessionState(appVersion: string, clientProtocol?: string): 
         dirty: doc?.isDirty ?? false,
         revision: revisionStore.getRevision(tab.id),
         documentKind,
+        active: tab.id === activeTabId,
+        visible: visibleIds.has(tab.id),
       };
     });
     return {
       label,
       focused: label === focusedLabel,
+      activeWorkspaceInstanceId:
+        useWorkspaceInstancesStore.getState().windows[label]?.activeWorkspaceInstanceId ?? null,
       tabs: sessionTabs,
     };
   });
@@ -161,7 +190,9 @@ export async function handleSessionGetState(
 ): Promise<void> {
   return wrapHandler(id, async () => {
     const clientProtocol = typeof args?.clientProtocol === "string" ? args.clientProtocol : undefined;
-    const state = buildSessionState(appVersion, clientProtocol);
+    // Ask the platform which window is actually on screen; this webview may not
+    // be it (#1208).
+    const state = buildSessionState(appVersion, clientProtocol, await resolveFocusedWindowLabel());
     await respond({ id, success: true, data: state });
   });
 }

--- a/src/services/mcpBridge/v2/types.ts
+++ b/src/services/mcpBridge/v2/types.ts
@@ -26,6 +26,16 @@ export interface DocumentSessionTab {
   revision: string;
   /** Additive alias for clients that prefer an explicit field name. */
   documentKind: DocumentKind;
+  /** True when this tab is the window's active tab. */
+  active: boolean;
+  /**
+   * True when this tab actually renders in the window right now. Under the
+   * workspace rail a window holds tabs from several workspace instances but
+   * shows only the active one's, so a tab can exist, be activatable, and still
+   * not be on screen (#1208). Without this the client cannot tell a successful
+   * activation from one that landed in a hidden instance.
+   */
+  visible: boolean;
 }
 
 /** Browser tab info returned in session.get_state. */
@@ -45,7 +55,18 @@ export type SessionTab = DocumentSessionTab | BrowserSessionTab;
 
 export interface SessionWindow {
   label: string;
+  /**
+   * True when the OS focus is on this window. This is NOT "the window that
+   * answered the request" — the bridge routes a request to whichever window
+   * owns the relevant workspace, which need not be the one the user is looking
+   * at (#1208).
+   */
   focused: boolean;
+  /**
+   * The workspace instance this window is currently showing, or null when the
+   * workspace rail is off (then every tab of the window is visible).
+   */
+  activeWorkspaceInstanceId: string | null;
   tabs: SessionTab[];
 }
 

--- a/src/services/mcpBridge/v2/workspace.ts
+++ b/src/services/mcpBridge/v2/workspace.ts
@@ -18,6 +18,10 @@
  *   - `new` and `open` accept an optional `windowLabel` so a
  *     multi-window workflow can target a specific window; default is
  *     focused.
+ *   - `switch_tab` reports the state it can OBSERVE, never the state it
+ *     intended (#1208). Both the activation and the workspace switch are
+ *     re-read from the stores before the response is built, so a silently
+ *     declined switch cannot be reported as a successful one.
  *   - `open` never reloads a tab that holds local content. `createTab`
  *     dedupes by path, so re-opening an already-open file returns the
  *     EXISTING tab; re-initialising it there discarded unsaved edits. Both
@@ -35,6 +39,7 @@
  */
 
 import { useTabStore } from "@/stores/tabStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
 import { useDocumentStore } from "@/stores/documentStore";
 import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
 import { respond } from "@/services/mcpBridge/utils";
@@ -156,14 +161,24 @@ export async function handleWorkspaceSwitchTab(
     // context — full workspace switch when the tab's owner is hidden, with
     // the change disclosed so the AI client can inform the user.
     const result = activateTabWithWorkspaceContext(owner[0], tabIdArg);
+    // #1208: report what the stores SAY, not what the coordinator intended. A
+    // silently-declined activation used to be indistinguishable from a real
+    // one, which is how a client could be told the tab was showing while the
+    // window had not moved. `workspaceSwitched` is likewise downgraded when the
+    // window is not actually showing the instance the coordinator named.
+    const activeTabId = useTabStore.getState().activeTabId[owner[0]] ?? null;
+    const activeInstanceId =
+      useWorkspaceInstancesStore.getState().windows[owner[0]]?.activeWorkspaceInstanceId ?? null;
+    const switchLanded =
+      result.workspaceSwitched && activeInstanceId === result.workspaceInstanceId;
     await respond({
       id,
       success: true,
       data: {
-        activated: result.activated,
-        workspaceSwitched: result.workspaceSwitched,
-        workspaceInstanceId: result.workspaceInstanceId,
-        activeTabId: useTabStore.getState().activeTabId[owner[0]] ?? null,
+        activated: result.activated && activeTabId === tabIdArg,
+        workspaceSwitched: switchLanded,
+        workspaceInstanceId: activeInstanceId,
+        activeTabId,
       },
     });
   });

--- a/src/services/mcpBridge/v2/workspace.ts
+++ b/src/services/mcpBridge/v2/workspace.ts
@@ -166,6 +166,12 @@ export async function handleWorkspaceSwitchTab(
     // one, which is how a client could be told the tab was showing while the
     // window had not moved. `workspaceSwitched` is likewise downgraded when the
     // window is not actually showing the instance the coordinator named.
+    //
+    // Reading `activated` off the alias is safe under a split: the WI-2
+    // activation seam converges `activeTabId` with the focused pane, and
+    // `activateTabWithWorkspaceContext.test.ts` pins that for the background,
+    // other-pane and browser-tab cases. If that invariant is ever relaxed, this
+    // check turns into a false negative and must move to the pane state.
     const activeTabId = useTabStore.getState().activeTabId[owner[0]] ?? null;
     const activeInstanceId =
       useWorkspaceInstancesStore.getState().windows[owner[0]]?.activeWorkspaceInstanceId ?? null;

--- a/src/shared/menu-ids.json
+++ b/src/shared/menu-ids.json
@@ -82,7 +82,6 @@
     "transform-uppercase",
     "underline",
     "undo",
-    "universal-toolbar",
     "unnest-blockquote",
     "unordered-list",
     "video",
@@ -244,5 +243,5 @@
     "zoom-in",
     "zoom-out"
   ],
-  "generatedAt": "2026-08-05T06:16:09.910Z"
+  "generatedAt": "2026-08-05T06:33:21.492Z"
 }

--- a/src/shared/menu-ids.json
+++ b/src/shared/menu-ids.json
@@ -82,6 +82,7 @@
     "transform-uppercase",
     "underline",
     "undo",
+    "universal-toolbar",
     "unnest-blockquote",
     "unordered-list",
     "video",
@@ -228,6 +229,7 @@
     "typewriter-mode",
     "underline",
     "undo",
+    "universal-toolbar",
     "unnest-blockquote",
     "unordered-list",
     "use-selection-find",
@@ -242,5 +244,5 @@
     "zoom-in",
     "zoom-out"
   ],
-  "generatedAt": "2026-07-18T08:37:00.317Z"
+  "generatedAt": "2026-08-05T06:16:09.910Z"
 }

--- a/src/shared/menuIdExtraction.ts
+++ b/src/shared/menuIdExtraction.ts
@@ -111,6 +111,7 @@ export const EXCLUDED_MENU_IDS: ReadonlySet<string> = new Set([
   "typewriter-mode",
   "word-wrap",
   "line-numbers",
+  "universal-toolbar",
   "show-invisibles",
   "diagram-preview",
   "fit-tables",

--- a/src/stores/settingsStore/shortcutDefinitions.ts
+++ b/src/stores/settingsStore/shortcutDefinitions.ts
@@ -89,7 +89,7 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   { id: "softUndoCursor", label: "Soft Undo Cursor", category: "navigation", defaultKey: "Alt-Mod-z", description: "Undo last cursor addition" },
   { id: "addCursorAbove", label: "Add Cursor Above", category: "navigation", defaultKey: "Mod-Alt-Up", description: "Add cursor one line above" },
   { id: "addCursorBelow", label: "Add Cursor Below", category: "navigation", defaultKey: "Mod-Alt-Down", description: "Add cursor one line below" },
-  { id: "formatToolbar", label: "Universal Toolbar", category: "navigation", defaultKey: "Mod-Shift-b", description: "Show the universal bottom toolbar" },
+  { id: "formatToolbar", label: "Universal Toolbar", category: "navigation", defaultKey: "Mod-Shift-b", menuId: "universal-toolbar", description: "Show the universal bottom toolbar" },
   { id: "sourcePeek", label: "Source Peek", category: "navigation", defaultKey: "F5", description: "Edit selection as markdown" },
   { id: "findReplace", label: "Find & Replace", category: "navigation", defaultKey: "Mod-f", menuId: "find-replace" },
   { id: "findNext", label: "Find Next", category: "navigation", defaultKey: "Mod-g", menuId: "find-next" },

--- a/src/styles/select-shared.css
+++ b/src/styles/select-shared.css
@@ -1,0 +1,92 @@
+/**
+ * Shared select primitive (#1209).
+ *
+ * A bare `<select>` keeps `appearance: auto`, so WebKit draws its own control —
+ * native bezel, native chevron, and a 5px pill radius — and author styling only
+ * partly applies. The workflow forms are select-heavy, so a fully tokenised
+ * stylesheet (338 `var()` references) still rendered as macOS chrome sitting in
+ * the middle of VMark's own design language. Text inputs were unaffected, which
+ * is why it survived review: the drift is invisible unless you look at a select.
+ *
+ * Rule 32's canonical-component table had no select, so every surface that
+ * needed one re-derived it. Settings had already solved it correctly — inline
+ * `appearance-none` plus a lucide chevron — but as Tailwind classes on one
+ * component rather than something a second caller could reuse.
+ *
+ * The chevron is drawn with `mask-image` and `background-color: currentColor`
+ * rather than a `background-image` data URI. A data URI bakes its stroke colour
+ * into the markup, which cannot follow a theme token and would need a second
+ * copy under `.dark-theme` with two hardcoded colours — exactly what rule 31
+ * forbids. A mask inherits `currentColor`, so one declaration is correct in
+ * every theme.
+ *
+ * `select` cannot host a reliable `::after` across engines, so the chevron
+ * lives on a wrapper:
+ *
+ *     <span class="vm-select-field">
+ *       <select class="vm-select">…</select>
+ *     </span>
+ *
+ * @coordinates-with .claude/rules/32-component-patterns.md — the canonical table
+ * @coordinates-with src/pages/settings/inputs.tsx — the prior inline solution
+ */
+
+/* Wrapper: owns the chevron, so the select itself stays a plain control. */
+.vm-select-field {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+}
+
+.vm-select-field::after {
+  content: "";
+  position: absolute;
+  right: var(--space-1-5);
+  width: var(--size-icon-xs);
+  height: var(--size-icon-xs);
+  pointer-events: none;
+  /* currentColor, so the chevron tracks the select's text colour in every
+     theme without a second hardcoded copy. */
+  background-color: var(--text-secondary);
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: contain;
+}
+
+.vm-select {
+  /* The point of the primitive: without this WebKit draws its own control. */
+  appearance: none;
+  width: 100%;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-sm);
+  color: var(--text-color);
+  background: var(--bg-color);
+  border: var(--border-thin) solid var(--border-color);
+  border-radius: var(--radius-sm);
+  /* Right padding clears the wrapper's chevron. */
+  padding: var(--space-1) var(--space-5) var(--space-1) var(--space-1-5);
+  cursor: pointer;
+  outline: none;
+}
+
+.vm-select:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+}
+
+/* Focus: bottom-anchored ring matching the form inputs beside it (rule 33 —
+   a visible replacement, never a bare `outline: none`). */
+.vm-select:focus-visible {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 var(--border-thin) var(--accent-bg);
+}
+
+.vm-select:disabled {
+  opacity: var(--opacity-disabled);
+  cursor: not-allowed;
+}
+
+.vm-select-field:has(.vm-select:disabled)::after {
+  opacity: var(--opacity-disabled);
+}

--- a/website/guide/mcp-tools.md
+++ b/website/guide/mcp-tools.md
@@ -40,6 +40,7 @@ No arguments.
     {
       "label": "main",
       "focused": true,
+      "activeWorkspaceInstanceId": "wsi-a1b2c3",
       "tabs": [
         {
           "id": "tab-1",
@@ -47,7 +48,9 @@ No arguments.
           "title": "notes",
           "dirty": false,
           "revision": "rev-x7Q3aB1F",
-          "kind": "markdown"
+          "kind": "markdown",
+          "active": true,
+          "visible": true
         },
         {
           "id": "tab-2",
@@ -55,7 +58,9 @@ No arguments.
           "title": "ci",
           "dirty": true,
           "revision": "rev-x7Q3aB1F",
-          "kind": "yaml-workflow"
+          "kind": "yaml-workflow",
+          "active": false,
+          "visible": false
         }
       ]
     }
@@ -67,6 +72,20 @@ No arguments.
   }
 }
 ```
+
+#### Knowing what is actually on screen
+
+A tab can exist, be addressable, and still not be showing. Three fields say so:
+
+| Field | Meaning |
+|---|---|
+| `tab.active` | This tab is its window's current tab. |
+| `tab.visible` | This tab renders right now. It is `false` when the tab belongs to a workspace instance the window is not currently showing. |
+| `window.activeWorkspaceInstanceId` | The workspace instance the window is showing, or `null` when the workspace rail is off (then every tab is visible). |
+
+`window.focused` is the window the **user** is looking at, read from the operating system. It is not "the window that answered this request" — VMark routes a request to whichever window owns the relevant workspace, which in a multi-window session is often a different one.
+
+Treat these as the confirmation step: after `workspace.switch_tab`, a follow-up `get_state` tells you whether the tab is really in front of the user. `switch_tab` itself re-reads the stores before answering, so it reports `activated: false` when an activation did not land rather than echoing the request back.
 
 The `kind` discriminator tells you whether to use `document.write` (for markdown) or `workflow.apply_patch` (for yaml-workflow) on that tab.
 


### PR DESCRIPTION
Closes #1204
Closes #1207
Closes #1208
Closes #1209
Closes #1215

Five open issues, each with its own commit. Two are straightforward feature/UI work; three are correctness fixes where the interesting part is what the investigation found.

## #1215 — Mermaid diagrams render as blank gray placeholders (Intel / macOS 13)

Mermaid's own `calculateSvgSizeAttrs` emits `width: 100%` with **no height** when `useMaxWidth` is on, leaving the SVG's height to be derived from its intrinsic aspect ratio. On the reporter's WebKit that derivation yields zero, so the diagram occupies a full-width box of nothing — which is exactly what a "blank gray placeholder" is. Markmap renders fine on the same machine because it writes explicit dimensions.

`ensureSvgSize` adds `aspect-ratio` from the root `viewBox` when the SVG declares no height, so the browser has a ratio to resolve against the width it was given. It is a no-op when a height or aspect-ratio is already present, and bails on a missing or degenerate viewBox.

I could not reproduce this locally — the fix is grounded in Mermaid's source and the Markmap contrast, not in a repro.

## #1209 — Native macOS select chrome overrides the design system

Workflow form `<select>`s rendered with the platform's own chrome, ignoring every token. New `.vm-select` primitive in `src/styles/select-shared.css`: `appearance: none` plus a `mask-image` chevron tinted with `background-color: var(--text-secondary)`, so it follows the theme instead of being a baked-in asset. Fully tokenized, light and dark.

Two things the issue mentions that I deliberately did **not** bundle here, so they are visible rather than silently skipped:

- Three `<select>`s outside the workflow forms (`BreakdownPanel`, the settings `inputs.tsx` wrapper, `LanguageSettings`) still render native chrome. The issue scopes the adoption to "the workflow forms", and those surfaces carry their own Tailwind styling I cannot re-verify visually from here.
- The adjacent bespoke-button debt (`workflow-editor-panel__btn` + the `workflow-diagnostics-banner__*` classes, ratcheting 88→84) is a 31-reference CSS refactor across four components. The issue labels it adjacent debt rather than the bug, and folding it in would trade review surface and unverifiable visual risk for a gate number.

## #1207 — Flaky `coherence::scan` git-revert test (~1 in 9)

I could not reproduce it in 38 runs, so this is not a proven fix for the flake. What the investigation did find is a real production defect with exactly the right failure shape: `git_output` returns `None` both when git fails and when its output is legitimately empty, so a transient `rev-parse HEAD` failure under load was read as "this repository has no HEAD" — and the classifier turned that into `ExternalUnknown`, **minting a spurious external-edit revision**.

Commits cannot vanish. A previously-known HEAD reading as absent is a failed observation, not a state change, so it now classifies as the new `GitClass::ObservationUnreliable` and the scan defers **without storing the bad observation** — the next scan then compares against the same good baseline and reconciles normally, so a transient failure costs one cycle instead of corrupting history. An unborn repository genuinely has no HEAD and keeps its existing handling; a merge in progress still wins over everything. Both directions are pinned by tests.

One coverage limit worth stating: the classifier is tested exhaustively, but the scan-level "does not store" branch is not reachable from an integration test. `observe()` returns `None` outright when `rev-parse --abbrev-ref HEAD` fails, so producing the partial failure this class describes (ref readable, sha not) would mean injecting an observation, and there is no seam for that. The branch is three lines with a single caller.

## #1204 — View menu toggle for the Universal Toolbar

The toolbar could only be summoned by <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> — undiscoverable, and missing from the menu bar that advertises every other view toggle.

Both entry points now call one function (`services/editor/universalToolbarToggle`). Showing the toolbar is not a single flag flip: it displaces the StatusBar and closes the FindBar first, because all three compete for the same strip. That sequence used to live inside the hook's keydown handler, and a second copy in the menu command would have drifted.

The item is a plain `MenuItem`, not a checkbox: when the toolbar is already visible a second invocation moves **focus** rather than hiding it (dismissal is Esc), so a checkmark would advertise a state the click cannot clear. A test pins that contract, since a menu item carrying the accelerator must behave exactly as the key does.

Adding `menuId` to the `formatToolbar` shortcut brings it under the rule-41 drift gate, so the frontend default, the Rust accelerator, the contract mirror and the docs table are now cross-checked.

Two knock-on changes the gates required:

- `viewCommands.ts` crossed the 300-line limit, so the `lint.*` commands moved to `lintCommands.ts` — a namespace of its own rather than a corner of `view.*`, mirroring the earlier `paneCommands.ts` split. `lint.next`/`lint.prev` had no behavioural test, only an id-list entry, so a move that swapped the two directions would have gone unnoticed; they have one now, running against the real lint store.
- The menu id defaulted into the action-registry partition, which made the actionRegistry contract test demand a `MENU_TO_ACTION` entry it must not have. Like `line-numbers` and `word-wrap`, it dispatches through the command bus.

## #1208 — MCP reports tab activation the UI never performs

An AI client opened a tab, switched to it, was told `{activated: true, workspaceSwitched: true}`, and nothing moved. Nothing in the payload let it notice. Three separate things were unobservable or wrong:

**`focused` was derived from the responding webview's own label.** The bridge routes a request to whichever window owns the relevant workspace, so the window that answers is frequently not the window the user is looking at. In a single-window session the two coincide, which is why this survived. It now comes from the platform, and the resolver is deliberately three-valued: a label, `null` for "resolved: no VMark window is focused", `undefined` for "could not find out". Only the last may fall back to the old guess, so a backgrounded app no longer claims the user is watching it.

**Document tabs carried no `active` flag at all** — only browser tabs did — so "which tab is showing?" was unanswerable. They now carry `active` and `visible`, and each window reports `activeWorkspaceInstanceId`. Under the workspace rail a window holds tabs from several instances and renders only one instance's, so a tab can exist, be activatable, and still be off screen. That is exactly the reported state where `get_state` listed four tabs and the strip showed one — previously indistinguishable from a bug.

**`switch_tab` echoed the coordinator's return value.** `activateWorkspaceInstance` no-ops silently on a non-member id and `switchWorkspaceInstance` returns `switched: true` without reading back, so a declined switch and a real one produced identical payloads. Both flags are now re-read from the stores before responding.

### What this does and does not claim

This makes the surface truthful. It does not by itself prove the reported session's root cause, which needs a multi-window repro. But the evidence now points at **routing** rather than activation: the issue notes the visible `Untitled-1` was absent from `session.get_state`, and `get_state` enumerates only the responding webview's tabs — so that webview was not the one on screen.

Provenance also answers the issue's open question: this **predates PR #1206**. The workspace-instance machinery landed in `12fafa40` (2026-07-30); #1206 only added Zod validation to the restore path.

The remaining root-cause candidate, left for a follow-up because it cannot be verified without that repro: `windowWorkspaceSync` registers exactly **one** root per window with the Rust router, taken from the legacy store, which tracks only the *active* instance. A request for a file inside a hidden instance is therefore unroutable by root and falls through to "focused document window, then main".

## Verification

- Every lint and ratchet leg of `pnpm check:all` passed locally: eslint, i18n, themes, keybinding-manifest, merge-drops, file-size, tauri-versions, extension-budget, store-coupling, mock-boundaries, command-errors, deps, knip, shell-slots.
- The local **coverage** leg is not a usable signal for this branch and I am not claiming it: the machine was under load average ~230 from an unrelated mutation-testing run, and a second process was writing the same `coverage/` directory concurrently. It exited non-zero on two tests this branch does not touch, both of which I re-ran individually — `WorkflowEngineSlot` passes in isolation, and `lazySurfaces` passes with a 60 s timeout instead of the 5 s default (it dynamically imports a large chunk). CI's `frontend` check on a clean runner is the authority here.
- `cargo test --lib` — 1864 passed, 0 failed.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
- One ratchet **win** recorded: knip `types` 60 → 59.
- #1215's rendering fix and #1209's chrome change are visual; both were checked in light and dark. #1215 cannot be confirmed against the reporter's hardware from here.
