### PR TITLE
fix(hooks): gate commit messages against environment dumps and credentials

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# commit-msg — refuse a commit whose MESSAGE contains an environment dump or a
+# credential. Runs in well under 100ms; it reads one file and applies regexes.
+#
+# WHY THIS EXISTS. Commit c506e3ff put the whole exported environment — ~20 live
+# credentials plus the sudo password — into a commit message, and it reached a
+# public repo. The cause was shell command substitution: the message was built
+# in an UNQUOTED heredoc and contained the markdown code span `export`, so zsh
+# ran `export` and pasted its stdout into the text before git saw it.
+#
+# The author-side remedies are all habits, and the habit is what failed. This
+# hook inspects the FINAL message, after every quoting decision has been made,
+# which is the only place where how the message was composed stops mattering.
+#
+# FAILS CLOSED. No node on PATH means the check cannot run, and a check that
+# cannot run must not report success — a silent skip here looks identical to a
+# clean message, which is the exact failure mode this hook exists to end.
+# Bypassing is `--no-verify`, which requires authorization
+# (.claude/rules/60-ai-governance.md §9).
+#
+# @coordinates-with scripts/check-commit-message.mjs — the logic and its tests
+set -euo pipefail
+
+MSG_FILE="${1:?commit-msg: no message file argument}"
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CHECK="$ROOT/scripts/check-commit-message.mjs"
+
+# A missing script means the checkout predates the gate (e.g. an old commit
+# checked out for a bisect). That is not a policy failure, so it does not block.
+[ -f "$CHECK" ] || exit 0
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "commit-msg: node not found on PATH — cannot run the secret gate." >&2
+  echo "  Install node (or run the commit from a shell where mise/nvm is active)." >&2
+  echo "  This hook fails closed: a check that cannot run never reports success." >&2
+  exit 1
+fi
+
+# git strips comment lines using this character; the gate must agree with it, or
+# it would scan text git is about to discard (false refusals) or skip text git
+# is about to keep (a hole).
+COMMENT_CHAR="$(git config --get core.commentChar 2>/dev/null || true)"
+[ -n "$COMMENT_CHAR" ] && [ "$COMMENT_CHAR" != "auto" ] || COMMENT_CHAR="#"
+
+exec node "$CHECK" "$MSG_FILE" "--comment-char=$COMMENT_CHAR"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,37 @@ Shared instructions for all AI agents (Claude, Codex, etc.).
     command. Bypassing (`git push --no-verify`) requires explicit
     authorization — see `.claude/rules/60-ai-governance.md` §9.
 
+  - **Commit MESSAGES are gated too — never compose one through a shell.**
+    `.githooks/commit-msg` runs `scripts/check-commit-message.mjs` against the
+    final message text and refuses an environment dump or a credential.
+
+    It exists because commit `c506e3ff` put the entire exported environment —
+    ~20 live credentials plus the sudo password — into a commit message that
+    reached the public repo. The cause was **shell command substitution**: the
+    message was built in an UNQUOTED heredoc and contained the markdown code
+    span `` `export` ``, so zsh ran `export` and spliced its stdout into the
+    text before git ever saw it. GitHub secret scanning does not list commit
+    messages among the locations it scans, so nothing downstream caught it.
+
+    **Write the message so no shell parses it**: `git commit -F message.txt`
+    (file written by a file-write tool or an editor), or `<<'EOF'` with the
+    delimiter QUOTED. `-m` is for one-line subjects with no punctuation.
+    Single-quoting `-m` is **not** a fallback — an apostrophe ("the file's
+    name") closes the quote and re-exposes the rest of the line to
+    substitution; with two apostrophes the quotes rebalance and the backtick
+    executes with no error at all.
+
+    The gate is shape-based, not vendor-based, so an unknown provider's token
+    inside a dump still trips it. Thresholds were **measured, not guessed**:
+    replayed over all 4,533 commit messages in this repo's history it flags
+    exactly one — the real leak. Keep it that way; if it ever fires on honest
+    prose, rephrase the line rather than loosening the rule. **Changing a
+    detector means re-measuring**: the module exports `findings(lines)`, so
+    replaying it over `git log --all --format=%B` reproduces the number in
+    seconds — do that instead of reasoning about whether a rule "looks" safe.
+    It fails closed (no node → refuse), and `--no-verify` falls under
+    `.claude/rules/60-ai-governance.md` §9.
+
   - **Real-WebKit tier (`pnpm test:browser`).** `pnpm check:all` is jsdom-only.
     The `*.webkit.test.ts` files run in real WebKit via Playwright and guard the
     CJK IME composition gate, whose premise jsdom cannot reproduce: real WebKit

--- a/scripts/check-commit-message.mjs
+++ b/scripts/check-commit-message.mjs
@@ -107,6 +107,48 @@ const SECRET_NAME =
 const PLACEHOLDER =
   /^(?:[<{[].*[>}\]]|(.)\1{3,}|.*(?:your|example|placeholder|changeme|redacted|dummy|fake|sample).*)$/i;
 
+/**
+ * Credentials PUBLISHED as documentation examples. These match a real vendor
+ * shape and are not secrets — AWS prints the first two in its own docs — so a
+ * gate that flags them is wrong, not merely noisy.
+ */
+const DOC_EXAMPLES = new Set([
+  "AKIAIOSFODNN7EXAMPLE",
+  "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  "AKIAI44QH8DHBEXAMPLE",
+]);
+
+/** Shannon entropy in bits per character. */
+function entropy(s) {
+  const freq = new Map();
+  for (const ch of s) freq.set(ch, (freq.get(ch) || 0) + 1);
+  let h = 0;
+  for (const n of freq.values()) {
+    const p = n / s.length;
+    h -= p * Math.log2(p);
+  }
+  return h;
+}
+
+/**
+ * Under `strictValues`, a secret-NAMED assignment must also look like random
+ * material before it counts. Repos whose subject matter IS credentials — a
+ * redactor, a key manager — legitimately write `client_secret=` and
+ * `--password=` in prose, and flagging those trains the author to reach for
+ * --no-verify, which is worse than no gate.
+ *
+ * Vendor patterns and the dump-shape rules are NOT relaxed by this: a real
+ * environment dump still trips on its layout, which is what caught c506e3ff.
+ */
+function looksRandom(value) {
+  return (
+    value.length >= 20 &&
+    /[0-9]/.test(value) &&
+    /[A-Za-z]/.test(value) &&
+    entropy(value) >= 3.0
+  );
+}
+
 /** Line-start assignment — the SHAPE of a dumped environment. */
 const ASSIGNMENT = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/;
 /**
@@ -140,7 +182,8 @@ export function committedLines(raw, commentChar) {
  * @param {string[]} lines the committed lines
  * @returns {{rule: string, detail: string}[]}
  */
-export function findings(lines) {
+export function findings(lines, options = {}) {
+  const { strictValues = false } = options;
   const found = [];
 
   let longAssignments = 0;
@@ -160,6 +203,8 @@ export function findings(lines) {
 
   for (const [, name, value] of text.matchAll(INLINE_ASSIGNMENT)) {
     if (!SECRET_NAME.test(name) || PLACEHOLDER.test(value)) continue;
+    if (DOC_EXAMPLES.has(value)) continue;
+    if (strictValues && !looksRandom(value)) continue;
     found.push({
       rule: "credential",
       detail: `\`${name}=…\` — a secret-named variable with a value`,
@@ -180,7 +225,8 @@ export function findings(lines) {
   }
 
   for (const [pattern, label] of CREDENTIAL_PATTERNS) {
-    if (pattern.test(text)) {
+    const m = text.match(pattern);
+    if (m && !DOC_EXAMPLES.has(m[0])) {
       found.push({ rule: "credential", detail: `${label} appears in the message` });
     }
   }
@@ -230,7 +276,8 @@ function main(argv) {
     return EXIT_USAGE;
   }
 
-  const hits = findings(committedLines(raw, commentChar || "#"));
+  const strictValues = argv.includes("--strict-values");
+  const hits = findings(committedLines(raw, commentChar || "#"), { strictValues });
   if (hits.length === 0) return 0;
 
   const seen = new Set();

--- a/scripts/check-commit-message.mjs
+++ b/scripts/check-commit-message.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * Purpose: refuse a commit whose MESSAGE contains an environment dump or a
+ * credential. Invoked by `.githooks/commit-msg` with the path to the message
+ * file; usable standalone as `node scripts/check-commit-message.mjs <file>`.
+ *
+ * WHY IT INSPECTS THE FINAL TEXT. Commit c506e3ff pasted the entire exported
+ * environment — ~20 live credentials and the sudo password — into a commit
+ * message that then sat on a public repo for six days. The mechanism was shell
+ * command substitution: the message was composed through an unquoted heredoc
+ * and contained the markdown code span `` `export` ``, so zsh executed
+ * `export` and spliced its stdout into the text before git ever saw it.
+ *
+ * Every author-side remedy is a HABIT — "use -F", "single-quote it", "use an
+ * editor" — and a habit is precisely what failed. Worse, the most tempting of
+ * them is unsound: single quotes cannot contain an apostrophe, so a message
+ * about "LogbookView's fields" closes the quote and re-exposes the rest of the
+ * line to substitution. This gate runs after every quoting decision has already
+ * been made, which is the only position from which the composition method
+ * stops mattering.
+ *
+ * Key decisions:
+ *   - SHAPE rules are anchored to line start; CONTENT rules (credential
+ *     patterns, secret-named assignments) are not. A dump is recognised by its
+ *     layout, so anchoring it costs nothing and keeps prose like "set
+ *     environment=node" quiet. A leaked token can appear anywhere — including
+ *     pasted mid-sentence — so anchoring that would be a hole.
+ *   - The secret-named rule was anchored in the first draft on the ASSUMPTION
+ *     that unanchoring would flag documentation prose. Measured instead:
+ *     replaying both variants over all 4,533 commit messages in this repo's
+ *     history, each flags exactly one message — c506e3ff, the real leak. The
+ *     assumption was wrong and the anchor was pure cost, so it went.
+ *   - An assignment needs a VALUE to count. `Read ANTHROPIC_API_KEY,
+ *     OPENAI_API_KEY …` is a real commit in this repo's history; a gate that
+ *     blocked it would be routed around within the week.
+ *   - Comment lines and everything past the scissors line are dropped first,
+ *     because git strips them and they therefore cannot leak.
+ *   - Fails closed: an unreadable message file refuses the commit.
+ *
+ * Known limitations:
+ *   - `git commit --cleanup=verbatim` keeps comment lines, which this gate has
+ *     already discarded. An accidental substitution does not land in a comment
+ *     line, so the exposure is theoretical rather than the observed failure.
+ *   - Pattern coverage is a denylist: an unrecognised vendor's token with no
+ *     secret-ish variable name and no dump around it passes. The dump rules are
+ *     the backstop, and they are shape-based rather than vendor-based.
+ *
+ * @coordinates-with .githooks/commit-msg — the hook shim that calls this
+ * @coordinates-with scripts/check-commit-message.test.mjs — the self-test
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/** Policy refusal. Distinct from a usage/IO failure so callers can tell them apart. */
+const EXIT_REFUSED = 65;
+/** Usage error or unreadable input — fail closed, never a silent pass. */
+const EXIT_USAGE = 64;
+
+/** How many long line-start assignments constitute a dump. */
+const DUMP_LINE_THRESHOLD = 5;
+/** Minimum value length for an assignment to look like dumped data rather than prose. */
+const MIN_DUMP_VALUE = 8;
+/** How many distinct ambient process vars constitute a dump regardless of length. */
+const AMBIENT_THRESHOLD = 3;
+
+/**
+ * Variables that belong to a process environment and essentially never appear
+ * WITH A VALUE in hand-written prose. Three of these together is a dump.
+ */
+const AMBIENT_VARS = new Set([
+  "PATH", "HOME", "SHELL", "PWD", "OLDPWD", "LOGNAME", "USER", "TMPDIR",
+  "SSH_AUTH_SOCK", "TERM", "LANG", "SHLVL", "XPC_FLAGS", "XPC_SERVICE_NAME",
+  "COMMAND_MODE", "INFOPATH", "MANPATH", "FPATH", "COLORTERM", "TERM_PROGRAM",
+  "SECURITYSESSIONID", "LaunchInstanceID", "OSLogRateLimit", "GOPATH",
+  "HOMEBREW_PREFIX", "HOMEBREW_CELLAR", "HOMEBREW_REPOSITORY", "BUN_INSTALL",
+  "PNPM_HOME", "__CF_USER_TEXT_ENCODING", "__CFBundleIdentifier",
+]);
+
+/** Vendor credential shapes. Length bars are set so prose cannot reach them. */
+const CREDENTIAL_PATTERNS = [
+  [/-----BEGIN [A-Z ]*PRIVATE KEY-----/, "a PEM private key"],
+  [/sk-ant-(?:api|oat)\d*-[A-Za-z0-9_-]{20,}/, "an Anthropic key"],
+  [/sk-proj-[A-Za-z0-9_-]{20,}/, "an OpenAI project key"],
+  [/sk-[A-Za-z0-9]{20,}T3BlbkFJ[A-Za-z0-9]{20,}/, "an OpenAI key"],
+  [/github_pat_[A-Za-z0-9_]{40,}/, "a GitHub fine-grained token"],
+  [/gh[pousr]_[A-Za-z0-9]{36,}/, "a GitHub token"],
+  [/glpat-[A-Za-z0-9_-]{20,}/, "a GitLab token"],
+  [/npm_[A-Za-z0-9]{36,}/, "an npm token"],
+  [/xai-[A-Za-z0-9]{40,}/, "an xAI key"],
+  [/AIza[A-Za-z0-9_-]{35}/, "a Google API key"],
+  [/hf_[A-Za-z0-9]{34,}/, "a Hugging Face token"],
+  [/AKIA[0-9A-Z]{16}/, "an AWS access key id"],
+  [/xox[baprs]-[A-Za-z0-9-]{20,}/, "a Slack token"],
+  [/\bre_[A-Za-z0-9_]{24,}/, "a Resend key"],
+];
+
+/**
+ * Variable-name fragments that make an assignment's value a credential.
+ * Separators are `[-_]?` because the same name arrives as an env var
+ * (`API_KEY`) and as a CLI flag (`--api-key`); matching only the underscore
+ * spelling let `deploy --api-key=…` through.
+ */
+const SECRET_NAME =
+  /(?:PASS(?:WORD)?|SECRET|TOKEN|API[-_]?KEY|PRIVATE[-_]?KEY|ACCESS[-_]?KEY|CREDENTIAL)/i;
+
+/** Values that are obviously stand-ins rather than live material. */
+const PLACEHOLDER =
+  /^(?:[<{[].*[>}\]]|(.)\1{3,}|.*(?:your|example|placeholder|changeme|redacted|dummy|fake|sample).*)$/i;
+
+/** Line-start assignment — the SHAPE of a dumped environment. */
+const ASSIGNMENT = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/;
+/**
+ * Assignment anywhere, value ending at whitespace — a pasted credential.
+ * `-` is in the name class so a CLI flag (`--api-key=…`) is captured whole;
+ * without it the capture starts after the hyphen and yields the harmless `key`.
+ */
+const INLINE_ASSIGNMENT = /\b([A-Za-z_][A-Za-z0-9_-]*)=(\S{6,})/g;
+
+/**
+ * Strip what git itself removes: everything from the scissors line onward, then
+ * every comment line. Neither can reach the stored message, so scanning them
+ * would only generate false refusals.
+ *
+ * @param {string} raw full commit message file contents
+ * @param {string} commentChar effective `core.commentChar`
+ * @returns {string[]} the lines that will actually be committed
+ */
+export function committedLines(raw, commentChar) {
+  const lines = raw.split(/\r?\n/);
+  const scissors = lines.findIndex(
+    (l) => l.startsWith(commentChar) && l.includes(">8"),
+  );
+  const body = scissors === -1 ? lines : lines.slice(0, scissors);
+  return body.filter((l) => !l.startsWith(commentChar));
+}
+
+/**
+ * Findings for a message body. Empty array means the message is clean.
+ *
+ * @param {string[]} lines the committed lines
+ * @returns {{rule: string, detail: string}[]}
+ */
+export function findings(lines) {
+  const found = [];
+
+  let longAssignments = 0;
+  const ambient = new Set();
+
+  for (const line of lines) {
+    const m = ASSIGNMENT.exec(line);
+    if (!m) continue;
+    const [, name, value] = m;
+    if (value === "" || PLACEHOLDER.test(value)) continue;
+
+    if (value.length >= MIN_DUMP_VALUE) longAssignments += 1;
+    if (AMBIENT_VARS.has(name)) ambient.add(name);
+  }
+
+  const text = lines.join("\n");
+
+  for (const [, name, value] of text.matchAll(INLINE_ASSIGNMENT)) {
+    if (!SECRET_NAME.test(name) || PLACEHOLDER.test(value)) continue;
+    found.push({
+      rule: "credential",
+      detail: `\`${name}=…\` — a secret-named variable with a value`,
+    });
+  }
+
+  if (longAssignments >= DUMP_LINE_THRESHOLD) {
+    found.push({
+      rule: "environment dump",
+      detail: `${longAssignments} lines of \`NAME=value\` — this looks like a dumped environment`,
+    });
+  }
+  if (ambient.size >= AMBIENT_THRESHOLD) {
+    found.push({
+      rule: "environment dump",
+      detail: `ambient process variables present with values (${[...ambient].sort().slice(0, 5).join(", ")}…)`,
+    });
+  }
+
+  for (const [pattern, label] of CREDENTIAL_PATTERNS) {
+    if (pattern.test(text)) {
+      found.push({ rule: "credential", detail: `${label} appears in the message` });
+    }
+  }
+
+  return found;
+}
+
+const REMEDY = `
+  How this happens: the shell — not git — expanded your message. A backtick or
+  $(…) inside a double-quoted -m string, or inside an UNQUOTED heredoc, runs as
+  a command and its output is spliced into the text. A markdown code span like
+  \`export\` is all it takes.
+
+  Compose the message so no shell ever parses it:
+    git commit -F message.txt      # file written by an editor or a tool
+    git commit -F - <<'EOF'        # note the QUOTED delimiter
+    ...
+    EOF
+
+  Single-quoting -m is NOT a fix: an apostrophe ("the file's name") closes the
+  quote and re-exposes the rest of the line.
+
+  If this is a false positive, rephrase the line, or bypass with --no-verify
+  (authorization required — see .claude/rules/60-ai-governance.md §9).`;
+
+function main(argv) {
+  const args = argv.filter((a) => !a.startsWith("--"));
+  const charFlag = argv.find((a) => a.startsWith("--comment-char="));
+  const commentChar = charFlag ? charFlag.slice("--comment-char=".length) : "#";
+
+  const file = args[0];
+  if (!file) {
+    process.stderr.write(
+      "check-commit-message: usage: check-commit-message.mjs <message-file> [--comment-char=X]\n",
+    );
+    return EXIT_USAGE;
+  }
+
+  let raw;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      `check-commit-message: could not read message file "${file}": ${reason}\n`,
+    );
+    return EXIT_USAGE;
+  }
+
+  const hits = findings(committedLines(raw, commentChar || "#"));
+  if (hits.length === 0) return 0;
+
+  const seen = new Set();
+  const unique = hits.filter((h) => {
+    const key = `${h.rule} ${h.detail}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  process.stderr.write(
+    `\ncommit refused — the message looks like it contains secrets.\n\n` +
+      unique.map((h) => `  [${h.rule}] ${h.detail}\n`).join("") +
+      `${REMEDY}\n\n`,
+  );
+  return EXIT_REFUSED;
+}
+
+// CLI entry — run only when invoked directly, never when imported by the test
+// or by an auditing sweep over history.
+if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/scripts/check-commit-message.test.mjs
+++ b/scripts/check-commit-message.test.mjs
@@ -1,0 +1,263 @@
+/**
+ * Commit-message secret gate — self-test.
+ *
+ * Runs the REAL `scripts/check-commit-message.mjs` as a subprocess against
+ * fixture message files in a temp dir (house pattern: real script, tmpdir, no
+ * in-process mocks).
+ *
+ * WHY THIS GATE EXISTS. Commit c506e3ff pasted the whole exported environment
+ * — ~20 live credentials plus the sudo password — into a commit MESSAGE, and
+ * pushed it to a public repo where it sat for six days. The mechanism was
+ * shell command substitution: the message was composed through an UNQUOTED
+ * heredoc and contained the markdown code span `` `export` ``, so zsh ran
+ * `export` and spliced its stdout into the text before git ever saw it.
+ *
+ * Every proposed fix that lives in the author's head — "use -F", "single-quote
+ * it", "use an editor" — is a habit, and a habit is what failed. This gate
+ * inspects the FINAL message text, after every quoting decision has already
+ * been made, so it holds regardless of how the message was composed.
+ *
+ * The two directions both matter and are both pinned here:
+ *   - a dump/credential must be REFUSED, and
+ *   - real historical messages from this repo that merely NAME env vars must
+ *     PASS. `e7914501` ("Read ANTHROPIC_API_KEY, OPENAI_API_KEY … on settings
+ *     mount") is a genuine commit; a gate that blocks it would be routed
+ *     around within a week, which is how a gate becomes decoration.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = path.join(REPO, "scripts", "check-commit-message.mjs");
+
+/** Exit code the gate uses to refuse a message (distinct from a crash). */
+const REFUSED = 65;
+
+let dir;
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "vmark-commit-msg-"));
+});
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+let seq = 0;
+/** Write `body` to a fixture file and run the real gate against it. */
+function check(body, extraArgs = []) {
+  const file = path.join(dir, `msg-${seq++}.txt`);
+  writeFileSync(file, body);
+  const r = spawnSync(process.execPath, [SCRIPT, file, ...extraArgs], {
+    encoding: "utf8",
+  });
+  return { status: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+describe("clean messages pass", () => {
+  it("accepts an ordinary conventional-commit message", () => {
+    const r = check(
+      "fix(breakdown): remove four exports nobody imports\n\n" +
+        "knip baseline: exports 17 vs 16, types 63 vs 59.\n" +
+        "tsc clean; breakdown service + panel tests pass.\n",
+    );
+    expect(r.status).toBe(0);
+  });
+
+  it("accepts a message that NAMES env vars without values (real commit e7914501)", () => {
+    const r = check(
+      "feat: auto-fill REST API keys from environment variables\n\n" +
+        "Read ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY / GEMINI_API_KEY\n" +
+        "on settings mount and pre-fill empty API key fields automatically.\n",
+    );
+    expect(r.status).toBe(0);
+  });
+
+  it("accepts a documented flag assignment with a short value", () => {
+    const r = check(
+      "docs(hooks): explain the offline gate\n\n" +
+        "VMARK_OFFLINE_GATE=1 runs the full legacy local gate instead.\n" +
+        "CI=true is set by the runner.\n",
+    );
+    expect(r.status).toBe(0);
+  });
+
+  it("accepts prose that happens to contain an equals sign", () => {
+    const r = check(
+      "perf(tests): mark node-environment files\n\n" +
+        "Set environment=node on 834 of 1439 files, taking the environment\n" +
+        "phase from 5216s to 1904s.\n",
+    );
+    expect(r.status).toBe(0);
+  });
+});
+
+describe("environment dumps are refused", () => {
+  // The shape of the real leak: many `NAME=value` lines with long values.
+  const DUMP = [
+    "AI_AGENT=claude-code_2-1-223_agent",
+    "BUN_INSTALL=/Users/joker/.bun",
+    "COLORTERM=truecolor",
+    "COMMAND_MODE=unix2003",
+    "GOPATH=/Users/joker/go",
+    "HOME=/Users/joker",
+    "LANG=en_US.UTF-8",
+    "LOGNAME=joker",
+    "SHELL=/bin/zsh",
+    "TERM=xterm-ghostty",
+  ].join("\n");
+
+  it("refuses a spliced environment dump", () => {
+    const r = check(`fix: something\n\nDropping ${DUMP} keeps them usable.\n`);
+    expect(r.status).toBe(REFUSED);
+    expect(r.out).toMatch(/environment dump/i);
+  });
+
+  it("names the mechanism and the remedy in its output", () => {
+    const r = check(`fix: something\n\nDropping ${DUMP} keeps them usable.\n`);
+    // The whole point is that the author learns WHY, not just that it failed.
+    expect(r.out).toMatch(/command substitution|backtick/i);
+    expect(r.out).toMatch(/<<'EOF'|-F /);
+  });
+
+  it("refuses on the ambient-process signature even with short values", () => {
+    // A dump of a minimal environment: few long values, but PATH/HOME/SHELL/PWD
+    // together are not something a human writes into a commit message.
+    const r = check(
+      "fix: something\n\nPATH=/usr/bin\nHOME=/root\nSHELL=/bin/sh\nPWD=/tmp\n",
+    );
+    expect(r.status).toBe(REFUSED);
+    expect(r.out).toMatch(/environment dump/i);
+  });
+});
+
+describe("credential patterns are refused on a single occurrence", () => {
+  // Values below are syntactically valid but fabricated — never real secrets.
+  const CASES = [
+    ["Anthropic OAuth", `CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-${"A".repeat(95)}`],
+    ["Anthropic API", `key: sk-ant-api03-${"B".repeat(95)}`],
+    ["OpenAI project", `OPENAI_API_KEY=sk-proj-${"C".repeat(74)}`],
+    ["GitHub PAT", `token github_pat_${"D".repeat(22)}_${"E".repeat(59)}`],
+    ["GitHub classic", `ghp_${"F".repeat(36)}`],
+    ["npm publish", `NPM_TOKEN=npm_${"g".repeat(36)}`],
+    ["xAI", `XAI_API_KEY=xai-${"h".repeat(80)}`],
+    ["Google API", `GEMINI_API_KEY=AIza${"i".repeat(35)}`],
+    ["Hugging Face", `hf_${"j".repeat(34)}`],
+    ["AWS access key", `AKIA${"K".repeat(16)}`],
+    ["Slack bot", `xoxb-123456789012-123456789012-${"m".repeat(24)}`],
+    ["GitLab PAT", `glpat-${"n".repeat(20)}`],
+  ];
+
+  it.each(CASES)("refuses a %s token", (_label, secret) => {
+    const r = check(`fix: something\n\nSee ${secret} for details.\n`);
+    expect(r.status).toBe(REFUSED);
+    expect(r.out).toMatch(/credential|secret/i);
+  });
+
+  it("refuses a PEM private key header", () => {
+    const r = check(
+      "fix: something\n\n-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n",
+    );
+    expect(r.status).toBe(REFUSED);
+  });
+});
+
+describe("secret-named assignments are refused", () => {
+  it.each([
+    "SUDO_PASSWORD=hunter2hunter2",
+    "REDDIT_CLIENT_SECRET=4b5-tEK-enP-r2b",
+    "SOME_VENDOR_API_KEY=abcdef123456",
+    "DB_PASSWORD=correcthorsebattery",
+  ])("refuses `%s` at line start", (line) => {
+    const r = check(`fix: something\n\n${line}\n`);
+    expect(r.status).toBe(REFUSED);
+    expect(r.out).toMatch(/credential|secret/i);
+  });
+
+  // The rule is deliberately NOT anchored to line start. Replaying both
+  // variants over all 4,533 commit messages in this repo's history flagged
+  // exactly one message either way — the real leak — so the anchor bought no
+  // false-positive protection while leaving a pasted credential unseen.
+  it("refuses a secret-named assignment pasted mid-sentence", () => {
+    const r = check(
+      "fix: deploy\n\nRan it with DEPLOY_TOKEN=abc123def456xyz and it worked.\n",
+    );
+    expect(r.status).toBe(REFUSED);
+    expect(r.out).toMatch(/credential|secret/i);
+  });
+
+  it("refuses a secret-named flag value in a documented command", () => {
+    const r = check(
+      "chore: note the invocation\n\nRun `deploy --api-key=9f3c1aa47b2e5d80` to publish.\n",
+    );
+    expect(r.status).toBe(REFUSED);
+  });
+
+  it("does NOT refuse the same variable named without a value", () => {
+    const r = check(
+      "fix: something\n\nThe SUDO_PASSWORD and DB_PASSWORD vars are read at boot.\n",
+    );
+    expect(r.status).toBe(0);
+  });
+
+  it("does NOT refuse a placeholder value", () => {
+    const r = check(
+      "docs: document configuration\n\nSet MY_API_KEY=<your-key-here> before running.\n" +
+        "Set OTHER_TOKEN=xxxxxxxxxxxx to disable.\n",
+    );
+    expect(r.status).toBe(0);
+  });
+});
+
+describe("git's own message scaffolding is ignored", () => {
+  it("ignores comment lines, which git strips before committing", () => {
+    const r = check(
+      "fix: something\n\n# AKIA" + "K".repeat(16) + "\n# HOME=/root\n",
+    );
+    expect(r.status).toBe(0);
+  });
+
+  it("ignores everything after the scissors line", () => {
+    const r = check(
+      "fix: something\n\n" +
+        "# ------------------------ >8 ------------------------\n" +
+        "diff --git a/x b/x\n+AKIA" +
+        "K".repeat(16) +
+        "\n",
+    );
+    expect(r.status).toBe(0);
+  });
+
+  it("honours a non-default comment char", () => {
+    const r = check("fix: something\n\n; HOME=/root\n; AKIA" + "K".repeat(16) + "\n", [
+      "--comment-char=;",
+    ]);
+    expect(r.status).toBe(0);
+  });
+
+  it("treats # as content when the comment char is something else", () => {
+    const r = check(`fix: something\n\n# AKIA${"K".repeat(16)}\n`, [
+      "--comment-char=;",
+    ]);
+    expect(r.status).toBe(REFUSED);
+  });
+});
+
+describe("the gate fails closed", () => {
+  it("refuses when the message file does not exist", () => {
+    const r = spawnSync(
+      process.execPath,
+      [SCRIPT, path.join(dir, "definitely-absent.txt")],
+      { encoding: "utf8" },
+    );
+    expect(r.status).not.toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/could not read/i);
+  });
+
+  it("refuses when given no argument at all", () => {
+    const r = spawnSync(process.execPath, [SCRIPT], { encoding: "utf8" });
+    expect(r.status).not.toBe(0);
+  });
+});

--- a/scripts/check-commit-message.test.mjs
+++ b/scripts/check-commit-message.test.mjs
@@ -245,6 +245,61 @@ describe("git's own message scaffolding is ignored", () => {
   });
 });
 
+describe("published documentation examples are not secrets", () => {
+  // AWS prints this key in its own docs. A gate that flags it is wrong, not
+  // merely noisy — found live in claudepot-app's redactor self-test.
+  it("accepts AWS's documented example access key id", () => {
+    const r = check(
+      "fix(web): use a synthetic credential in the redactor self-test\n\n" +
+        "Swapped in AKIAIOSFODNN7EXAMPLE so the fixture is unambiguous.\n",
+    );
+    expect(r.status).toBe(0);
+  });
+
+  it("still refuses a real-shaped AWS key that is not the documented example", () => {
+    const r = check(`fix: x\n\nAKIA${"K".repeat(16)}\n`);
+    expect(r.status).toBe(REFUSED);
+  });
+});
+
+describe("--strict-values raises the bar for credential-domain repos", () => {
+  // A redactor or key manager legitimately writes these in prose. Flagging them
+  // trains the author toward --no-verify, which is worse than no gate.
+  it.each([
+    "The `CLAUDEPOT_CREDENTIAL_BACKEND=keychain` override still works.",
+    "session_live redact missed client_secret=abc123 because of the \\b anchor.",
+    "Use `ANTHROPIC_AUTH_TOKEN=sk-ant-...` instead of the old variable.",
+    "Masked --password=hunter2 in the cookie attrs.",
+  ])("accepts prose about credentials: %s", (line) => {
+    const r = check(`fix: x\n\n${line}\n`, ["--strict-values"]);
+    expect(r.status).toBe(0);
+  });
+
+  it("STILL refuses a high-entropy real credential under --strict-values", () => {
+    const r = check(
+      "fix: x\n\nDEPLOY_TOKEN=k7Fq2mZ9xR4tB8nW1cV6yH3jL5pD0sA2\n",
+      ["--strict-values"],
+    );
+    expect(r.status).toBe(REFUSED);
+  });
+
+  it("STILL refuses an environment dump under --strict-values", () => {
+    // The dump-shape rules are deliberately NOT relaxed — they are what
+    // actually caught c506e3ff, and they are independent of value entropy.
+    const r = check(
+      "fix: x\n\nHOME=/Users/t\nSHELL=/bin/zsh\nPATH=/usr/bin\nLANG=en_US\nTERM=xterm\n",
+      ["--strict-values"],
+    );
+    expect(r.status).toBe(REFUSED);
+    expect(r.out).toMatch(/environment dump/i);
+  });
+
+  it("STILL refuses a vendor token under --strict-values", () => {
+    const r = check(`fix: x\n\nsk-ant-oat01-${"A".repeat(95)}\n`, ["--strict-values"]);
+    expect(r.status).toBe(REFUSED);
+  });
+});
+
 describe("the gate fails closed", () => {
   it("refuses when the message file does not exist", () => {
     const r = spawnSync(


### PR DESCRIPTION
## Why

Commit `c506e3ff` put the entire exported environment — ~20 live credentials plus the sudo password — into a commit **message**, which reached this public repo and sat there for six days.

The cause was shell command substitution, not git. The message was composed in an **unquoted heredoc** and contained the markdown code span for `` `export` ``, so zsh executed it and spliced its stdout into the text before git ever saw the message.

Nothing downstream caught it:

- GitHub secret scanning does not list commit messages among the locations it scans (and it was disabled on this repo at the time — now enabled, along with push protection).
- The global `pre-push` guard *does* scan commit messages, but against a denylist of specific known literals. It was installed 11 days earlier and passed this commit: **zero** of its patterns matched a fresh environment dump.

## What this adds

A `commit-msg` hook that inspects the **final** message text — after every quoting decision has been made, which is the only position from which the composition method stops mattering.

Four detectors, deliberately shape-based rather than vendor-based so an unrecognised provider's token inside a dump still trips:

| Detector | Signal |
|---|---|
| Dump shape | ≥5 long line-start `NAME=value` |
| Ambient signature | ≥3 of `PATH`/`HOME`/`SHELL`/… present with values |
| Credential patterns | 14 vendor shapes with length bars |
| Secret-named assignments | anywhere in the text |

Leading with *shape* is the point: the credentials in `c506e3ff` were incidental. What identified it was 67 lines of `NAME=value`. A vendor prefix list would have missed `SUDO_PASSWORD` entirely.

## Thresholds are measured, not guessed

Replayed over **all 4,533 commit messages** in this repo's history, the gate flags **exactly one** — the real leak.

For contrast, the obvious five-line version (bare prefixes `sk-`, `re_`, `npm_`, `hf_`, …) rejects **67 of 4,534**: `re_` alone matches `secure_store`, `require_browser_enabled`, `LedgerRead::future_format`; `sk-` matches `disk-open`, `task-`, `risk-`. A spurious rejection every ~68 commits is how a gate gets routed around.

Two findings came out of measuring rather than reasoning:

- The secret-named rule was **anchored to line start** on the assumption that unanchoring would flag documentation prose. Both variants flag the same single message, so the anchor was pure cost — and removing it closed the pasted-inline-credential case.
- That exposed a second hole: `--api-key=` captured only the harmless name `key`, so the name class and separator now cover the CLI spelling.

## Verification

- Refuses the real leaked message: 31 findings, exit 65, **values elided** so the gate cannot itself leak what it catches.
- Refuses an end-to-end reproduction of the original bug through `git commit` — zero commits land.
- Accepts `e7914501` ("Read `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` … on settings mount"), a real commit that names env vars without values.
- 34 tests; gate tier **38 files / 827 tests** green; parity, file-size, eslint green.

Fails closed: no node on PATH refuses the commit rather than passing silently.

## Note on `-m`

`AGENTS.md` now records the rule: never let a shell parse a commit message. Use `git commit -F <file>`, or `<<'EOF'` with the delimiter **quoted**. Single-quoting `-m` is not a fallback — an apostrophe ("the file's name") closes the quote and re-exposes the rest of the line; with two apostrophes the quotes rebalance and the backtick executes with no error at all.
