### PR TITLE
fix(toast): use AlertCircle for error toasts + bump to 0.9.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.28",
+  "version": "0.9.29",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.28';
+const VERSION = '0.9.29';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6280,7 +6280,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.28"
+version = "0.9.29"
 dependencies = [
  "base64 0.23.0",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.28"
+version = "0.9.29"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { FeatureErrorBoundary } from "@/components/FeatureErrorBoundary";
 import { useTranslation, withTranslation, type WithTranslation } from "react-i18next";
 import { Routes, Route } from "react-router-dom";
 import { Toaster } from "sonner";
-import { CheckCircle, XCircle, Info, AlertTriangle, Loader2 } from "lucide-react";
+import { CheckCircle, AlertCircle, Info, AlertTriangle, Loader2 } from "lucide-react";
 import { DocumentSplitContainer } from "@/components/Editor";
 import { Sidebar } from "@/components/Sidebar";
 import { SidebarResizeHandle } from "@/components/Sidebar/SidebarResizeHandle";
@@ -284,7 +284,10 @@ function App() {
           closeButton
           icons={{
             success: <CheckCircle size={16} />,
-            error: <XCircle size={16} />,
+            // AlertCircle, not XCircle: an X-in-a-circle reads as a second
+            // (bigger) close button next to sonner's own closeButton. Keeping
+            // the severity ramp as i / ! / ⚠ leaves the X unique to dismissal.
+            error: <AlertCircle size={16} />,
             info: <Info size={16} />,
             warning: <AlertTriangle size={16} />,
             loading: <Loader2 size={16} className="animate-spin" />,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { FeatureErrorBoundary } from "@/components/FeatureErrorBoundary";
 import { useTranslation, withTranslation, type WithTranslation } from "react-i18next";
 import { Routes, Route } from "react-router-dom";
 import { Toaster } from "sonner";
-import { CheckCircle, AlertCircle, Info, AlertTriangle, Loader2 } from "lucide-react";
+import { TOAST_ICONS } from "@/components/toastIcons";
 import { DocumentSplitContainer } from "@/components/Editor";
 import { Sidebar } from "@/components/Sidebar";
 import { SidebarResizeHandle } from "@/components/Sidebar/SidebarResizeHandle";
@@ -282,16 +282,7 @@ function App() {
         <Toaster
           position="top-center"
           closeButton
-          icons={{
-            success: <CheckCircle size={16} />,
-            // AlertCircle, not XCircle: an X-in-a-circle reads as a second
-            // (bigger) close button next to sonner's own closeButton. Keeping
-            // the severity ramp as i / ! / ⚠ leaves the X unique to dismissal.
-            error: <AlertCircle size={16} />,
-            info: <Info size={16} />,
-            warning: <AlertTriangle size={16} />,
-            loading: <Loader2 size={16} className="animate-spin" />,
-          }}
+          icons={TOAST_ICONS}
         />
       </WindowProvider>
     </ErrorBoundary>

--- a/src/components/toastIcons.tsx
+++ b/src/components/toastIcons.tsx
@@ -1,0 +1,26 @@
+/**
+ * Purpose: the icon set sonner's `<Toaster>` renders per toast severity.
+ *
+ * Extracted from `App.tsx`, which is the document window's composition root and
+ * sits at the 300-line limit — an explanatory comment on one icon was enough to
+ * push it over. A severity→icon map is data, not composition, so it does not
+ * belong in the root anyway.
+ *
+ * @coordinates-with src/App.tsx — the sole consumer, passed as `<Toaster icons>`
+ * @module components/toastIcons
+ */
+
+import { CheckCircle, AlertCircle, Info, AlertTriangle, Loader2 } from "lucide-react";
+
+const SIZE = 16;
+
+export const TOAST_ICONS = {
+  success: <CheckCircle size={SIZE} />,
+  // AlertCircle, not XCircle: an X-in-a-circle reads as a second (and larger)
+  // close button beside sonner's own `closeButton`. Keeping the severity ramp
+  // as i / ! / ⚠ leaves the X shape unique to dismissal.
+  error: <AlertCircle size={SIZE} />,
+  info: <Info size={SIZE} />,
+  warning: <AlertTriangle size={SIZE} />,
+  loading: <Loader2 size={SIZE} className="animate-spin" />,
+};


### PR DESCRIPTION
## What

Two commits, one CI cycle:

1. **`fix(toast)`** — error toasts use `AlertCircle` instead of `XCircle`. An X-in-a-circle reads as a second (larger) close button beside sonner's own `closeButton`; keeping the severity ramp as `i` / `!` / `⚠` leaves the X unique to dismissal.
2. **`chore`** — version bump to 0.9.29 across the five files plus the derived `src-tauri/Cargo.lock`.

## Why they are in the same PR

Per `.claude/rules/40-version-bump.md`, a standalone bump PR pays a full CI cycle to change five version strings. Folding the bump into the change being released halves the pipeline for a release. This is the first release to use that path.

## Notes

The toast change is presentational and carries no test: no test references the toast icon set, and `.claude/rules/10-tdd.md` exempts visual-only changes. The rationale is recorded as a comment at the call site so the next reader does not "fix" it back to `XCircle`.