### PR TITLE
ci: migrate every action off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         run: pnpm vitest run --coverage --shard=${{ matrix.shard }}/4 --reporter=blob --reporter=default --outputFile.blob=.vitest-reports/blob-${{ matrix.shard }}.json --coverage.thresholds.lines=0 --coverage.thresholds.functions=0 --coverage.thresholds.statements=0 --coverage.thresholds.branches=0
 
       # `include-hidden-files` is REQUIRED: vitest writes blobs to
-      # `.vitest-reports/`, a dot-directory, and upload-artifact@v4 treats
+      # `.vitest-reports/`, a dot-directory, and upload-artifact treats
       # everything under one as hidden and skips it by default. The blob was
       # written and then silently not uploaded.
       #
@@ -138,7 +138,7 @@ jobs:
       # `ENOENT: scandir '.vitest-reports'` in fe-coverage — an error message
       # pointing at the consumer instead of the producer. Fail where the file
       # should have been made.
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: blob-report-${{ matrix.shard }}
           path: .vitest-reports/*
@@ -154,7 +154,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-node-pnpm
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: .vitest-reports
           pattern: blob-report-*

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/.vitepress/dist
 
@@ -76,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload mutants report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mutants-report
           path: src-tauri/mutants.out/
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload Stryker report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: stryker-report
           path: reports/mutation/

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload lcov report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rust-lcov
           path: src-tauri/lcov.info

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload failure evidence
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: soak-evidence
           path: |

--- a/.github/workflows/tier0-e2e.yml
+++ b/.github/workflows/tier0-e2e.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload journey artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tier0-e2e-artifacts
           path: e2e/artifacts/


### PR DESCRIPTION
ci: migrate every action off the deprecated Node 20 runtime

GitHub is forcing node20 actions onto Node 24 ahead of removing the runtime
(changelog 2025-09-19); download-artifact@v4 was the one warning in the log,
but an audit of every pinned ref found six.

Each action's declared runtime was read from its own action.yml at the exact
ref this repo pins, rather than inferred from version numbers:

| Action | Was | Now |
|---|---|---|
| actions/upload-artifact (x6) | v4 node20 | v7 node24 |
| actions/download-artifact | v4 node20 | v8 node24 |
| actions/deploy-pages | v4 node20 | v5 node24 |
| actions/upload-pages-artifact | v3 composite | v5 |
| actions/checkout (soak) | v4 node20 | v7 |
| actions/setup-node (soak) | v4 node20 | v7 |
| pnpm/action-setup (soak) | v4 node20 | pinned SHA, node24 |

upload-pages-artifact is the one a grep for node20 could not find: it is a
composite, and v3 wrapped upload-artifact@v4 internally. v5 wraps v7.0.0. The
whole transitive chain is now node24 — the other composites (rust-toolchain,
install-action) run only `run:` steps, and claude-code-action's setup-bun is
node24.

soak.yml had drifted furthest: it was the only workflow still on checkout@v4
and setup-node@v4, and the only one spelling pnpm/action-setup as a floating
tag while the other seven pin the SHA. It now matches.

Breaking changes checked, not assumed:

- download-artifact v5 changed path layout for single downloads BY ID; ci.yml
  downloads by `pattern` with `merge-multiple`, so it does not apply.
- v8 stops unzipping non-zipped downloads and defaults `digest-mismatch` to
  `error`. Our artifacts are zipped (`archive` defaults true), and failing on
  a hash mismatch is the loud default.
- `merge-multiple`, `include-hidden-files` and `if-no-files-found` all still
  exist — the coverage gate depends on the last two, and the comment above
  them records the silent-skip bug that cost a debugging round already.
- v6/v7 require runner >= 2.327.1; all jobs use GitHub-hosted runners.

Verified: gate tier 645 tests (including the ci.yml parity and byte-identity
checks, which read the file at runtime and no import graph can see), the GHA
suite's 575 tests including the round-trip over real workflow files, and all
workflow YAML parses.
