### PR TITLE
fix(window-close): log the close flow in release, recover from a stall (#1253)

### DIFF
--- a/.claude/hooks/multi-format-tdd-guard.test.mjs
+++ b/.claude/hooks/multi-format-tdd-guard.test.mjs
@@ -84,13 +84,19 @@ describe("multi-format-tdd-guard — Rust scope tracks the decomposed module", (
     expect(runGuard(write("src-tauri/src/window_manager.rs")).status).toBe(0);
   });
 
-  it("blocks an untested submodule (window_manager/commands.rs)", () => {
-    // commands.rs has neither an inline #[cfg(test)] nor a sibling commands.test.rs.
-    expect(runGuard(write("src-tauri/src/window_manager/commands.rs")).status).toBe(2);
+  it("blocks an untested submodule", () => {
+    // A SYNTHETIC path, like the TS case above. This named the real
+    // `commands.rs` until that file gained tests (#1253), at which point the
+    // guard's own test failed — the assertion was pinned to repo state rather
+    // than to guard behaviour, so writing a test made the gate look broken.
+    expect(runGuard(write("src-tauri/src/window_manager/__no_test__.rs")).status).toBe(2);
   });
 
   it("allows a submodule that has a sibling .test.rs", () => {
-    // path_validation.rs ships path_validation.test.rs.
+    // path_validation.rs ships path_validation.test.rs; commands.rs ships
+    // commands.test.rs. Naming real files is fine in THIS direction: a file
+    // losing its tests should fail the gate's test too.
     expect(runGuard(write("src-tauri/src/window_manager/path_validation.rs")).status).toBe(0);
+    expect(runGuard(write("src-tauri/src/window_manager/commands.rs")).status).toBe(0);
   });
 });

--- a/src-tauri/src/app_setup.rs
+++ b/src-tauri/src/app_setup.rs
@@ -123,13 +123,19 @@ pub(crate) fn handle_document_window_close_event(
     use tauri::Emitter;
     if let tauri::WindowEvent::CloseRequested { api, .. } = event {
         let label = window.label();
-        log::debug!("[Tauri] WindowEvent::CloseRequested for window '{}'", label);
+        // INFO, not debug (#1253). `prevent_close` below hands the outcome to
+        // the frontend with no timeout and no fallback, so when a close stalls
+        // the only way to tell "Rust never saw the click" from "the frontend
+        // never finished" is a line here — and release builds filter `debug!`,
+        // which is why the first report of a stuck window arrived with a log
+        // that said nothing at all.
+        log::info!("[Tauri] WindowEvent::CloseRequested for window '{}'", label);
         // Only intercept close for document windows
         if label == "main" || label.starts_with("doc-") {
             api.prevent_close();
             // Include target label in payload so frontend can filter
             let _ = window.emit("window:close-requested", label);
-            log::debug!("[Tauri] Emitted window:close-requested to '{}'", label);
+            log::info!("[Tauri] Emitted window:close-requested to '{}'", label);
         }
         // Settings and other non-document windows close normally
     }
@@ -227,4 +233,20 @@ pub(crate) fn handle_run_event(app: &tauri::AppHandle, event: tauri::RunEvent) {
 #[tauri::command]
 pub fn debug_log(message: String) {
     log::debug!("[Frontend] {}", message);
+}
+
+/// Window-close milestones from the frontend, at INFO (#1253).
+///
+/// Deliberately separate from `debug_log`: that one is `debug!` and so is
+/// filtered out of release builds, which is exactly why the first report of a
+/// window that would not close arrived with a log containing nothing about the
+/// close at all. The close flow has no timeout and no fallback, so these few
+/// lines are the only way to tell where a stall happened — which await never
+/// returned — from a log a user can actually send.
+///
+/// Kept to state transitions, not per-keystroke noise: a handful of lines per
+/// close attempt.
+#[tauri::command]
+pub fn window_close_log(message: String) {
+    log::info!("[WindowClose] {}", message);
 }

--- a/src-tauri/src/command_registry.rs
+++ b/src-tauri/src/command_registry.rs
@@ -140,6 +140,7 @@ macro_rules! all_commands {
             ai_provider::validate_model,
             #[cfg(debug_assertions)]
             app_setup::debug_log,
+            app_setup::window_close_log,
             temp_html::write_temp_html,
             file_write::atomic_write_file,
             webview_edit::trigger_webview_edit,

--- a/src-tauri/src/window_manager/commands.rs
+++ b/src-tauri/src/window_manager/commands.rs
@@ -61,17 +61,29 @@ pub fn open_workspace_with_files_in_new_window(
     create_document_window_with_url(&app, url).map_err(|e| CommandError::internal(e.to_string()))
 }
 
-/// Close a specific window by label
+/// Close a specific window by label.
+///
+/// Generic over the runtime so a mock app can exercise the not-found branch
+/// (`commands.test.rs`); the `#[tauri::command]` macro is unaffected.
+///
+/// Logs at INFO, not debug (#1253). This is the last step of the window-close
+/// flow, and release builds filter `debug!` — so when a close stalled, the log
+/// a user could send us was silent about whether `close_window` was ever
+/// reached, let alone whether `destroy()` returned. The "called" and "destroy
+/// result" pair is what distinguishes a frontend that never got here from a
+/// `destroy()` that never came back.
 #[tauri::command]
-pub fn close_window(app: AppHandle, label: String) -> Result<(), CommandError> {
-    log::debug!("[Tauri] close_window called for '{}'", label);
+pub fn close_window<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    label: String,
+) -> Result<(), CommandError> {
+    log::info!("[Tauri] close_window called for '{}'", label);
 
     if let Some(window) = app.get_webview_window(&label) {
-        log::debug!("[Tauri] destroying window '{}'", label);
         let result = window
             .destroy()
             .map_err(|e| CommandError::internal(e.to_string()));
-        log::debug!("[Tauri] window '{}' destroy result: {:?}", label, result);
+        log::info!("[Tauri] window '{}' destroy result: {:?}", label, result);
         result
     } else {
         // The label names no live window: absent, not malformed.
@@ -93,3 +105,7 @@ pub fn request_quit(app: AppHandle) {
     use tauri::Emitter;
     let _ = app.emit("app:quit-requested", ());
 }
+
+#[cfg(test)]
+#[path = "commands.test.rs"]
+mod tests;

--- a/src-tauri/src/window_manager/commands.test.rs
+++ b/src-tauri/src/window_manager/commands.test.rs
@@ -1,0 +1,52 @@
+//! Tests for `window_manager/commands.rs`.
+//!
+//! These commands mostly create real windows, which a mock runtime cannot do
+//! meaningfully — so the coverage here is the branch that needs no window:
+//! `close_window` against a label that names none.
+//!
+//! That branch matters for #1253. The frontend calls `close_window` as the last
+//! step of the close flow and awaits it; if it can reject for a reason the
+//! caller does not distinguish, a close can fail in a way that looks identical
+//! to a hang. Pinning the error CODE (not its message text) is what lets the
+//! caller tell "no such window" from a real failure.
+
+// tauri::test::MockRuntime crashes the test binary at startup on
+// windows-latest (STATUS_ENTRYPOINT_NOT_FOUND); the `test` feature of tauri is
+// not enabled there (see the target-specific dev-dependency in Cargo.toml), so
+// these are cfg-gated to match the other mock-runtime suites in this crate.
+#![cfg(not(target_os = "windows"))]
+
+use super::close_window;
+use crate::command_error::ErrorCode;
+
+fn mock_app() -> tauri::App<tauri::test::MockRuntime> {
+    tauri::test::mock_builder()
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("build mock app")
+}
+
+#[test]
+fn close_window_reports_not_found_for_an_unknown_label() {
+    let app = mock_app();
+
+    let err = close_window(app.handle().clone(), "doc-does-not-exist".into())
+        .expect_err("closing a label that names no window must fail");
+
+    // The CODE is the contract — a caller branching on message text breaks the
+    // day someone rewords it (see .claude/rules/50-codebase-conventions.md).
+    assert_eq!(err.code(), ErrorCode::NotFound);
+}
+
+#[test]
+fn close_window_error_names_the_label_for_diagnosis() {
+    let app = mock_app();
+
+    let err = close_window(app.handle().clone(), "doc-42".into())
+        .expect_err("closing a label that names no window must fail");
+
+    assert!(
+        err.message().contains("doc-42"),
+        "the error should name the label it could not find, got: {}",
+        err.message()
+    );
+}

--- a/src/hooks/useWindowClose.comprehensive.test.tsx
+++ b/src/hooks/useWindowClose.comprehensive.test.tsx
@@ -585,10 +585,16 @@ describe("useWindowClose — closeLog debug_log catch (line 50)", () => {
     vi.clearAllMocks();
   });
 
-  it("catches debug_log invoke failure and warns", async () => {
-    // Make debug_log reject, but all other invokes succeed
+  it("catches window_close_log invoke failure and warns", async () => {
+    // #1253 — close milestones go to `window_close_log` (INFO), not
+    // `debug_log` (debug!, filtered out of release builds). A shipped build
+    // used to record nothing about a close, which is why the first stuck-window
+    // report arrived with a log that said nothing.
+    //
+    // Logging must never be able to fail a close, so the invoke is
+    // fire-and-forget and its rejection only warns.
     vi.mocked(invoke).mockImplementation(async (cmd: string) => {
-      if (cmd === "debug_log") throw new Error("debug_log failed");
+      if (cmd === "window_close_log") throw new Error("window_close_log failed");
       return undefined;
     });
 
@@ -606,7 +612,7 @@ describe("useWindowClose — closeLog debug_log catch (line 50)", () => {
 
     expect(warnSpy).toHaveBeenCalledWith(
       "[WindowClose]",
-      "debug_log invoke failed:",
+      "window_close_log invoke failed:",
       expect.any(Error)
     );
     warnSpy.mockRestore();

--- a/src/hooks/useWindowClose.lifecycle.test.tsx
+++ b/src/hooks/useWindowClose.lifecycle.test.tsx
@@ -81,6 +81,75 @@ function resetStores() {
   );
 }
 
+// #1253 — a close that NEVER settles must not brick the window.
+//
+// `activeCloseRef` is cleared only when the flow settles, so before this a
+// stalled step made every later close request join a dead promise: the user
+// clicks the traffic light repeatedly and nothing happens at all, with no
+// recovery but killing the process. Nothing in the flow has a timeout, and
+// every decision point is a blocking native dialog that can only resolve.
+describe("useWindowClose — a stalled close does not brick the window (#1253)", () => {
+  beforeEach(() => {
+    listeners.clear();
+    resetStores();
+    vi.clearAllMocks();
+    vi.mocked(invoke).mockResolvedValue(undefined);
+  });
+
+  /**
+   * Advance only the clock the stall check reads. Fake timers would also
+   * replace the timers `waitFor` runs on, which deadlocks the test.
+   */
+  function atTime(ms: number) {
+    vi.spyOn(Date, "now").mockReturnValue(ms);
+  }
+
+  /** Set up a dirty tab whose save prompt never settles. */
+  async function renderWithStalledPrompt() {
+    const tabId = useTabStore.getState().createTab(WINDOW, null);
+    useDocumentStore.getState().initDocument(tabId, "initial", null);
+    useDocumentStore.getState().setContent(tabId, "dirty");
+    // Never resolves — the shape of the observed stall.
+    mockPromptSaveForDirtyDocument.mockImplementation(() => new Promise(() => {}));
+
+    await act(async () => {
+      render(<TestHarness />);
+    });
+    await waitFor(() => expect(listeners.has("window:close-requested")).toBe(true));
+  }
+
+  it("joins a recent in-flight close rather than stacking a second prompt", async () => {
+    atTime(1_000_000);
+    await renderWithStalledPrompt();
+
+    void listeners.get("window:close-requested")!({ payload: WINDOW });
+    await waitFor(() => expect(mockPromptSaveForDirtyDocument).toHaveBeenCalledTimes(1));
+
+    // A user reading a save dialog must never be interrupted by a second one.
+    atTime(1_000_000 + 60_000);
+    void listeners.get("window:close-requested")!({ payload: WINDOW });
+    await Promise.resolve();
+
+    expect(mockPromptSaveForDirtyDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a fresh attempt once the in-flight close has clearly stalled", async () => {
+    atTime(1_000_000);
+    await renderWithStalledPrompt();
+
+    void listeners.get("window:close-requested")!({ payload: WINDOW });
+    await waitFor(() => expect(mockPromptSaveForDirtyDocument).toHaveBeenCalledTimes(1));
+
+    // Past the stall threshold the user's renewed request wins: the old
+    // attempt is abandoned in place (cancelling nothing, discarding nothing)
+    // and a new flow runs, so clicking X eventually works again.
+    atTime(1_000_000 + 6 * 60 * 1000);
+    void listeners.get("window:close-requested")!({ payload: WINDOW });
+
+    await waitFor(() => expect(mockPromptSaveForDirtyDocument).toHaveBeenCalledTimes(2));
+  });
+});
+
 describe("useWindowClose — concurrent close requests join (WI-1/WI-7 shape)", () => {
   beforeEach(() => {
     listeners.clear();

--- a/src/hooks/useWindowClose.ts
+++ b/src/hooks/useWindowClose.ts
@@ -42,20 +42,45 @@ import { runWindowCloseFlow } from "@/services/windowClose/windowCloseFlow";
 import { safeUnlisten } from "@/utils/safeUnlisten";
 import { windowCloseLog, windowCloseWarn, windowCloseError } from "@/utils/debug";
 
-// Dev-only logging for debugging window close issues
-// Logs to console and Rust debug_log
-/* v8 ignore start -- import.meta.env.DEV=true in vitest; production no-op branch never reached in tests */
-const closeLog = import.meta.env.DEV
-  ? (label: string, ...args: unknown[]) => {
-      const msg = `[WindowClose:${label}] ${args.map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ')}`;
-      windowCloseLog(msg);
-      // Log to terminal via Rust (fire-and-forget, but log failures in dev)
-      invoke("debug_log", { message: msg }).catch((e) => {
-        windowCloseWarn("debug_log invoke failed:", e);
-      });
+/**
+ * Close-flow milestones — logged in RELEASE builds too (#1253).
+ *
+ * This used to be `import.meta.env.DEV ? … : () => {}`, so a shipped build
+ * recorded nothing about a window close. When a user reported a window that
+ * could not be closed, the log they sent was silent — not because nothing
+ * happened, but because every line describing it had been compiled out. The
+ * Rust side had the same problem (`debug!`, filtered at the release Info
+ * level), so there was no way to tell which await never returned.
+ *
+ * Routes to `window_close_log`, which logs at INFO, rather than `debug_log`,
+ * which is `debug!` and would still vanish. Console output stays dev-only:
+ * `windowCloseLog` is already a no-op in production, and the file log is what
+ * a user can actually send.
+ */
+const closeLog = (label: string, ...args: unknown[]) => {
+  const msg = `[WindowClose:${label}] ${args.map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ')}`;
+  windowCloseLog(msg);
+  // Fire-and-forget: logging must never be able to fail a close.
+  invoke("window_close_log", { message: msg }).catch((e) => {
+    /* v8 ignore start -- import.meta.env.DEV=true in vitest; production branch never taken */
+    if (import.meta.env.DEV) {
+      windowCloseWarn("window_close_log invoke failed:", e);
     }
-  : () => {};
-/* v8 ignore stop */
+    /* v8 ignore stop */
+  });
+};
+
+/**
+ * How long an in-flight close may sit before a NEW close request is treated as
+ * a retry rather than joined to it (#1253).
+ *
+ * Generous on purpose: the flow legitimately blocks on native save/pin dialogs,
+ * and a user reading one must never be interrupted by a second. Five minutes is
+ * far longer than any real prompt takes to answer and far shorter than "the
+ * window is permanently unclosable", which is what the previous unbounded join
+ * produced.
+ */
+const STALL_RETRY_AFTER_MS = 5 * 60 * 1000;
 
 /**
  * Handle window and tab close events with save confirmation.
@@ -68,6 +93,8 @@ export function useWindowClose() {
   const windowLabel = useWindowLabel();
   /** The in-flight close, shared by every trigger (WI-1/WI-7 shape). */
   const activeCloseRef = useRef<Promise<boolean> | null>(null);
+  /** When that attempt started — the basis for the stall check below. */
+  const activeCloseStartedAtRef = useRef<number>(0);
   /** The close attempt Rust was already answered for — cancel_quit is sent
    *  exactly once per attempt, however many quit events joined it. */
   const answeredQuitForRef = useRef<Promise<boolean> | null>(null);
@@ -79,8 +106,23 @@ export function useWindowClose() {
     // the real outcome to know whether to send cancel_quit.
     const existing = activeCloseRef.current;
     if (existing) {
-      closeLog(windowLabel, "joining in-flight close");
-      return existing;
+      const age = Date.now() - activeCloseStartedAtRef.current;
+      if (age < STALL_RETRY_AFTER_MS) {
+        closeLog(windowLabel, "joining in-flight close");
+        return existing;
+      }
+      // Stalled (#1253). `activeCloseRef` is cleared only when the flow
+      // SETTLES, so a step that never settles made every later close request
+      // join a dead promise — the user clicks the traffic light again and
+      // again and nothing happens, with no way out but killing the process.
+      // Nothing in the flow has a timeout, and every decision point is a
+      // blocking native dialog that can only resolve, never reject.
+      //
+      // A fresh attempt is the conservative recovery: it cancels nothing,
+      // forces nothing, and discards no buffer. It costs at worst a second
+      // prompt for a user who walked away mid-dialog — and that user has just
+      // asked to close again, so acting on the newer request is right.
+      closeLog(windowLabel, `in-flight close stalled for ${age}ms — starting a fresh attempt`);
     }
 
     const run = runWindowCloseFlow(windowLabel, closeLog)
@@ -89,9 +131,13 @@ export function useWindowClose() {
         return false;
       })
       .finally(() => {
-        activeCloseRef.current = null;
+        // Only retire OUR attempt. A stalled flow that finally settles after a
+        // fresh one started would otherwise null the newer attempt's ref,
+        // letting a third request run a third flow concurrently.
+        if (activeCloseRef.current === run) activeCloseRef.current = null;
       });
     activeCloseRef.current = run;
+    activeCloseStartedAtRef.current = Date.now();
     return run;
   }, [windowLabel]);
 


### PR DESCRIPTION
Refs #1253 — does **not** close it. This fixes two defects found while investigating and makes the underlying stall diagnosable; the stall itself is not yet identified.

## Defect 1 — the close flow was invisible in release builds

`closeLog` was `import.meta.env.DEV ? … : () => {}`, so a shipped build recorded **nothing** about a window close. The Rust lines were `log::debug!`, filtered at the release Info level.

@b34601512 reported "no `CloseRequested` in the log" and read it as evidence the handler never fired. It was not evidence of anything — and asking them for a debug log would have been useless, because a release build cannot produce one.

Close milestones now log at INFO through a dedicated `window_close_log` command — deliberately **not** `debug_log`, which is `debug!` and would still vanish — and the Rust CloseRequested/emit/destroy lines are `info!`.

## Defect 2 — a stalled flow permanently bricked the window

- `api.prevent_close()` is unconditional, with no timeout and no fallback.
- `activeCloseRef` was cleared **only** in `.finally()`, so a step that never settled made every later close request join a dead promise. That is exactly *"clicking X repeatedly does nothing."*
- There is **no timeout anywhere** in the close path, and every decision point is a blocking native dialog that can only resolve, never reject.

One stall anywhere therefore converted into an unclosable window with no recovery but killing the process.

A close request arriving more than five minutes into an in-flight attempt now starts a fresh one. Conservative by construction: it cancels nothing, forces nothing, discards no buffer. The threshold is far longer than any real prompt takes to answer, so a user reading a save dialog is never interrupted by a second — and `.finally` now retires only its **own** attempt, so a stalled flow settling late cannot clear a newer attempt's ref and let a third run concurrently.

## What is NOT fixed: the underlying stall

Three hypotheses investigated and **refuted**:

| Theory | Refuted by |
|---|---|
| Unowned native dialog hidden behind another window | `tauri-plugin-dialog` does `builder.parent(&window)` on desktop |
| `collect_live_document_refs` hanging | has a `tokio::time::timeout`, fails closed |
| Workspace-config lock contention between instances | lock-free atomic write; errors reject rather than hang |

Leading remaining suspect: `close_window` calls `window.destroy()` on the very webview awaiting its IPC response — the existing comment already half-concedes this ("may never reach this line"). It fits every symptom, including the absent dialog: with no unsaved changes the flow takes the clean path where **no dialog is expected**. Confirming it needs a Windows log across the stall, which the logging above finally makes possible.

## Incidental

- `close_window` is generic over the runtime so a mock app can exercise its not-found branch — which is what let `commands.rs` have tests at all.
- The multi-format guard's own test asserted `commands.rs` was untested, pinning the assertion to repo state rather than guard behaviour, so adding tests made the gate look broken. It now uses a synthetic path, matching the TypeScript case beside it.

## Verification

2084 Rust tests · `clippy -D warnings` clean · `check:static` green (38 gate files / 836 tests) · 116 close-flow JS tests.
