### PR TITLE
CI: close the Tier-0 rolling issue on green, and unbreak both watchers

### DIFF
--- a/.github/workflows/baseline-review.yml
+++ b/.github/workflows/baseline-review.yml
@@ -137,6 +137,15 @@ jobs:
         # would turn a standing reminder into a backlog of duplicates, which is
         # the failure mode the cost-report workflow already documented.
         run: |
+          # The label must EXIST before it is used: `gh issue create --label`
+          # fails outright on an unknown label, and it did — this workflow's
+          # first real run died with "could not add label: 'baseline-review' not
+          # found", having produced its whole report and then thrown it away.
+          # Creating it here rather than by hand keeps the workflow
+          # self-contained: a fresh clone or fork has no labels either.
+          # `--force` makes this idempotent.
+          gh label create baseline-review --repo "$REPO" --force \
+            --color BFD4F2 --description "Rolling issue: frozen baselines due for review."
           existing=$(gh issue list --repo "$REPO" --label baseline-review --state open \
                        --limit 1 --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then

--- a/.github/workflows/gate-liveness.yml
+++ b/.github/workflows/gate-liveness.yml
@@ -93,6 +93,15 @@ jobs:
           REPO: ${{ github.repository }}
         shell: bash
         run: |
+          # The label must EXIST before it is used: `gh issue create --label`
+          # fails outright on an unknown label, and it did — this workflow's
+          # first real run died with "could not add label: 'gate-liveness' not
+          # found", having produced its whole report and then thrown it away.
+          # Creating it here rather than by hand keeps the workflow
+          # self-contained: a fresh clone or fork has no labels either.
+          # `--force` makes this idempotent.
+          gh label create gate-liveness --repo "$REPO" --force \
+            --color BFD4F2 --description "Rolling issue: a gate declared in a workflow has stopped concluding."
           existing=$(gh issue list --repo "$REPO" --label gate-liveness --state open \
                        --limit 1 --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then

--- a/.github/workflows/tier0-e2e.yml
+++ b/.github/workflows/tier0-e2e.yml
@@ -242,3 +242,39 @@ jobs:
           else
             gh issue create --title "$TITLE" --body "$BODY"
           fi
+
+  resolve:
+    # The reporting job above only ever OPENS or comments. Nothing closed the
+    # rolling issue, so a fixed failure stayed open indefinitely and the next
+    # reader re-investigates a solved problem — issue #1243 sat open across the
+    # eight dispatches that fixed it and the green run that proved it. A rolling
+    # issue needs both edges or it is a write-only log with an issue number.
+    #
+    # Same permission split as the reporting job, for the same reason: this job
+    # checks out nothing and runs no project code, so `issues: write` is never
+    # held by the job that compiles the crate and drives a live app.
+    name: Close the tracking issue once journeys pass
+    needs: journeys
+    if: success()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Close the rolling issue
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Tier-0 E2E journeys failed"
+          NUMBER=$(gh issue list --state open --search "\"$TITLE\" in:title" \
+            --json number,title --jq ".[] | select(.title == \"$TITLE\") | .number" | head -n1)
+          if [ -z "$NUMBER" ]; then
+            echo "No open tracking issue — nothing to close."
+            exit 0
+          fi
+          gh issue close "$NUMBER" --reason completed --comment \
+            "Journeys passed on $(date -u +%Y-%m-%d): $RUN_URL (commit ${GITHUB_SHA}). Closing automatically; a later failure reopens a fresh issue."


### PR DESCRIPTION
Three workflow defects, all found by **running** the workflows rather than reading them.

## 1. The Tier-0 rolling issue had no closing edge

The reporting job is `if: failure()` and only ever opens or comments. Nothing closed the issue, so a fixed failure stayed open indefinitely. #1243 was filed by this workflow's own first run, survived the eight dispatches that fixed it and the green run that proved it, and would have stayed open through every future green run. A rolling issue needs both edges or it is a write-only log with an issue number.

The new job carries the same permission split, for the same stated reason as the reporting job: it checks out nothing and runs no project code, so `issues: write` is never held by the job that compiles the crate and drives a live desktop app. It no-ops when nothing is open.

## 2 & 3. Both watchers failed their first real run — same defect, twice

`baseline-review` and `gate-liveness` were merged earlier today and had **never run**. Dispatching them showed both dying in the same place:

```
could not add label: 'gate-liveness' not found
```

`gh issue create --label X` fails outright on an unknown label, so each workflow computed its entire report and then threw it away. Two instances of one defect, so it is fixed as a class in both files.

The label is now created idempotently by the workflow (`gh label create --force`) rather than by hand in repository settings — creating it by hand would leave the workflow depending on repo state that is not in the repo, and a fresh clone or fork would fail again somewhere nobody is watching.

## Why this keeps happening, and what already catches it

The liveness checker reported exactly this before I dispatched anything:

> ✗ baseline-review.yml: no verdict on record — it has NEVER run. A workflow that exists and never concludes protects nothing.

That is the same finding that produced the checker, after `tier0-e2e.yml` sat unrun for five days post-merge and then needed eight dispatches to work. **A scheduled workflow is unproven until it has concluded once.** These two are now proven; the concluding run IDs are recorded below once this merges.

## Verification

Both files parse to their intended jobs with the intended `needs`/`if`/permissions; `pnpm vitest --config vitest.gates.config.ts` 791 passed.