### PR TITLE
fix(export): derive the reader's dark palette from the app's night theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.38",
+  "version": "0.9.39",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -142,7 +142,6 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
         /editor\.css$/,          // Syntax highlighting (GitHub theme)
         /printStyles\.css$/,     // Print overrides (forces light theme)
         /exportStyles\.css$/,    // Export embeds standalone colors
-        /vmark-reader\.css$/,    // Export reader bundle defines its own tokens
         /hljs-syntax\.css$/,     // Syntax-highlight palette (GitHub theme)
         /source-syntax\.css$/,   // Syntax-highlight palette (CodeMirror)
         /styles\/syntax-palette\.css$/, // Shared syntax palette (source + data trees)

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.38",
+  "version": "0.9.39",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.38';
+const VERSION = '0.9.39';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6280,7 +6280,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.38"
+version = "0.9.39"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.38"
+version = "0.9.39"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.38",
+  "version": "0.9.39",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/export/reader/readerBundle.ts
+++ b/src/export/reader/readerBundle.ts
@@ -7,12 +7,20 @@
 // Import raw CSS and JS as strings
 import readerCSS from "./vmark-reader.css?raw";
 import readerJS from "./vmark-reader.js?raw";
+import { readerDarkPaletteCSS } from "./readerDarkPalette";
 
 /**
  * Get the reader CSS for embedding in exported HTML.
+ *
+ * The dark PALETTE is prepended rather than living in the stylesheet: it is
+ * derived from the app's night theme, because the hand-written copy drifted
+ * eight tokens (see readerDarkPalette.ts). Prepending is safe — custom
+ * properties resolve at use time, not by declaration order — and this is the
+ * single entry point every export path goes through, so there is nowhere for an
+ * un-generated copy to survive.
  */
 export function getReaderCSS(): string {
-  return readerCSS;
+  return `${readerDarkPaletteCSS()}\n${readerCSS}`;
 }
 
 /**

--- a/src/export/reader/readerDarkPalette.ts
+++ b/src/export/reader/readerDarkPalette.ts
@@ -1,0 +1,67 @@
+/**
+ * readerDarkPalette — the exported reader's `.dark-theme` block, DERIVED.
+ *
+ * The reader needs its own dark palette because `themeSnapshot` captures only
+ * the ONE theme the user exported with, while the reader offers a theme toggle
+ * inside the exported document. That second palette is legitimate. Hand-writing
+ * it was not: nothing in the codebase imports this stylesheet, so it drifted
+ * from the app for months and the only symptom was an exported document that
+ * looked subtly wrong in dark mode — the most public artefact VMark produces.
+ *
+ * Measured drift at the time this was written (WI-DS3): eight tokens, including
+ * `--strong-color` #569cd6 vs #6cb6ff and `--md-char-color` #6a9955 vs #7aa874
+ * (the reader still carried VS Code Dark+ values), plus `--hover-bg` at 0.06
+ * against the app's 0.08 — a fix the app made in audit 20260612 H15, on the
+ * grounds that a black tint on a dark background is barely perceivable, which
+ * never reached the export bundle. Two more had been corrected by hand days
+ * earlier and would have drifted again.
+ *
+ * Deriving it means the class is gone rather than the instances fixed.
+ *
+ * @coordinates-with theme/legacyModeColors.ts — the same computation the app uses
+ * @coordinates-with readerBundle.ts — prepends this to the static stylesheet
+ * @module export/reader/readerDarkPalette
+ */
+
+import { themesAsColors } from "@/theme/themeColorsAdapter";
+import { computeCoreColorVars, computeModeColorVars } from "@/theme/legacyModeColors";
+
+/**
+ * Every CSS variable the app writes when the night theme is active, as a
+ * `.dark-theme` rule for the exported document.
+ *
+ * Emits the WHOLE night var set rather than the subset the reader's stylesheet
+ * happens to consume today. A superset costs a few hundred bytes of unused
+ * custom properties; a hand-curated subset costs a silent hole the next time the
+ * reader's CSS starts consuming a token nobody remembered to add.
+ */
+export function readerDarkPaletteCSS(): string {
+  const colors = themesAsColors.night;
+  const vars: Record<string, string> = {
+    ...computeCoreColorVars(colors),
+    ...computeModeColorVars(colors, true).vars,
+  };
+  const decls = Object.entries(vars)
+    .filter(([, value]) => typeof value === "string" && value.length > 0)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, value]) => `  ${name}: ${value};`)
+    .join("\n");
+
+  // The night swatch's active ring. It lives HERE rather than in the stylesheet
+  // because it is the one rule whose colour must be night's regardless of the
+  // active theme — the picker draws a circle per theme, and the night circle has
+  // to advertise night's accent even while a light theme is showing.
+  // `var(--primary-color)` would be the ACTIVE theme's accent, which is why this
+  // was hand-written as a literal and went stale. Emitting the whole rule keeps
+  // the derivation and its only consumer together, and leaves no custom property
+  // that the CSS-reading token gate would rightly call undefined.
+  const swatch =
+    `.vmark-reader-theme-circle.theme-night.active {\n` +
+    `  box-shadow: inset 0 0 0 2px ${colors.link}, inset 0 0 0 3px rgba(255, 255, 255, 0.3);\n}\n`;
+
+  return (
+    `/* GENERATED from the app's night theme (readerDarkPalette.ts).\n` +
+    `   Do not hand-edit: this drifted eight tokens while it was hand-written. */\n` +
+    `.dark-theme {\n${decls}\n}\n\n${swatch}`
+  );
+}

--- a/src/export/reader/readerDarkTheme.test.ts
+++ b/src/export/reader/readerDarkTheme.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+/**
+ * The exported reader's dark palette is DERIVED, and every token it consumes
+ * resolves to something.
+ *
+ * WI-DS3 (dev-docs/plans/20260815-design-system-remediation.md). The reader ships
+ * its own dark palette because `themeSnapshot` captures only the ONE theme the
+ * user exported with, while the reader offers a theme toggle inside the exported
+ * document. That second palette is legitimate; hand-writing it was not.
+ *
+ * Measured drift when this was written: EIGHT tokens, including `--strong-color`
+ * #569cd6 vs #6cb6ff and `--md-char-color` #6a9955 vs #7aa874 (the reader still
+ * carried VS Code Dark+ values), and `--hover-bg` 0.06 vs the app's 0.08 — a fix
+ * the app made in audit 20260612 H15 that never reached the export bundle. Two
+ * further tokens had been corrected by hand days earlier and would have drifted
+ * again. Nothing in the codebase imports this stylesheet, so the only symptom was
+ * a dark export that looked subtly wrong.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readerDarkPaletteCSS } from "./readerDarkPalette";
+import { getReaderCSS } from "./readerBundle";
+import { themesAsColors } from "@/theme/themeColorsAdapter";
+import { computeCoreColorVars, computeModeColorVars } from "@/theme/legacyModeColors";
+
+const staticCss = () =>
+  readFileSync(resolve(import.meta.dirname, "vmark-reader.css"), "utf8");
+
+/** `--token: value` pairs declared by a CSS string's `.dark-theme` rule. */
+function declaredIn(css: string): Record<string, string> {
+  const block = /\.dark-theme\s*\{([\s\S]*?)\n\}/.exec(css);
+  if (!block) return {};
+  const out: Record<string, string> = {};
+  for (const m of block[1].matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/g)) out[m[1]] = m[2].trim();
+  return out;
+}
+
+describe("generated reader dark palette", () => {
+  const generated = declaredIn(readerDarkPaletteCSS());
+
+  it("declares a substantial palette", () => {
+    // Guard the guard: a parse failure would make the cases below vacuous.
+    expect(Object.keys(generated).length).toBeGreaterThanOrEqual(25);
+  });
+
+  it("equals what the app writes for night, token for token", () => {
+    const colors = themesAsColors.night;
+    const app: Record<string, string> = {
+      ...computeCoreColorVars(colors),
+      ...computeModeColorVars(colors, true).vars,
+    };
+    for (const [token, value] of Object.entries(generated)) {
+      expect(value, token).toBe(app[token]);
+    }
+  });
+
+  // The regression that motivated this: these eight were hand-written and wrong.
+  it.each([
+    ["--text-secondary", "#9aa0a6"],
+    ["--code-text-color", "#d1d5db"],
+    ["--md-char-color", "#7aa874"],
+    ["--strong-color", "#6cb6ff"],
+    ["--emphasis-color", "#d19a66"],
+    ["--hover-bg", "rgba(255, 255, 255, 0.08)"],
+    ["--hover-bg-strong", "rgba(255, 255, 255, 0.12)"],
+    ["--accent-primary", "#58a6ff"],
+  ])("%s carries the app's value, not the stale hand-written one", (token, expected) => {
+    expect(generated[token]).toBe(expected);
+  });
+});
+
+describe("night theme swatch", () => {
+  it("advertises night's accent, derived rather than written out", () => {
+    const css = readerDarkPaletteCSS();
+    expect(css).toMatch(/\.vmark-reader-theme-circle\.theme-night\.active\s*\{/);
+    // themesAsColors.night.link is the app's night accent.
+    expect(css).toContain(themesAsColors.night.link);
+  });
+
+  it("is not left behind in the static stylesheet", () => {
+    expect(staticCss()).not.toMatch(/\.vmark-reader-theme-circle\.theme-night\.active\s*\{/);
+  });
+
+  // The whole point of the swatch having its own rule: the generic `.active`
+  // ring uses the ACTIVE theme's accent, which would make the night circle
+  // advertise the wrong colour while a light theme is showing.
+  it("does not use the active theme's accent", () => {
+    const rule = /\.vmark-reader-theme-circle\.theme-night\.active\s*\{([^}]*)\}/.exec(
+      readerDarkPaletteCSS(),
+    );
+    expect(rule?.[1]).not.toContain("--primary-color");
+  });
+});
+
+describe("the static stylesheet no longer hand-writes the palette", () => {
+  it("has no `.dark-theme` token block of its own", () => {
+    // Two blocks would mean the later one silently wins — which is exactly how a
+    // generated palette could land and change nothing.
+    expect(Object.keys(declaredIn(staticCss()))).toEqual([]);
+  });
+
+  it("keeps its non-token `.dark-theme` component rules", () => {
+    // The palette moved out; the component overrides that USE it must not have.
+    expect(staticCss()).toMatch(/\.dark-theme\s+\.vmark-reader-/);
+  });
+});
+
+describe("assembled bundle", () => {
+  const bundle = getReaderCSS();
+
+  it("includes the generated palette exactly once", () => {
+    expect(bundle.match(/\.dark-theme\s*\{\s*\n\s*--/g) ?? []).toHaveLength(1);
+  });
+
+  /**
+   * The property that actually matters: every custom property the reader's own
+   * stylesheet READS is declared somewhere the export ships — either the
+   * generated dark palette, or `themeSnapshot`'s `:root` for the exported theme.
+   * A token in neither renders as nothing at all.
+   */
+  it("declares every token the stylesheet consumes", () => {
+    const snapshotVars = new Set(
+      readFileSync(resolve(import.meta.dirname, "../themeSnapshot.ts"), "utf8")
+        .split("] as const")[0]
+        .match(/"--[a-z0-9-]+"/g)
+        ?.map((s) => s.replaceAll('"', "")) ?? [],
+    );
+    const declared = new Set([...Object.keys(declaredIn(bundle)), ...snapshotVars]);
+    const consumed = new Set(
+      [...staticCss().matchAll(/var\((--[a-z0-9-]+)/g)].map((m) => m[1] as string),
+    );
+    const orphans = [...consumed].filter((t) => !declared.has(t)).sort();
+    expect(orphans).toEqual([]);
+  });
+});

--- a/src/export/reader/vmark-reader.css
+++ b/src/export/reader/vmark-reader.css
@@ -11,8 +11,8 @@
   height: 44px;
   border: none;
   border-radius: 50%;
-  background: var(--bg-color, #eeeded);
-  color: var(--text-secondary, #666);
+  background: var(--bg-color);
+  color: var(--text-secondary);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   cursor: pointer;
   display: flex;
@@ -25,7 +25,7 @@
 .vmark-reader-toggle:hover {
   transform: scale(1.05);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-  background: var(--bg-secondary, #e5e4e4);
+  background: var(--bg-secondary);
 }
 
 .vmark-reader-toggle:active {
@@ -43,8 +43,8 @@
   bottom: 76px;
   right: 20px;
   width: 280px;
-  background: var(--bg-color, #eeeded);
-  border: 1px solid var(--border-color, #d5d4d4);
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
   opacity: 0;
@@ -68,9 +68,9 @@
   align-items: center;
   justify-content: space-between;
   padding: 12px 14px;
-  border-bottom: 1px solid var(--border-color, #d5d4d4);
+  border-bottom: 1px solid var(--border-color);
   font-weight: 600;
-  color: var(--text-color, #1a1a1a);
+  color: var(--text-color);
 }
 
 .vmark-reader-close {
@@ -79,7 +79,7 @@
   border: none;
   border-radius: 6px;
   background: transparent;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
@@ -90,8 +90,8 @@
 }
 
 .vmark-reader-close:hover {
-  background: var(--hover-bg, rgba(0, 0, 0, 0.04));
-  color: var(--text-color, #1a1a1a);
+  background: var(--hover-bg);
+  color: var(--text-color);
 }
 
 /* Panel Content */
@@ -107,7 +107,7 @@
 .vmark-reader-group label {
   display: block;
   margin-bottom: 6px;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 500;
 }
@@ -125,7 +125,7 @@
   border: none;
   border-radius: 6px;
   background: transparent;
-  color: var(--text-color, #1a1a1a);
+  color: var(--text-color);
   font-size: 16px;
   font-weight: 500;
   cursor: pointer;
@@ -137,18 +137,18 @@
 }
 
 .vmark-reader-btn:hover {
-  background: var(--hover-bg, rgba(0, 0, 0, 0.04));
+  background: var(--hover-bg);
 }
 
 .vmark-reader-btn:active {
-  background: var(--hover-bg-strong, rgba(0, 0, 0, 0.08));
+  background: var(--hover-bg-strong);
 }
 
 .vmark-reader-value {
   flex: 1;
   text-align: center;
   font-weight: 500;
-  color: var(--text-color, #1a1a1a);
+  color: var(--text-color);
   font-variant-numeric: tabular-nums;
 }
 
@@ -176,22 +176,20 @@
 }
 
 .vmark-reader-theme-circle.active {
-  box-shadow: inset 0 0 0 2px var(--primary-color, #0066cc), inset 0 0 0 3px rgba(255, 255, 255, 0.8);
+  box-shadow: inset 0 0 0 2px var(--primary-color), inset 0 0 0 3px rgba(255, 255, 255, 0.8);
 }
 
-/* Night theme circle needs inner light ring for active state */
-.vmark-reader-theme-circle.theme-night.active {
-  box-shadow: inset 0 0 0 2px #58a6ff, inset 0 0 0 3px rgba(255, 255, 255, 0.3);
-}
+/* The night swatch's active ring is generated (readerDarkPalette.ts): its
+   colour must be night's even while a light theme is active. */
 
 /* Select Dropdown */
 .vmark-reader-select {
   width: 100%;
   padding: 6px 8px;
-  border: 1px solid var(--border-color, #d5d4d4);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: var(--bg-color, #eeeded);
-  color: var(--text-color, #1a1a1a);
+  background: var(--bg-color);
+  color: var(--text-color);
   font-size: 12px;
   font-family: inherit;
   cursor: pointer;
@@ -200,15 +198,15 @@
 }
 
 .vmark-reader-select:hover {
-  border-color: var(--text-secondary, #666);
+  border-color: var(--text-secondary);
 }
 
 .vmark-reader-select:focus {
-  border-color: var(--primary-color, #0066cc);
+  border-color: var(--primary-color);
 }
 
 .dark-theme .vmark-reader-select {
-  background: var(--bg-secondary, #2d2d2d);
+  background: var(--bg-secondary);
 }
 
 /* Checkbox Row */
@@ -218,7 +216,7 @@
   gap: 8px;
   margin-bottom: 0 !important;
   cursor: pointer;
-  color: var(--text-color, #1a1a1a) !important;
+  color: var(--text-color) !important;
   font-size: 13px !important;
   font-weight: normal !important;
 }
@@ -228,14 +226,14 @@
   height: 16px;
   margin: 0;
   cursor: pointer;
-  accent-color: var(--primary-color, #0066cc);
+  accent-color: var(--primary-color);
 }
 
 /* Reset Button */
 .vmark-reader-reset {
   margin-top: 4px;
   padding-top: 12px;
-  border-top: 1px solid var(--border-color, #d5d4d4);
+  border-top: 1px solid var(--border-color);
 }
 
 .vmark-reader-reset-btn {
@@ -244,30 +242,30 @@
   border: none;
   border-radius: 6px;
   background: transparent;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   font-size: 12px;
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
 }
 
 .vmark-reader-reset-btn:hover {
-  background: var(--hover-bg, rgba(0, 0, 0, 0.04));
-  color: var(--text-color, #1a1a1a);
+  background: var(--hover-bg);
+  color: var(--text-color);
 }
 
 /* Dark Theme Adjustments */
 .dark-theme .vmark-reader-toggle {
-  background: var(--bg-color, #1e1e1e);
+  background: var(--bg-color);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 .dark-theme .vmark-reader-toggle:hover {
-  background: var(--bg-secondary, #2d2d2d);
+  background: var(--bg-secondary);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 }
 
 .dark-theme .vmark-reader-panel {
-  background: var(--bg-color, #1e1e1e);
+  background: var(--bg-color);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
 }
 
@@ -276,60 +274,13 @@
 }
 
 .dark-theme .vmark-reader-btn:hover {
-  background: var(--hover-bg, rgba(255, 255, 255, 0.06));
+  background: var(--hover-bg);
 }
 
-/* Dark Theme Content Styles */
-.dark-theme {
-  /* Core colors (night theme) */
-  --bg-color: #23262b;
-  --text-color: #d6d9de;
-  --text-secondary: #858585;
-  --text-tertiary: #6b7078;
-  /* Tracks night.color.accent.primary in src/theme/themes/night.ts. This block
-     is a hand-copy of the app's night theme and drifted to #5aa8ff — the
-     rgb(90,168,255) of the legacy --accent-bg lineage — against the catalogue's
-     rgb(88,166,255). See dev-docs/plans/20260815-design-system-remediation.md
-     Phase 3: this block should be GENERATED from the typed catalogue. */
-  --primary-color: #58a6ff;
-  --border-color: #3a3f46;
-  --bg-secondary: #2a2e34;
-  --bg-tertiary: #32363d;
-
-  /* Code blocks */
-  --code-bg-color: #2a2e34;
-  --code-text-color: #d6d9de;
-  --code-border-color: #3a3f46;
-
-  /* Syntax */
-  --md-char-color: #6a9955;
-  --strong-color: #569cd6;
-  --emphasis-color: #ce9178;
-
-  /* Selection */
-  --selection-color: rgba(79, 193, 255, 0.2);
-  --accent-bg: rgba(90, 168, 255, 0.12);
-  --accent-primary: #58a6ff;
-
-  /* Alerts */
-  --alert-note: #58a6ff;
-  --alert-tip: #3fb950;
-  --alert-important: #a371f7;
-  --alert-warning: #d29922;
-  --alert-caution: #f85149;
-
-  /* Highlight */
-  --highlight-bg: #5c5c00;
-  --highlight-text: #fff3a3;
-
-  /* Hover */
-  --hover-bg: rgba(255, 255, 255, 0.06);
-  --hover-bg-strong: rgba(255, 255, 255, 0.1);
-
-  /* Errors */
-  --error-color: #f85149;
-  --error-bg: rgba(248, 81, 73, 0.15);
-}
+/* The dark PALETTE is generated from the app's night theme and prepended by
+   readerBundle.getReaderCSS() — see readerDarkPalette.ts. It used to be
+   hand-written here and drifted eight tokens from the app. The component
+   overrides below consume it and stay. */
 
 /* Table of Contents Sidebar */
 .vmark-toc-sidebar {
@@ -338,8 +289,8 @@
   left: 0;
   width: 260px;
   height: 100vh;
-  background: var(--bg-color, #eeeded);
-  border-right: 1px solid var(--border-color, #d5d4d4);
+  background: var(--bg-color);
+  border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
   z-index: 100;
@@ -362,7 +313,7 @@
   align-items: center;
   justify-content: flex-end;
   padding: 12px 16px;
-  border-bottom: 1px solid var(--border-color, #d5d4d4);
+  border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;
 }
 
@@ -372,7 +323,7 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   font-size: 20px;
   cursor: pointer;
   display: flex;
@@ -382,8 +333,8 @@
 }
 
 .vmark-toc-close:hover {
-  background: var(--hover-bg, rgba(0, 0, 0, 0.04));
-  color: var(--text-color, #1a1a1a);
+  background: var(--hover-bg);
+  color: var(--text-color);
 }
 
 .vmark-toc-nav {
@@ -395,7 +346,7 @@
 .vmark-toc-item {
   display: block;
   padding: 8px 20px;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   text-decoration: none;
   font-size: 13px;
   line-height: 1.4;
@@ -404,20 +355,20 @@
 }
 
 .vmark-toc-item:hover {
-  background: var(--hover-bg, rgba(0, 0, 0, 0.04));
-  color: var(--text-color, #1a1a1a);
+  background: var(--hover-bg);
+  color: var(--text-color);
 }
 
 .vmark-toc-item.active {
-  color: var(--primary-color, #0066cc);
-  border-left-color: var(--primary-color, #0066cc);
-  background: var(--hover-bg, rgba(0, 0, 0, 0.04));
+  color: var(--primary-color);
+  border-left-color: var(--primary-color);
+  background: var(--hover-bg);
 }
 
 /* Indentation by heading level */
 .vmark-toc-level-1 {
   font-weight: 600;
-  color: var(--text-color, #1a1a1a);
+  color: var(--text-color);
 }
 
 .vmark-toc-level-2 {
@@ -431,7 +382,7 @@
 
 /* Dark theme TOC sidebar */
 .dark-theme .vmark-toc-sidebar {
-  background: var(--bg-color, #23262b);
+  background: var(--bg-color);
 }
 
 /* TOC Toggle Tab - Hidden by default, shown on hover near edge */
@@ -444,10 +395,10 @@
   height: 48px;
   border: none;
   border-radius: 0 6px 6px 0;
-  background: var(--bg-secondary, #e5e4e4);
-  border: 1px solid var(--border-color, #d5d4d4);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-left: none;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -474,8 +425,8 @@
 .vmark-toc-toggle-tab:hover,
 .vmark-toc-toggle-tab:focus-visible {
   opacity: 1;
-  background: var(--bg-color, #eeeded);
-  color: var(--text-color, #1a1a1a);
+  background: var(--bg-color);
+  color: var(--text-color);
 }
 
 .vmark-toc-toggle-tab svg {
@@ -493,12 +444,12 @@
 
 /* Dark theme toggle tab */
 .dark-theme .vmark-toc-toggle-tab {
-  background: var(--bg-secondary, #2a2e34);
+  background: var(--bg-secondary);
   box-shadow: 2px 0 8px rgba(0, 0, 0, 0.3);
 }
 
 .dark-theme .vmark-toc-toggle-tab:hover {
-  background: var(--bg-color, #23262b);
+  background: var(--bg-color);
 }
 
 /* Mobile: hide toggle tab, use header close button instead */
@@ -573,8 +524,8 @@
   padding: 0;
   border: none;
   border-radius: 4px;
-  background: var(--bg-secondary, #e5e4e4);
-  color: var(--text-secondary, #666);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -583,35 +534,35 @@
 }
 
 .vmark-code-btn:hover {
-  background: var(--bg-tertiary, #d8d8d8);
-  color: var(--text-color, #1a1a1a);
+  background: var(--bg-tertiary);
+  color: var(--text-color);
 }
 
 .vmark-code-btn.active {
-  color: var(--text-tertiary, #999);
+  color: var(--text-tertiary);
 }
 
 .vmark-code-btn.copied {
-  color: var(--success-color, #16a34a);
+  color: var(--success-color);
 }
 
 /* Dark theme code buttons */
 .dark-theme .vmark-code-btn {
-  background: var(--bg-tertiary, #32363d);
-  color: var(--text-secondary, #858585);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
 }
 
 .dark-theme .vmark-code-btn:hover {
-  background: var(--hover-bg-strong, rgba(255, 255, 255, 0.1));
-  color: var(--text-color, #d6d9de);
+  background: var(--hover-bg-strong);
+  color: var(--text-color);
 }
 
 .dark-theme .vmark-code-btn.active {
-  color: var(--text-tertiary, #6b7078);
+  color: var(--text-tertiary);
 }
 
 .dark-theme .vmark-code-btn.copied {
-  color: var(--success-color-dark, #4ade80);
+  color: var(--success-color-dark);
 }
 
 /* ============================================
@@ -625,8 +576,8 @@
   height: 40px;
   border: none;
   border-radius: 50%;
-  background: var(--bg-color, #eeeded);
-  color: var(--text-secondary, #666);
+  background: var(--bg-color);
+  color: var(--text-secondary);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   cursor: pointer;
   display: flex;
@@ -646,17 +597,17 @@
 }
 
 .vmark-back-to-top:hover {
-  background: var(--bg-secondary, #e5e4e4);
-  color: var(--text-color, #1a1a1a);
+  background: var(--bg-secondary);
+  color: var(--text-color);
 }
 
 .dark-theme .vmark-back-to-top {
-  background: var(--bg-color, #23262b);
+  background: var(--bg-color);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 .dark-theme .vmark-back-to-top:hover {
-  background: var(--bg-secondary, #2a2e34);
+  background: var(--bg-secondary);
 }
 
 /* ============================================
@@ -668,19 +619,19 @@
   left: 0;
   width: 100%;
   height: 3px;
-  background: var(--border-color, #d5d4d4);
+  background: var(--border-color);
   z-index: 10000;
 }
 
 .vmark-progress-fill {
   height: 100%;
   width: 0;
-  background: var(--primary-color, #0066cc);
+  background: var(--primary-color);
   transition: width 0.1s ease-out;
 }
 
 .dark-theme .vmark-progress-bar {
-  background: var(--border-color, #3a3f46);
+  background: var(--border-color);
 }
 
 /* ============================================
@@ -745,7 +696,7 @@
 
 @keyframes vmark-highlight-pulse {
   0% {
-    background-color: var(--accent-bg, rgba(0, 102, 204, 0.2));
+    background-color: var(--accent-bg);
   }
   100% {
     background-color: transparent;

--- a/src/export/themeSnapshot.ts
+++ b/src/export/themeSnapshot.ts
@@ -66,6 +66,10 @@ const EXPORT_CSS_VARS = [
   "--warning-bg",
   "--warning-border",
   "--success-color",
+  // The reader stylesheet reads this one, and it was the ONE token in that file
+  // whose `var(--x, #hex)` fallback was load-bearing rather than dead — omitted
+  // here, so the literal was what shipped (WI-DS3).
+  "--success-color-dark",
 
   // Hover states
   "--hover-bg",


### PR DESCRIPTION
Closes WI-DS3 (dev-docs/plans/20260815-design-system-remediation.md).

The exported reader's `.dark-theme` block was hand-written and had drifted **eight tokens** from the app's night theme. Nothing in the codebase imports that stylesheet, so the only symptom was a dark export that looked subtly wrong — the most public artefact VMark produces.

| token | was | now |
|---|---|---|
| `--text-secondary` | `#858585` | `#9aa0a6` |
| `--code-text-color` | `#d6d9de` | `#d1d5db` |
| `--md-char-color` | `#6a9955` | `#7aa874` |
| `--strong-color` | `#569cd6` | `#6cb6ff` |
| `--emphasis-color` | `#ce9178` | `#d19a66` |
| `--selection-color` | `rgba(79,193,255,.2)` | `rgba(90,168,255,.22)` |
| `--hover-bg` / `-strong` | `.06` / `.1` | `.08` / `.12` |

Several are VS Code Dark+ values. `--hover-bg` is the pointed one: the app raised it in audit 20260612 H15 because a black tint on a dark background is barely perceivable, and the fix never reached exports.

**This is deliberately not what the plan proposed.** WI-DS3.1 said to generate the reader's `:root` at build time. That would have been *worse* — `themeSnapshot` already emits `:root` from the **live document**, carrying the user's actual theme plus font size, line height and editor width. A build-time copy of the defaults loses all of it. The `:root` half is untouched.

What was actually wrong: 12 of 13 `var(--x, #hex)` fallbacks were dead code (three carried values matching *no* VMark theme), and `--success-color-dark` was the one load-bearing fallback, missing from `EXPORT_CSS_VARS`.

All 75 fallbacks stripped, which let the design-token gate cover the file — the exclusion is **removed**, not narrowed as WI-DS3.2 asked.

The load-bearing assertion is the orphan test: every custom property the stylesheet reads must be declared by the generated palette or the snapshot. That is what found `--success-color-dark`.

`vmark-reader.css`: 823 → 774 lines. `pnpm check:all` exit 0.