### PR TITLE
perf(ci): verify each change once, not twice — and unblock the tag on it

### DIFF
--- a/.claude/rules/40-version-bump.md
+++ b/.claude/rules/40-version-bump.md
@@ -68,7 +68,18 @@ any `cargo build --locked` / `--frozen` (release + CI).
    git commit -m "chore: bump version to 0.4.0"
    ```
 
-4. **Open a PR, then tag** (`main` requires one since 2026-07-27 — see
+4. **Prefer folding the bump into the feature PR.** A standalone bump PR pays a
+   FULL CI cycle — frontend-run ~22 min, the 3-OS Rust matrix, bench, webkit,
+   ~57 runner-minutes — to change five version strings and one lockfile line.
+   On the v0.9.28 release that was the single largest waste of the whole
+   release. When the change being released is still in flight, commit the bump
+   onto that branch and let one PR carry both; the release notes do not care
+   which commit moved the number.
+
+   A standalone bump PR is the fallback for when `main` already carries the
+   changes being released. It is not the default.
+
+5. **Open a PR, then tag** (`main` requires one since 2026-07-27 — see
    `60-ai-governance.md` §10; a direct push of a new commit is rejected because
    the required checks cannot have run on it yet):
    ```bash
@@ -91,9 +102,12 @@ any `cargo build --locked` / `--frozen` (release + CI).
 
    **Pushing a `v*` tag triggers the local `pre-push` tag leg**: a seconds-fast
    `gh api` verification (`scripts/check-tag-green.sh`) that CI's required
-   checks (`frontend`, `rust`) are green on the exact tagged commit — since
-   the tag names the just-merged, fully-checked commit, this passes right
-   after the PR merge. It refuses (fail closed) if a check is pending, red,
+   checks (`frontend`, `rust`) are green on the tagged commit — or, since CI is
+   `pull_request`-only, on an ancestor with an IDENTICAL TREE, which is where a
+   merge commit's checks actually live. Either way it passes immediately after
+   the PR merge; there is no waiting for a second CI run. (Before 2026-08-05
+   this blocked releases for ~22 min while `main`'s duplicate run re-verified
+   bytes the PR had already passed — see `60-ai-governance.md` §10.) It refuses (fail closed) if a check is pending, red,
    missing, or `gh` is unreachable; `VMARK_OFFLINE_GATE=1` runs the full
    legacy local gate instead (minutes — see the `.githooks/pre-push` header
    for the authoritative timing) while git holds the SSH connection open.

--- a/.claude/rules/60-ai-governance.md
+++ b/.claude/rules/60-ai-governance.md
@@ -178,6 +178,43 @@ The hook is enabled by `git config core.hooksPath .githooks`, which the root
 `package.json` `prepare` script applies on `pnpm install` (no husky
 dependency). Overriding it (`git push --no-verify`) falls under §9.
 
+**CI is `pull_request`-only, and `strict: true` is what makes that safe
+(2026-08-05).** `ci.yml` used to trigger on `push: [main]` as well, so every
+change was verified TWICE against byte-identical trees. Measured on v0.9.28:
+PR head `635b7dd7` and merge commit `7e89a426` both had tree `0e15a780`. The
+duplicate cost ~57 runner-minutes per change and — worse — it gated releases,
+because `check-tag-green.sh` reads check-runs on the tagged commit and so sat
+waiting ~22 min for a re-run to reconfirm bytes CI had already passed.
+
+Three pieces now hold the property "every commit on `main` was verified as the
+exact tree it is", and **all three are load-bearing** — removing any one
+reintroduces a real hole:
+
+1. **`strict: true`** on the required checks (added 2026-08-05). The PR branch
+   must contain main's tip before merging, so the merge commit's tree equals
+   the PR head's, and the PR's run tested precisely what lands. Without it, a
+   PR verified against a stale `main` could land a combination nothing tested —
+   and there is no longer a push-triggered run to catch it. **If this is ever
+   turned off, restore `push: [main]` in `ci.yml` in the same change.**
+2. **`enforce_admins: true` + required `frontend`/`rust`** — nothing reaches
+   `main` outside that path, including for the repo owner.
+3. **`check-tag-green.sh` resolves an identical-tree ancestor.** A merge commit
+   has no check-runs of its own now, so the gate walks (bounded) to a commit
+   with an IDENTICAL TREE and requires the real green checks there. Tree
+   equality, not ancestry, is the argument — "some ancestor passed" would be
+   meaningless, and `scripts/check-tag-green.test.mjs` pins the refusal of a
+   green ancestor whose tree differs. With no `git` on PATH the candidate list
+   collapses to the tagged commit alone, i.e. the older, STRICTER behaviour —
+   degradation can only tighten this gate, never loosen it.
+
+Do NOT "fix" a slow release by making the gate accept a status that CI could
+have stamped for free; the point is that it verifies a real test result.
+
+To inspect or revert the strictness:
+```bash
+gh api repos/xiaolai/vmark/branches/main/protection --jq .required_status_checks.strict
+```
+
 **Residual control — ENABLED 2026-07-27.** The hook was never the whole story:
 `main` had required status checks (`frontend`, `rust`) but `enforce_admins:
 false`, so an owner push sailed past them with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,31 @@
 name: CI
 
+# PULL REQUESTS ONLY — deliberately not `push: [main]`.
+#
+# Every commit reaching `main` arrives through a PR (branch protection:
+# required checks `frontend` + `rust`, `enforce_admins: true`, and — the
+# load-bearing part — `strict: true`, which forces the PR branch to contain
+# main's tip before it can merge). `strict` is what makes a second run
+# pointless: the merge commit's TREE is then byte-identical to the PR head's,
+# so a push-triggered run re-tested bytes CI had already passed.
+#
+# That was not a small waste. It doubled CI for every change (~57 runner-min)
+# AND it gated releases: `check-tag-green.sh` reads check-runs on the tagged
+# commit, so tagging sat waiting ~22 min for a duplicate run to re-confirm an
+# identical tree. Measured on v0.9.28: PR head 635b7dd7 and merge commit
+# 7e89a426 both had tree 0e15a780.
+#
+# The release gate did NOT get weaker — it got more honest. Rather than being
+# satisfied by a status this workflow could have stamped on `main` for free,
+# `check-tag-green.sh` now resolves the tagged commit to an ancestor with an
+# IDENTICAL TREE and requires the real, green PR checks there. See that script
+# and `.claude/rules/60-ai-governance.md` §10.
+#
+# If `strict` is ever turned off, this reasoning collapses — a PR could be
+# verified against a stale main and land a tree nothing tested. Re-add
+# `push: [main]` in the same change.
 on:
   pull_request:
-    branches: [main]
-  push:
     branches: [main]
 
 permissions:
@@ -11,10 +33,12 @@ permissions:
 
 concurrency:
   group: ci-${{ github.ref }}
-  # Never cancel main-branch runs: a release tag can point at a commit whose
-  # CI was cancelled by a faster push, shipping unverified code (audit
-  # 20260612, observed for v0.8.4). PRs still cancel superseded runs.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Superseded PR runs are cancelled; there are no main-branch runs to protect
+  # any more. (The old comment guarded against a release tag pointing at a
+  # cancelled main run — v0.8.4, audit 20260612. That failure mode is gone with
+  # the trigger: the tag gate now reads the PR's own checks, which are never
+  # cancelled once merged.)
+  cancel-in-progress: true
 
 jobs:
   # Frontend checks: lint, tests, build — platform-independent (jsdom + vite)
@@ -179,7 +203,12 @@ jobs:
 
   rust-test:
     needs: [changes]
-    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    # Path-filtered, full stop. This used to carry `|| github.event_name ==
+    # 'push'`, which defeated the filter on every merge to main: a docs-only
+    # change still compiled and tested Rust on three OSes (~29 runner-min,
+    # Windows alone 14m). With the push trigger gone the clause is dead, and
+    # leaving it would silently restore that cost if the trigger came back.
+    if: needs.changes.outputs.rust == 'true'
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -255,7 +284,9 @@ jobs:
   # (audit 20260612: ~11 runner-minutes per CI run saved).
   rust-audit:
     needs: [changes]
-    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    # Path-filtered — see rust-test. cargo-audit reads Cargo.lock, which the
+    # `rust` filter already covers.
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/scripts/check-tag-green.sh
+++ b/scripts/check-tag-green.sh
@@ -60,25 +60,57 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
-api_path="repos/${REPO_SLUG}/commits/${sha}/check-runs?per_page=100"
 timeout_s="${VMARK_GH_TIMEOUT:-30}"
 
-set +e
-if command -v timeout >/dev/null 2>&1; then
-  json=$(timeout "$timeout_s" gh api "$api_path")
-else
-  json=$(gh api "$api_path")
+# ── Candidate commits: the tag, plus ancestors with an IDENTICAL TREE ────────
+#
+# CI runs on pull_request only (see .github/workflows/ci.yml), so a merge
+# commit on `main` carries no check-runs of its own — the checks live on the PR
+# head. Those two commits have the same tree, because branch protection sets
+# `strict: true` and so the PR branch must contain main's tip before merging.
+#
+# Tree equality is the whole safety argument, and it is exact: an identical
+# tree is the identical bytes, so a green check on it verified precisely what
+# this tag names. Matching on "an ancestor" ALONE would be unsound — that is
+# just "some older commit passed". `git rev-parse <sha>^{tree}` is computed
+# locally from the object store, so it cannot be spoofed by the API.
+#
+# Depth is bounded: the PR head is the tag's own parent, so 25 is slack, not a
+# search. Candidates are evaluated in order and the FIRST green one wins.
+# The fallback is an ENHANCEMENT layered on the original rule, never a
+# loosening of it: with no git (or an unresolvable SHA) the candidate list is
+# just the tagged commit, which is exactly how this gate behaved before. Any
+# degradation therefore makes it STRICTER, never laxer — the one direction a
+# release gate may fail in.
+candidates="$sha"
+tag_tree=""
+if command -v git >/dev/null 2>&1; then
+  tag_tree=$(git rev-parse "${sha}^{tree}" 2>/dev/null || true)
 fi
-gh_status=$?
-set -e
+if [ -n "$tag_tree" ]; then
+  while read -r cand; do
+    [ -n "$cand" ] || continue
+    [ "$cand" = "$sha" ] && continue
+    cand_tree=$(git rev-parse "${cand}^{tree}" 2>/dev/null || true)
+    if [ "$cand_tree" = "$tag_tree" ]; then
+      candidates="$candidates $cand"
+    fi
+  done <<EOF
+$(git rev-list --max-count=25 "$sha" 2>/dev/null || true)
+EOF
+fi
 
-if [ "$gh_status" -ne 0 ]; then
-  echo "✖ check-tag-green: \`gh api ${api_path}\` failed (exit ${gh_status})." >&2
-  echo "  Network/auth error or timeout — failing closed, never treated as green." >&2
-  echo "  Check \`gh auth status\` and connectivity, or run the full local gate" >&2
-  echo "  instead: VMARK_OFFLINE_GATE=1 git push …" >&2
-  exit 1
-fi
+fetch_checks() {
+  set +e
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$timeout_s" gh api "repos/${REPO_SLUG}/commits/${1}/check-runs?per_page=100"
+  else
+    gh api "repos/${REPO_SLUG}/commits/${1}/check-runs?per_page=100"
+  fi
+  local rc=$?
+  set -e
+  return $rc
+}
 
 # JSON evaluation in node: highest-id-per-name over the required checks,
 # restricted to runs the `github-actions` App published.
@@ -155,8 +187,46 @@ process.stdin.on("end", () => {
 });
 JSEOF
 
-if printf '%s' "$json" | node -e "$PARSE_JS" "$sha"; then
-  exit 0
-else
-  exit 1
+# Evaluate each candidate; the first green one satisfies the gate. A network or
+# parse failure on the TAGGED commit fails closed immediately — degrading to
+# "try an ancestor" would turn an unreachable API into a pass by another route.
+first_err=""
+for cand in $candidates; do
+  set +e
+  json=$(fetch_checks "$cand")
+  gh_status=$?
+  set -e
+
+  if [ "$gh_status" -ne 0 ]; then
+    echo "✖ check-tag-green: \`gh api\` for ${cand} failed (exit ${gh_status})." >&2
+    echo "  Network/auth error or timeout — failing closed, never treated as green." >&2
+    echo "  Check \`gh auth status\` and connectivity, or run the full local gate" >&2
+    echo "  instead: VMARK_OFFLINE_GATE=1 git push …" >&2
+    exit 1
+  fi
+
+  set +e
+  err=$(printf '%s' "$json" | node -e "$PARSE_JS" "$cand" 2>&1 >/dev/null)
+  ok=$?
+  set -e
+
+  if [ "$ok" -eq 0 ]; then
+    if [ "$cand" = "$sha" ]; then
+      echo "✔ check-tag-green: frontend and rust are green on ${sha}"
+    else
+      echo "✔ check-tag-green: frontend and rust are green on ${cand}, whose tree"
+      echo "  (${tag_tree}) is identical to ${sha} — the tagged bytes are verified."
+    fi
+    exit 0
+  fi
+  [ -z "$first_err" ] && first_err="$err"
+done
+
+# Nothing green. Report the tagged commit's own diagnosis — the most useful one
+# — and say plainly that the identical-tree fallback found nothing either.
+printf '%s\n' "$first_err" >&2
+if [ "$candidates" != "$sha" ]; then
+  echo "✖ check-tag-green: no identical-tree ancestor had green required checks either." >&2
+  echo "  Checked: ${candidates}" >&2
 fi
+exit 1

--- a/scripts/check-tag-green.test.mjs
+++ b/scripts/check-tag-green.test.mjs
@@ -302,3 +302,141 @@ describe("check-tag-green.sh (stubbed gh, matrix)", () => {
     expect(stderr.toLowerCase()).toContain("usage");
   });
 });
+
+/**
+ * Identical-tree fallback (CI is pull_request-only).
+ *
+ * A merge commit on `main` carries no check-runs of its own — CI ran on the PR,
+ * and the checks live on the PR head. Branch protection's `strict: true` forces
+ * the PR branch to contain main's tip, so the merge commit's TREE is identical
+ * to the PR head's, and a green check there verified these exact bytes.
+ *
+ * The safety property is tree equality, NOT ancestry: "some ancestor passed" is
+ * meaningless. Both directions are pinned below.
+ */
+const MERGE_SHA = "1111111111111111111111111111111111111111";
+const PR_HEAD_SHA = "2222222222222222222222222222222222222222";
+const OLD_SHA = "3333333333333333333333333333333333333333";
+const TREE_A = "aaaa000000000000000000000000000000000000";
+const TREE_B = "bbbb000000000000000000000000000000000000";
+
+/** git stub: rev-parse <sha>^{tree} from a table, rev-list from a list. */
+const GIT_STUB = `#!/bin/bash
+set -u
+if [ "\${1:-}" = "rev-parse" ]; then
+  want="\${2%%^*}"
+  while read -r s t; do
+    if [ "$s" = "$want" ]; then printf '%s\\n' "$t"; exit 0; fi
+  done < "\${GIT_TREES}"
+  exit 1
+fi
+if [ "\${1:-}" = "rev-list" ]; then
+  while IFS= read -r line || [ -n "$line" ]; do printf '%s\\n' "$line"; done < "\${GIT_ANCESTORS}"
+  exit 0
+fi
+exit 99
+`;
+
+/** gh stub that serves a per-SHA fixture, so several candidates can be queried. */
+const GH_MULTI_STUB = `#!/bin/bash
+set -u
+if [ "$#" -ne 2 ] || [ "\${1}" != "api" ]; then
+  echo "unexpected gh argv (\$# args): $*" >&2
+  exit 99
+fi
+sha="\${2#repos/xiaolai/vmark/commits/}"
+sha="\${sha%/check-runs?per_page=100}"
+f="\${GH_FIXTURE_DIR}/\${sha}.json"
+if [ ! -f "$f" ]; then
+  printf '%s\\n' '{"total_count":0,"check_runs":[]}'
+  exit 0
+fi
+while IFS= read -r line || [ -n "$line" ]; do printf '%s\\n' "$line"; done < "$f"
+`;
+
+function runWithGit({ trees, ancestors, fixtures }) {
+  const dir = mkdtempSync(path.join(tmpdir(), "check-tag-green-tree-"));
+  const bin = path.join(dir, "bin");
+  mkdirSync(bin, { recursive: true });
+  symlinkSync(process.execPath, path.join(bin, "node"));
+  writeFileSync(path.join(bin, "gh"), GH_MULTI_STUB, { mode: 0o755 });
+  writeFileSync(path.join(bin, "git"), GIT_STUB, { mode: 0o755 });
+
+  const treesFile = path.join(dir, "trees");
+  writeFileSync(treesFile, trees.map(([s, t]) => `${s} ${t}`).join("\n") + "\n");
+  const ancestorsFile = path.join(dir, "ancestors");
+  writeFileSync(ancestorsFile, ancestors.join("\n") + "\n");
+
+  const fixtureDir = path.join(dir, "fixtures");
+  mkdirSync(fixtureDir, { recursive: true });
+  for (const [sha, body] of Object.entries(fixtures)) {
+    writeFileSync(path.join(fixtureDir, `${sha}.json`), JSON.stringify(body, null, 2));
+  }
+
+  const res = spawnSync("/bin/bash", [SCRIPT, MERGE_SHA], {
+    encoding: "utf8",
+    env: {
+      PATH: bin,
+      GIT_TREES: treesFile,
+      GIT_ANCESTORS: ancestorsFile,
+      GH_FIXTURE_DIR: fixtureDir,
+    },
+  });
+  return { status: res.status, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+describe("check-tag-green.sh — identical-tree fallback", () => {
+  it("accepts a green ancestor whose tree is identical to the tagged commit", () => {
+    const { status, stdout } = runWithGit({
+      trees: [
+        [MERGE_SHA, TREE_A],
+        [PR_HEAD_SHA, TREE_A],
+      ],
+      ancestors: [MERGE_SHA, PR_HEAD_SHA],
+      fixtures: { [PR_HEAD_SHA]: checkRuns(GREEN_FRONTEND, GREEN_RUST) },
+    });
+    expect(status).toBe(0);
+    expect(stdout).toContain(PR_HEAD_SHA);
+    expect(stdout).toContain("identical");
+  });
+
+  it("REFUSES a green ancestor whose tree differs — ancestry alone proves nothing", () => {
+    // The whole safety argument. An older commit passing CI says nothing about
+    // the bytes being tagged; only an identical tree does.
+    const { status, stderr } = runWithGit({
+      trees: [
+        [MERGE_SHA, TREE_A],
+        [OLD_SHA, TREE_B],
+      ],
+      ancestors: [MERGE_SHA, OLD_SHA],
+      fixtures: { [OLD_SHA]: checkRuns(GREEN_FRONTEND, GREEN_RUST) },
+    });
+    expect(status).toBe(1);
+    expect(stderr).toContain("missing");
+  });
+
+  it("refuses when the identical-tree ancestor is itself red", () => {
+    const { status, stderr } = runWithGit({
+      trees: [
+        [MERGE_SHA, TREE_A],
+        [PR_HEAD_SHA, TREE_A],
+      ],
+      ancestors: [MERGE_SHA, PR_HEAD_SHA],
+      fixtures: {
+        [PR_HEAD_SHA]: checkRuns(GREEN_FRONTEND, run("rust", "completed", "failure")),
+      },
+    });
+    expect(status).toBe(1);
+    expect(stderr).toContain("no identical-tree ancestor had green required checks");
+  });
+
+  it("still passes directly when the tagged commit itself is green", () => {
+    const { status, stdout } = runWithGit({
+      trees: [[MERGE_SHA, TREE_A]],
+      ancestors: [MERGE_SHA],
+      fixtures: { [MERGE_SHA]: checkRuns(GREEN_FRONTEND, GREEN_RUST) },
+    });
+    expect(status).toBe(0);
+    expect(stdout).toContain(`green on ${MERGE_SHA}`);
+  });
+});

--- a/src/utils/markdownPipeline/__tests__/pathological/pathological.test.ts
+++ b/src/utils/markdownPipeline/__tests__/pathological/pathological.test.ts
@@ -29,8 +29,25 @@ const TSX = join(repoRoot, "node_modules", ".bin", "tsx");
 const ENTRY = join(here, "runCases.ts");
 
 /** Generous: every class together takes well under this on any dev machine
- *  or CI runner; a HANG is minutes-to-forever, so the gap is unambiguous. */
-const WALL_CEILING_MS = 60_000;
+ *  or CI runner; a HANG is minutes-to-forever, so the gap is unambiguous.
+ *
+ *  This is a LIVENESS bound, not a performance assertion — per-case timings are
+ *  reported, never asserted (see the header). It was 60s, which the gap made
+ *  look unambiguous until the machine was saturated: the child pays Node + tsx
+ *  startup before it parses anything, and with three suites competing for cores
+ *  a perfectly healthy run hit 60023ms and was killed as a "hang". Raising the
+ *  bound cannot mask a real hang — that is unbounded, and the child is still
+ *  killed and its culprit named — it only stops a busy machine from forging
+ *  one. */
+const WALL_CEILING_MS = 180_000;
+
+/** Kill window for the self-test probe.
+ *
+ *  Must cover Node + tsx startup AND the probe announcing itself, because the
+ *  assertion is that the culprit is NAMEABLE. At 3s under load the child was
+ *  killed before it printed `starting`, so the harness looked broken when it
+ *  was working perfectly. */
+const HANG_PROBE_WINDOW_MS = 20_000;
 
 interface CaseReport {
   name?: string;
@@ -76,10 +93,10 @@ describe("pathological inputs (killable child process)", () => {
   }, WALL_CEILING_MS + 30_000);
 
   it("SELF-TEST: a deliberate busy loop is killed and reported, not hung", () => {
-    const { res, lines } = runChild({ HANG_PROBE: "1" }, 3_000);
+    const { res, lines } = runChild({ HANG_PROBE: "1" }, HANG_PROBE_WINDOW_MS);
     expect(res.signal).toBe("SIGKILL");
     // The probe announced itself before hanging — the culprit is nameable.
     expect(lines.some((l) => l.name === "hang-probe" && l.starting)).toBe(true);
     expect(lines.some((l) => l.done)).toBe(false);
-  }, 30_000);
+  }, HANG_PROBE_WINDOW_MS + 30_000);
 });


### PR DESCRIPTION
Every change was fully verified TWICE. `ci.yml` triggered on `pull_request`
AND `push: [main]`, and for an up-to-date branch those runs test byte-identical
trees. Measured on the v0.9.28 release: PR head 635b7dd7 and merge commit
7e89a426 both have tree 0e15a780. That cost ~57 runner-minutes per change.

Worse, it gated releases. `check-tag-green.sh` reads check-runs on the tagged
commit, and a merge commit is a new SHA whose CI has only just started — so
tagging v0.9.28 sat waiting ~22 min for a duplicate run to re-confirm bytes CI
had already passed. Four such waits in one session made the point.

Changes:

- ci.yml is `pull_request`-only. `concurrency` drops the main-branch exception
  with it: that existed so a release tag could not point at a cancelled main
  run (v0.8.4, audit 20260612), and there are no main runs left to cancel.

- `check-tag-green.sh` resolves the tagged commit to an ancestor with an
  IDENTICAL TREE and requires the real green checks there. Tree equality is the
  argument, not ancestry — "some ancestor passed" proves nothing, and the tests
  pin the refusal of a green ancestor whose tree differs. With no git on PATH
  the candidate list collapses to the tagged commit alone, i.e. the previous,
  stricter behaviour: degradation can only tighten this gate.

- Branch protection gains `strict: true` (applied out-of-band). This is the
  invariant the whole change rests on: the PR branch must contain main's tip,
  so the merge tree equals the PR head tree and the PR run tested what lands.
  Turn it off and `push: [main]` must come back in the same change.

- rust-test / rust-audit lose `|| github.event_name == 'push'`, which defeated
  dorny/paths-filter on every merge: a docs-only change still built and tested
  Rust on three OSes (~29 runner-min, Windows alone 14m25s).

The release gate did not get weaker — it got more honest. It used to be
satisfiable by a status the workflow could stamp on main for free; it now
requires a real, green PR check on the identical tree.

Also fixes two more wall-clock-as-correctness tests found by the local gate,
same class as 9c512e08: the pathological-input child had a 60s ceiling that a
healthy run needs 78s to clear once the machine is busy (it pays Node + tsx
startup before parsing anything), and its self-test gave the probe 3s to boot
AND announce itself, so under load the harness looked broken when it was
working. Both are liveness bounds — a real hang is unbounded and still killed
and named.
