### PR TITLE
feat(mcp): target Antigravity, Grok and opencode; retire Gemini CLI

### DIFF
--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -100,7 +100,7 @@
   },
   "testLimit": 800,
   "testFiles": {
-    "src-tauri/src/mcp_config/config_io.test.rs": 847,
+    "src-tauri/src/mcp_config/config_io.test.rs": 832,
     "src/components/Editor/SourceEditor.test.tsx": 937,
     "src/components/Editor/UniversalToolbar/GroupDropdown.test.tsx": 1041,
     "src/components/Editor/UniversalToolbar/UniversalToolbar.test.tsx": 1636,

--- a/server/content/src/server/runtime.test.ts
+++ b/server/content/src/server/runtime.test.ts
@@ -17,6 +17,35 @@ async function write(rel: string, content: string): Promise<void> {
   await fs.writeFile(abs, content, "utf8");
 }
 
+/**
+ * Wall-clock budget for a test in this file.
+ *
+ * Every test here binds a real socket, writes real files, drives a real
+ * watcher and makes several HTTP round trips. Vitest's 5000ms default is a
+ * budget for a unit test, and this file's first case spent 5072ms — missing it
+ * by 72ms — when the machine was busy. Raising the bound costs nothing on the
+ * passing path; a genuine hang still fails, just later.
+ */
+const LIVE_SOCKET_TIMEOUT_MS = 30_000;
+
+/**
+ * Poll `read` until it reports `expected`, or fail after `LIVE_SOCKET_TIMEOUT_MS`.
+ *
+ * Replaces a fixed `setTimeout(600)` that guessed at how long a debounced
+ * watcher rebuild takes. A fixed sleep is wrong in both directions: it wastes
+ * 600ms when the rebuild lands in 20ms, and it fails when a loaded machine
+ * takes 700ms — the same wall-clock-as-correctness mistake as the timeout above.
+ */
+async function until(read: () => Promise<number>, expected: number): Promise<number> {
+  const deadline = Date.now() + LIVE_SOCKET_TIMEOUT_MS;
+  let seen = await read();
+  while (seen !== expected && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 25));
+    seen = await read();
+  }
+  return seen;
+}
+
 /** Mint a nonce over the wire, bootstrap, return the session Cookie header. */
 async function liveCookie(url: string): Promise<string> {
   const mint = await fetch(`${url}/__mint`, { headers: { authorization: `Bearer ${BOOTSTRAP}` } });
@@ -62,7 +91,7 @@ describe("startKbServer — live over a real socket", () => {
     const html = await note.text();
     expect(html).toContain("<h1>Home</h1>");
     expect(html).toContain('href="/note/Note.md"');
-  });
+  }, LIVE_SOCKET_TIMEOUT_MS);
 
   it("refreshes the index after a file is added (watcher)", async () => {
     await write("A.md", "a");
@@ -73,10 +102,14 @@ describe("startKbServer — live over a real socket", () => {
     expect(before.docs).toBe(1);
 
     await write("B.md", "b");
-    // Wait for the debounced watcher rebuild.
-    await new Promise((r) => setTimeout(r, 600));
 
-    const after = (await (await fetch(`${server.url}/__health`, { headers: { cookie } })).json()) as { docs: number };
-    expect(after.docs).toBe(2);
-  });
+    // Poll for the debounced watcher rebuild rather than guessing its duration.
+    const after = await until(async () => {
+      const health = (await (
+        await fetch(`${server.url}/__health`, { headers: { cookie } })
+      ).json()) as { docs: number };
+      return health.docs;
+    }, 2);
+    expect(after).toBe(2);
+  }, LIVE_SOCKET_TIMEOUT_MS);
 });

--- a/server/content/vitest.config.ts
+++ b/server/content/vitest.config.ts
@@ -16,6 +16,12 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
+    // Liveness bound, not a performance assertion — see the root
+    // `vitest.config.ts`. These tests bind real sockets and drive a real file
+    // watcher, and the live-socket case timed out at 5072ms against the 5000ms
+    // default purely because the machine was busy.
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],

--- a/server/mcp/vitest.config.ts
+++ b/server/mcp/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['__tests__/**/*.test.ts'],
+    // Liveness bound, not a performance assertion — see the root
+    // `vitest.config.ts`. Kept in step so the three projects cannot drift.
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/src-tauri/locales/de.yml
+++ b/src-tauri/locales/de.yml
@@ -299,6 +299,7 @@ errors:
 
   # MCP client config — provider and sidecar binary resolution
   mcp.unknownProvider: "Unbekannter Anbieter: %{provider}"
+  mcp.legacyProvider: "%{name} wird nicht mehr unterstützt; der verbliebene VMark-Eintrag kann nur entfernt werden."
   mcp.noHomeDir: "Home-Verzeichnis konnte nicht ermittelt werden"
   mcp.exePathFailed: "Pfad der ausführbaren Datei konnte nicht ermittelt werden: %{detail}"
   mcp.exeDirFailed: "Verzeichnis der ausführbaren Datei konnte nicht ermittelt werden"
@@ -309,11 +310,11 @@ errors:
   mcp.invalidToml: "Ungültiges TOML: %{detail}"
   mcp.jsonSerializeFailed: "JSON-Serialisierungsfehler: %{detail}"
   mcp.invalidJsonStructure: "Ungültige JSON-Struktur"
-  mcp.serversNotObject: "mcpServers ist kein Objekt"
+  mcp.serversNotObject: "%{key} ist kein Objekt"
   mcp.serversNotTable: "mcp_servers ist keine Tabelle"
-  mcp.vmarkEntryNotObject: "mcpServers.vmark ist kein Objekt"
+  mcp.vmarkEntryNotObject: "%{key} ist kein Objekt"
   mcp.vmarkEntryNotTable: "mcp_servers.vmark ist keine Tabelle"
-  mcp.envNotObject: "mcpServers.vmark.env ist kein Objekt"
+  mcp.envNotObject: "%{key} ist kein Objekt"
   mcp.envNotTable: "mcp_servers.vmark.env ist keine Tabelle"
 
   # MCP-Bridge — die Client-Anmeldedaten, an die der Autorisierungsprincipal gebunden ist

--- a/src-tauri/locales/en.yml
+++ b/src-tauri/locales/en.yml
@@ -300,6 +300,7 @@ errors:
 
   # MCP client config — provider and sidecar binary resolution
   mcp.unknownProvider: "Unknown provider: %{provider}"
+  mcp.legacyProvider: "%{name} is discontinued; the leftover VMark entry can only be removed."
   mcp.noHomeDir: "Cannot determine home directory"
   mcp.exePathFailed: "Cannot get executable path: %{detail}"
   mcp.exeDirFailed: "Cannot get executable directory"
@@ -310,11 +311,11 @@ errors:
   mcp.invalidToml: "Invalid TOML: %{detail}"
   mcp.jsonSerializeFailed: "JSON serialization error: %{detail}"
   mcp.invalidJsonStructure: "Invalid JSON structure"
-  mcp.serversNotObject: "mcpServers is not an object"
+  mcp.serversNotObject: "%{key} is not an object"
   mcp.serversNotTable: "mcp_servers is not a table"
-  mcp.vmarkEntryNotObject: "mcpServers.vmark is not an object"
+  mcp.vmarkEntryNotObject: "%{key} is not an object"
   mcp.vmarkEntryNotTable: "mcp_servers.vmark is not a table"
-  mcp.envNotObject: "mcpServers.vmark.env is not an object"
+  mcp.envNotObject: "%{key} is not an object"
   mcp.envNotTable: "mcp_servers.vmark.env is not a table"
 
   # MCP bridge — the per-client credential the authorization principal binds to

--- a/src-tauri/locales/es.yml
+++ b/src-tauri/locales/es.yml
@@ -299,6 +299,7 @@ errors:
 
   # MCP client config — provider and sidecar binary resolution
   mcp.unknownProvider: "Proveedor desconocido: %{provider}"
+  mcp.legacyProvider: "%{name} está descontinuado; la entrada restante de VMark solo se puede eliminar."
   mcp.noHomeDir: "No se pudo determinar el directorio de inicio"
   mcp.exePathFailed: "No se pudo obtener la ruta del ejecutable: %{detail}"
   mcp.exeDirFailed: "No se pudo obtener el directorio del ejecutable"
@@ -309,11 +310,11 @@ errors:
   mcp.invalidToml: "TOML no válido: %{detail}"
   mcp.jsonSerializeFailed: "Error de serialización JSON: %{detail}"
   mcp.invalidJsonStructure: "Estructura JSON no válida"
-  mcp.serversNotObject: "mcpServers no es un objeto"
+  mcp.serversNotObject: "%{key} no es un objeto"
   mcp.serversNotTable: "mcp_servers no es una tabla"
-  mcp.vmarkEntryNotObject: "mcpServers.vmark no es un objeto"
+  mcp.vmarkEntryNotObject: "%{key} no es un objeto"
   mcp.vmarkEntryNotTable: "mcp_servers.vmark no es una tabla"
-  mcp.envNotObject: "mcpServers.vmark.env no es un objeto"
+  mcp.envNotObject: "%{key} no es un objeto"
   mcp.envNotTable: "mcp_servers.vmark.env no es una tabla"
 
   # Puente MCP: las credenciales de cliente a las que se vincula el principal de autorización

--- a/src-tauri/locales/fr.yml
+++ b/src-tauri/locales/fr.yml
@@ -299,6 +299,7 @@ errors:
 
   # MCP client config — provider and sidecar binary resolution
   mcp.unknownProvider: "Fournisseur inconnu : %{provider}"
+  mcp.legacyProvider: "%{name} est abandonné ; l'entrée VMark restante ne peut être que supprimée."
   mcp.noHomeDir: "Impossible de déterminer le répertoire personnel"
   mcp.exePathFailed: "Impossible d'obtenir le chemin de l'exécutable : %{detail}"
   mcp.exeDirFailed: "Impossible d'obtenir le répertoire de l'exécutable"
@@ -309,11 +310,11 @@ errors:
   mcp.invalidToml: "TOML invalide : %{detail}"
   mcp.jsonSerializeFailed: "Erreur de sérialisation JSON : %{detail}"
   mcp.invalidJsonStructure: "Structure JSON invalide"
-  mcp.serversNotObject: "mcpServers n'est pas un objet"
+  mcp.serversNotObject: "%{key} n'est pas un objet"
   mcp.serversNotTable: "mcp_servers n'est pas une table"
-  mcp.vmarkEntryNotObject: "mcpServers.vmark n'est pas un objet"
+  mcp.vmarkEntryNotObject: "%{key} n'est pas un objet"
   mcp.vmarkEntryNotTable: "mcp_servers.vmark n'est pas une table"
-  mcp.envNotObject: "mcpServers.vmark.env n'est pas un objet"
+  mcp.envNotObject: "%{key} n'est pas un objet"
   mcp.envNotTable: "mcp_servers.vmark.env n'est pas une table"
 
   # Passerelle MCP — les identifiants client auxquels le principal d'autorisation est lié

--- a/src-tauri/locales/it.yml
+++ b/src-tauri/locales/it.yml
@@ -299,6 +299,7 @@ errors:
 
   # MCP client config — provider and sidecar binary resolution
   mcp.unknownProvider: "Provider sconosciuto: %{provider}"
+  mcp.legacyProvider: "%{name} è stato dismesso; la voce VMark residua può solo essere rimossa."
   mcp.noHomeDir: "Impossibile determinare la directory home"
   mcp.exePathFailed: "Impossibile ottenere il percorso dell'eseguibile: %{detail}"
   mcp.exeDirFailed: "Impossibile ottenere la directory dell'eseguibile"
@@ -309,11 +310,11 @@ errors:
   mcp.invalidToml: "TOML non valido: %{detail}"
   mcp.jsonSerializeFailed: "Errore di serializzazione JSON: %{detail}"
   mcp.invalidJsonStructure: "Struttura JSON non valida"
-  mcp.serversNotObject: "mcpServers non è un oggetto"
+  mcp.serversNotObject: "%{key} non è un oggetto"
   mcp.serversNotTable: "mcp_servers non è una tabella"
-  mcp.vmarkEntryNotObject: "mcpServers.vmark non è un oggetto"
+  mcp.vmarkEntryNotObject: "%{key} non è un oggetto"
   mcp.vmarkEntryNotTable: "mcp_servers.vmark non è una tabella"
-  mcp.envNotObject: "mcpServers.vmark.env non è un oggetto"
+  mcp.envNotObject: "%{key} non è un oggetto"
   mcp.envNotTable: "mcp_servers.vmark.env non è una tabella"
 
   # Bridge MCP: le credenziali del client a cui è associato il principal di autorizzazione

--- a/src-tauri/locales/ja.yml
+++ b/src-tauri/locales/ja.yml
@@ -299,6 +299,7 @@ errors:
 
   # MCP client config — provider and sidecar binary resolution
   mcp.unknownProvider: "不明なプロバイダーです: %{provider}"
+  mcp.legacyProvider: "%{name} は廃止されました。残っている VMark エントリは削除のみ可能です。"
   mcp.noHomeDir: "ホームディレクトリを特定できません"
   mcp.exePathFailed: "実行ファイルのパスを取得できません: %{detail}"
   mcp.exeDirFailed: "実行ファイルのディレクトリを取得できません"
@@ -309,11 +310,11 @@ errors:
   mcp.invalidToml: "TOML が無効です: %{detail}"
   mcp.jsonSerializeFailed: "JSON のシリアライズエラー: %{detail}"
   mcp.invalidJsonStructure: "JSON の構造が無効です"
-  mcp.serversNotObject: "mcpServers がオブジェクトではありません"
+  mcp.serversNotObject: "%{key} がオブジェクトではありません"
   mcp.serversNotTable: "mcp_servers がテーブルではありません"
-  mcp.vmarkEntryNotObject: "mcpServers.vmark がオブジェクトではありません"
+  mcp.vmarkEntryNotObject: "%{key} がオブジェクトではありません"
   mcp.vmarkEntryNotTable: "mcp_servers.vmark がテーブルではありません"
-  mcp.envNotObject: "mcpServers.vmark.env がオブジェクトではありません"
+  mcp.envNotObject: "%{key} がオブジェクトではありません"
   mcp.envNotTable: "mcp_servers.vmark.env がテーブルではありません"
 
   # MCP ブリッジ — 認可プリンシパルが結び付くクライアント資格情報

--- a/src-tauri/locales/ko.yml
+++ b/src-tauri/locales/ko.yml
@@ -299,6 +299,7 @@ errors:
 
   # MCP client config — provider and sidecar binary resolution
   mcp.unknownProvider: "알 수 없는 제공자: %{provider}"
+  mcp.legacyProvider: "%{name}은(는) 지원이 중단되었습니다. 남아 있는 VMark 항목은 제거만 가능합니다."
   mcp.noHomeDir: "홈 디렉터리를 확인할 수 없습니다"
   mcp.exePathFailed: "실행 파일 경로를 가져올 수 없습니다: %{detail}"
   mcp.exeDirFailed: "실행 파일 디렉터리를 가져올 수 없습니다"
@@ -309,11 +310,11 @@ errors:
   mcp.invalidToml: "잘못된 TOML: %{detail}"
   mcp.jsonSerializeFailed: "JSON 직렬화 오류: %{detail}"
   mcp.invalidJsonStructure: "잘못된 JSON 구조"
-  mcp.serversNotObject: "mcpServers가 객체가 아닙니다"
+  mcp.serversNotObject: "%{key}가 객체가 아닙니다"
   mcp.serversNotTable: "mcp_servers가 테이블이 아닙니다"
-  mcp.vmarkEntryNotObject: "mcpServers.vmark가 객체가 아닙니다"
+  mcp.vmarkEntryNotObject: "%{key}가 객체가 아닙니다"
   mcp.vmarkEntryNotTable: "mcp_servers.vmark가 테이블이 아닙니다"
-  mcp.envNotObject: "mcpServers.vmark.env가 객체가 아닙니다"
+  mcp.envNotObject: "%{key}가 객체가 아닙니다"
   mcp.envNotTable: "mcp_servers.vmark.env가 테이블이 아닙니다"
 
   # MCP 브리지 — 권한 주체가 연결되는 클라이언트 자격 증명

--- a/src-tauri/locales/pt-BR.yml
+++ b/src-tauri/locales/pt-BR.yml
@@ -299,6 +299,7 @@ errors:
 
   # MCP client config — provider and sidecar binary resolution
   mcp.unknownProvider: "Provedor desconhecido: %{provider}"
+  mcp.legacyProvider: "%{name} foi descontinuado; a entrada restante do VMark só pode ser removida."
   mcp.noHomeDir: "Não foi possível determinar o diretório inicial"
   mcp.exePathFailed: "Não foi possível obter o caminho do executável: %{detail}"
   mcp.exeDirFailed: "Não foi possível obter o diretório do executável"
@@ -309,11 +310,11 @@ errors:
   mcp.invalidToml: "TOML inválido: %{detail}"
   mcp.jsonSerializeFailed: "Erro de serialização JSON: %{detail}"
   mcp.invalidJsonStructure: "Estrutura JSON inválida"
-  mcp.serversNotObject: "mcpServers não é um objeto"
+  mcp.serversNotObject: "%{key} não é um objeto"
   mcp.serversNotTable: "mcp_servers não é uma tabela"
-  mcp.vmarkEntryNotObject: "mcpServers.vmark não é um objeto"
+  mcp.vmarkEntryNotObject: "%{key} não é um objeto"
   mcp.vmarkEntryNotTable: "mcp_servers.vmark não é uma tabela"
-  mcp.envNotObject: "mcpServers.vmark.env não é um objeto"
+  mcp.envNotObject: "%{key} não é um objeto"
   mcp.envNotTable: "mcp_servers.vmark.env não é uma tabela"
 
   # Ponte MCP: as credenciais de cliente às quais o principal de autorização é vinculado

--- a/src-tauri/locales/zh-CN.yml
+++ b/src-tauri/locales/zh-CN.yml
@@ -299,6 +299,7 @@ errors:
 
   # MCP client config — provider and sidecar binary resolution
   mcp.unknownProvider: "未知的提供商：%{provider}"
+  mcp.legacyProvider: "%{name} 已停止支持；残留的 VMark 条目只能移除。"
   mcp.noHomeDir: "无法确定用户主目录"
   mcp.exePathFailed: "无法获取可执行文件路径：%{detail}"
   mcp.exeDirFailed: "无法获取可执行文件所在目录"
@@ -309,11 +310,11 @@ errors:
   mcp.invalidToml: "TOML 无效：%{detail}"
   mcp.jsonSerializeFailed: "JSON 序列化错误：%{detail}"
   mcp.invalidJsonStructure: "JSON 结构无效"
-  mcp.serversNotObject: "mcpServers 不是对象"
+  mcp.serversNotObject: "%{key} 不是对象"
   mcp.serversNotTable: "mcp_servers 不是表"
-  mcp.vmarkEntryNotObject: "mcpServers.vmark 不是对象"
+  mcp.vmarkEntryNotObject: "%{key} 不是对象"
   mcp.vmarkEntryNotTable: "mcp_servers.vmark 不是表"
-  mcp.envNotObject: "mcpServers.vmark.env 不是对象"
+  mcp.envNotObject: "%{key} 不是对象"
   mcp.envNotTable: "mcp_servers.vmark.env 不是表"
 
   # MCP 桥接 —— 授权主体所绑定的客户端凭据

--- a/src-tauri/locales/zh-TW.yml
+++ b/src-tauri/locales/zh-TW.yml
@@ -299,6 +299,7 @@ errors:
 
   # MCP client config — provider and sidecar binary resolution
   mcp.unknownProvider: "未知的服務商：%{provider}"
+  mcp.legacyProvider: "%{name} 已停止支援；殘留的 VMark 條目只能移除。"
   mcp.noHomeDir: "無法確定使用者家目錄"
   mcp.exePathFailed: "無法取得可執行檔路徑：%{detail}"
   mcp.exeDirFailed: "無法取得可執行檔所在目錄"
@@ -309,11 +310,11 @@ errors:
   mcp.invalidToml: "TOML 無效：%{detail}"
   mcp.jsonSerializeFailed: "JSON 序列化錯誤：%{detail}"
   mcp.invalidJsonStructure: "JSON 結構無效"
-  mcp.serversNotObject: "mcpServers 不是物件"
+  mcp.serversNotObject: "%{key} 不是物件"
   mcp.serversNotTable: "mcp_servers 不是表"
-  mcp.vmarkEntryNotObject: "mcpServers.vmark 不是物件"
+  mcp.vmarkEntryNotObject: "%{key} 不是物件"
   mcp.vmarkEntryNotTable: "mcp_servers.vmark 不是表"
-  mcp.envNotObject: "mcpServers.vmark.env 不是物件"
+  mcp.envNotObject: "%{key} 不是物件"
   mcp.envNotTable: "mcp_servers.vmark.env 不是資料表"
 
   # MCP 橋接 —— 授權主體所綁定的用戶端憑證

--- a/src-tauri/src/mcp_config/client_token_field.rs
+++ b/src-tauri/src/mcp_config/client_token_field.rs
@@ -63,11 +63,20 @@ pub(crate) fn usable(raw: Option<&str>) -> Option<String> {
     Some(token.to_string())
 }
 
-/// Read the credential out of a JSON `vmark` entry.
+/// Read the credential out of a JSON `vmark` entry (`mcpServers` schema).
 pub(crate) fn read_json(entry: &JsonValue) -> Option<String> {
+    read_json_under(entry, "env")
+}
+
+/// Read the credential from under `env_key` in a JSON `vmark` entry.
+///
+/// The env map's key is the one schema difference this field has across the
+/// JSON formats: `mcpServers` entries call it `env`, opencode calls it
+/// `environment`.
+pub(crate) fn read_json_under(entry: &JsonValue, env_key: &str) -> Option<String> {
     usable(
         entry
-            .get("env")
+            .get(env_key)
             .and_then(|env| env.get(TOKEN_ENV_KEY))
             .and_then(JsonValue::as_str),
     )
@@ -92,11 +101,25 @@ pub(crate) fn read_toml(entry: &TomlItem) -> Option<String> {
 /// `env` holding the user's `NODE_OPTIONS` or `HTTPS_PROXY` would be discarded
 /// on every install and every Repair click.
 pub(crate) fn write_json(entry: &mut Map<String, JsonValue>, token: &str) -> Result<(), String> {
+    write_json_under(entry, "env", "mcpServers.vmark.env", token)
+}
+
+/// Write the credential under `env_key`, keeping the user's other variables.
+///
+/// `env_path` is the dotted path named in the error when the existing value is
+/// not an object — `mcpServers.vmark.env` or `mcp.vmark.environment` — so the
+/// message points at the field the user actually has in their file.
+pub(crate) fn write_json_under(
+    entry: &mut Map<String, JsonValue>,
+    env_key: &str,
+    env_path: &str,
+    token: &str,
+) -> Result<(), String> {
     let env = entry
-        .entry("env")
+        .entry(env_key)
         .or_insert_with(|| JsonValue::Object(Map::new()))
         .as_object_mut()
-        .ok_or_else(|| rust_i18n::t!("errors.mcp.envNotObject").to_string())?;
+        .ok_or_else(|| rust_i18n::t!("errors.mcp.envNotObject", key = env_path).to_string())?;
     env.insert(
         TOKEN_ENV_KEY.to_string(),
         JsonValue::String(token.to_string()),

--- a/src-tauri/src/mcp_config/client_token_field.test.rs
+++ b/src-tauri/src/mcp_config/client_token_field.test.rs
@@ -42,6 +42,32 @@ fn json_round_trips_a_written_token() {
     assert_eq!(read_json(&value), Some("tok-json".to_string()));
 }
 
+/// opencode calls the env map `environment` — same field rules, different key.
+#[test]
+fn json_round_trips_under_a_custom_env_key() {
+    let mut entry = Map::new();
+    write_json_under(&mut entry, "environment", "mcp.vmark.environment", "tok-oc").expect("write");
+    let value = JsonValue::Object(entry);
+    assert_eq!(
+        read_json_under(&value, "environment"),
+        Some("tok-oc".to_string())
+    );
+    assert_eq!(
+        read_json(&value),
+        None,
+        "the token under `environment` must not read back from `env`"
+    );
+}
+
+#[test]
+fn json_write_under_a_custom_key_names_that_key_in_its_error() {
+    let mut entry: Map<String, JsonValue> =
+        serde_json::from_value(serde_json::json!({ "environment": "oops" })).expect("entry");
+    let err = write_json_under(&mut entry, "environment", "mcp.vmark.environment", "tok")
+        .expect_err("a scalar environment cannot hold the token");
+    assert!(err.contains("mcp.vmark.environment"), "unexpected: {err}");
+}
+
 /// The user's own `env` keys are theirs. Replacing the object wholesale is
 /// the bug `vmark_entry.rs` exists to prevent, one level deeper.
 #[test]

--- a/src-tauri/src/mcp_config/commands.rs
+++ b/src-tauri/src/mcp_config/commands.rs
@@ -78,6 +78,7 @@ fn build_diagnostic(
     ProviderDiagnostic {
         provider: provider.id.to_string(),
         name: provider.name.to_string(),
+        legacy: provider.legacy,
         config_path: config_path.to_string_lossy().to_string(),
         config_exists,
         has_vmark,
@@ -87,6 +88,36 @@ fn build_diagnostic(
         status,
         message,
     }
+}
+
+/// Whether a provider belongs in the Integrations panel at all.
+///
+/// A legacy provider (a tool VMark no longer targets) earns a row only while
+/// its config still holds a vmark entry to remove. Absent, unconfigured and
+/// unreadable configs are all skipped: there is nothing a discontinued tool's
+/// row could offer for them, and an Install button would write into a config
+/// nothing reads anymore.
+fn should_list(provider: &ProviderConfig, existing: &ExistingConfig) -> bool {
+    !provider.legacy
+        || matches!(
+            existing,
+            ExistingConfig::Parsed {
+                has_vmark: true,
+                ..
+            }
+        )
+}
+
+/// Refuse config-writing commands for a legacy provider.
+///
+/// The panel never offers Install or Preview for one, so reaching this is a
+/// caller bug or a stale UI — either way the config of a discontinued tool
+/// must not gain a fresh vmark entry.
+fn require_active(config: &ProviderConfig) -> Result<(), String> {
+    if config.legacy {
+        return Err(rust_i18n::t!("errors.mcp.legacyProvider", name = config.name).to_string());
+    }
+    Ok(())
 }
 
 /// Diagnose MCP configuration for all AI providers
@@ -103,6 +134,9 @@ pub fn mcp_config_diagnose() -> Result<Vec<ProviderDiagnostic>, String> {
         // `config_exists` comes out of this read rather than a separate
         // `path.exists()` stat, so it cannot disagree with what was read.
         let existing = read_existing_config(&path, provider.id)?;
+        if !should_list(provider, &existing) {
+            continue;
+        }
         diagnostics.push(build_diagnostic(
             provider,
             &path,
@@ -125,6 +159,7 @@ pub fn mcp_config_diagnose() -> Result<Vec<ProviderDiagnostic>, String> {
 #[tauri::command]
 pub fn mcp_config_preview(provider: String) -> Result<ConfigPreview, String> {
     let config = get_provider_config(&provider)?;
+    require_active(config)?;
     let path = get_config_path(config)?;
     let binary_path = get_mcp_binary_path()?;
 
@@ -164,6 +199,7 @@ pub fn mcp_config_preview(provider: String) -> Result<ConfigPreview, String> {
 #[tauri::command]
 pub fn mcp_config_install(provider: String) -> Result<InstallResult, String> {
     let config = get_provider_config(&provider)?;
+    require_active(config)?;
     let path = get_config_path(config)?;
     let binary_path = get_mcp_binary_path()?;
 

--- a/src-tauri/src/mcp_config/commands.test.rs
+++ b/src-tauri/src/mcp_config/commands.test.rs
@@ -16,6 +16,14 @@ const PROVIDER: ProviderConfig = ProviderConfig {
     name: "Claude Code",
     id: "claude",
     relative_path: ".claude.json",
+    legacy: false,
+};
+
+const LEGACY_PROVIDER: ProviderConfig = ProviderConfig {
+    name: "Gemini CLI",
+    id: "gemini",
+    relative_path: ".gemini/settings.json",
+    legacy: true,
 };
 
 /// A binary path that certainly exists on every platform the tests run on.
@@ -110,4 +118,53 @@ fn a_vmark_entry_pointing_elsewhere_reports_a_path_mismatch() {
         Some("/Applications/VMark.app/other"),
     );
     assert!(matches!(d.status, DiagnosticStatus::PathMismatch));
+}
+
+// -- legacy providers: a row only while there is something to remove --------
+//
+// Gemini CLI is discontinued. A permanent row would nag every user with an
+// Install button for a tool nothing reads; no row at all would strand the
+// machines that still carry a vmark entry from an earlier install.
+
+#[test]
+fn a_legacy_provider_with_a_vmark_entry_is_listed() {
+    assert!(should_list(&LEGACY_PROVIDER, &parsed(Some("/opt/vmark"))));
+}
+
+#[test]
+fn a_legacy_provider_without_a_vmark_entry_is_not_listed() {
+    assert!(!should_list(&LEGACY_PROVIDER, &ExistingConfig::Absent));
+    assert!(!should_list(&LEGACY_PROVIDER, &parsed(None)));
+    assert!(!should_list(
+        &LEGACY_PROVIDER,
+        &ExistingConfig::Unreadable {
+            detail: "Invalid JSON".to_string()
+        }
+    ));
+}
+
+#[test]
+fn an_active_provider_is_always_listed() {
+    assert!(should_list(&PROVIDER, &ExistingConfig::Absent));
+    assert!(should_list(&PROVIDER, &parsed(None)));
+    assert!(should_list(&PROVIDER, &parsed(Some("/opt/vmark"))));
+}
+
+#[test]
+fn the_diagnostic_carries_the_legacy_flag() {
+    let d = build_diagnostic(
+        &LEGACY_PROVIDER,
+        Path::new("/home/u/.gemini/settings.json"),
+        parsed(Some("/opt/vmark")),
+        None,
+    );
+    assert!(d.legacy);
+    assert!(!diagnose(parsed(None), None).legacy);
+}
+
+#[test]
+fn install_and_preview_refuse_a_legacy_provider() {
+    let err = require_active(&LEGACY_PROVIDER).expect_err("legacy providers take no new install");
+    assert!(err.contains("Gemini CLI"), "unexpected error: {err}");
+    require_active(&PROVIDER).expect("active providers install normally");
 }

--- a/src-tauri/src/mcp_config/config_io.rs
+++ b/src-tauri/src/mcp_config/config_io.rs
@@ -1,15 +1,17 @@
 //! Config *content* — reading, generating, and removing MCP entries.
 //!
-//! Handles the JSON (Claude Desktop, Claude Code, Gemini) and TOML (Codex)
-//! config formats for adding/removing the vmark MCP server entry. Filesystem
-//! side effects live in `install_io.rs` and `backup_io.rs`; the parsed-document
-//! representation lives in `parsed_config.rs`; the vmark entry's own
-//! field-level upsert lives in `vmark_entry.rs`.
+//! Handles the JSON (Claude Desktop, Claude Code, Antigravity), opencode-JSON
+//! (`opencode.json`) and TOML (Codex, Grok) config formats for adding/removing
+//! the vmark MCP server entry. Filesystem side effects live in `install_io.rs`
+//! and `backup_io.rs`; the parsed-document representation lives in
+//! `parsed_config.rs`; the vmark entry's own field-level upsert lives in
+//! `vmark_entry.rs` (opencode's in `opencode_entry.rs`).
 //!
 //! Key decision: both formats round-trip **non-destructively** — see
 //! `parsed_config.rs`. Only the bytes VMark owns may change.
 
 use super::install_io::read_config_for_merge;
+use super::opencode_entry::upsert_opencode_vmark;
 use super::parsed_config::{merge_base, parse, Parsed};
 use super::vmark_entry::{upsert_json_vmark, upsert_toml_vmark, TomlEntryStyle};
 use std::path::Path;
@@ -20,18 +22,25 @@ use toml_edit::{DocumentMut, Item as TomlItem, Table as TomlTable};
 /// Classified in exactly one place. Four functions previously repeated the
 /// `"claude-desktop" | "claude" | "gemini" => JSON, "codex" => TOML` match,
 /// which is how one of them could validate differently from the others.
+///
+/// `OpenCode` is JSON *syntax* with a different schema: the server map lives
+/// under `mcp`, an entry's `command` is one array holding the program and its
+/// arguments, env vars live under `environment`, and entries carry
+/// `type`/`enabled` fields. See `opencode_entry.rs`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ConfigFormat {
     Json,
+    OpenCode,
     Toml,
 }
 
 impl ConfigFormat {
     /// The key holding the server map. JSON configs camelCase it; TOML ones
-    /// snake_case it.
+    /// snake_case it; opencode shortens it to `mcp`.
     pub(crate) fn servers_key(self) -> &'static str {
         match self {
             ConfigFormat::Json => "mcpServers",
+            ConfigFormat::OpenCode => "mcp",
             ConfigFormat::Toml => "mcp_servers",
         }
     }
@@ -40,8 +49,9 @@ impl ConfigFormat {
 /// Map a provider id to its config format, or reject an unknown provider.
 pub(crate) fn config_format(provider_id: &str) -> Result<ConfigFormat, String> {
     match provider_id {
-        "claude-desktop" | "claude" | "gemini" => Ok(ConfigFormat::Json),
-        "codex" => Ok(ConfigFormat::Toml),
+        "claude-desktop" | "claude" | "gemini" | "antigravity" => Ok(ConfigFormat::Json),
+        "opencode" => Ok(ConfigFormat::OpenCode),
+        "codex" | "grok" => Ok(ConfigFormat::Toml),
         _ => Err(rust_i18n::t!("errors.mcp.unknownProvider", provider = provider_id).to_string()),
     }
 }
@@ -94,7 +104,7 @@ pub(crate) fn read_existing_config(
     }
     match parse(format, &content) {
         Ok(parsed) => {
-            let entry = parsed.vmark_entry();
+            let entry = parsed.vmark_entry(format);
             Ok(ExistingConfig::Parsed {
                 has_vmark: entry.is_some(),
                 binary_path: entry.and_then(|e| e.command().map(str::to_string)),
@@ -127,7 +137,7 @@ pub(crate) fn client_token_in(
         return Ok(None);
     };
     Ok(parse(format, content)?
-        .vmark_entry()
+        .vmark_entry(format)
         .and_then(|entry| entry.client_token()))
 }
 
@@ -158,11 +168,11 @@ pub(crate) fn generate_config_content(
     let key = format.servers_key();
 
     match format {
-        ConfigFormat::Json => {
+        ConfigFormat::Json | ConfigFormat::OpenCode => {
             let mut json: serde_json::Value = match merge_base(existing_content) {
                 Some(c) => match parse(format, c)? {
                     Parsed::Json(v) => v,
-                    Parsed::Toml(_) => unreachable!("JSON format parses to Parsed::Json"),
+                    Parsed::Toml(_) => unreachable!("JSON syntax parses to Parsed::Json"),
                 },
                 None => serde_json::json!({}),
             };
@@ -173,9 +183,16 @@ pub(crate) fn generate_config_content(
                 .entry(key)
                 .or_insert_with(|| serde_json::json!({}))
                 .as_object_mut()
-                .ok_or_else(|| rust_i18n::t!("errors.mcp.serversNotObject").to_string())?;
+                .ok_or_else(|| {
+                    rust_i18n::t!("errors.mcp.serversNotObject", key = key).to_string()
+                })?;
 
-            upsert_json_vmark(servers, binary_path, client_token)?;
+            match format {
+                ConfigFormat::OpenCode => {
+                    upsert_opencode_vmark(servers, binary_path, client_token)?
+                }
+                _ => upsert_json_vmark(servers, binary_path, client_token)?,
+            }
             Parsed::Json(json).serialize()
         }
         ConfigFormat::Toml => {
@@ -253,3 +270,7 @@ pub(crate) fn remove_vmark_from_config(
 #[cfg(test)]
 #[path = "config_io.test.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "config_io_formats.test.rs"]
+mod format_tests;

--- a/src-tauri/src/mcp_config/config_io.test.rs
+++ b/src-tauri/src/mcp_config/config_io.test.rs
@@ -268,22 +268,7 @@ fn toml_non_table_vmark_entry_is_rejected() {
     );
 }
 
-// -- format classification is defined once (finding 8) ---------------------
-
-#[test]
-fn every_shipped_provider_classifies_to_exactly_one_format() {
-    for provider in super::super::providers::PROVIDERS {
-        let format = config_format(provider.id)
-            .unwrap_or_else(|e| panic!("provider {} has no format: {e}", provider.id));
-        let expected = if provider.id == "codex" {
-            ConfigFormat::Toml
-        } else {
-            ConfigFormat::Json
-        };
-        assert_eq!(format, expected, "provider {}", provider.id);
-    }
-    config_format("nope").expect_err("unknown providers have no format");
-}
+// -- format classification is defined once: see `config_io_formats.test.rs` -
 
 // -- remove_vmark_from_config: already correct; lock the behavior in -------
 

--- a/src-tauri/src/mcp_config/config_io_formats.test.rs
+++ b/src-tauri/src/mcp_config/config_io_formats.test.rs
@@ -1,0 +1,187 @@
+//! Tests for `config_io.rs` — per-provider format mapping and the opencode
+//! schema (included via `#[path]`; the general content-merging suite lives in
+//! `config_io.test.rs`, which is size-frozen).
+//!
+//! The provider set here is the one the Integrations panel ships: Antigravity
+//! replaced Gemini CLI (same `mcpServers` JSON, different file), Grok reads
+//! Codex-shaped TOML, and opencode has its own JSON schema — `mcp` key,
+//! program-plus-arguments in one `command` array, env vars under
+//! `environment`.
+
+use super::*;
+
+const BIN: &str = "/opt/vmark/vmark-mcp-server";
+const TOK: &str = "tok-fixture";
+
+// -- format classification is defined once ---------------------------------
+
+#[test]
+fn every_shipped_provider_classifies_to_exactly_one_format() {
+    for provider in super::super::providers::PROVIDERS {
+        let format = config_format(provider.id)
+            .unwrap_or_else(|e| panic!("provider {} has no format: {e}", provider.id));
+        let expected = match provider.id {
+            "codex" | "grok" => ConfigFormat::Toml,
+            "opencode" => ConfigFormat::OpenCode,
+            _ => ConfigFormat::Json,
+        };
+        assert_eq!(format, expected, "provider {}", provider.id);
+    }
+    config_format("nope").expect_err("unknown providers have no format");
+}
+
+#[test]
+fn each_format_names_its_own_server_map_key() {
+    assert_eq!(ConfigFormat::Json.servers_key(), "mcpServers");
+    assert_eq!(ConfigFormat::OpenCode.servers_key(), "mcp");
+    assert_eq!(ConfigFormat::Toml.servers_key(), "mcp_servers");
+}
+
+// -- antigravity and grok reuse the proven machinery ------------------------
+
+#[test]
+fn antigravity_writes_the_mcp_servers_json_shape() {
+    let out =
+        generate_config_content("antigravity", BIN, TOK, None).expect("fresh antigravity install");
+    let json: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(json["mcpServers"]["vmark"]["command"], BIN);
+    assert_eq!(json["mcpServers"]["vmark"]["env"]["VMARK_MCP_TOKEN"], TOK);
+}
+
+#[test]
+fn grok_writes_the_codex_toml_shape() {
+    let existing = "# grok config\n[cli]\nvim_mode = true\n";
+    let out = generate_config_content("grok", BIN, TOK, Some(existing)).expect("grok merges");
+    assert!(
+        out.contains("# grok config"),
+        "user comment survives:\n{out}"
+    );
+    let doc: toml::Table = out.parse().unwrap();
+    assert_eq!(doc["cli"]["vim_mode"].as_bool(), Some(true));
+    assert_eq!(doc["mcp_servers"]["vmark"]["command"].as_str(), Some(BIN));
+    assert_eq!(
+        doc["mcp_servers"]["vmark"]["env"]["VMARK_MCP_TOKEN"].as_str(),
+        Some(TOK)
+    );
+}
+
+// -- opencode: generate ------------------------------------------------------
+
+#[test]
+fn opencode_fresh_install_writes_the_opencode_schema() {
+    let out = generate_config_content("opencode", BIN, TOK, None).expect("fresh opencode install");
+    let json: serde_json::Value = serde_json::from_str(&out).unwrap();
+    let vmark = &json["mcp"]["vmark"];
+    assert_eq!(vmark["type"], "local");
+    assert_eq!(vmark["command"], serde_json::json!([BIN]));
+    assert_eq!(vmark["enabled"], true);
+    assert_eq!(vmark["environment"]["VMARK_MCP_TOKEN"], TOK);
+    assert!(
+        json.get("mcpServers").is_none(),
+        "opencode must not receive the mcpServers spelling:\n{out}"
+    );
+}
+
+#[test]
+fn opencode_install_preserves_unrelated_config() {
+    let existing = r#"{
+      "$schema": "https://opencode.ai/config.json",
+      "provider": { "anthropic": { "options": { "timeout": 9000 } } },
+      "model": "anthropic/claude-fable-5",
+      "mcp": { "context7": { "type": "remote", "url": "https://mcp.context7.com/mcp" } }
+    }"#;
+    let out =
+        generate_config_content("opencode", BIN, TOK, Some(existing)).expect("opencode merges");
+    let json: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+    assert_eq!(json["$schema"], "https://opencode.ai/config.json");
+    assert_eq!(json["model"], "anthropic/claude-fable-5");
+    assert_eq!(
+        json["provider"]["anthropic"]["options"]["timeout"], 9000,
+        "provider settings must survive"
+    );
+    assert_eq!(
+        json["mcp"]["context7"]["url"],
+        "https://mcp.context7.com/mcp"
+    );
+    assert_eq!(json["mcp"]["vmark"]["command"], serde_json::json!([BIN]));
+}
+
+#[test]
+fn opencode_malformed_json_is_rejected() {
+    let err = generate_config_content("opencode", BIN, TOK, Some("// jsonc comment\n{}"))
+        .expect_err("JSONC is not JSON; refusing beats guessing");
+    assert!(err.contains("Invalid JSON"), "unexpected: {err}");
+}
+
+#[test]
+fn opencode_non_object_mcp_key_is_rejected() {
+    let err = generate_config_content("opencode", BIN, TOK, Some(r#"{"mcp": []}"#))
+        .expect_err("a non-object mcp cannot receive the vmark entry");
+    assert!(err.contains("mcp is not an object"), "unexpected: {err}");
+}
+
+// -- opencode: read back -----------------------------------------------------
+
+#[test]
+fn opencode_binary_path_is_read_from_the_command_arrays_first_element() {
+    let installed = generate_config_content("opencode", BIN, TOK, None).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("opencode.json");
+    std::fs::write(&path, &installed).unwrap();
+
+    match read_existing_config(&path, "opencode").expect("valid JSON parses") {
+        ExistingConfig::Parsed {
+            has_vmark,
+            binary_path,
+        } => {
+            assert!(has_vmark);
+            assert_eq!(binary_path.as_deref(), Some(BIN));
+        }
+        other => panic!("expected Parsed, got {other:?}"),
+    }
+}
+
+#[test]
+fn opencode_client_token_is_read_from_environment() {
+    let installed = generate_config_content("opencode", BIN, TOK, None).unwrap();
+    assert_eq!(
+        client_token_in("opencode", Some(&installed)).expect("parses"),
+        Some(TOK.to_string())
+    );
+}
+
+#[test]
+fn opencode_install_is_idempotent() {
+    let once = generate_config_content("opencode", BIN, TOK, None).unwrap();
+    let twice = generate_config_content("opencode", BIN, TOK, Some(&once)).unwrap();
+    assert_eq!(once, twice, "a repeat install must not churn the file");
+}
+
+// -- opencode: remove --------------------------------------------------------
+
+#[test]
+fn opencode_uninstall_removes_only_the_vmark_entry() {
+    let existing = r#"{
+      "model": "anthropic/claude-fable-5",
+      "mcp": {
+        "vmark": { "type": "local", "command": ["/opt/vmark/vmark-mcp-server"] },
+        "context7": { "type": "remote", "url": "https://mcp.context7.com/mcp" }
+      }
+    }"#;
+    let out = remove_vmark_from_config("opencode", existing)
+        .unwrap()
+        .expect("vmark was present, so the document changed");
+    let json: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(json["model"], "anthropic/claude-fable-5");
+    assert!(json["mcp"]["context7"].is_object());
+    assert!(json["mcp"].get("vmark").is_none());
+}
+
+#[test]
+fn opencode_uninstall_reports_nothing_to_remove() {
+    assert_eq!(
+        remove_vmark_from_config("opencode", r#"{"mcp": {"other": {}}}"#).unwrap(),
+        None
+    );
+}

--- a/src-tauri/src/mcp_config/mod.rs
+++ b/src-tauri/src/mcp_config/mod.rs
@@ -4,7 +4,10 @@
 //! - Claude Desktop: ~/Library/Application Support/Claude/claude_desktop_config.json
 //! - Claude Code: ~/.claude.json
 //! - Codex CLI: ~/.codex/config.toml
-//! - Gemini CLI: ~/.gemini/settings.json
+//! - Antigravity CLI: ~/.gemini/config/mcp_config.json
+//! - Grok CLI: ~/.grok/config.toml
+//! - opencode: ~/.config/opencode/opencode.json
+//! - Gemini CLI (legacy, removal only): ~/.gemini/settings.json
 
 mod backup_io;
 pub(crate) mod client_token_field;
@@ -13,6 +16,7 @@ pub mod commands;
 mod config_io;
 mod create_io;
 mod install_io;
+mod opencode_entry;
 mod parsed_config;
 mod providers;
 mod types;

--- a/src-tauri/src/mcp_config/opencode_entry.rs
+++ b/src-tauri/src/mcp_config/opencode_entry.rs
@@ -1,0 +1,60 @@
+//! The `vmark` server entry in opencode's schema (`opencode.json`, `mcp` key).
+//!
+//! opencode's MCP schema differs from the `mcpServers` one in three ways:
+//! `command` is a single array holding the program and its arguments, env vars
+//! live under `environment`, and entries carry `type`/`enabled` fields. The
+//! ownership rule is the same as `vmark_entry.rs`: rewrite only what VMark
+//! owns, leave every other byte of the entry to the user.
+//!
+//! What VMark owns here:
+//! - `type` — always `"local"`; the sidecar is a stdio process, never remote.
+//! - `command[0]` — the sidecar binary path. Later elements are user-added
+//!   arguments and survive a repair.
+//! - `environment.VMARK_MCP_TOKEN` — the per-client credential
+//!   (`client_token_field.rs` writes only that one key).
+//! - `enabled: true`, but only when the key is ABSENT — written on create so
+//!   the entry states what it does (opencode checks `enabled === false`, so an
+//!   absent key already means enabled), while a user's deliberate `false` is a
+//!   setting, and Repair must not flip it back.
+
+use super::client_token_field;
+use serde_json::{json, Map, Value as JsonValue};
+
+pub(crate) fn upsert_opencode_vmark(
+    servers: &mut Map<String, JsonValue>,
+    binary_path: &str,
+    client_token: &str,
+) -> Result<(), String> {
+    let entry = servers
+        .entry("vmark")
+        .or_insert_with(|| JsonValue::Object(Map::new()));
+    let entry = entry.as_object_mut().ok_or_else(|| {
+        rust_i18n::t!("errors.mcp.vmarkEntryNotObject", key = "mcp.vmark").to_string()
+    })?;
+
+    entry.insert("type".to_string(), JsonValue::String("local".to_string()));
+
+    match entry.get_mut("command") {
+        Some(JsonValue::Array(command)) if !command.is_empty() => {
+            command[0] = JsonValue::String(binary_path.to_string());
+        }
+        _ => {
+            entry.insert("command".to_string(), json!([binary_path]));
+        }
+    }
+
+    if !entry.contains_key("enabled") {
+        entry.insert("enabled".to_string(), JsonValue::Bool(true));
+    }
+
+    client_token_field::write_json_under(
+        entry,
+        "environment",
+        "mcp.vmark.environment",
+        client_token,
+    )
+}
+
+#[cfg(test)]
+#[path = "opencode_entry.test.rs"]
+mod tests;

--- a/src-tauri/src/mcp_config/opencode_entry.test.rs
+++ b/src-tauri/src/mcp_config/opencode_entry.test.rs
@@ -1,0 +1,108 @@
+//! Tests for `opencode_entry.rs` (included via `#[path]`).
+//!
+//! opencode's entry schema differs from the `mcpServers` one, so what VMark
+//! owns differs too: `type`, `command[0]`, and `environment.VMARK_MCP_TOKEN`.
+//! Everything else on the entry — extra command arguments, other environment
+//! variables, a deliberate `enabled: false` — is the user's.
+
+use super::*;
+use serde_json::{json, Map, Value as JsonValue};
+
+const BIN: &str = "/opt/vmark/vmark-mcp-server";
+const TOK: &str = "tok-fixture";
+
+fn servers_from(value: JsonValue) -> Map<String, JsonValue> {
+    value.as_object().expect("fixture is an object").clone()
+}
+
+fn upsert(mut servers: Map<String, JsonValue>) -> Map<String, JsonValue> {
+    upsert_opencode_vmark(&mut servers, BIN, TOK).expect("upsert succeeds");
+    servers
+}
+
+#[test]
+fn a_fresh_entry_has_the_full_opencode_shape() {
+    let servers = upsert(Map::new());
+    let entry = &servers["vmark"];
+
+    assert_eq!(entry["type"], "local");
+    assert_eq!(entry["command"], json!([BIN]));
+    assert_eq!(entry["enabled"], true, "a fresh entry states its own state");
+    assert_eq!(entry["environment"]["VMARK_MCP_TOKEN"], TOK);
+}
+
+#[test]
+fn user_added_command_arguments_survive_a_repair() {
+    // opencode's `command` is program-plus-arguments in one array; only the
+    // first element is VMark's.
+    let servers = upsert(servers_from(json!({
+        "vmark": { "command": ["/stale/vmark-mcp-server", "--log-level", "debug"] }
+    })));
+    assert_eq!(
+        servers["vmark"]["command"],
+        json!([BIN, "--log-level", "debug"])
+    );
+}
+
+#[test]
+fn a_deliberate_enabled_false_is_not_flipped_back() {
+    let servers = upsert(servers_from(json!({
+        "vmark": { "command": [BIN], "enabled": false }
+    })));
+    assert_eq!(servers["vmark"]["enabled"], false);
+}
+
+#[test]
+fn user_environment_variables_survive() {
+    let servers = upsert(servers_from(json!({
+        "vmark": { "environment": { "HTTPS_PROXY": "http://127.0.0.1:7890" } }
+    })));
+    let environment = &servers["vmark"]["environment"];
+    assert_eq!(environment["HTTPS_PROXY"], "http://127.0.0.1:7890");
+    assert_eq!(environment["VMARK_MCP_TOKEN"], TOK);
+}
+
+#[test]
+fn a_non_array_command_is_repaired_to_the_canonical_one() {
+    // A string `command` is invalid in opencode's schema; install replaces it
+    // rather than crashing or appending to it.
+    let servers = upsert(servers_from(json!({
+        "vmark": { "command": "/stale/vmark-mcp-server" }
+    })));
+    assert_eq!(servers["vmark"]["command"], json!([BIN]));
+}
+
+#[test]
+fn an_empty_command_array_is_repaired_to_the_canonical_one() {
+    let servers = upsert(servers_from(json!({ "vmark": { "command": [] } })));
+    assert_eq!(servers["vmark"]["command"], json!([BIN]));
+}
+
+#[test]
+fn a_stale_type_is_rewritten_to_local() {
+    // `type` is VMark's: the sidecar is a local stdio process, never remote.
+    let servers = upsert(servers_from(json!({
+        "vmark": { "type": "remote", "command": [BIN] }
+    })));
+    assert_eq!(servers["vmark"]["type"], "local");
+}
+
+#[test]
+fn other_server_entries_are_untouched() {
+    let servers = upsert(servers_from(json!({
+        "context7": { "type": "remote", "url": "https://mcp.context7.com/mcp" }
+    })));
+    assert_eq!(
+        servers["context7"],
+        json!({ "type": "remote", "url": "https://mcp.context7.com/mcp" })
+    );
+    assert!(servers.contains_key("vmark"));
+}
+
+#[test]
+fn a_non_object_vmark_entry_is_an_error() {
+    let mut servers = servers_from(json!({ "vmark": "oops" }));
+    let err = upsert_opencode_vmark(&mut servers, BIN, TOK)
+        .expect_err("a scalar vmark entry cannot be upserted");
+    assert!(err.contains("mcp.vmark"), "unexpected error: {err}");
+}

--- a/src-tauri/src/mcp_config/parsed_config.rs
+++ b/src-tauri/src/mcp_config/parsed_config.rs
@@ -20,7 +20,7 @@ use toml_edit::{DocumentMut, Item as TomlItem};
 /// reports "Invalid JSON"/"Invalid TOML" identically.
 pub(crate) fn parse(format: ConfigFormat, content: &str) -> Result<Parsed, String> {
     match format {
-        ConfigFormat::Json => serde_json::from_str(content)
+        ConfigFormat::Json | ConfigFormat::OpenCode => serde_json::from_str(content)
             .map(Parsed::Json)
             .map_err(|e| {
                 rust_i18n::t!("errors.mcp.invalidJson", detail = e.to_string()).to_string()
@@ -57,14 +57,23 @@ pub(crate) enum Parsed {
 
 impl Parsed {
     /// The `vmark` entry under this document's server map, if present.
-    pub(crate) fn vmark_entry(&self) -> Option<VmarkEntry<'_>> {
+    ///
+    /// Takes the format because the document alone cannot answer: a
+    /// `Parsed::Json` may be either the `mcpServers` schema or opencode's
+    /// `mcp` one, and they differ in both the map's key and the entry's shape.
+    pub(crate) fn vmark_entry(&self, format: ConfigFormat) -> Option<VmarkEntry<'_>> {
         match self {
-            Parsed::Json(json) => json
-                .get(ConfigFormat::Json.servers_key())
-                .and_then(|s| s.get("vmark"))
-                .map(VmarkEntry::Json),
+            Parsed::Json(json) => {
+                let entry = json
+                    .get(format.servers_key())
+                    .and_then(|s| s.get("vmark"))?;
+                Some(match format {
+                    ConfigFormat::OpenCode => VmarkEntry::OpenCode(entry),
+                    _ => VmarkEntry::Json(entry),
+                })
+            }
             Parsed::Toml(doc) => doc
-                .get(ConfigFormat::Toml.servers_key())
+                .get(format.servers_key())
                 .and_then(TomlItem::as_table_like)
                 .and_then(|s| s.get("vmark"))
                 .map(VmarkEntry::Toml),
@@ -84,6 +93,9 @@ impl Parsed {
 
 pub(crate) enum VmarkEntry<'a> {
     Json(&'a JsonValue),
+    /// opencode's schema: `command` is one array whose first element is the
+    /// program, and env vars live under `environment`.
+    OpenCode(&'a JsonValue),
     Toml(&'a TomlItem),
 }
 
@@ -91,6 +103,11 @@ impl VmarkEntry<'_> {
     pub(crate) fn command(&self) -> Option<&str> {
         match self {
             VmarkEntry::Json(v) => v.get("command").and_then(|c| c.as_str()),
+            VmarkEntry::OpenCode(v) => v
+                .get("command")
+                .and_then(JsonValue::as_array)
+                .and_then(|c| c.first())
+                .and_then(JsonValue::as_str),
             VmarkEntry::Toml(v) => v.as_table_like()?.get("command").and_then(TomlItem::as_str),
         }
     }
@@ -99,6 +116,7 @@ impl VmarkEntry<'_> {
     pub(crate) fn client_token(&self) -> Option<String> {
         match self {
             VmarkEntry::Json(v) => client_token_field::read_json(v),
+            VmarkEntry::OpenCode(v) => client_token_field::read_json_under(v, "environment"),
             VmarkEntry::Toml(v) => client_token_field::read_toml(v),
         }
     }

--- a/src-tauri/src/mcp_config/providers.rs
+++ b/src-tauri/src/mcp_config/providers.rs
@@ -11,6 +11,10 @@ pub(crate) struct ProviderConfig {
     pub id: &'static str,
     /// Path relative to `$HOME`. Claude Desktop differs per platform.
     pub relative_path: &'static str,
+    /// A tool VMark no longer targets. A legacy provider appears in
+    /// diagnostics only while its config still holds a vmark entry, and the
+    /// only action offered is removal — install and preview refuse it.
+    pub legacy: bool,
 }
 
 /// Claude Desktop config path per platform:
@@ -29,21 +33,55 @@ pub(crate) const PROVIDERS: &[ProviderConfig] = &[
         name: "Claude Desktop",
         id: "claude-desktop",
         relative_path: CLAUDE_DESKTOP_PATH,
+        legacy: false,
     },
     ProviderConfig {
         name: "Claude Code",
         id: "claude",
         relative_path: ".claude.json",
+        legacy: false,
     },
     ProviderConfig {
         name: "Codex CLI",
         id: "codex",
         relative_path: ".codex/config.toml",
+        legacy: false,
     },
+    // Antigravity CLI (`agy`) is Google's successor to Gemini CLI. It keeps
+    // the `.gemini` directory but reads MCP servers from its own file, in the
+    // same `mcpServers` JSON shape.
+    ProviderConfig {
+        name: "Antigravity CLI",
+        id: "antigravity",
+        relative_path: ".gemini/config/mcp_config.json",
+        legacy: false,
+    },
+    // xAI's Grok CLI (`xai-org/grok-build`). Its `[mcp_servers.<name>]` TOML
+    // is the same shape Codex reads.
+    ProviderConfig {
+        name: "Grok CLI",
+        id: "grok",
+        relative_path: ".grok/config.toml",
+        legacy: false,
+    },
+    // opencode deep-merges `config.json`, `opencode.json` and `opencode.jsonc`
+    // in its global config dir, so writing plain JSON to `opencode.json` is
+    // additive even for a user whose own settings live in `opencode.jsonc` —
+    // which VMark could not round-trip (serde_json does not parse comments).
+    ProviderConfig {
+        name: "opencode",
+        id: "opencode",
+        relative_path: ".config/opencode/opencode.json",
+        legacy: false,
+    },
+    // Gemini CLI is discontinued (replaced by Antigravity). Kept only so a
+    // machine that still carries a vmark entry from an earlier install gets a
+    // removal path in the Integrations panel.
     ProviderConfig {
         name: "Gemini CLI",
         id: "gemini",
         relative_path: ".gemini/settings.json",
+        legacy: true,
     },
 ];
 

--- a/src-tauri/src/mcp_config/providers.test.rs
+++ b/src-tauri/src/mcp_config/providers.test.rs
@@ -73,6 +73,65 @@ fn handles_an_empty_string() {
     assert_eq!(display_path(""), "");
 }
 
+// -- The provider set itself (Gemini CLI replaced by Antigravity; -----------
+// -- opencode and Grok added) -----------------------------------------------
+
+#[test]
+fn the_active_provider_set_names_the_tools_vmark_targets() {
+    let active: Vec<&str> = PROVIDERS
+        .iter()
+        .filter(|p| !p.legacy)
+        .map(|p| p.id)
+        .collect();
+    assert_eq!(
+        active,
+        vec![
+            "claude-desktop",
+            "claude",
+            "codex",
+            "antigravity",
+            "grok",
+            "opencode"
+        ]
+    );
+}
+
+#[test]
+fn gemini_is_the_only_legacy_provider() {
+    let legacy: Vec<&str> = PROVIDERS
+        .iter()
+        .filter(|p| p.legacy)
+        .map(|p| p.id)
+        .collect();
+    assert_eq!(legacy, vec!["gemini"]);
+}
+
+#[test]
+fn new_provider_config_paths_are_the_documented_ones() {
+    // Antigravity keeps Google's `.gemini` dir but its own file — it does NOT
+    // read the legacy `settings.json`, so the two must stay distinct paths.
+    let path_of = |id: &str| {
+        PROVIDERS
+            .iter()
+            .find(|p| p.id == id)
+            .expect("provider exists")
+            .relative_path
+    };
+    assert_eq!(path_of("antigravity"), ".gemini/config/mcp_config.json");
+    assert_eq!(path_of("gemini"), ".gemini/settings.json");
+    assert_eq!(path_of("grok"), ".grok/config.toml");
+    assert_eq!(path_of("opencode"), ".config/opencode/opencode.json");
+}
+
+#[test]
+fn provider_ids_are_unique() {
+    let mut ids: Vec<&str> = PROVIDERS.iter().map(|p| p.id).collect();
+    ids.sort_unstable();
+    let before = ids.len();
+    ids.dedup();
+    assert_eq!(before, ids.len(), "duplicate provider id");
+}
+
 #[test]
 fn the_resolved_binary_path_is_never_verbatim() {
     // The property that actually matters, asserted against whatever this

--- a/src-tauri/src/mcp_config/types.rs
+++ b/src-tauri/src/mcp_config/types.rs
@@ -71,6 +71,9 @@ pub enum DiagnosticStatus {
 pub struct ProviderDiagnostic {
     pub provider: String,
     pub name: String,
+    /// A discontinued tool (Gemini CLI). The panel shows such a row only
+    /// because a vmark entry is still in its config, and offers removal only.
+    pub legacy: bool,
     #[serde(rename = "configPath")]
     pub config_path: String,
     #[serde(rename = "configExists")]

--- a/src-tauri/src/mcp_config/vmark_entry.rs
+++ b/src-tauri/src/mcp_config/vmark_entry.rs
@@ -122,9 +122,9 @@ pub(crate) fn upsert_json_vmark(
     let entry = servers
         .entry("vmark")
         .or_insert_with(|| JsonValue::Object(Map::new()));
-    let entry = entry
-        .as_object_mut()
-        .ok_or_else(|| rust_i18n::t!("errors.mcp.vmarkEntryNotObject").to_string())?;
+    let entry = entry.as_object_mut().ok_or_else(|| {
+        rust_i18n::t!("errors.mcp.vmarkEntryNotObject", key = "mcpServers.vmark").to_string()
+    })?;
 
     entry.insert(
         "command".to_string(),

--- a/src/lib/cjkFormatter/rules/fullwidthScaling.test.ts
+++ b/src/lib/cjkFormatter/rules/fullwidthScaling.test.ts
@@ -25,6 +25,22 @@ function elapsed(fn: () => void): number {
   return performance.now() - started;
 }
 
+/**
+ * The fastest of `runs` samples.
+ *
+ * Scheduler noise is one-sided: a descheduled worker can only make a sample
+ * look SLOWER, never faster. So the minimum is the sample least contaminated by
+ * the rest of the suite, and it preserves the property under test — a quadratic
+ * implementation is quadratic in its best run too. A single sample is what made
+ * the ratio assertion below flake inside the full parallel suite while passing
+ * in isolation.
+ */
+function fastest(runs: number, fn: () => void): number {
+  let best = Infinity;
+  for (let i = 0; i < runs; i++) best = Math.min(best, elapsed(fn));
+  return best;
+}
+
 describe("normalizeFullwidthPunctuation scaling", () => {
   it("converts a 10k-comma run after a CJK char well inside the budget", () => {
     const input = `中${",".repeat(10_000)}`;
@@ -62,8 +78,11 @@ describe("normalizeFullwidthPunctuation scaling", () => {
     // Warm up so JIT/first-run costs do not land on the small sample.
     normalizeFullwidthPunctuation(run(500));
 
-    const small = elapsed(() => normalizeFullwidthPunctuation(run(2_000)));
-    const large = elapsed(() => normalizeFullwidthPunctuation(run(8_000)));
+    // Best-of-5 on both sides: the baseline is sub-millisecond, so a single
+    // sample of `large` that catches one preemption is enough to blow a 12x
+    // ratio that the algorithm itself never approaches.
+    const small = fastest(5, () => normalizeFullwidthPunctuation(run(2_000)));
+    const large = fastest(5, () => normalizeFullwidthPunctuation(run(8_000)));
 
     // 4x input under a quadratic law is ~16x time; allow a very wide margin
     // for timer noise on a sub-millisecond baseline.

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -381,6 +381,8 @@
   "integrations.installMcp.remove": "Entfernen",
   "integrations.installMcp.install": "Installieren",
   "integrations.installMcp.recheck": "Erneut prüfen",
+  "integrations.installMcp.legacyBadge": "Eingestellt",
+  "integrations.installMcp.legacyHint": "Dieses Tool wird nicht mehr unterstützt. Entfernen Sie den verbliebenen VMark-Eintrag.",
   "integrations.group.aiProviders": "KI-Anbieter",
   "integrations.detectCli.label": "CLI-Anbieter erkennen",
   "integrations.detectCli.description": "Nach installierten KI-CLIs suchen (claude, codex, gemini, ollama)",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -381,6 +381,8 @@
   "integrations.installMcp.remove": "Remove",
   "integrations.installMcp.install": "Install",
   "integrations.installMcp.recheck": "Recheck",
+  "integrations.installMcp.legacyBadge": "Discontinued",
+  "integrations.installMcp.legacyHint": "This tool is discontinued. Remove the leftover VMark entry.",
   "integrations.group.aiProviders": "AI Providers",
   "integrations.detectCli.label": "Detect CLI Providers",
   "integrations.detectCli.description": "Scan for installed AI CLIs (claude, codex, gemini, ollama)",

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -381,6 +381,8 @@
   "integrations.installMcp.remove": "Eliminar",
   "integrations.installMcp.install": "Instalar",
   "integrations.installMcp.recheck": "Comprobar de nuevo",
+  "integrations.installMcp.legacyBadge": "Descontinuado",
+  "integrations.installMcp.legacyHint": "Esta herramienta está descontinuada. Elimina la entrada restante de VMark.",
   "integrations.group.aiProviders": "Proveedores de IA",
   "integrations.detectCli.label": "Detectar proveedores de CLI",
   "integrations.detectCli.description": "Buscar CLIs de IA instalados (claude, codex, gemini, ollama)",

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -381,6 +381,8 @@
   "integrations.installMcp.remove": "Supprimer",
   "integrations.installMcp.install": "Installer",
   "integrations.installMcp.recheck": "Revérifier",
+  "integrations.installMcp.legacyBadge": "Abandonné",
+  "integrations.installMcp.legacyHint": "Cet outil est abandonné. Supprimez l'entrée VMark restante.",
   "integrations.group.aiProviders": "Fournisseurs IA",
   "integrations.detectCli.label": "Détecter les fournisseurs CLI",
   "integrations.detectCli.description": "Rechercher les CLI IA installés (claude, codex, gemini, ollama)",

--- a/src/locales/it/settings.json
+++ b/src/locales/it/settings.json
@@ -381,6 +381,8 @@
   "integrations.installMcp.remove": "Rimuovi",
   "integrations.installMcp.install": "Installa",
   "integrations.installMcp.recheck": "Ricontrolla",
+  "integrations.installMcp.legacyBadge": "Dismesso",
+  "integrations.installMcp.legacyHint": "Questo strumento è stato dismesso. Rimuovi la voce VMark residua.",
   "integrations.group.aiProviders": "Provider IA",
   "integrations.detectCli.label": "Rileva provider CLI",
   "integrations.detectCli.description": "Cerca le CLI IA installate (claude, codex, gemini, ollama)",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -381,6 +381,8 @@
   "integrations.installMcp.remove": "削除",
   "integrations.installMcp.install": "インストール",
   "integrations.installMcp.recheck": "再確認",
+  "integrations.installMcp.legacyBadge": "提供終了",
+  "integrations.installMcp.legacyHint": "このツールは提供が終了しました。残っている VMark エントリを削除してください。",
   "integrations.group.aiProviders": "AIプロバイダー",
   "integrations.detectCli.label": "CLIプロバイダーを検出",
   "integrations.detectCli.description": "インストール済みのAI CLI（claude、codex、gemini、ollama）をスキャンする",

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -381,6 +381,8 @@
   "integrations.installMcp.remove": "제거",
   "integrations.installMcp.install": "설치",
   "integrations.installMcp.recheck": "다시 확인",
+  "integrations.installMcp.legacyBadge": "지원 중단",
+  "integrations.installMcp.legacyHint": "이 도구는 지원이 중단되었습니다. 남아 있는 VMark 항목을 제거하세요.",
   "integrations.group.aiProviders": "AI 제공자",
   "integrations.detectCli.label": "CLI 제공자 감지",
   "integrations.detectCli.description": "설치된 AI CLI 검색 (claude, codex, gemini, ollama)",

--- a/src/locales/pt-BR/settings.json
+++ b/src/locales/pt-BR/settings.json
@@ -381,6 +381,8 @@
   "integrations.installMcp.remove": "Remover",
   "integrations.installMcp.install": "Instalar",
   "integrations.installMcp.recheck": "Verificar novamente",
+  "integrations.installMcp.legacyBadge": "Descontinuado",
+  "integrations.installMcp.legacyHint": "Esta ferramenta foi descontinuada. Remova a entrada restante do VMark.",
   "integrations.group.aiProviders": "Provedores de IA",
   "integrations.detectCli.label": "Detectar provedores CLI",
   "integrations.detectCli.description": "Verificar CLIs de IA instalados (claude, codex, gemini, ollama)",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -381,6 +381,8 @@
   "integrations.installMcp.remove": "移除",
   "integrations.installMcp.install": "安装",
   "integrations.installMcp.recheck": "重新检查",
+  "integrations.installMcp.legacyBadge": "已停用",
+  "integrations.installMcp.legacyHint": "该工具已停止支持，请移除残留的 VMark 条目。",
   "integrations.group.aiProviders": "AI 提供商",
   "integrations.detectCli.label": "检测 CLI 提供商",
   "integrations.detectCli.description": "扫描已安装的 AI CLI（claude、codex、gemini、ollama）",

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -381,6 +381,8 @@
   "integrations.installMcp.remove": "移除",
   "integrations.installMcp.install": "安裝",
   "integrations.installMcp.recheck": "重新檢查",
+  "integrations.installMcp.legacyBadge": "已停用",
+  "integrations.installMcp.legacyHint": "該工具已停止支援，請移除殘留的 VMark 條目。",
   "integrations.group.aiProviders": "AI 提供者",
   "integrations.detectCli.label": "偵測 CLI 提供者",
   "integrations.detectCli.description": "掃描已安裝的 AI CLI（claude、codex、gemini、ollama）",

--- a/src/pages/settings/McpConfigInstaller.test.tsx
+++ b/src/pages/settings/McpConfigInstaller.test.tsx
@@ -13,6 +13,7 @@ function diagnostic(over: Partial<ProviderDiagnostic> = {}): ProviderDiagnostic 
   return {
     provider: "claude",
     name: "Claude Code",
+    legacy: false,
     configPath: "/Users/someone/.claude.json",
     configExists: true,
     hasVmark: false,
@@ -165,6 +166,32 @@ describe("McpConfigInstaller — what each status offers", () => {
 
     expect(await screen.findByRole("button", { name: "Install" })).toBeInTheDocument();
     expect(screen.getByTitle("/")).toBeInTheDocument();
+  });
+
+  it("marks a legacy provider and offers only Remove", async () => {
+    // A legacy row (discontinued Gemini CLI) is listed only because a vmark
+    // entry is still in its config; every other action is refused backend-side.
+    withDiagnostics([
+      diagnostic({
+        provider: "gemini",
+        name: "Gemini CLI",
+        legacy: true,
+        status: "Valid",
+        hasVmark: true,
+        binaryExists: true,
+        configuredBinaryPath: "/opt/vmark-mcp-server",
+        expectedBinaryPath: "/opt/vmark-mcp-server",
+        configPath: "/Users/someone/.gemini/settings.json",
+      }),
+    ]);
+    render(<McpConfigInstaller />);
+
+    expect(await screen.findByRole("button", { name: "Remove" })).toBeInTheDocument();
+    expect(screen.getByText("Discontinued")).toBeInTheDocument();
+    expect(screen.getByText(/leftover VMark entry/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Install" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Update" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Repair" })).not.toBeInTheDocument();
   });
 });
 

--- a/src/pages/settings/McpConfigInstaller.tsx
+++ b/src/pages/settings/McpConfigInstaller.tsx
@@ -8,16 +8,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useTranslation } from "react-i18next";
-import { SettingsGroup, Button, CopyButton } from "./components";
+import { SettingsGroup } from "./components";
 import { McpConfigPreviewDialog } from "./McpConfigPreviewDialog";
 import { CcSwitchImportRow } from "./CcSwitchImportRow";
-import { getFileName } from "@/utils/paths";
-import { DiagnosticIcon } from "./DiagnosticIcon";
+import { ProviderRow } from "./McpProviderRow";
 import {
-  diagnosticMessage,
-  formatPath,
   installMessage,
-  rowActions,
   uninstallMessage,
   type InstallResult,
   type ProviderDiagnostic,
@@ -32,89 +28,6 @@ interface ConfigPreview {
   currentContent: string | null;
   proposedContent: string;
   backupPath: string;
-}
-
-/** Shorten path to just filename for display */
-function shortenPath(path: string): string {
-  return getFileName(path) || path;
-}
-
-interface ProviderRowProps {
-  diagnostic: ProviderDiagnostic;
-  onPreview: () => void;
-  onRepair: () => void;
-  onUninstall: () => void;
-  onRecheck: () => void;
-  loading: boolean;
-}
-
-function ProviderRow(props: ProviderRowProps) {
-  const { diagnostic, onPreview, onRepair, onUninstall, onRecheck, loading } = props;
-  const { t } = useTranslation("settings");
-  const actions = rowActions(diagnostic);
-  const broken = diagnostic.status === "ConfigUnreadable";
-
-  const diagnosticText = diagnosticMessage(diagnostic, t);
-
-  return (
-    <div className="flex flex-col py-2.5">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2.5 flex-1 min-w-0">
-          <DiagnosticIcon status={diagnostic.status} />
-          <div className="min-w-0 flex-1">
-            <div className="text-sm font-medium text-[var(--text-color)] truncate">
-              {diagnostic.name}
-            </div>
-            <div className="flex items-center gap-1">
-              <span
-                className="text-xs text-[var(--text-tertiary)] font-mono truncate"
-                title={formatPath(diagnostic.configPath)}
-              >
-                {shortenPath(diagnostic.configPath)}
-              </span>
-              <CopyButton text={diagnostic.configPath} size="xs" />
-            </div>
-          </div>
-        </div>
-        <div className="flex items-center gap-2 ml-3">
-          {actions.repair && (
-            <Button size="sm" variant="warning" onClick={onRepair} disabled={loading}>
-              {t("integrations.installMcp.repair")}
-            </Button>
-          )}
-          {actions.update && (
-            <Button size="sm" onClick={onPreview} disabled={loading}>
-              {t("integrations.installMcp.update")}
-            </Button>
-          )}
-          {actions.remove && (
-            <Button size="sm" variant="danger" onClick={onUninstall} disabled={loading}>
-              {t("integrations.installMcp.remove")}
-            </Button>
-          )}
-          {actions.install && (
-            <Button size="sm" variant="primary" onClick={onPreview} disabled={loading}>
-              {t("integrations.installMcp.install")}
-            </Button>
-          )}
-          {actions.recheck && (
-            <Button size="sm" onClick={onRecheck} disabled={loading}>
-              {t("integrations.installMcp.recheck")}
-            </Button>
-          )}
-        </div>
-      </div>
-      {diagnosticText && (
-        <div
-          className={`mt-1 ml-6.5 text-xs ${
-            broken ? "text-[var(--error-color)]" : "text-[var(--warning-color)]"
-          }`}
-        >
-          {diagnosticText}
-        </div>
-      )}
-    </div>
-  );
 }
 
 interface McpConfigInstallerProps {

--- a/src/pages/settings/McpConfigPreviewDialog.tsx
+++ b/src/pages/settings/McpConfigPreviewDialog.tsx
@@ -26,10 +26,15 @@ interface McpConfigPreviewDialogProps {
   loading: boolean;
 }
 
+// The non-legacy half of `PROVIDERS` in providers.rs — legacy providers never
+// reach this dialog because the backend refuses to preview them.
 const PROVIDER_NAMES: Record<string, string> = {
+  "claude-desktop": "Claude Desktop",
   claude: "Claude Code",
   codex: "Codex CLI",
-  gemini: "Gemini CLI",
+  antigravity: "Antigravity CLI",
+  grok: "Grok CLI",
+  opencode: "opencode",
 };
 
 export function McpConfigPreviewDialog({

--- a/src/pages/settings/McpProviderRow.tsx
+++ b/src/pages/settings/McpProviderRow.tsx
@@ -1,0 +1,114 @@
+/**
+ * Purpose: render one AI provider's row in the Integrations panel — its status
+ *   icon, name, config path, and the buttons its diagnostic permits.
+ *
+ * Split out of `McpConfigInstaller.tsx` when the legacy-provider badge pushed
+ * that file over the 300-line gate. The row is presentational: every action is
+ * a callback, and which buttons exist is decided by `rowActions` rather than
+ * here, so the button policy stays testable without rendering.
+ *
+ * @coordinates-with src/pages/settings/mcpConfigMessages.ts — rowActions, diagnosticMessage
+ * @coordinates-with src/pages/settings/McpConfigInstaller.tsx — the only caller
+ * @module pages/settings/McpProviderRow
+ */
+
+import { useTranslation } from "react-i18next";
+import { Button, CopyButton } from "./components";
+import { getFileName } from "@/utils/paths";
+import { DiagnosticIcon } from "./DiagnosticIcon";
+import {
+  diagnosticMessage,
+  formatPath,
+  rowActions,
+  type ProviderDiagnostic,
+} from "./mcpConfigMessages";
+
+/** Shorten path to just filename for display */
+function shortenPath(path: string): string {
+  return getFileName(path) || path;
+}
+
+interface ProviderRowProps {
+  diagnostic: ProviderDiagnostic;
+  onPreview: () => void;
+  onRepair: () => void;
+  onUninstall: () => void;
+  onRecheck: () => void;
+  loading: boolean;
+}
+
+export function ProviderRow(props: ProviderRowProps) {
+  const { diagnostic, onPreview, onRepair, onUninstall, onRecheck, loading } = props;
+  const { t } = useTranslation("settings");
+  const actions = rowActions(diagnostic);
+  const broken = diagnostic.status === "ConfigUnreadable";
+
+  const diagnosticText = diagnosticMessage(diagnostic, t);
+
+  return (
+    <div className="flex flex-col py-2.5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2.5 flex-1 min-w-0">
+          <DiagnosticIcon status={diagnostic.status} />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5 min-w-0">
+              <span className="text-sm font-medium text-[var(--text-color)] truncate">
+                {diagnostic.name}
+              </span>
+              {diagnostic.legacy && (
+                <span className="text-[10px] px-1.5 py-0.5 rounded font-medium bg-[var(--warning-bg)] text-[var(--warning-color)] flex-shrink-0">
+                  {t("integrations.installMcp.legacyBadge")}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-1">
+              <span
+                className="text-xs text-[var(--text-tertiary)] font-mono truncate"
+                title={formatPath(diagnostic.configPath)}
+              >
+                {shortenPath(diagnostic.configPath)}
+              </span>
+              <CopyButton text={diagnostic.configPath} size="xs" />
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 ml-3">
+          {actions.repair && (
+            <Button size="sm" variant="warning" onClick={onRepair} disabled={loading}>
+              {t("integrations.installMcp.repair")}
+            </Button>
+          )}
+          {actions.update && (
+            <Button size="sm" onClick={onPreview} disabled={loading}>
+              {t("integrations.installMcp.update")}
+            </Button>
+          )}
+          {actions.remove && (
+            <Button size="sm" variant="danger" onClick={onUninstall} disabled={loading}>
+              {t("integrations.installMcp.remove")}
+            </Button>
+          )}
+          {actions.install && (
+            <Button size="sm" variant="primary" onClick={onPreview} disabled={loading}>
+              {t("integrations.installMcp.install")}
+            </Button>
+          )}
+          {actions.recheck && (
+            <Button size="sm" onClick={onRecheck} disabled={loading}>
+              {t("integrations.installMcp.recheck")}
+            </Button>
+          )}
+        </div>
+      </div>
+      {diagnosticText && (
+        <div
+          className={`mt-1 ml-6.5 text-xs ${
+            broken ? "text-[var(--error-color)]" : "text-[var(--warning-color)]"
+          }`}
+        >
+          {diagnosticText}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/settings/mcpConfigMessages.test.ts
+++ b/src/pages/settings/mcpConfigMessages.test.ts
@@ -17,6 +17,7 @@ function diagnostic(over: Partial<ProviderDiagnostic> = {}): ProviderDiagnostic 
   return {
     provider: "claude",
     name: "Claude Code",
+    legacy: false,
     configPath: "/Users/someone/.claude.json",
     configExists: true,
     hasVmark: false,
@@ -80,6 +81,20 @@ describe("rowActions", () => {
       remove: false,
     });
   });
+
+  it("offers only Remove on a legacy provider, whatever its status", () => {
+    // A legacy row exists only because a vmark entry is still in the config
+    // of a discontinued tool; writing a fresh entry there is refused backend-side.
+    for (const status of ["Valid", "BinaryMissing", "PathMismatch"] as const) {
+      expect(rowActions(diagnostic({ status, hasVmark: true, legacy: true }))).toEqual({
+        repair: false,
+        update: false,
+        remove: true,
+        install: false,
+        recheck: false,
+      });
+    }
+  });
 });
 
 describe("diagnosticMessage", () => {
@@ -116,6 +131,14 @@ describe("diagnosticMessage", () => {
       message: "backend says so",
     });
     expect(diagnosticMessage(unknown, t)).toBe("backend says so");
+  });
+
+  it("explains a legacy row regardless of its status", () => {
+    for (const status of ["Valid", "BinaryMissing", "PathMismatch"] as const) {
+      expect(diagnosticMessage(diagnostic({ status, legacy: true }), t)).toBe(
+        "integrations.installMcp.legacyHint",
+      );
+    }
   });
 });
 

--- a/src/pages/settings/mcpConfigMessages.ts
+++ b/src/pages/settings/mcpConfigMessages.ts
@@ -13,11 +13,19 @@
  * `message` is a parse/IO detail (localized Rust-side via `errors.mcp.*`) that
  * the frontend cannot reconstruct — it is interpolated, not replaced.
  *
+ * `legacy` is a SECOND dimension, orthogonal to `status`: it marks a provider
+ * VMark no longer targets (Gemini CLI), whose row exists only to remove a
+ * leftover entry. It short-circuits both functions here, because a
+ * discontinued tool's row offers the same one action and the same advice
+ * whatever its config happens to say.
+ *
  * Kept out of the component file so the derivation can grow without pushing
- * `McpConfigInstaller.tsx` further over the file-size baseline.
+ * `McpConfigInstaller.tsx` back over the 300-line limit; the row markup itself
+ * lives in `McpProviderRow.tsx` for the same reason.
  *
  * @coordinates-with src-tauri/src/mcp_config/commands.rs — builds the prose these replace
- * @coordinates-with src-tauri/src/mcp_config/types.rs — DiagnosticStatus, UninstallResult.changed
+ * @coordinates-with src-tauri/src/mcp_config/types.rs — DiagnosticStatus, ProviderDiagnostic.legacy, UninstallResult.changed
+ * @coordinates-with src/pages/settings/McpProviderRow.tsx — the sole consumer of rowActions
  * @module pages/settings/mcpConfigMessages
  */
 
@@ -29,6 +37,9 @@ import type { DiagnosticStatus } from "./DiagnosticIcon";
 export interface ProviderDiagnostic {
   provider: string;
   name: string;
+  /** A discontinued tool. The backend lists it only while a vmark entry is
+   * still in its config; the row offers removal and nothing else. */
+  legacy: boolean;
   configPath: string;
   configExists: boolean;
   hasVmark: boolean;
@@ -66,10 +77,19 @@ export interface RowActions {
  * the old `showInstall = !hasVmark` turned that unknown into an Install button
  * pointed at a file the install path refuses to parse. Recheck replaces it:
  * the fix happens in the user's editor, and this re-runs the diagnosis.
+ *
+ * A legacy row exists only to be removed: Install/Update/Repair would write a
+ * fresh entry into the config of a discontinued tool, and the backend refuses
+ * them anyway.
  */
-export function rowActions(diagnostic: Pick<ProviderDiagnostic, "status" | "hasVmark">): RowActions {
+export function rowActions(
+  diagnostic: Pick<ProviderDiagnostic, "status" | "hasVmark" | "legacy">,
+): RowActions {
   if (diagnostic.status === "ConfigUnreadable") {
     return { repair: false, update: false, remove: false, install: false, recheck: true };
+  }
+  if (diagnostic.legacy) {
+    return { repair: false, update: false, remove: true, install: false, recheck: false };
   }
   const mismatch = diagnostic.status === "PathMismatch";
   return {
@@ -90,9 +110,14 @@ export function rowActions(diagnostic: Pick<ProviderDiagnostic, "status" | "hasV
  * silently rendering blank.
  */
 export function diagnosticMessage(
-  diagnostic: Pick<ProviderDiagnostic, "status" | "message" | "configPath">,
+  diagnostic: Pick<ProviderDiagnostic, "status" | "message" | "configPath" | "legacy">,
   t: TFunction<"settings">,
 ): string {
+  // A legacy row is present precisely because there is something to remove;
+  // whatever else its status says, the advice is the same.
+  if (diagnostic.legacy) {
+    return t("integrations.installMcp.legacyHint");
+  }
   switch (diagnostic.status) {
     case "BinaryMissing":
       return t("integrations.installMcp.statusBinaryMissing");

--- a/src/plugins/linkPopup/LinkPopupView.test.ts
+++ b/src/plugins/linkPopup/LinkPopupView.test.ts
@@ -80,6 +80,7 @@ import { Schema } from "@tiptap/pm/model";
 import { EditorState, type Transaction } from "@tiptap/pm/state";
 // isImeKeyEvent is mocked above — no direct import needed
 import { linkPopupError } from "@/utils/debug";
+import { ASYNC_IMPORT_WAIT } from "@/test/waitBudget";
 
 // ---------------------------------------------------------------------------
 // Document fixture: <p><a href=HREF>link</a> tail</p> — the link spans 1..5,
@@ -471,7 +472,7 @@ describe("LinkPopupView", () => {
 
     await vi.waitFor(() => {
       expect(openUrl).toHaveBeenCalledWith(HREF);
-    });
+    }, ASYNC_IMPORT_WAIT);
 
     popup.destroy();
   });
@@ -489,7 +490,7 @@ describe("LinkPopupView", () => {
 
     await vi.waitFor(() => {
       expect(openUrl).toHaveBeenCalledWith("https://pasted.example");
-    });
+    }, ASYNC_IMPORT_WAIT);
 
     popup.destroy();
   });
@@ -513,8 +514,8 @@ describe("LinkPopupView", () => {
         "../appendix/cards.md#bern",
         null,
       );
-    });
-    await vi.waitFor(() => expect(mockClosePopup).toHaveBeenCalled());
+    }, ASYNC_IMPORT_WAIT);
+    await vi.waitFor(() => expect(mockClosePopup).toHaveBeenCalled(), ASYNC_IMPORT_WAIT);
 
     const { openUrl } = await import("@tauri-apps/plugin-opener");
     expect(openUrl).not.toHaveBeenCalled();
@@ -537,7 +538,7 @@ describe("LinkPopupView", () => {
 
     await vi.waitFor(() => {
       expect(mockOpenFilepathLink).toHaveBeenCalled();
-    });
+    }, ASYNC_IMPORT_WAIT);
     expect(mockClosePopup).not.toHaveBeenCalled();
 
     popup.destroy();
@@ -559,7 +560,7 @@ describe("LinkPopupView", () => {
     mockClosePopup.mockClear();
 
     resolveOpen(true);
-    await vi.waitFor(() => expect(mockOpenFilepathLink).toHaveBeenCalled());
+    await vi.waitFor(() => expect(mockOpenFilepathLink).toHaveBeenCalled(), ASYNC_IMPORT_WAIT);
 
     // The completion belongs to the old popup — it must not close the new one.
     expect(mockClosePopup).not.toHaveBeenCalled();
@@ -598,7 +599,7 @@ describe("LinkPopupView", () => {
 
     await vi.waitFor(() => {
       expect(writeText).toHaveBeenCalledWith("https://pasted.example");
-    });
+    }, ASYNC_IMPORT_WAIT);
 
     popup.destroy();
   });
@@ -624,7 +625,7 @@ describe("LinkPopupView", () => {
         "Failed to copy URL:",
         expect.any(Error)
       );
-    });
+    }, ASYNC_IMPORT_WAIT);
 
     popup.destroy();
 

--- a/src/plugins/linkPopup/__tests__/LinkPopupView.test.ts
+++ b/src/plugins/linkPopup/__tests__/LinkPopupView.test.ts
@@ -60,6 +60,7 @@ vi.mock("@/plugins/shared/popupHostDom", () => ({
 
 // Import after mocking
 import { LinkPopupView } from "../LinkPopupView";
+import { ASYNC_IMPORT_WAIT } from "@/test/waitBudget";
 
 // Helper functions
 const createMockRect = (overrides: Partial<DOMRect> = {}): DOMRect => ({
@@ -317,7 +318,7 @@ describe("LinkPopupView", () => {
       // Use vi.waitFor to reliably wait for the async dynamic import chain
       await vi.waitFor(() => {
         expect(mockOpenUrl).toHaveBeenCalledWith("https://test.com");
-      });
+      }, ASYNC_IMPORT_WAIT);
     });
 
     it("copy button copies URL to clipboard", async () => {

--- a/src/plugins/linkPopup/tiptap.test.ts
+++ b/src/plugins/linkPopup/tiptap.test.ts
@@ -420,7 +420,7 @@ describe("linkPopupExtension", () => {
       // Wait deterministically for the dynamic openUrl import to resolve.
       await vi.waitFor(() => {
         expect(mockOpenUrl).toHaveBeenCalledWith("http://example.com");
-      });
+      }, { timeout: 5000 }); // budget: src/test/waitBudget.ts
     });
 
     it("Ctrl+click on external link opens in browser", async () => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,13 @@
 import "@testing-library/jest-dom";
+import { configure as configureTestingLibrary } from "@testing-library/react";
 import { expect, vi } from "vitest";
 import React from "react";
 import "./localStorageShim";
+import { ASYNC_IMPORT_WAIT } from "./waitBudget";
+
+// Suite-wide async-wait budget. Rationale (and the `vi.waitFor` twin, which
+// has no global equivalent) live in `./waitBudget`.
+configureTestingLibrary({ asyncUtilTimeout: ASYNC_IMPORT_WAIT.timeout });
 
 // vitest-axe matchers (RW-15 / L11): register `toHaveNoViolations` globally so
 // a11y tests can assert `expect(await axe(el)).toHaveNoViolations()`.

--- a/src/test/waitBudget.ts
+++ b/src/test/waitBudget.ts
@@ -1,0 +1,19 @@
+/**
+ * Purpose: the one async-wait budget for the test suite.
+ *
+ * `setup.ts` feeds it to Testing Library's `configure({ asyncUtilTimeout })`,
+ * which covers every `waitFor`/`findBy*` in the codebase. `vi.waitFor` has no
+ * global equivalent, so those call sites pass this object explicitly.
+ *
+ * Why it exists: 1000ms (vitest's default) is a WALL-CLOCK budget, and the full
+ * suite runs ~1450 files across every core at once. A wait on a dynamic import
+ * can miss that budget because the worker was descheduled rather than because
+ * the code is wrong — three consecutive full runs failed on three disjoint sets
+ * of such tests, every one passing in isolation. Raising the bound costs
+ * nothing on the passing path and still fails a real regression, just later.
+ *
+ * @module test/waitBudget
+ */
+
+/** Wait budget, in the options shape `vi.waitFor` takes. */
+export const ASYNC_IMPORT_WAIT = { timeout: 5000 } as const;

--- a/src/utils/ccswitchLink.test.ts
+++ b/src/utils/ccswitchLink.test.ts
@@ -27,9 +27,31 @@ describe("buildCcSwitchImportLink", () => {
     expect(q.name).toBe("vmark");
   });
 
-  it("defaults apps to claude,codex,gemini (comma-separated, literal)", () => {
+  it("defaults apps to claude,codex,grok,opencode (comma-separated, literal)", () => {
     const link = buildCcSwitchImportLink("/bin/x");
-    expect(link).toContain("apps=claude,codex,gemini");
+    expect(link).toContain("apps=claude,codex,grok,opencode");
+  });
+
+  it("only names app ids CC-Switch's parser accepts", () => {
+    // CC-Switch rejects the ENTIRE link if any one id is unknown, so a typo or
+    // a VMark-side provider id smuggled in here breaks the hand-off silently
+    // from VMark's side. This is the id set its `parse_mcp_deeplink` matches.
+    const accepted = new Set([
+      "claude",
+      "codex",
+      "gemini",
+      "grokbuild",
+      "grok",
+      "opencode",
+      "openclaw",
+      "hermes",
+    ]);
+    const q = parseQuery(buildCcSwitchImportLink("/bin/x"));
+    for (const app of q.apps.split(",")) {
+      expect(accepted, `CC-Switch would reject "${app}"`).toContain(app);
+    }
+    // VMark's own provider id for Antigravity has no CC-Switch counterpart.
+    expect(q.apps).not.toContain("antigravity");
   });
 
   it("honors a custom apps list", () => {

--- a/src/utils/ccswitchLink.ts
+++ b/src/utils/ccswitchLink.ts
@@ -15,8 +15,21 @@
  * @module utils/ccswitchLink
  */
 
-/** AI CLIs CC-Switch can sync VMark's MCP entry into, by default. */
-const DEFAULT_APPS = ["claude", "codex", "gemini"];
+/**
+ * AI CLIs CC-Switch can sync VMark's MCP entry into, by default.
+ *
+ * These are **CC-Switch's** app ids, not VMark's provider ids, and its parser
+ * rejects the whole link if any one of them is unknown — so this list may only
+ * contain ids CC-Switch accepts: `claude`, `codex`, `gemini`, `grokbuild`,
+ * `grok`, `opencode`, `openclaw`, `hermes`. In particular **Antigravity is not
+ * one of them**, so VMark's own `antigravity` provider has no counterpart here;
+ * it is installed through the panel's own Install button instead.
+ *
+ * `gemini` is deliberately absent: Gemini CLI is discontinued (see the legacy
+ * provider in `providers.rs`), and a default hand-off should not write a fresh
+ * entry into a tool VMark is retiring.
+ */
+const DEFAULT_APPS = ["claude", "codex", "grok", "opencode"];
 
 /**
  * Build a CC-Switch import deep link for VMark's MCP server.
@@ -24,7 +37,7 @@ const DEFAULT_APPS = ["claude", "codex", "gemini"];
  * @param binaryPath Absolute path to the `vmark-mcp-server` sidecar binary
  *   (this is machine-specific, so the link is for the user's own machine,
  *   not for sharing across machines).
- * @param apps CC-Switch app ids to import into (default: claude, codex, gemini).
+ * @param apps CC-Switch app ids to import into (default: see `DEFAULT_APPS`).
  */
 export function buildCcSwitchImportLink(
   binaryPath: string,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,20 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
+    // A test timeout is a LIVENESS bound — "this hung" — not a performance
+    // assertion. Vitest's 5000ms default is sized for an isolated unit test,
+    // but this suite runs ~1450 files across every core at once, so for any
+    // test doing real I/O, a dynamic import, or a heavy render, 5000ms of wall
+    // clock measures how busy the machine is rather than whether the code is
+    // correct. Four separate tests failed that way in one session — at 5072ms,
+    // 6814ms and ~1000ms waits — each passing in isolation in a few seconds.
+    //
+    // Raising it cannot mask a correctness bug: a wrong result still fails
+    // immediately, and only a genuine hang takes longer to report. Actual
+    // performance budgets stay explicit and separate (see
+    // `fullwidthScaling.test.ts`), where they belong.
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
     include: [
       "src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
       "scripts/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",

--- a/website/guide/mcp-setup.md
+++ b/website/guide/mcp-setup.md
@@ -39,7 +39,16 @@ Supported AI assistants:
 - **Claude Desktop** - Anthropic's desktop app
 - **Claude Code** - CLI for developers
 - **Codex CLI** - OpenAI's coding assistant
-- **Gemini CLI** - Google's AI assistant
+- **Antigravity CLI** - Google's `agy`, the successor to Gemini CLI
+- **Grok CLI** - xAI's coding agent
+- **opencode** - the open-source, provider-agnostic terminal agent
+
+::: info Gemini CLI is discontinued
+Google replaced Gemini CLI with Antigravity. If an earlier VMark install left a
+`vmark` entry in `~/.gemini/settings.json`, the Integrations panel shows a
+**Discontinued** row for it with a **Remove** button; new installs target
+Antigravity instead.
+:::
 
 ::: info Other MCP-Compatible Clients
 Other MCP-compatible clients such as Cursor, Windsurf, and similar tools can also connect to VMark's MCP server. Configure them manually by pointing to the MCP server binary path (see [Manual Configuration](#manual-configuration) below).
@@ -129,9 +138,9 @@ Edit `~/.codex/config.toml`:
 command = "/Applications/VMark.app/Contents/MacOS/vmark-mcp-server"
 ```
 
-### Gemini CLI
+### Antigravity CLI
 
-Edit `~/.gemini/settings.json`:
+Edit `~/.gemini/config/mcp_config.json`:
 
 ```json
 {
@@ -142,6 +151,46 @@ Edit `~/.gemini/settings.json`:
   }
 }
 ```
+
+### Grok CLI
+
+Edit `~/.grok/config.toml`:
+
+```toml
+[mcp_servers.vmark]
+command = "/Applications/VMark.app/Contents/MacOS/vmark-mcp-server"
+```
+
+### opencode
+
+Edit `~/.config/opencode/opencode.json`. opencode's schema differs from the
+`mcpServers` one: the key is `mcp`, and `command` is a single array holding
+the program and its arguments:
+
+```json
+{
+  "mcp": {
+    "vmark": {
+      "type": "local",
+      "command": ["/Applications/VMark.app/Contents/MacOS/vmark-mcp-server"],
+      "enabled": true
+    }
+  }
+}
+```
+
+If your own settings live in `opencode.jsonc`, leave them there — opencode
+merges both files, so VMark's entry in `opencode.json` is additive. VMark writes
+the plain-JSON file because it cannot round-trip the comments in a `.jsonc` one.
+
+::: warning An existing `vmark` entry in `opencode.jsonc` wins
+opencode merges `config.json`, then `opencode.json`, then `opencode.jsonc`, and
+the last one read takes precedence. So if you previously added a `vmark` entry
+to `opencode.jsonc` by hand, it overrides the one VMark manages — VMark will
+report the provider as valid while opencode keeps using your older entry (and
+its stale binary path). Delete the hand-written `mcp.vmark` block from
+`opencode.jsonc` and let the Integrations panel own it.
+:::
 
 ::: tip Finding the Binary Path
 On macOS, the MCP server binary is inside VMark.app:


### PR DESCRIPTION
## What

Settings → Integrations targets the AI CLIs that are actually current:

| Provider | Config file | Format |
|---|---|---|
| Antigravity CLI (`agy`) | `~/.gemini/config/mcp_config.json` | `mcpServers` JSON |
| Grok CLI | `~/.grok/config.toml` | `[mcp_servers.*]` TOML |
| opencode | `~/.config/opencode/opencode.json` | `mcp` JSON, own schema |
| Gemini CLI | `~/.gemini/settings.json` | legacy — removal only |

Gemini CLI is discontinued (replaced by Antigravity); opencode and Grok had no support at all.

## Notes for review

**Paths were verified against the installed binaries, not docs.** `agy`'s own preflight reads `~/.gemini/config/mcp_config.json` — *not* the legacy `settings.json` in the same tree. Grok's bundled docs specify `[mcp_servers.<name>]`, the shape Codex already uses.

**opencode needed a real schema, not just a path.** Server map is `mcp` (not `mcpServers`), `command` is one array of program-plus-arguments, env vars live under `environment`. VMark owns `command[0]`, `type` and the credential; user arguments, other env vars and a deliberate `enabled: false` survive a Repair.

**opencode.json vs opencode.jsonc.** VMark writes plain JSON because `serde_json` cannot round-trip comments. opencode deep-merges `config.json` → `opencode.json` → `opencode.jsonc`, so the entry is additive — but a *hand-written* `vmark` entry in the `.jsonc` wins, which would let VMark report "valid" while opencode used a stale one. Documented as a warning.

**Gemini CLI is retired, not deleted.** Its row appears only while its config still holds a `vmark` entry; preview and install refuse it, uninstall stays available — removing the leftover entry is the row's entire purpose.

**CC-Switch ids are a different vocabulary.** Read from its `parse_mcp_deeplink`: an unknown id rejects the *entire* link, and it has no `antigravity`. So the default list gains `grok`/`opencode`, drops `gemini`, and excludes `antigravity` deliberately. A test pins it against the accepted set.

## Flake fixes (third commit)

Five tests across four unrelated areas failed in full-suite runs while passing in isolation; three consecutive runs gave three *disjoint* failure sets. Root cause: **no vitest project set `testTimeout`**, so all three ran on the 5000ms default — which, with ~1450 files across every core, measures machine load rather than correctness. Observed failures were 5072ms and 6814ms; one missed by 72ms.

A test timeout is a **liveness** bound, not a performance assertion, so raising it cannot mask a correctness bug. Real performance budgets stay explicit — `fullwidthScaling` keeps its 2000ms ceiling and 12× ratio untouched; its *sampling* became best-of-5, which is strictly more sensitive to genuine quadratic blow-up than relaxing the bound.

## Verification

`pnpm check:all` green end-to-end: 35309 + 500 + 159 tests, coverage 94.27/90.60/93.74/95.13 against floors 93.9/90.35/93.4/94.7, all 25 lint gates, three builds. Rust: `fmt --check`, `clippy -D warnings`, 1908/1908.