### PR TITLE
fix(tests): kill the pathological runner, not its launcher

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -35,6 +35,7 @@
       ],
       "ignoreBinaries": [
         "du",
+        "pgrep",
         "smoke"
       ]
     },

--- a/src/utils/markdownPipeline/__tests__/pathological/pathological.test.ts
+++ b/src/utils/markdownPipeline/__tests__/pathological/pathological.test.ts
@@ -26,7 +26,6 @@ import { pathologicalCases } from "./pathologicalCases";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "../../../../..");
-const TSX = join(repoRoot, "node_modules", ".bin", "tsx");
 const ENTRY = join(here, "runCases.ts");
 
 /** Generous: every class together takes well under this on any dev machine
@@ -58,8 +57,21 @@ interface CaseReport {
   done?: boolean;
 }
 
+/** Spawn `node --import tsx` DIRECTLY — never `node_modules/.bin/tsx`.
+ *
+ *  The tsx CLI is a launcher: it spawns the real runner as its own child and
+ *  relays SIGINT/SIGTERM to it. SIGKILL is uncatchable, so the relay never
+ *  runs — `spawnSync`'s timeout kills the launcher and REPARENTS the runner to
+ *  PID 1, where it spins forever. The self-test's deliberate busy loop made
+ *  that leak unconditional: every run of this file abandoned a process pegging
+ *  a full core, and four of them once cost ~3.5 cores for 20 hours.
+ *
+ *  SIGTERM is NOT the fix: tsx would then exit normally with 143, so
+ *  `res.signal` becomes null and the hang detector below silently stops
+ *  detecting hangs. Removing the launcher keeps SIGKILL honest — the direct
+ *  child IS the runner, so killing it kills the code under test. */
 function runChild(env: Record<string, string>, timeoutMs: number) {
-  const res = spawnSync(TSX, [ENTRY], {
+  const res = spawnSync(process.execPath, ["--import", "tsx", ENTRY], {
     cwd: repoRoot,
     encoding: "utf8",
     timeout: timeoutMs,
@@ -71,6 +83,26 @@ function runChild(env: Record<string, string>, timeoutMs: number) {
     .filter((l) => l.startsWith("{"))
     .map((l) => JSON.parse(l) as CaseReport);
   return { res, lines };
+}
+
+/** PIDs still running the child entry. `pgrep -f` matches the whole command
+ *  line, so it finds a runner abandoned at ANY depth — which is the only way
+ *  to observe the leak from in here. */
+function survivingRunners(): string[] {
+  const res = spawnSync("pgrep", ["-f", ENTRY], { encoding: "utf8" });
+  return (res.stdout ?? "").split("\n").map((l) => l.trim()).filter(Boolean);
+}
+
+/** Poll until the kill is reaped, or give up. A leaked runner NEVER clears, so
+ *  a real regression cannot buy a pass by waiting longer. */
+function waitForNoRunners(budgetMs: number): string[] {
+  const deadline = Date.now() + budgetMs;
+  let alive = survivingRunners();
+  while (alive.length > 0 && Date.now() < deadline) {
+    spawnSync("sleep", ["0.25"]);
+    alive = survivingRunners();
+  }
+  return alive;
 }
 
 describe("pathological inputs (killable child process)", () => {
@@ -99,5 +131,17 @@ describe("pathological inputs (killable child process)", () => {
     // The probe announced itself before hanging — the culprit is nameable.
     expect(lines.some((l) => l.name === "hang-probe" && l.starting)).toBe(true);
     expect(lines.some((l) => l.done)).toBe(false);
+
+    // REGRESSION GUARD: the kill must reach the code under test, not just its
+    // launcher. Reintroduce a wrapper between us and the runner (see
+    // runChild) and this probe silently abandons a core-pegging process on
+    // every run — while every assertion above still passes.
+    if (process.platform !== "win32") {
+      expect(
+        waitForNoRunners(5_000),
+        "the killed probe left a process running the child entry: it was " +
+          "reparented to PID 1 and is now spinning on a core forever",
+      ).toEqual([]);
+    }
   }, HANG_PROBE_WINDOW_MS + 30_000);
 });

--- a/src/utils/markdownPipeline/__tests__/pathological/runCases.ts
+++ b/src/utils/markdownPipeline/__tests__/pathological/runCases.ts
@@ -1,8 +1,14 @@
 /**
- * WI-3.1 — the pathological child entry, run under `tsx` by
+ * WI-3.1 — the pathological child entry, run under the `tsx` loader by
  * `pathological.test.ts` so a synchronous parser/serializer hang is
  * KILLABLE. A vitest timeout cannot interrupt a busy loop on its own event
- * loop; a child process can always be terminated from outside.
+ * loop; a child process can be terminated from outside.
+ *
+ * "From outside" only holds while THIS process is the parent's direct child.
+ * The parent must therefore spawn `node --import tsx`, never the `.bin/tsx`
+ * launcher: the launcher cannot relay the SIGKILL that enforces the timeout,
+ * so it dies alone and leaves this process spinning under PID 1. See the
+ * runChild comment in `pathological.test.ts`.
  *
  * Runs the markdown pipeline against a StarterKit-only schema: the pipeline
  * (`src/utils/markdownPipeline/`) is leaf-pure by ADR-013, but the FULL


### PR DESCRIPTION
## The leak

Every run of `pathological.test.ts` abandoned a process pegging a full core. Four of them once cost **~3.5 cores for 20 hours**.

The mechanism: the file spawned `node_modules/.bin/tsx`, and the tsx CLI is a **launcher** — it spawns the real runner as its own child and relays `SIGINT`/`SIGTERM`. `SIGKILL` is uncatchable, so that relay never runs. `spawnSync`'s timeout therefore killed the launcher and **reparented the runner to PID 1**, where the hang probe's deliberate busy loop spun forever.

The leak was **unconditional** — the probe exists in order to hang, so every single run leaked one.

## The fix

Spawn `node --import tsx` directly. With no launcher in between, the direct child *is* the runner, so the `SIGKILL` that enforces the timeout reaches the code under test.

**`SIGTERM` is not the fix**, and that's the trap worth recording: tsx would then exit normally with 143, `res.signal` would become `null`, and the hang detector below it would **silently stop detecting hangs** — trading a visible CPU leak for invisible lost coverage.

## Why it ships with an assertion, not just a repair

Every assertion in this file passed the entire time the leak was running. A fix alone would leave nothing to notice a regression.

So after the hang probe, the test `pgrep -f`s the child entry and polls until nothing survives. A leaked runner never clears, so a regression can't buy a pass by waiting longer; reintroducing a wrapper between the test and the runner now fails loudly instead of quietly burning a core. Skipped on `win32`, where `pgrep` doesn't exist.

## Verification

- Both tests pass (78s).
- No abandoned `runCases.ts` or stray `tsx` processes remain on the machine afterwards — checked with `pgrep` after a full run.
- eslint clean.

Test-only change; no production source touched.
