### PR TITLE
chore: bump version to 0.9.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.33",
+  "version": "0.9.34",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.33",
+  "version": "0.9.34",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.33';
+const VERSION = '0.9.34';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6280,7 +6280,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.33"
+version = "0.9.34"
 dependencies = [
  "base64 0.23.0",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.33"
+version = "0.9.34"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.33",
+  "version": "0.9.34",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Bumps 0.9.33 → 0.9.34 across all five version files plus the derived `src-tauri/Cargo.lock`.

## What this release carries

**#1252 — `forbidden path` on non-home Windows drives** (#1256). Opening any file in a workspace on a drive other than the profile drive failed. Two causes: the static capability scope covers `$HOME/**`, `/Volumes/**`, `/mnt/**`, `/media/**`, and on Windows `$HOME` is `C:\Users\<name>`; and the runtime grant never covered the workspace tree — subdirectories were ungranted, and a workspace restored from session, recents, or MCP was never granted at all, because scope grants are in-memory and do not survive a restart. Fixed at the funnel, with the grant made recursive.

**#1253 — partial only; the root cause is NOT fixed** (#1257). Two real defects around it are:

- The close flow logged **nothing** in release builds — frontend logging compiled out, Rust lines at `debug!` under an Info filter. This is why the first report arrived with a log that said nothing about the close.
- A stalled close permanently bricked the window: `prevent_close()` is unconditional with no timeout, and the in-flight close was cleared only on settle, so every later click joined a dead promise. Clicking X repeatedly now recovers.

The underlying stall is still unidentified. Nothing here should be read as fixing it.

## Verification

`pnpm check:all` green on `main` before any version file was touched — exit code confirmed directly, not inferred from a pipeline.

## Note

An attempt to reproduce #1253 on real Windows hardware was **void** and is not cited anywhere in this release: a bare `cargo build --release` emits `cargo:rustc-cfg=dev`, so the binary loaded `devUrl` instead of the embedded frontend, and the window that "would not close" contained a WebView2 error page rather than VMark. The Rust-side logging shipped here did fire correctly during that run, which is the one thing it established.
