### PR TITLE
fix(update): bound the check, log the flow, and let a stalled update recover

### DIFF
--- a/src-tauri/src/app_setup.rs
+++ b/src-tauri/src/app_setup.rs
@@ -250,3 +250,22 @@ pub fn debug_log(message: String) {
 pub fn window_close_log(message: String) {
     log::info!("[WindowClose] {}", message);
 }
+
+/// Update-flow milestones from the frontend, at INFO (#1270).
+///
+/// Same reasoning as `window_close_log` above, for the other flow that can
+/// stall with no timeout: the update check and download are network calls, and
+/// a connection that stalls never settles. The state machine had no milestone
+/// logging at any tier, so a report of a frozen update arrived with nothing
+/// describing which step hung.
+///
+/// Deliberately a sibling of `window_close_log` rather than a generalisation
+/// of it: that command shipped for a still-open report, and reworking it to
+/// save three lines here would put the diagnostic being used to investigate
+/// this stall at risk. Generalise when a third flow needs it.
+///
+/// Kept to state transitions: download progress events are not logged.
+#[tauri::command]
+pub fn update_log(message: String) {
+    log::info!("[Update] {}", message);
+}

--- a/src-tauri/src/command_registry.rs
+++ b/src-tauri/src/command_registry.rs
@@ -141,6 +141,7 @@ macro_rules! all_commands {
             #[cfg(debug_assertions)]
             app_setup::debug_log,
             app_setup::window_close_log,
+            app_setup::update_log,
             temp_html::write_temp_html,
             file_write::atomic_write_file,
             webview_edit::trigger_webview_edit,

--- a/src/components/StatusBar/UpdateIndicator.test.tsx
+++ b/src/components/StatusBar/UpdateIndicator.test.tsx
@@ -6,6 +6,11 @@ import userEvent from "@testing-library/user-event";
 const mockCheckForUpdates = vi.fn();
 const mockRestartApp = vi.fn();
 const mockOpenSettingsWindow = vi.fn();
+const mockRecoverFromStall = vi.fn();
+// Stall detection is time-based and tested directly in useUpdateStall.test.ts.
+// Here it is a switch, so these cases assert what the indicator DOES about a
+// stall rather than re-testing how one is detected.
+let mockStalled = false;
 
 vi.mock("@/stores/mcpStore", () => ({
   useMcpStore: vi.fn((selector: (state: Record<string, unknown>) => unknown) =>
@@ -27,6 +32,11 @@ vi.mock("@/hooks/useUpdateOperations", () => ({
     skipVersion: vi.fn(),
     requestState: vi.fn(),
   }),
+  recoverFromStall: (...args: unknown[]) => mockRecoverFromStall(...args),
+}));
+
+vi.mock("@/hooks/useUpdateStall", () => ({
+  useUpdateStall: () => mockStalled,
 }));
 
 vi.mock("@/services/navigation/settingsWindow", () => ({
@@ -40,6 +50,7 @@ let mockSettingsState: Record<string, unknown>;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockStalled = false;
   mockUpdateState = {
     status: "idle",
     updateInfo: null,
@@ -305,6 +316,71 @@ describe("UpdateIndicator", () => {
       const button = screen.getByTitle("Installing update...");
       expect(button).toBeInTheDocument();
       expect(button.style.cursor).toBe("default");
+    });
+  });
+
+  // #1270: checking/downloading/installing are non-interactive, so a flow that
+  // stops progressing left the user with a permanent spinner and no way out.
+  // A stall makes the indicator clickable regardless of the state's normal
+  // interactivity, and the click resets the flow rather than re-entering it.
+  describe("stalled flow", () => {
+    it.each(["checking", "downloading", "installing"] as const)(
+      "makes a stalled %s state clickable",
+      (status) => {
+        mockUpdateState.status = status;
+        mockStalled = true;
+        render(<UpdateIndicator />);
+
+        const button = screen.getByRole("button");
+        expect(button.style.cursor).toBe("pointer");
+      },
+    );
+
+    it("says the flow is stalled rather than showing the normal label", () => {
+      mockUpdateState.status = "checking";
+      mockStalled = true;
+      render(<UpdateIndicator />);
+
+      expect(screen.queryByTitle("Checking for updates...")).not.toBeInTheDocument();
+      expect(screen.getByRole("button")).toHaveAttribute(
+        "title",
+        "Update stalled — click to reset",
+      );
+    });
+
+    it("recovers the flow when a stalled indicator is clicked", async () => {
+      const user = userEvent.setup();
+      mockUpdateState.status = "downloading";
+      mockStalled = true;
+      render(<UpdateIndicator />);
+
+      await user.click(screen.getByRole("button"));
+
+      expect(mockRecoverFromStall).toHaveBeenCalledTimes(1);
+    });
+
+    // A stalled `error` must reset rather than fire another check into the
+    // same stuck guard — that retry would join the dead promise.
+    it("prefers recovery over retry when an error state is stalled", async () => {
+      const user = userEvent.setup();
+      mockUpdateState.status = "error";
+      mockStalled = true;
+      render(<UpdateIndicator />);
+
+      await user.click(screen.getByRole("button"));
+
+      expect(mockRecoverFromStall).toHaveBeenCalledTimes(1);
+      expect(mockCheckForUpdates).not.toHaveBeenCalled();
+    });
+
+    // The negative that keeps the feature honest: a healthy non-interactive
+    // state must stay non-interactive.
+    it("leaves a healthy downloading state non-clickable", () => {
+      mockUpdateState.status = "downloading";
+      mockStalled = false;
+      render(<UpdateIndicator />);
+
+      expect(screen.getByRole("button").style.cursor).toBe("default");
     });
   });
 });

--- a/src/components/StatusBar/UpdateIndicator.tsx
+++ b/src/components/StatusBar/UpdateIndicator.tsx
@@ -14,7 +14,8 @@ import { useTranslation } from "react-i18next";
 import { RefreshCw, Download, CheckCircle, AlertCircle } from "lucide-react";
 import { useMcpStore, type UpdateStatus } from "@/stores/mcpStore";
 import { useSettingsStore } from "@/stores/settingsStore";
-import { useUpdateOperations } from "@/hooks/useUpdateOperations";
+import { useUpdateOperations, recoverFromStall } from "@/hooks/useUpdateOperations";
+import { useUpdateStall } from "@/hooks/useUpdateStall";
 import { openSettingsWindow } from "@/services/navigation/settingsWindow";
 
 /**
@@ -83,6 +84,10 @@ export function UpdateIndicator() {
   const downloadProgress = useMcpStore((state) => state.update.downloadProgress);
   const autoDownload = useSettingsStore((state) => state.update.autoDownload);
   const { checkForUpdates, restartApp } = useUpdateOperations();
+  // `checking`/`downloading`/`installing` are non-interactive, so a flow that
+  // stops progressing has no way out — the guard is never released and every
+  // retry joins a promise that will never settle (#1270).
+  const stalled = useUpdateStall();
 
   const config = getIndicatorConfig(status);
 
@@ -100,9 +105,15 @@ export function UpdateIndicator() {
       ? Math.round((downloadProgress.downloaded / downloadProgress.total) * 100)
       : null;
 
+  // A stalled flow overrides the config: it becomes clickable regardless of
+  // the state's normal interactivity, and says so.
+  const clickable = config.clickable || stalled;
+
   // Build title with additional context
   let title = t(config.titleKey);
-  if (status === "available" && updateInfo) {
+  if (stalled) {
+    title = t("updateStalled");
+  } else if (status === "available" && updateInfo) {
     title = t("updateAvailableVersion", { version: updateInfo.version });
   } else if (status === "downloading") {
     title = downloadPercent !== null ? t("updateDownloadingPercent", { percent: downloadPercent }) : t("updateDownloading");
@@ -111,7 +122,15 @@ export function UpdateIndicator() {
   }
 
   const handleClick = () => {
-    if (!config.clickable) return;
+    if (!clickable) return;
+
+    // Checked before the status chain: a stalled `checking`/`downloading`
+    // matches none of those branches, and a stalled `error` should reset
+    // rather than fire another check into the same stuck guard.
+    if (stalled) {
+      recoverFromStall();
+      return;
+    }
 
     /* v8 ignore start -- @preserve reason: status branch chain (available/ready/error) not fully exercised in tests */
     if (status === "available") {
@@ -130,7 +149,7 @@ export function UpdateIndicator() {
       onClick={handleClick}
       title={title}
       aria-label={title}
-      style={{ cursor: config.clickable ? "pointer" : "default" }}
+      style={{ cursor: clickable ? "pointer" : "default" }}
     >
       <Icon size={12} />
       {config.showDot && <span className="status-update-dot" />}

--- a/src/hooks/useUpdateOperations.test.ts
+++ b/src/hooks/useUpdateOperations.test.ts
@@ -27,18 +27,27 @@ vi.mock("@tauri-apps/api/app", () => ({
 }));
 
 import { renderHook, act } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
 import { useMcpStore } from "@/stores/mcpStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import {
   useUpdateOperations,
   useUpdateOperationHandler,
   clearPendingUpdate,
+  recoverFromStall,
 } from "./useUpdateOperations";
+import { inFlight } from "@/services/updates/updateSingleFlight";
 
 describe("useUpdateOperations", () => {
   beforeEach(() => {
     useMcpStore.getState().resetUpdate();
     mockEmit.mockClear();
+    // The single-flight guards are module state. A test that leaves a promise
+    // deliberately unsettled (see the stall cases below) would otherwise brick
+    // every later test in this file — which is precisely the production defect
+    // being tested, so it must not be allowed to leak between cases.
+    recoverFromStall();
+    vi.mocked(invoke).mockClear();
   });
 
   it("returns all operation functions", () => {
@@ -231,6 +240,104 @@ describe("useUpdateOperations", () => {
     expect(mockDownloadAndInstall).toHaveBeenCalledTimes(1);
     expect(firstDone).toBe(true);
     expect(secondDone).toBe(true);
+  });
+
+  // The check is a network call and had no timeout, so a connection that
+  // STALLED — neither resolving nor rejecting — held the single-flight guard
+  // open forever. Bounding it is what makes `.finally()` a valid place to
+  // clear the guard at all.
+  it("bounds check() with a timeout so a stalled connection cannot hang forever", async () => {
+    mockCheck.mockReset();
+    mockCheck.mockResolvedValue(null);
+    const { result } = renderHook(() => useUpdateOperations());
+
+    await act(async () => {
+      await result.current.checkForUpdates();
+    });
+
+    expect(mockCheck).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+    const [{ timeout }] = mockCheck.mock.calls[0] as [{ timeout: number }];
+    expect(timeout).toBeGreaterThan(0);
+  });
+
+  // THE regression assertion for #1270. A promise that never settles leaves
+  // `inFlight.check` non-null forever; every later caller returns that dead
+  // promise, so the feature is bricked for the life of the window and the
+  // StatusBar spinner is permanent. Same mechanism as the #1253 close stall.
+  //
+  // This asserts the release valve exists, not merely that the timeout was
+  // added: a timeout narrows the window, recovery is what escapes it.
+  it("recoverFromStall releases a check that never settles, so a retry reaches the plugin", async () => {
+    mockCheck.mockReset();
+    // A connection that hangs rather than failing — never resolves, never rejects.
+    mockCheck.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useUpdateOperations());
+
+    await act(async () => {
+      void result.current.checkForUpdates();
+      await Promise.resolve();
+    });
+    expect(mockCheck).toHaveBeenCalledTimes(1);
+
+    // Without recovery, every retry joins the dead promise — no new call.
+    await act(async () => {
+      void result.current.checkForUpdates();
+      await Promise.resolve();
+    });
+    expect(mockCheck).toHaveBeenCalledTimes(1);
+    expect(inFlight.check).not.toBeNull();
+
+    act(() => {
+      recoverFromStall();
+    });
+    expect(inFlight.check).toBeNull();
+
+    // And now a retry actually reaches the plugin.
+    mockCheck.mockResolvedValue(null);
+    await act(async () => {
+      await result.current.checkForUpdates();
+    });
+    expect(mockCheck).toHaveBeenCalledTimes(2);
+  });
+
+  // Recovery drops pendingUpdate too: re-entering downloadAndInstall on the
+  // same Update resource is not supported by the plugin, so a retry has to
+  // run a fresh check and obtain a new one.
+  it("recoverFromStall clears pendingUpdate and returns the flow to idle", () => {
+    useMcpStore.getState().setPendingUpdate({ downloadAndInstall: vi.fn() } as never);
+    useMcpStore.getState().setUpdateStatus("downloading");
+
+    act(() => {
+      recoverFromStall();
+    });
+
+    expect(useMcpStore.getState().update.pendingUpdate).toBeNull();
+    expect(useMcpStore.getState().update.status).toBe("idle");
+    expect(inFlight.download).toBeNull();
+  });
+
+  // #1270 arrived with no way to tell which step hung, because the update
+  // state machine logged nothing at any tier. These milestones go to `info!`
+  // via a dedicated command so they survive a release build.
+  it("logs check milestones at release level", async () => {
+    mockCheck.mockReset();
+    mockCheck.mockResolvedValue(null);
+    const { result } = renderHook(() => useUpdateOperations());
+
+    await act(async () => {
+      await result.current.checkForUpdates();
+    });
+
+    const logged = vi
+      .mocked(invoke)
+      .mock.calls.filter(([cmd]) => cmd === "update_log")
+      .map(([, args]) => (args as { message: string }).message);
+
+    expect(logged.some((m) => m.includes("check:start"))).toBe(true);
+    expect(logged.some((m) => m.includes("check:returned"))).toBe(true);
   });
 });
 

--- a/src/hooks/useUpdateOperations.ts
+++ b/src/hooks/useUpdateOperations.ts
@@ -1,46 +1,44 @@
 /**
  * Update Operations Hook
  *
- * Purpose: Provides check/download/install/restart operations for app updates.
- *   The actual check/download work runs in whichever window the user clicked
- *   from — `pendingUpdate` is a Tauri JS resource that can't cross window
- *   boundaries, so the operation must complete in the same window that
- *   created it. Cross-window emit is reserved for restart (no shared state).
+ * Purpose: React adapters over the update flows, plus the cross-window
+ *   restart/state events. The flows themselves live in
+ *   `services/updates/updateFlows.ts` — they have no React dependency, and
+ *   this file outgrew the 300-line limit holding both (ADR-013).
  *
- * Pipeline: User clicks "Check now" in Settings → `checkForUpdates()` calls
- *   Tauri updater `check()` directly → updates local `useMcpStore` →
- *   subsequent `downloadAndInstall()` uses the same window's pendingUpdate.
+ * Pipeline: User clicks "Check now" in Settings → `checkForUpdates()` →
+ *   `runUpdateCheck()` → updates local `useMcpStore` → a subsequent
+ *   `downloadAndInstall()` uses the same window's pendingUpdate.
  *
  * Key decisions:
  *   - Run check/download in the calling window (pendingUpdate is window-local).
  *     The previous "always route to main" design broke when main was destroyed
  *     (closed via traffic light / Cmd+W on macOS) — the cross-window emit went
  *     to nobody and the "Check now" button silently did nothing.
- *   - Per-window single-flight via module-level `inFlight.{check,download}`:
- *     spam-clicks, the auto-retry timer, and the auto-download effect all
- *     share one in-flight promise so the Tauri updater plugin is never
- *     called twice in parallel from the same window.
  *   - Restart still emits cross-window because it needs to coordinate with
  *     dirty-document handling in the main window's useUpdateChecker.
  *   - Settings → Check, Settings → Download is the typical user path; it
  *     all runs in the Settings window with one consistent pendingUpdate ref.
  *   - clearPendingUpdate exported for cleanup after restart.
- *   - Version comparison uses getVersion() from Tauri app API.
+ *   - `recoverFromStall` is the release valve for a flow that stops
+ *     progressing — see its own doc, and `updateSingleFlight.ts` for why a
+ *     `.finally()`-only guard needs one at all (#1270).
  *
+ * @coordinates-with updateFlows.ts — the check/download implementations
+ * @coordinates-with useUpdateStall.ts — decides when recovery is offered
  * @coordinates-with useUpdateChecker.ts — auto-check on startup (main window)
  * @coordinates-with useUpdateSync.ts — broadcasts state across windows
  * @coordinates-with mcpStore.ts — `update` slice holds status, info, progress
- * @coordinates-with updateProgressThrottle.ts — coalesces per-chunk writes
  * @module hooks/useUpdateOperations
  */
 
 import { useCallback } from "react";
-import { check } from "@tauri-apps/plugin-updater";
 import { emit } from "@tauri-apps/api/event";
 import { useMcpStore } from "@/stores/mcpStore";
 import { useSettingsStore } from "@/stores/settingsStore";
-import { getVersion } from "@tauri-apps/api/app";
-import { shouldWriteProgress } from "@/services/updates/updateProgressThrottle";
+import { runUpdateCheck, runUpdateDownload } from "@/services/updates/updateFlows";
+import { clearInFlight } from "@/services/updates/updateSingleFlight";
+import { updateFlowLog } from "@/services/updates/updateFlowLog";
 import i18n from "@/i18n";
 
 // Event names for cross-window communication
@@ -50,151 +48,6 @@ const EVENTS = {
   REQUEST_RESTART: "app:restart-for-update",
   REQUEST_STATE: "update:request-state",
 } as const;
-
-// Per-window single-flight gates: spam-clicks, the auto-retry timer, and the
-// auto-download effect all await the same in-flight promise rather than issuing
-// parallel `check()`/`download` calls against the Tauri updater plugin (the
-// parallel-check churn was a contributor to the v0.7.11 freeze). Held in a
-// holder object so the formatter doesn't rewrite the reassignment to `const`.
-const inFlight: { check: Promise<boolean> | null; download: Promise<boolean> | null } = {
-  check: null,
-  download: null,
-};
-
-/**
- * Run the update check inline in the current window. Updates the local
- * `useMcpStore` and stores `pendingUpdate` here so the same window can
- * later call download. Standalone (no React deps) so any caller — manual
- * button, auto-check on startup, the legacy cross-window listener — can
- * share the same code path.
- */
-async function runUpdateCheck(): Promise<boolean> {
-  // Single-flight: if a check is already in progress in this window, every
-  // caller (manual button, auto-check, retry timer, cross-window listener)
-  // shares the same result. Otherwise overlapping callers spawn parallel
-  // `check()` requests, each broadcasting status churn back to the other
-  // window via useUpdateSync — the cascade behind the v0.7.11 freeze.
-  if (inFlight.check) return inFlight.check;
-
-  inFlight.check = (async () => {
-    const store = useMcpStore.getState();
-    const settings = useSettingsStore.getState();
-
-    store.setUpdateStatus("checking");
-
-    try {
-      const update = await check();
-
-      if (update) {
-        store.setPendingUpdate(update);
-        const currentVersion = await getVersion();
-        store.setUpdateInfo({
-          version: update.version,
-          notes: update.body ?? "",
-          pubDate: update.date ?? "",
-          currentVersion,
-        });
-        store.setUpdateStatus("available");
-        // New update — clear any prior dismiss flag so the banner shows.
-        store.clearDismissed();
-        settings.updateUpdateSetting("lastCheckTimestamp", Date.now());
-        return true;
-      }
-
-      store.setUpdateStatus("up-to-date");
-      store.setPendingUpdate(null);
-      settings.updateUpdateSetting("lastCheckTimestamp", Date.now());
-      return false;
-    } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : i18n.t("dialog:toast.updateCheckFailedGeneric");
-      store.setUpdateError(message);
-      // Don't update lastCheckTimestamp on error — the check didn't complete.
-      return false;
-    } finally {
-      inFlight.check = null;
-    }
-  })();
-
-  return inFlight.check;
-}
-
-/**
- * Run download/install inline in the current window using the local
- * `pendingUpdate`. Returns false if no pendingUpdate is held here (caller
- * may decide to re-check or surface an error).
- */
-async function runUpdateDownload(): Promise<boolean> {
-  // Single-flight: prevent two callers (manual click + auto-download effect)
-  // from each invoking pendingUpdate.downloadAndInstall on the same Update
-  // resource — the underlying Tauri resource is not safe to download twice.
-  if (inFlight.download) return inFlight.download;
-
-  const initial = useMcpStore.getState();
-  const pendingUpdate = initial.update.pendingUpdate;
-  if (!pendingUpdate) return false;
-
-  inFlight.download = (async () => {
-    const store = useMcpStore.getState();
-    store.setUpdateStatus("downloading");
-    store.setDownloadProgress({ downloaded: 0, total: null });
-
-    // Track progress in locals (avoids stale-state reads). Store writes are
-    // throttled via shouldWriteProgress so a chunky download doesn't flood
-    // re-renders and the cross-window broadcast.
-    let downloadedBytes = 0;
-    let totalBytes: number | null = null;
-    let lastWritten = -1;
-
-    try {
-      await pendingUpdate.downloadAndInstall((event) => {
-        const live = useMcpStore.getState();
-        switch (event.event) {
-          case "Started":
-            downloadedBytes = 0;
-            totalBytes = event.data.contentLength ?? null;
-            lastWritten = 0;
-            live.setDownloadProgress({ downloaded: 0, total: totalBytes });
-            break;
-          case "Progress":
-            downloadedBytes += event.data.chunkLength;
-            if (shouldWriteProgress(downloadedBytes, lastWritten, totalBytes)) {
-              lastWritten = downloadedBytes;
-              live.setDownloadProgress({ downloaded: downloadedBytes, total: totalBytes });
-            }
-            break;
-          case "Finished":
-            // Bytes are in; the updater now writes/installs them (takes a
-            // moment). Snap to 100% and switch to the install phase instead of
-            // leaving a frozen "Downloading…" with no bar.
-            live.setDownloadProgress({ downloaded: totalBytes ?? downloadedBytes, total: totalBytes });
-            live.setUpdateStatus("installing");
-            break;
-        }
-      });
-
-      const done = useMcpStore.getState();
-      done.setUpdateStatus("ready");
-      done.setDownloadProgress(null);
-      return true;
-    } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : i18n.t("dialog:toast.updateDownloadFailedGeneric");
-      const failed = useMcpStore.getState();
-      failed.setDownloadProgress(null);
-      failed.setUpdateError(message);
-      return false;
-    } finally {
-      inFlight.download = null;
-    }
-  })();
-
-  return inFlight.download;
-}
 
 /**
  * Hook for update operations.
@@ -296,4 +149,28 @@ export function useUpdateOperationHandler() {
  */
 export function clearPendingUpdate() {
   useMcpStore.getState().setPendingUpdate(null);
+}
+
+/**
+ * Release a stalled update flow so the user can try again.
+ *
+ * `checking`, `downloading` and `installing` are all non-interactive states in
+ * the StatusBar indicator, so a flow that stops progressing leaves no way out:
+ * the guard is never cleared, every retry joins a promise that will never
+ * settle, and the spinner is permanent for the life of the window. This is the
+ * release valve for that — the same remedy #1253 needed for window close.
+ *
+ * Resets the store as well as the guards, which drops `pendingUpdate`. That is
+ * deliberate: a retry then runs a fresh `check()` and downloads through a NEW
+ * Update resource, rather than re-entering `downloadAndInstall` on the same
+ * one, which the plugin does not support.
+ *
+ * Whatever stalled underneath is NOT cancelled — the updater exposes no
+ * cancellation. If it ever completes it writes into a store slice that has
+ * moved on, which is harmless; the alternative is a permanently stuck UI.
+ */
+export function recoverFromStall(): void {
+  updateFlowLog("stall:recover", { status: useMcpStore.getState().update.status });
+  clearInFlight();
+  useMcpStore.getState().resetUpdate();
 }

--- a/src/hooks/useUpdateStall.test.ts
+++ b/src/hooks/useUpdateStall.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for useUpdateStall (#1270).
+ *
+ * The hook exists so a flow that stops progressing stops being permanent.
+ * These cases pin the two properties that matter: a live transfer must NOT be
+ * reported as stalled (a false positive offers a reset button mid-download),
+ * and a state that genuinely stops moving must be.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useMcpStore } from "@/stores/mcpStore";
+import {
+  useUpdateStall,
+  stallThresholdFor,
+  CHECK_STALL_MS,
+  TRANSFER_STALL_MS,
+} from "./useUpdateStall";
+
+describe("stallThresholdFor", () => {
+  it("bounds only the states that can stall", () => {
+    expect(stallThresholdFor("checking")).toBe(CHECK_STALL_MS);
+    expect(stallThresholdFor("downloading")).toBe(TRANSFER_STALL_MS);
+    expect(stallThresholdFor("installing")).toBe(TRANSFER_STALL_MS);
+  });
+
+  // Every other state is either terminal or already clickable, so a stall
+  // notion for it would be meaningless.
+  it.each(["idle", "up-to-date", "available", "ready", "error"] as const)(
+    "leaves %s unbounded",
+    (status) => {
+      expect(stallThresholdFor(status)).toBeNull();
+    },
+  );
+
+  // The check carries a 30s request timeout, so its threshold has to sit
+  // above that or the hook fires while the bounded call is still legitimately
+  // running.
+  it("gives the check room beyond its own request timeout", () => {
+    expect(CHECK_STALL_MS).toBeGreaterThan(30_000);
+  });
+
+  // The download is deliberately unbounded (a total-request timeout would
+  // abort slow-but-working transfers), so it needs the more generous window.
+  it("gives transfers a longer window than the check", () => {
+    expect(TRANSFER_STALL_MS).toBeGreaterThan(CHECK_STALL_MS);
+  });
+});
+
+describe("useUpdateStall", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useMcpStore.getState().resetUpdate();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not report a stall for a state that cannot stall", () => {
+    useMcpStore.getState().setUpdateStatus("available");
+    const { result } = renderHook(() => useUpdateStall());
+
+    act(() => {
+      vi.advanceTimersByTime(TRANSFER_STALL_MS * 2);
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("reports a stall once a checking state stops progressing", () => {
+    useMcpStore.getState().setUpdateStatus("checking");
+    const { result } = renderHook(() => useUpdateStall());
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(CHECK_STALL_MS + 5_000);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  // The important negative: a download that is still moving bytes must never
+  // be offered a reset button, however long it takes overall.
+  it("does not report a stall while a download keeps making progress", () => {
+    const store = useMcpStore.getState();
+    store.setUpdateStatus("downloading");
+    store.setDownloadProgress({ downloaded: 0, total: 1_000 });
+
+    const { result, rerender } = renderHook(() => useUpdateStall());
+
+    for (let i = 1; i <= 6; i++) {
+      act(() => {
+        vi.advanceTimersByTime(TRANSFER_STALL_MS / 2);
+        useMcpStore.getState().setDownloadProgress({ downloaded: i * 100, total: 1_000 });
+      });
+      rerender();
+      expect(result.current).toBe(false);
+    }
+  });
+
+  it("reports a stall when a download stops making progress", () => {
+    const store = useMcpStore.getState();
+    store.setUpdateStatus("downloading");
+    store.setDownloadProgress({ downloaded: 500, total: 1_000 });
+
+    const { result } = renderHook(() => useUpdateStall());
+
+    act(() => {
+      vi.advanceTimersByTime(TRANSFER_STALL_MS + 5_000);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  // Recovery moves the flow back to idle; the hook must follow rather than
+  // latching on the stale verdict.
+  it("clears the stall once the flow leaves the stalled state", () => {
+    useMcpStore.getState().setUpdateStatus("checking");
+    const { result, rerender } = renderHook(() => useUpdateStall());
+
+    act(() => {
+      vi.advanceTimersByTime(CHECK_STALL_MS + 5_000);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      useMcpStore.getState().resetUpdate();
+    });
+    rerender();
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useUpdateStall.ts
+++ b/src/hooks/useUpdateStall.ts
@@ -1,0 +1,100 @@
+/**
+ * Update stall detection.
+ *
+ * Purpose: report whether the update flow has stopped making observable
+ *   progress, so the StatusBar indicator can offer a way out of a state that
+ *   is otherwise permanent.
+ *
+ * Key decisions:
+ *   - Detected per window and held in local refs, NOT in the store. The
+ *     cross-window snapshot in `useUpdateSync` is compared by JSON for echo
+ *     suppression; a timestamp changes on every tick, so putting one in the
+ *     broadcast payload would defeat that suppression and reintroduce the
+ *     A↔B feedback loop documented there.
+ *   - Only `checking`, `downloading` and `installing` can stall. Every other
+ *     state is either terminal or already clickable.
+ *   - "Progress" means any observable change — status OR download progress.
+ *     A healthy download writes progress regularly (throttled by
+ *     `shouldWriteProgress`), so a live transfer keeps resetting the clock.
+ *
+ * Thresholds are deliberately generous, because a false positive offers the
+ * user a reset button during a slow-but-working download. `installing` shares
+ * the transfer threshold: it emits no progress events at all, so it can sit
+ * quiet for a while legitimately.
+ *
+ * @coordinates-with useUpdateOperations.ts — recoverFromStall is the action
+ * @coordinates-with UpdateIndicator.tsx — renders the escape hatch
+ * @module hooks/useUpdateStall
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { useMcpStore, type UpdateStatus, type DownloadProgress } from "@/stores/mcpStore";
+
+/** A bounded `check()` should settle well inside this; it carries a 30s timeout. */
+export const CHECK_STALL_MS = 60_000;
+
+/** Download and install are unbounded by design — give them real room. */
+export const TRANSFER_STALL_MS = 180_000;
+
+/** How often to re-evaluate. Coarse: this drives a tooltip, not an animation. */
+const TICK_MS = 5_000;
+
+const STALLABLE: readonly UpdateStatus[] = ["checking", "downloading", "installing"];
+
+/** Threshold for a status, or null when that status cannot stall. */
+export function stallThresholdFor(status: UpdateStatus): number | null {
+  if (status === "checking") return CHECK_STALL_MS;
+  if (status === "downloading" || status === "installing") return TRANSFER_STALL_MS;
+  return null;
+}
+
+/** Serialise the observable progress signal for change detection. */
+function progressKey(status: UpdateStatus, progress: DownloadProgress | null): string {
+  return `${status}:${progress?.downloaded ?? -1}:${progress?.total ?? -1}`;
+}
+
+/**
+ * True when the update flow has sat in a stallable state without any
+ * observable change for longer than its threshold.
+ */
+export function useUpdateStall(): boolean {
+  const status = useMcpStore((state) => state.update.status);
+  const downloadProgress = useMcpStore((state) => state.update.downloadProgress);
+
+  const [stalled, setStalled] = useState(false);
+  // Null until the first effect runs. `Date.now()` is impure, so it cannot be
+  // called during render — including as a `useRef` initialiser, which runs on
+  // every render even though only the first value is kept.
+  const changedAtRef = useRef<number | null>(null);
+  const lastKeyRef = useRef<string | null>(null);
+
+  // Pure during render; the effect below reacts to it changing.
+  const key = progressKey(status, downloadProgress);
+
+  // Restart the clock whenever anything observable moves. Touches refs only —
+  // no setState here, so an observed change cannot cascade a render.
+  useEffect(() => {
+    if (lastKeyRef.current !== key) {
+      lastKeyRef.current = key;
+      changedAtRef.current = Date.now();
+    }
+  }, [key]);
+
+  useEffect(() => {
+    const threshold = stallThresholdFor(status);
+    if (threshold === null) return;
+
+    // Evaluated only on the interval, never synchronously on mount: a
+    // synchronous setState in an effect cascades renders, and with thresholds
+    // measured in minutes a first verdict one tick late costs nothing.
+    const timer = setInterval(() => {
+      const since = changedAtRef.current;
+      setStalled(since !== null && Date.now() - since >= threshold);
+    }, TICK_MS);
+    return () => clearInterval(timer);
+  }, [status, key]);
+
+  // Derived, not stored: leaving a stallable state clears the verdict
+  // immediately rather than waiting for the next tick to correct it.
+  return stalled && STALLABLE.includes(status);
+}

--- a/src/locales/de/statusbar.json
+++ b/src/locales/de/statusbar.json
@@ -57,6 +57,7 @@
   "updateReady": "Klicken zum Neustart und Aktualisieren",
   "updateReadyVersion": "v{{version}} bereit — klicken zum Neustart",
   "updateError": "Update-Prüfung fehlgeschlagen — klicken zum Wiederholen",
+  "updateStalled": "Update hängt fest — zum Zurücksetzen klicken",
   "autoSavedAt": "Automatisch gespeichert um {{time}}",
   "terminal.search.placeholder": "Suchen...",
   "terminal.search.label": "Terminal-Ausgabe durchsuchen",

--- a/src/locales/en/statusbar.json
+++ b/src/locales/en/statusbar.json
@@ -57,6 +57,7 @@
   "updateReady": "Click to restart and update",
   "updateReadyVersion": "v{{version}} ready — click to restart",
   "updateError": "Update check failed — click to retry",
+  "updateStalled": "Update stalled — click to reset",
   "autoSavedAt": "Auto-saved at {{time}}",
   "terminal.search.placeholder": "Search...",
   "terminal.search.label": "Search terminal output",

--- a/src/locales/es/statusbar.json
+++ b/src/locales/es/statusbar.json
@@ -57,6 +57,7 @@
   "updateReady": "Haz clic para reiniciar y actualizar",
   "updateReadyVersion": "v{{version}} listo — haz clic para reiniciar",
   "updateError": "Error al buscar actualizaciones — haz clic para reintentar",
+  "updateStalled": "Actualización detenida: haz clic para reiniciar",
   "autoSavedAt": "Guardado automáticamente a las {{time}}",
   "terminal.search.placeholder": "Buscar...",
   "terminal.search.label": "Buscar en la salida del terminal",

--- a/src/locales/fr/statusbar.json
+++ b/src/locales/fr/statusbar.json
@@ -57,6 +57,7 @@
   "updateReady": "Cliquez pour redémarrer et mettre à jour",
   "updateReadyVersion": "v{{version}} prête — cliquez pour redémarrer",
   "updateError": "Échec de la vérification des mises à jour — cliquez pour réessayer",
+  "updateStalled": "Mise à jour bloquée — cliquez pour réinitialiser",
   "autoSavedAt": "Enregistré automatiquement à {{time}}",
   "terminal.search.placeholder": "Rechercher...",
   "terminal.search.label": "Rechercher dans la sortie du terminal",

--- a/src/locales/it/statusbar.json
+++ b/src/locales/it/statusbar.json
@@ -57,6 +57,7 @@
   "updateReady": "Clicca per riavviare e aggiornare",
   "updateReadyVersion": "v{{version}} pronto — clicca per riavviare",
   "updateError": "Verifica aggiornamento fallita — clicca per riprovare",
+  "updateStalled": "Aggiornamento bloccato — clicca per reimpostare",
   "autoSavedAt": "Salvato automaticamente alle {{time}}",
   "terminal.search.placeholder": "Cerca...",
   "terminal.search.label": "Cerca nell'output del terminale",

--- a/src/locales/ja/statusbar.json
+++ b/src/locales/ja/statusbar.json
@@ -57,6 +57,7 @@
   "updateReady": "クリックして再起動し、アップデートを適用",
   "updateReadyVersion": "v{{version}} 準備完了 — クリックして再起動",
   "updateError": "アップデート確認失敗 — クリックして再試行",
+  "updateStalled": "更新が停止しました。クリックしてリセット",
   "autoSavedAt": "{{time}} に自動保存",
   "terminal.search.placeholder": "検索...",
   "terminal.search.label": "ターミナル出力を検索",

--- a/src/locales/ko/statusbar.json
+++ b/src/locales/ko/statusbar.json
@@ -57,6 +57,7 @@
   "updateReady": "클릭하여 재시작 및 업데이트",
   "updateReadyVersion": "v{{version}} 준비됨 — 클릭하여 재시작",
   "updateError": "업데이트 확인 실패 — 클릭하여 재시도",
+  "updateStalled": "업데이트가 중단되었습니다. 클릭하여 초기화",
   "autoSavedAt": "{{time}}에 자동 저장됨",
   "terminal.search.placeholder": "검색...",
   "terminal.search.label": "터미널 출력 검색",

--- a/src/locales/pt-BR/statusbar.json
+++ b/src/locales/pt-BR/statusbar.json
@@ -57,6 +57,7 @@
   "updateReady": "Clique para reiniciar e atualizar",
   "updateReadyVersion": "v{{version}} pronta — clique para reiniciar",
   "updateError": "Falha na verificação de atualização — clique para tentar novamente",
+  "updateStalled": "Atualização travada — clique para redefinir",
   "autoSavedAt": "Salvo automaticamente às {{time}}",
   "terminal.search.placeholder": "Pesquisar...",
   "terminal.search.label": "Pesquisar saída do terminal",

--- a/src/locales/zh-CN/statusbar.json
+++ b/src/locales/zh-CN/statusbar.json
@@ -57,6 +57,7 @@
   "updateReady": "点击重启并更新",
   "updateReadyVersion": "v{{version}} 已就绪 — 点击重启",
   "updateError": "更新检查失败 — 点击重试",
+  "updateStalled": "更新已停滞，点击重置",
   "autoSavedAt": "自动保存于 {{time}}",
   "terminal.search.placeholder": "搜索...",
   "terminal.search.label": "搜索终端输出",

--- a/src/locales/zh-TW/statusbar.json
+++ b/src/locales/zh-TW/statusbar.json
@@ -57,6 +57,7 @@
   "updateReady": "點擊以重新啟動並更新",
   "updateReadyVersion": "v{{version}} 已就緒 — 點擊以重新啟動",
   "updateError": "更新檢查失敗 — 點擊重試",
+  "updateStalled": "更新已停滯，點擊重設",
   "autoSavedAt": "自動儲存於 {{time}}",
   "terminal.search.placeholder": "搜尋...",
   "terminal.search.label": "搜尋終端機輸出",

--- a/src/services/updates/updateFlowLog.ts
+++ b/src/services/updates/updateFlowLog.ts
@@ -1,0 +1,54 @@
+/**
+ * Update-flow milestone logging, visible in RELEASE builds.
+ *
+ * Purpose: record the update state machine's transitions to the log file a
+ *   user can actually send with a bug report.
+ *
+ * Why this is not `updateLog` in `utils/debug.ts`:
+ *   The debug tier compiles to a no-op in production. The update flow had no
+ *   milestone logging of ANY tier, so a report like "clicked update and the
+ *   app froze" (#1270) arrives with nothing describing which step stalled —
+ *   the same dead end that #1253 hit for window close, where the lines existed
+ *   but had been compiled out. Either way the user's log cannot answer the one
+ *   question that matters: which await never returned.
+ *
+ *   Routes to `update_log`, which is `info!`, rather than `debug_log`, which is
+ *   `debug!` and is filtered at the release Info level.
+ *
+ * A sibling command rather than a generalised one: `window_close_log` shipped
+ * two days before this for an unresolved report, and rewriting its command
+ * surface to save three lines of Rust would destabilise the diagnostic being
+ * relied on to investigate a sibling stall. If a third flow needs this,
+ * generalise then — with all three in hand.
+ *
+ * Kept to state transitions, not per-chunk noise: a download emits progress
+ * events continuously and those are deliberately NOT logged here.
+ *
+ * @coordinates-with src-tauri/src/app_setup.rs — update_log command
+ * @coordinates-with useUpdateOperations.ts — the transitions being recorded
+ * @module services/updates/updateFlowLog
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { updateSyncWarn } from "@/utils/debug";
+
+/**
+ * Record one update-flow milestone at INFO in the file log.
+ *
+ * Fire-and-forget: logging must never be able to fail an update. A rejected
+ * invoke is swallowed in production and surfaced only in dev.
+ */
+export function updateFlowLog(label: string, ...args: unknown[]): void {
+  const detail = args
+    .map((a) => (typeof a === "object" && a !== null ? JSON.stringify(a) : String(a)))
+    .join(" ");
+  const message = detail ? `[${label}] ${detail}` : `[${label}]`;
+
+  invoke("update_log", { message }).catch((e) => {
+    /* v8 ignore start -- @preserve reason: import.meta.env.DEV is true under vitest; the production branch is never taken */
+    if (import.meta.env.DEV) {
+      updateSyncWarn("update_log invoke failed:", e);
+    }
+    /* v8 ignore stop */
+  });
+}

--- a/src/services/updates/updateFlows.ts
+++ b/src/services/updates/updateFlows.ts
@@ -1,0 +1,190 @@
+/**
+ * Update check and download flows.
+ *
+ * Purpose: the two standalone operations behind every update entry point —
+ *   the manual button, the startup auto-check, the retry timer and the
+ *   cross-window listener all share these, so the Tauri updater plugin sees
+ *   one call path per window.
+ *
+ * These live in `services/` rather than `hooks/` because they have no React
+ * dependency at all (ADR-013). They were extracted from `useUpdateOperations`
+ * when that file outgrew the 300-line limit; the hooks there are now thin
+ * React adapters over these.
+ *
+ * Key decisions:
+ *   - Both run in the CALLING window. `pendingUpdate` is a Tauri JS resource
+ *     that cannot cross window boundaries, so the download must happen in the
+ *     window whose check created it.
+ *   - Single-flight per window via the shared `inFlight` guards, so spam
+ *     clicks, the auto-retry timer and the auto-download effect await one
+ *     promise instead of issuing parallel plugin calls (parallel-check churn
+ *     was a contributor to the v0.7.11 freeze).
+ *
+ * @coordinates-with useUpdateOperations.ts — the React adapters
+ * @coordinates-with updateSingleFlight.ts — the guards these set and clear
+ * @coordinates-with updateProgressThrottle.ts — coalesces per-chunk writes
+ * @module services/updates/updateFlows
+ */
+
+import { check } from "@tauri-apps/plugin-updater";
+import { getVersion } from "@tauri-apps/api/app";
+import { useMcpStore } from "@/stores/mcpStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { shouldWriteProgress } from "@/services/updates/updateProgressThrottle";
+import { inFlight } from "@/services/updates/updateSingleFlight";
+import { updateFlowLog } from "@/services/updates/updateFlowLog";
+import i18n from "@/i18n";
+
+/**
+ * Bound the check so a stalled connection cannot hold the single-flight guard
+ * open forever. Milliseconds — the plugin passes this to `Duration::from_millis`
+ * and then to the HTTP request. This is a small metadata fetch, so 30s is
+ * generous.
+ *
+ * The DOWNLOAD is deliberately left unbounded. The plugin applies `timeout` as
+ * a TOTAL request timeout including body read, so any value low enough to catch
+ * a stall would also abort a legitimate slow download of a ~40MB artifact —
+ * worse than the bug it would fix. The download's stall path is handled by
+ * `recoverFromStall` instead.
+ */
+const UPDATE_CHECK_TIMEOUT_MS = 30_000;
+
+/**
+ * Run the update check inline in the current window. Updates the local
+ * `useMcpStore` and stores `pendingUpdate` here so the same window can
+ * later call download.
+ */
+export async function runUpdateCheck(): Promise<boolean> {
+  // Single-flight: if a check is already in progress in this window, every
+  // caller (manual button, auto-check, retry timer, cross-window listener)
+  // shares the same result. Otherwise overlapping callers spawn parallel
+  // `check()` requests, each broadcasting status churn back to the other
+  // window via useUpdateSync — the cascade behind the v0.7.11 freeze.
+  if (inFlight.check) return inFlight.check;
+
+  inFlight.check = (async () => {
+    const store = useMcpStore.getState();
+    const settings = useSettingsStore.getState();
+
+    store.setUpdateStatus("checking");
+    updateFlowLog("check:start");
+
+    try {
+      const update = await check({ timeout: UPDATE_CHECK_TIMEOUT_MS });
+      updateFlowLog("check:returned", { found: update !== null });
+
+      if (update) {
+        store.setPendingUpdate(update);
+        const currentVersion = await getVersion();
+        store.setUpdateInfo({
+          version: update.version,
+          notes: update.body ?? "",
+          pubDate: update.date ?? "",
+          currentVersion,
+        });
+        store.setUpdateStatus("available");
+        // New update — clear any prior dismiss flag so the banner shows.
+        store.clearDismissed();
+        settings.updateUpdateSetting("lastCheckTimestamp", Date.now());
+        return true;
+      }
+
+      store.setUpdateStatus("up-to-date");
+      store.setPendingUpdate(null);
+      settings.updateUpdateSetting("lastCheckTimestamp", Date.now());
+      return false;
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : i18n.t("dialog:toast.updateCheckFailedGeneric");
+      updateFlowLog("check:failed", message);
+      store.setUpdateError(message);
+      // Don't update lastCheckTimestamp on error — the check didn't complete.
+      return false;
+    } finally {
+      inFlight.check = null;
+    }
+  })();
+
+  return inFlight.check;
+}
+
+/**
+ * Run download/install inline in the current window using the local
+ * `pendingUpdate`. Returns false if no pendingUpdate is held here (caller
+ * may decide to re-check or surface an error).
+ */
+export async function runUpdateDownload(): Promise<boolean> {
+  // Single-flight: prevent two callers (manual click + auto-download effect)
+  // from each invoking pendingUpdate.downloadAndInstall on the same Update
+  // resource — the underlying Tauri resource is not safe to download twice.
+  if (inFlight.download) return inFlight.download;
+
+  const initial = useMcpStore.getState();
+  const pendingUpdate = initial.update.pendingUpdate;
+  if (!pendingUpdate) return false;
+
+  inFlight.download = (async () => {
+    const store = useMcpStore.getState();
+    store.setUpdateStatus("downloading");
+    store.setDownloadProgress({ downloaded: 0, total: null });
+    updateFlowLog("download:start");
+
+    // Track progress in locals (avoids stale-state reads). Store writes are
+    // throttled via shouldWriteProgress so a chunky download doesn't flood
+    // re-renders and the cross-window broadcast.
+    let downloadedBytes = 0;
+    let totalBytes: number | null = null;
+    let lastWritten = -1;
+
+    try {
+      await pendingUpdate.downloadAndInstall((event) => {
+        const live = useMcpStore.getState();
+        switch (event.event) {
+          case "Started":
+            downloadedBytes = 0;
+            totalBytes = event.data.contentLength ?? null;
+            lastWritten = 0;
+            live.setDownloadProgress({ downloaded: 0, total: totalBytes });
+            break;
+          case "Progress":
+            downloadedBytes += event.data.chunkLength;
+            if (shouldWriteProgress(downloadedBytes, lastWritten, totalBytes)) {
+              lastWritten = downloadedBytes;
+              live.setDownloadProgress({ downloaded: downloadedBytes, total: totalBytes });
+            }
+            break;
+          case "Finished":
+            // Bytes are in; the updater now writes/installs them (takes a
+            // moment). Snap to 100% and switch to the install phase instead of
+            // leaving a frozen "Downloading…" with no bar.
+            live.setDownloadProgress({ downloaded: totalBytes ?? downloadedBytes, total: totalBytes });
+            live.setUpdateStatus("installing");
+            updateFlowLog("download:finished", { bytes: totalBytes ?? downloadedBytes });
+            break;
+        }
+      });
+
+      const done = useMcpStore.getState();
+      done.setUpdateStatus("ready");
+      done.setDownloadProgress(null);
+      updateFlowLog("install:ready");
+      return true;
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : i18n.t("dialog:toast.updateDownloadFailedGeneric");
+      updateFlowLog("download:failed", message);
+      const failed = useMcpStore.getState();
+      failed.setDownloadProgress(null);
+      failed.setUpdateError(message);
+      return false;
+    } finally {
+      inFlight.download = null;
+    }
+  })();
+
+  return inFlight.download;
+}

--- a/src/services/updates/updateSingleFlight.ts
+++ b/src/services/updates/updateSingleFlight.ts
@@ -1,0 +1,60 @@
+/**
+ * Update single-flight guards.
+ *
+ * Purpose: hold the per-window in-flight promises for the update check and
+ *   download, and expose the ONE way to release them.
+ *
+ * Key decisions:
+ *   - Lives outside `useUpdateOperations` because the recovery path has to be
+ *     able to reach these guards. While they were module-private to that hook,
+ *     nothing could clear them, which is what made a stalled flow permanent.
+ *   - Held in a holder object rather than two `let`s so the formatter doesn't
+ *     rewrite the reassignment to `const`.
+ *
+ * Why this exists at all — the failure it guards against:
+ *   Both guards are cleared in a `.finally()`. That is correct only while the
+ *   awaited promise is guaranteed to settle. `check()` and
+ *   `downloadAndInstall()` are network calls, and a connection that STALLS
+ *   never settles — it neither resolves nor rejects. When that happens the
+ *   guard stays non-null forever, every later caller returns the same dead
+ *   promise and awaits it forever, and the feature is bricked for the life of
+ *   the window.
+ *
+ *   This is the same mechanism as the window-close stall (#1253), where
+ *   `activeCloseRef` was likewise cleared only in `.finally()` and one
+ *   unsettled step made every later close request join a dead promise. Two
+ *   instances of one defect: the fix is a release valve, not another guard.
+ *
+ * @coordinates-with useUpdateOperations.ts — sets and awaits these guards
+ * @coordinates-with useUpdateStall.ts — detects the stall that calls for release
+ * @module services/updates/updateSingleFlight
+ */
+
+/**
+ * Per-window in-flight gates. Spam-clicks, the auto-retry timer and the
+ * auto-download effect all await the same promise rather than issuing
+ * parallel calls into the Tauri updater plugin (parallel-check churn was a
+ * contributor to the v0.7.11 freeze).
+ */
+export const inFlight: {
+  check: Promise<boolean> | null;
+  download: Promise<boolean> | null;
+} = {
+  check: null,
+  download: null,
+};
+
+/**
+ * Release both guards so the next caller reaches the plugin instead of
+ * joining a promise that will never settle.
+ *
+ * This does NOT cancel whatever is still pending underneath — the Tauri
+ * updater exposes no cancellation. The caller is expected to also drop
+ * `pendingUpdate`, so a retry runs a fresh `check()` and operates on a NEW
+ * Update resource rather than re-entering `downloadAndInstall` on the same
+ * one (which the plugin does not support).
+ */
+export function clearInFlight(): void {
+  inFlight.check = null;
+  inFlight.download = null;
+}

--- a/website/guide/settings.md
+++ b/website/guide/settings.md
@@ -410,6 +410,18 @@ Displays app version, links to the website and GitHub repository, and update man
 
 When an update is available, a card appears showing the new version number, release date, and release notes. You can **Download** the update, **Skip** this version, or — once downloaded — **Restart to Update**.
 
+#### If an update gets stuck
+
+Checking and downloading both go over the network, and a connection that hangs rather than failing outright can leave the status bar indicator spinning indefinitely. If it stops making progress, the indicator becomes clickable and its tooltip reads **Update stalled — click to reset**. Clicking it returns the updater to idle so you can try again; it does not change anything you have already downloaded, and a retry starts from a fresh check.
+
+Update activity is written to the log file, so if the problem repeats, the log is worth attaching to a bug report:
+
+| Platform | Log location |
+|---|---|
+| macOS | `~/Library/Logs/app.vmark/` |
+| Windows | `%LOCALAPPDATA%\app.vmark\logs\` |
+| Linux | `~/.local/share/app.vmark/logs/` |
+
 ### Reset
 
 | Setting | Description |


### PR DESCRIPTION
Investigating #1270 (Windows: app freezes after clicking update) surfaced a real defect in the flow that report lands on, of exactly the shape #1253 had. This fixes that defect.

**It does not claim to fix #1270.** That is Windows-only, unreproducible on macOS, and the reporter has not sent a version or a log yet. Relates to #1270 rather than closing it.

## The class

#1253 and this share a mechanism: **a user-initiated async flow with no timeout on its awaits, a re-entry guard cleared only on settle, and no release-visible trace of which step stopped.**

| #1253 (fixed) | Update flow (this PR) |
|---|---|
| `activeCloseRef` cleared only in `.finally()` | `inFlight.check` / `inFlight.download` cleared only in `.finally()` |
| `prevent_close()` unconditional, no timeout | `check()` and `downloadAndInstall()` called bare — `CheckOptions.timeout` exists and was unused |
| Later closes join a dead promise | Later callers return the same dead promise |
| Flow invisible in release | **No milestone logging at any tier** |

A `.finally()` is a correct place to clear a guard only while the awaited promise is guaranteed to settle. A connection that **stalls** never settles — it neither resolves nor rejects — so the guard stayed non-null for the life of the window. And `checking`, `downloading` and `installing` are all `clickable: false` in the StatusBar indicator, so there was no way to retry out of it.

This is not a second instance, it is a third: the file's own comments already recorded the v0.7.11 freeze in the same feature.

**#1252 is deliberately not treated as part of this class** — it was an fs-scope permission bug on non-home drives, a different mechanism. Three Windows issues in a row is not automatically one defect.

## Three changes

**1. `check({ timeout: 30_000 })`** — a bounded metadata request, which is what makes `.finally()` a valid place to clear the guard at all.

The **download is deliberately left unbounded**. The plugin applies `timeout` as a *total* request timeout including body read (`Duration::from_millis` → reqwest `.timeout()`), so any value low enough to catch a stall would also abort a legitimate slow transfer of a ~40MB artifact. That would be worse than the bug it fixed.

**2. Release-visible milestone logging** via a new `update_log` (`info!`) command. The state machine logged nothing at any tier, which is why #1270 arrived unanswerable.

A sibling of `window_close_log` rather than a generalisation of it: that command shipped two days ago for a still-open report, and reworking its surface to save three lines of Rust would put the diagnostic being used to investigate a sibling stall at risk. Generalise when a third flow needs it.

**3. `recoverFromStall`** — the release valve. `useUpdateStall` reports a flow that has made no observable change for 60s (check) or 180s (download/install); a stalled indicator then becomes clickable regardless of the state's normal interactivity.

Recovery clears the guards and resets the slice, dropping `pendingUpdate` **on purpose**: a retry then runs a fresh check and downloads through a *new* Update resource rather than re-entering `downloadAndInstall` on the same one, which the plugin does not support. Whatever stalled underneath is not cancelled — the updater exposes no cancellation — but it writes into a slice that has moved on, which is harmless next to a permanently stuck UI.

## The tests have teeth

I verified the regression tests fail without the fix rather than assuming: neutering `clearInFlight` turns 29 passing tests into **16 failures**. The cascade is itself the defect — one leaked stalled promise bricks every later action, which is precisely what the user experiences.

The negative case is pinned too: a download that keeps moving bytes is never reported as stalled, however long it takes overall, so nobody is offered a reset button mid-transfer.

## Why a file moved

`useUpdateOperations.ts` sat at 299 of its 300-line limit, so the two flow functions moved to `services/updates/updateFlows.ts`. They already carried a "standalone (no React deps)" note, so this is the ADR-013 tier boundary rather than a convenience split, and every existing import path is unchanged (several suites mock `./useUpdateOperations`).

## Also

Corrects the log locations in `website/guide/settings.md`. Tauri's `app_log_dir` uses `data_local_dir()` off macOS, so Windows is `%LOCALAPPDATA%` and Linux is `~/.local/share` — not `%APPDATA%` and `~/.config`, which is what I had said earlier when asking the reporter for logs.

## Verification

- `pnpm check:static` — green (38 gate files, 836 tests, all ratchets held including knip and file-size)
- `pnpm test:coverage` — exit 0, thresholds hold
- `pnpm typecheck` — clean
- `cargo test`, `cargo clippy --all-targets -- -D warnings` (exit 0, zero warnings), `cargo fmt --check` — all clean
- `pnpm lint:i18n` — 0 untranslated; the new `updateStalled` key is translated in all 10 locales
- `markdownlint` on the changed guide page — clean
