### PR TITLE
fix(mcp): let the Settings window open ccswitch:// links (#1202)

### DIFF
--- a/src-tauri/capabilities/settings.json
+++ b/src-tauri/capabilities/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "settings-window",
-  "description": "[capability-version: 0.8.2] Settings window capability — UI-only, no filesystem, shell, PTY, or MCP access. Settings are stored via Zustand persist (localStorage), not direct filesystem operations. `updater:default` is required because Settings → About hosts the 'Check for Updates' / 'Download' buttons; useUpdateOperations runs check()/downloadAndInstall() inline in whichever window the user clicked from, by design (the prior 'always route to main' approach silently dropped clicks when main had been closed). Without this permission, every manual Check Now from Settings throws a permission-denied error that bubbles up as 'Failed to check for updates' while the main window's startup auto-check (which has updater:default via default.json) succeeds against the same endpoint — the exact symptom reported in #909.",
+  "description": "[capability-version: 0.9.28] Settings window capability — UI-only, no filesystem, shell, PTY, or MCP access. Settings are stored via Zustand persist (localStorage), not direct filesystem operations. `updater:default` is required because Settings → About hosts the 'Check for Updates' / 'Download' buttons; useUpdateOperations runs check()/downloadAndInstall() inline in whichever window the user clicked from, by design (the prior 'always route to main' approach silently dropped clicks when main had been closed). Without this permission, every manual Check Now from Settings throws a permission-denied error that bubbles up as 'Failed to check for updates' while the main window's startup auto-check (which has updater:default via default.json) succeeds against the same endpoint — the exact symptom reported in #909. The scoped `opener:allow-open-url` for `ccswitch://*` is required because the CC-Switch MCP import button renders in THIS window: `opener:default` permits only mailto:, tel:, http:// and https://, and the identical scope in default.json covers `main`/`doc-*` only, so every click failed with 'Not allowed to open url' on every platform (#1202).",
   "windows": ["settings"],
   "permissions": [
     "core:default",
@@ -13,6 +13,10 @@
     "dialog:default",
     "log:default",
     "opener:default",
-    "updater:default"
+    "updater:default",
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [{ "url": "ccswitch://*" }]
+    }
   ]
 }

--- a/src-tauri/src/capabilities.test.rs
+++ b/src-tauri/src/capabilities.test.rs
@@ -1,0 +1,94 @@
+//! Capability-file contract (#1202).
+//!
+//! Tauri capability files are per-WINDOW. A permission granted in
+//! `default.json` covers `main` and `doc-*` and reaches the Settings window not
+//! at all — which is how the CC-Switch import button shipped dead: the
+//! `ccswitch://*` opener scope was declared in `default.json` while the button
+//! that uses it lives in the Settings window, so every click raised
+//! "Not allowed to open url ccswitch://…" on every platform.
+//!
+//! Nothing pinned that pairing, so these tests read the shipped JSON and assert
+//! the scope sits in the capability of the window that actually needs it.
+
+use serde_json::Value;
+
+const DEFAULT_CAPABILITY: &str = include_str!("../capabilities/default.json");
+const SETTINGS_CAPABILITY: &str = include_str!("../capabilities/settings.json");
+
+fn parse(raw: &str) -> Value {
+    serde_json::from_str(raw).expect("capability file is valid JSON")
+}
+
+/// Window-label globs the capability applies to.
+fn windows(capability: &Value) -> Vec<String> {
+    capability["windows"]
+        .as_array()
+        .expect("capability declares windows")
+        .iter()
+        .map(|w| w.as_str().expect("window label is a string").to_string())
+        .collect()
+}
+
+/// Every URL string allowed by a scoped `opener:allow-open-url` entry.
+fn allowed_open_urls(capability: &Value) -> Vec<String> {
+    capability["permissions"]
+        .as_array()
+        .expect("capability declares permissions")
+        .iter()
+        .filter(|p| p["identifier"] == "opener:allow-open-url")
+        .flat_map(|p| {
+            p["allow"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+        })
+        .filter_map(|entry| entry["url"].as_str().map(str::to_owned))
+        .collect()
+}
+
+#[test]
+fn the_settings_window_may_open_ccswitch_links() {
+    // The CC-Switch import row renders in `src/pages/settings/` — the Settings
+    // window — so this is the capability that has to carry the scheme.
+    let settings = parse(SETTINGS_CAPABILITY);
+    assert!(
+        windows(&settings).iter().any(|w| w == "settings"),
+        "settings.json must govern the settings window"
+    );
+    assert!(
+        allowed_open_urls(&settings)
+            .iter()
+            .any(|u| u.starts_with("ccswitch://")),
+        "the settings window needs an opener scope for ccswitch:// — \
+         `opener:default` allows only mailto:, tel:, http:// and https://, so \
+         without this the import button fails with 'Not allowed to open url'"
+    );
+}
+
+#[test]
+fn the_document_capability_keeps_its_ccswitch_scope() {
+    // Document windows also surface the link (Settings can be opened from
+    // either surface in future); losing it here would be a silent regression of
+    // the same class, so pin both rather than moving the grant around.
+    let default = parse(DEFAULT_CAPABILITY);
+    assert!(
+        allowed_open_urls(&default)
+            .iter()
+            .any(|u| u.starts_with("ccswitch://")),
+        "default.json lost its ccswitch:// opener scope"
+    );
+}
+
+#[test]
+fn capability_windows_do_not_overlap_between_default_and_settings() {
+    // The bug was a grant landing in a capability whose windows exclude the
+    // caller. That is only diagnosable if the split stays disjoint — if
+    // `default.json` ever also matched "settings", a missing settings grant
+    // would be masked and the next such bug would be invisible again.
+    let default_windows = windows(&parse(DEFAULT_CAPABILITY));
+    assert!(
+        !default_windows.iter().any(|w| w == "settings" || w == "*"),
+        "default.json must not cover the settings window: {default_windows:?}"
+    );
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,6 +85,12 @@ pub(crate) use supported_files::has_supported_extension;
 #[path = "lib.test.rs"]
 mod lib_test;
 
+// Capability files are data, not code, and nothing else reads them at build
+// time — so their contract is pinned here (#1202).
+#[cfg(test)]
+#[path = "capabilities.test.rs"]
+mod capabilities_test;
+
 /// Build and run the Tauri application with all plugins, commands, and event handlers.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {

--- a/src-tauri/src/mcp_config/providers.rs
+++ b/src-tauri/src/mcp_config/providers.rs
@@ -87,6 +87,29 @@ fn get_target_triple() -> &'static str {
     }
 }
 
+/// Present a canonical path the way third-party tools expect it.
+///
+/// `canonicalize()` returns a Windows extended-length (verbatim) path —
+/// `\\?\C:\…`, or `\\?\UNC\server\share` for a network path. That string
+/// is not internal: it is written into the `command` field of Claude's,
+/// Codex's and Gemini's config files and into the `ccswitch://v1/import`
+/// payload, where consumers do not recognise the prefix (#1202).
+///
+/// Always compiled — a no-op on Unix, whose paths never carry the prefix — so
+/// the rule is unit-tested on every platform rather than only on Windows CI.
+/// Mirrors `workspace_validation::strip_verbatim_prefix`, which does the same
+/// for the frontend; the two stay separate because they are different
+/// boundaries and neither module should depend on the other.
+fn display_path(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{rest}")
+    } else if let Some(rest) = path.strip_prefix(r"\\?\") {
+        rest.to_owned()
+    } else {
+        path.to_owned()
+    }
+}
+
 pub(crate) fn get_mcp_binary_path() -> Result<String, String> {
     let binary_name_with_target = format!("vmark-mcp-server-{}", get_target_triple());
     let binary_name_simple = "vmark-mcp-server";
@@ -98,7 +121,7 @@ pub(crate) fn get_mcp_binary_path() -> Result<String, String> {
             .join("binaries")
             .join(&binary_name_with_target);
         if dev_path.exists() {
-            return Ok(dev_path.to_string_lossy().to_string());
+            return Ok(display_path(&dev_path.to_string_lossy()));
         }
         // Fallback: try current exe location
     }
@@ -120,11 +143,12 @@ pub(crate) fn get_mcp_binary_path() -> Result<String, String> {
     };
     let simple_path = exe_dir.join(&simple_name);
     if simple_path.exists() {
-        return Ok(simple_path
-            .canonicalize()
-            .unwrap_or(simple_path)
-            .to_string_lossy()
-            .to_string());
+        return Ok(display_path(
+            &simple_path
+                .canonicalize()
+                .unwrap_or(simple_path)
+                .to_string_lossy(),
+        ));
     }
 
     // macOS only: try Resources folder (alternative bundle location)
@@ -132,19 +156,24 @@ pub(crate) fn get_mcp_binary_path() -> Result<String, String> {
     {
         let resources_path = exe_dir.join("../Resources").join(&binary_name_with_target);
         if resources_path.exists() {
-            return Ok(resources_path
-                .canonicalize()
-                .unwrap_or(resources_path)
-                .to_string_lossy()
-                .to_string());
+            return Ok(display_path(
+                &resources_path
+                    .canonicalize()
+                    .unwrap_or(resources_path)
+                    .to_string_lossy(),
+            ));
         }
     }
 
     // Fallback: try next to executable with target suffix
     let prod_path = exe_dir.join(&binary_name_with_target);
     if prod_path.exists() {
-        return Ok(prod_path.to_string_lossy().to_string());
+        return Ok(display_path(&prod_path.to_string_lossy()));
     }
 
     Err(rust_i18n::t!("errors.mcp.binaryNotFound", name = binary_name_simple).to_string())
 }
+
+#[cfg(test)]
+#[path = "providers.test.rs"]
+mod providers_test;

--- a/src-tauri/src/mcp_config/providers.test.rs
+++ b/src-tauri/src/mcp_config/providers.test.rs
@@ -1,0 +1,88 @@
+//! Binary-path shape for the MCP config writers (#1202).
+//!
+//! `get_mcp_binary_path` runs `canonicalize()`, which on Windows returns an
+//! extended-length VERBATIM path (`\\?\C:\…`). That string is not an internal
+//! detail: it is written verbatim into the `command` field of Claude's, Codex's
+//! and Gemini's config files, and into the `ccswitch://v1/import` payload. The
+//! reporter's link carried `\\?\C:\SEC\VMark\vmark-mcp-server.exe`.
+//!
+//! Third-party consumers do not recognise the prefix — the same reason
+//! `workspace_validation` already strips it before handing a path to the
+//! frontend. These pin the stripping rather than the (untestable here)
+//! canonicalize call, so the rule holds on every platform's CI.
+
+use super::*;
+
+#[test]
+fn strips_a_windows_verbatim_drive_prefix() {
+    assert_eq!(
+        display_path(r"\\?\C:\SEC\VMark\vmark-mcp-server.exe"),
+        r"C:\SEC\VMark\vmark-mcp-server.exe"
+    );
+}
+
+#[test]
+fn rewrites_a_verbatim_unc_prefix_back_to_a_plain_unc_path() {
+    // `\\?\UNC\server\share\x` is the verbatim spelling of `\\server\share\x`;
+    // stripping only the `\\?\` would yield `UNC\server\share\x`, a relative
+    // path pointing nowhere.
+    assert_eq!(
+        display_path(r"\\?\UNC\server\share\vmark-mcp-server.exe"),
+        r"\\server\share\vmark-mcp-server.exe"
+    );
+}
+
+#[test]
+fn leaves_an_ordinary_windows_path_untouched() {
+    assert_eq!(
+        display_path(r"C:\Program Files\VMark\vmark-mcp-server.exe"),
+        r"C:\Program Files\VMark\vmark-mcp-server.exe"
+    );
+}
+
+#[test]
+fn leaves_a_unix_path_untouched() {
+    assert_eq!(
+        display_path("/Applications/VMark.app/Contents/MacOS/vmark-mcp-server"),
+        "/Applications/VMark.app/Contents/MacOS/vmark-mcp-server"
+    );
+}
+
+#[test]
+fn leaves_a_plain_unc_path_untouched() {
+    assert_eq!(
+        display_path(r"\\server\share\vmark-mcp-server.exe"),
+        r"\\server\share\vmark-mcp-server.exe"
+    );
+}
+
+#[test]
+fn does_not_strip_a_prefix_that_merely_appears_mid_path() {
+    // Only a LEADING prefix is a verbatim marker.
+    assert_eq!(display_path(r"C:\odd\\?\name.exe"), r"C:\odd\\?\name.exe");
+}
+
+#[test]
+fn is_idempotent() {
+    let once = display_path(r"\\?\C:\VMark\vmark-mcp-server.exe");
+    assert_eq!(display_path(&once), once);
+}
+
+#[test]
+fn handles_an_empty_string() {
+    assert_eq!(display_path(""), "");
+}
+
+#[test]
+fn the_resolved_binary_path_is_never_verbatim() {
+    // The property that actually matters, asserted against whatever this
+    // platform resolves. In dev/CI the binary may be absent, in which case the
+    // resolution errors — an error carries no path, so there is nothing to
+    // check and nothing to wrongly pass.
+    if let Ok(path) = get_mcp_binary_path() {
+        assert!(
+            !path.starts_with(r"\\?\"),
+            "resolved binary path leaked a verbatim prefix: {path}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1202

## The reported bug: the button could never have worked

Tauri capabilities are scoped **per window**. The `ccswitch://*` opener scope was declared in `capabilities/default.json`, whose `windows` are `["main", "doc-*"]` — but the CC-Switch import button renders in `src/pages/settings/`, i.e. the Settings window, governed by `capabilities/settings.json`. That file carries only `opener:default`, and the plugin's default permission set allows exactly `mailto:`, `tel:`, `https://` and `http://`.

So every click hit `tauri-plugin-opener`'s scope check and produced its `Not allowed to open url {url}` error. **This is not Windows-specific** — the issue was filed from Windows, but macOS and Linux fail identically. The fix is the same scoped grant in the Settings capability.

### Why it shipped, and what stops the next one

Nothing tied a grant to the window that needs it, so a permission could sit in the wrong capability file and look present in review. `src-tauri/src/capabilities.test.rs` now reads the shipped JSON and asserts three things:

- the settings capability grants the `ccswitch://` scheme,
- the document capability keeps its copy (so moving the grant is not silently accepted as fixing it),
- the two capabilities' window sets stay **disjoint** — if `default.json` ever also matched `settings`, a missing settings grant would be masked and this whole class of bug would go back to being invisible.

## A second defect the report exposes

The reporter's link carried `{"command":"\\\\?\\C:\\SEC\\VMark\\vmark-mcp-server.exe"}` — a Windows extended-length **verbatim** path, straight out of `canonicalize()` in `get_mcp_binary_path`.

That string is not an internal detail. It is written into the `command` field of Claude's, Codex's and Gemini's config files as well as the import link, and third-party consumers do not recognise the `\\?\` prefix. `workspace_validation` already strips it for exactly this reason before handing a path to the frontend.

Every return from the resolver now passes through `display_path`, so the invariant holds structurally rather than case-by-case, and the UNC spelling is rewritten to `\\server\share\…` rather than left as a relative `UNC\…` (stripping only `\\?\` there would produce a path pointing nowhere).

## Out of scope

The reporter's second screenshot shows the link also failing when pasted into a browser. That is downstream of VMark — either CC-Switch is not registered as a `ccswitch://` protocol handler on that machine, or CC-Switch rejected the payload. This PR makes VMark emit a correct link and open it; whether CC-Switch accepts it is on the other side.

## Verification

- `cargo test --lib` — 1876 passed, 0 failed (+12 new).
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
- The path helper is compiled and tested on **every** platform (a no-op on Unix), so the Windows rule is not left to Windows-only CI.
- Not verifiable here: that CC-Switch itself accepts the import. Needs the reporter's machine.