### PR TITLE
fix: notarize and staple the DMG so downloads pass Gatekeeper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,6 +316,69 @@ jobs:
           # (renamed from includeUpdaterJson in tauri-action v1.0.0)
           uploadUpdaterJson: false
 
+      # tauri-action signs, notarizes and staples the .app, and signs the .dmg —
+      # but it never notarizes the disk image itself. A signed-but-unnotarized
+      # dmg is refused by `spctl -t open` with "Unnotarized Developer ID", so
+      # the download is rejected before the stapled app inside is ever assessed.
+      #
+      # tauri-action has already uploaded the un-stapled dmg to the draft
+      # release, so the stapled copy has to replace it with --clobber. Only the
+      # dmg changes; the updater path (.app.tar.gz + .sig) is untouched.
+      - name: Notarize and staple DMG (macOS)
+        if: matrix.platform == 'macos-latest'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ needs.create-release.outputs.version }}
+          MATRIX_ARGS: ${{ matrix.args }}
+        run: |
+          set -euo pipefail
+
+          # Fail closed. A missing secret must not silently skip notarization
+          # and ship an unnotarized dmg behind a green build.
+          test -n "$APPLE_TEAM_ID" || { echo "FAIL: APPLE_TEAM_ID is empty"; exit 1; }
+
+          TARGET="${MATRIX_ARGS##*--target }"
+          DMG=$(ls "src-tauri/target/$TARGET/release/bundle/dmg/"*.dmg | head -1)
+          echo "Notarizing $DMG"
+
+          # notarytool has no internal retry and Apple's notary service drops
+          # connections intermittently: a timed-out *status poll* fails the step
+          # after the upload has already succeeded and been accepted.
+          # $1 is a log label; the rest is the command. The label exists so the
+          # failure message never echoes the expanded argv — the shell expands
+          # $APPLE_PASSWORD before retry() is entered, so echoing "$*" would
+          # write the app-specific password into the build log.
+          retry() {
+            label="$1"; shift
+            for i in 1 2 3 4 5; do
+              "$@" && return 0
+              echo "attempt $i failed, retrying in 10s: $label" >&2
+              sleep 10
+            done
+            echo "FAIL: gave up after 5 attempts: $label" >&2
+            return 1
+          }
+
+          retry "notarytool submit" xcrun notarytool submit "$DMG" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+          retry "stapler staple" xcrun stapler staple "$DMG"
+          xcrun stapler validate "$DMG"
+
+          # The gate. Must print `accepted` / `source=Notarized Developer ID`.
+          # No `|| true` — a rejected dmg has to fail the build.
+          spctl -a -vv -t open --context context:primary-signature "$DMG"
+
+          # Replace the un-stapled copy tauri-action already uploaded.
+          retry "gh release upload" gh release upload "$VERSION" "$DMG" --clobber --repo "$REPO"
+
   publish-release:
     needs: [create-release, build-tauri]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,6 +326,12 @@ jobs:
       # dmg changes; the updater path (.app.tar.gz + .sig) is untouched.
       - name: Notarize and staple DMG (macOS)
         if: matrix.platform == 'macos-latest'
+        # Bounded like the tauri-action step above. This is the only step that
+        # blocks on Apple's notary service: `notarytool --wait` has no default
+        # timeout, and the retry wrapper multiplies that by five. build-tauri
+        # sets no job-level timeout, so without this a stalled submission idles
+        # a macOS runner for GitHub's 360-minute default at a 10x billing rate.
+        timeout-minutes: 45
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
@@ -338,8 +344,16 @@ jobs:
           set -euo pipefail
 
           # Fail closed. A missing secret must not silently skip notarization
-          # and ship an unnotarized dmg behind a green build.
-          test -n "$APPLE_TEAM_ID" || { echo "FAIL: APPLE_TEAM_ID is empty"; exit 1; }
+          # and ship an unnotarized dmg behind a green build. All three are
+          # required, not just the team id: an empty APPLE_ID or APPLE_PASSWORD
+          # otherwise fails five full dmg uploads deep, behind a generic
+          # notarytool error, instead of here with the name of what is missing.
+          # ${!var-} not ${!var}: indirect expansion of an unset name is an
+          # error under `set -u`, and the point here is to REPORT the missing
+          # secret by name, not to abort with "unbound variable".
+          for var in APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            test -n "${!var-}" || { echo "FAIL: $var is empty"; exit 1; }
+          done
 
           TARGET="${MATRIX_ARGS##*--target }"
           DMG=$(ls "src-tauri/target/$TARGET/release/bundle/dmg/"*.dmg | head -1)


### PR DESCRIPTION
tauri-action signs, notarizes and staples the .app and signs the .dmg, but it
never notarizes the disk image itself. The shipped dmg therefore carried a
Developer ID signature and no notarization ticket, so `spctl -t open` rejected
it with "Unnotarized Developer ID" — the download is refused before the stapled
app inside is ever assessed.

Add a notarize-and-staple step after the Tauri build. Because tauri-action
builds and uploads in a single step, the un-stapled dmg has already been
attached to the draft release by then, so the stapled copy replaces it with
`gh release upload --clobber`.

The step fails closed. An empty APPLE_TEAM_ID aborts instead of silently
skipping notarization behind a green build, and the closing spctl gate carries
no `|| true`, so a rejected dmg fails the job rather than printing a success
line over a bad artifact.

notarytool has no internal retry and Apple's notary service drops connections
intermittently: a timed-out status poll fails the step after the upload has
already succeeded and been accepted server-side. Submit, staple and the
re-upload are wrapped in a bounded retry.

The retry wrapper takes a log label instead of echoing its argv. The shell
expands $APPLE_PASSWORD before the function is entered, so printing "$*" would
write the app-specific password into the build log on every retry. CI log
masking would likely redact it, but that is a backstop, not a control.

Only the dmg is affected — the updater path (.app.tar.gz + .sig) is untouched,
so update delivery is unchanged.
