### PR TITLE
fix(ci): measure baseline staleness against real history, not a depth-1 clone

### DIFF
--- a/.github/workflows/baseline-review.yml
+++ b/.github/workflows/baseline-review.yml
@@ -56,6 +56,12 @@ jobs:
       watcherDetail: ${{ steps.watcher.outputs.detail }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Staleness is `git log -1 -- <path>`, which in the default depth-1
+          # checkout sees ONE commit and reports 0d for every baseline — the
+          # shape of a healthy register, and the exact signal this report
+          # exists to surface. Issue #1248 was filed that way.
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@v7

--- a/scripts/check-review-schedule.mjs
+++ b/scripts/check-review-schedule.mjs
@@ -174,6 +174,36 @@ function measure(entryPath) {
   return sawScalar ? scalars : null;
 }
 
+/**
+ * A shallow clone cannot answer "how long has this gone unchanged".
+ *
+ * `git log -1 -- <path>` in a depth-1 checkout can only ever return the single
+ * fetched commit, so EVERY baseline reports the run's own timestamp — 0d,
+ * forever, sorted meaninglessly. That is exactly what this report existed to
+ * detect ("a row that never moves is the finding"), rendered undetectable.
+ *
+ * It shipped that way: issue #1248 was filed with all 11 rows at 0d while the
+ * same command locally reported 0–8d. `actions/checkout` defaults to
+ * `fetch-depth: 1`, and nothing objected, because zeros look like data.
+ *
+ * Refusing is the documented contract for report mode — informational, "unless
+ * it cannot measure" — and it fails LOUD rather than publishing a table of
+ * zeros that reads as a healthy register.
+ */
+function assertCanMeasureHistory() {
+  const out = spawnSync("git", ["rev-parse", "--is-shallow-repository"], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  if (out.status !== 0 || out.stdout.trim() !== "true") return;
+  console.error(
+    "check-review-schedule --report: this is a SHALLOW clone, so every baseline " +
+      "would report 0d and the staleness column would be a lie.\n" +
+      "Fetch full history: `actions/checkout` with `fetch-depth: 0`.",
+  );
+  process.exit(1);
+}
+
 /** Days since the file last changed in git, or null when it cannot be read. */
 function daysSinceChange(entryPath, now) {
   const out = spawnSync("git", ["log", "-1", "--format=%ct", "--", entryPath], {
@@ -192,6 +222,8 @@ if (Number.isNaN(now)) {
   console.error(`--today=${todayFlag} is not a date`);
   process.exit(1);
 }
+
+assertCanMeasureHistory();
 
 const rows = Object.keys(tracked)
   .map((p) => ({ path: p, size: measure(p), stale: daysSinceChange(p, now), target: tracked[p] }))

--- a/scripts/check-review-schedule.test.mjs
+++ b/scripts/check-review-schedule.test.mjs
@@ -35,7 +35,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -155,6 +155,45 @@ describe("--report is a measurement, not a verdict", () => {
   it("validation mode needs no clock at all", () => {
     const r = run({ paths: ["a.json", "b.json"], schedule: sched });
     expect(r.status, r.stdout + r.stderr).toBe(0);
+  });
+});
+
+describe("a shallow clone cannot measure staleness", () => {
+  /** A throwaway repo with the script inside it, so ROOT resolves to it. */
+  function shallowFixture({ shallow }) {
+    const dir = mkdtempSync(path.join(tmpdir(), "review-shallow-"));
+    const git = (...args) =>
+      spawnSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", ...args], { cwd: dir, encoding: "utf8" });
+    git("init", "-q");
+    git("commit", "-q", "--allow-empty", "-m", "one");
+    mkdirSync(path.join(dir, "scripts"));
+    copyFileSync(SCRIPT, path.join(dir, "scripts", "check-review-schedule.mjs"));
+    // `git rev-parse --is-shallow-repository` answers on this file's existence.
+    if (shallow) writeFileSync(path.join(dir, ".git", "shallow"), "");
+    const m = manifestFixture(dir, ["a.json"]);
+    const s = scheduleFixture(dir, { tracked: { "a.json": "zero" }, exempt: {} });
+    return spawnSync(
+      process.execPath,
+      [path.join(dir, "scripts", "check-review-schedule.mjs"), `--manifest=${m}`, `--schedule=${s}`, "--report"],
+      { encoding: "utf8", cwd: dir },
+    );
+  }
+
+  it("refuses instead of publishing a table of zeros (issue #1248)", () => {
+    // Every row read 0d in CI because actions/checkout defaults to depth 1, so
+    // `git log -1 -- <path>` only ever saw the fetched commit. Zeros look like
+    // data, which is why nothing objected for as long as it did.
+    const r = shallowFixture({ shallow: true });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/SHALLOW/);
+    expect(r.stderr).toMatch(/fetch-depth: 0/);
+    expect(r.stdout).not.toMatch(/Unchanged for/);
+  });
+
+  it("reports normally with full history — the check is not just always-fail", () => {
+    const r = shallowFixture({ shallow: false });
+    expect(r.status, r.stdout + r.stderr).toBe(0);
+    expect(r.stdout).toMatch(/Unchanged for/);
   });
 });
 


### PR DESCRIPTION
The baseline-debt report (#1248) says *"a row that never moves is the finding"* — and its staleness column could never show one.

`actions/checkout` defaults to `fetch-depth: 1`, so `git log -1 -- <path>` sees exactly one commit and every baseline reports the run's own timestamp. Issue #1248 was filed with all 11 rows at **0d**. The same command on a full clone:

| Baseline | Filed in #1248 | Actual |
|---|---:|---:|
| `fidelityLedger.ts` | 0d | **8d** |
| `.dependency-cruiser-known-violations.json` | 0d | **6d** |
| `plugin-store-coupling-baseline.json` | 0d | **6d** |
| `specDeltas.json` | 0d | **5d** |
| …all 11 | 0d | 0–8d, correctly sorted |

The sort ("stalest first") was meaningless too, and the workflow hardcodes `hasDebt=true`, so the issue opens every run regardless. The net effect: a scheduled job that files a confident-looking report which cannot express the one signal it was built to detect.

## Changes

- **`fetch-depth: 0`** on the checkout, so there is history to measure.
- **`--report` refuses in a shallow clone** instead of printing zeros. This is the already-documented contract for report mode — informational, *"unless it cannot measure"*. Without it the fix regresses silently the next time someone edits the workflow, because a table of zeros is indistinguishable from a healthy register. That indistinguishability is why this survived.

## Test

Builds a real git repo, marks it shallow, and asserts the refusal (exit 1, message naming `fetch-depth: 0`, no table printed). Its positive control runs the same fixture with history present and asserts a normal report, so the check cannot degrade into always-fail.

Gate tier: 37 files / 793 tests green.

## Note on the debt itself

Unchanged by this PR — the numbers in #1248 are real, only their ages were wrong. With real ages visible the register looks healthy rather than stalled: every tracked baseline has moved within 8 days.
