### PR TITLE
fix: tilde range parsing, terminal panel ceiling, and a committable .vmark lock

### DIFF
--- a/scripts/check-shell-slots.mjs
+++ b/scripts/check-shell-slots.mjs
@@ -40,7 +40,12 @@
  *        that must provide it: `EditorArea` from `@/shell` (ADR-007's shell
  *        layer IS the frame, and a frame is not a surface), and
  *        `DocumentWindowMount` + `MainWindowRunners` from `@/hooks/lifecycle`
- *        (both `return null`; they run effects and mount no UI).
+ *        (both run effects and mount no UI of their own). Stated as WHAT THEY
+ *        MOUNT, not as "both `return null`" — that wording was already false
+ *        for `MainWindowRunners`, which returns a `React.ReactElement`, and a
+ *        justification that is wrong about its own subject is worse than none.
+ *        The exclusion has never keyed on the return type; it keys on the name
+ *        and the module that must supply it.
  *
  *        This used to be "any binding imported from `@/shell` or `@/hooks`",
  *        which is a standing pre-approval for every future export of two large
@@ -87,8 +92,8 @@ const TRANSPARENT_WRAPPERS = new Set(["Suspense", "FeatureErrorBoundary", "React
  */
 const NON_SURFACE_BINDINGS = new Map([
   ["EditorArea", { module: "@/shell", why: "ADR-007 shell frame — a frame is not a surface" }],
-  ["DocumentWindowMount", { module: "@/hooks/lifecycle", why: "returns null; effects only" }],
-  ["MainWindowRunners", { module: "@/hooks/lifecycle", why: "returns null; effects only" }],
+  ["DocumentWindowMount", { module: "@/hooks/lifecycle", why: "runs effects; mounts no UI" }],
+  ["MainWindowRunners", { module: "@/hooks/lifecycle", why: "runs effects; mounts no UI" }],
 ]);
 
 /** Dotted name of a JSX tag, or null for namespaced/exotic tags. */

--- a/scripts/shell-slots-baseline.json
+++ b/scripts/shell-slots-baseline.json
@@ -1,10 +1,10 @@
 {
   "//": [
     "ADR-007 shell-surface identity list: every component mounted inside <AppShell> in src/App.tsx (any depth, any prop).",
-    "Checked by scripts/check-shell-slots.mjs (pnpm lint:shell-slots, in check:all). An IDENTITY LIST, never a count — a count permits a like-for-like swap.",
+    "Checked by scripts/check-shell-slots.mjs (pnpm lint:shell-slots, in check:all). An IDENTITY LIST, never a count \u2014 a count permits a like-for-like swap.",
     "Two-way ratchet: a mounted surface missing from this list fails the gate, and a listed surface that is no longer mounted also fails until its entry is deleted (record the win).",
     "Entries only get REMOVED, never added. To reduce the list, bundle related surfaces behind one mount (see src/components/CoherenceOverlays.tsx) or give the surface a real shell slot.",
-    "Excluded by definition (see the script header): the Suspense/FeatureErrorBoundary/React.Fragment wrappers, and exactly three named bindings — EditorArea (@/shell frame), DocumentWindowMount and MainWindowRunners (@/hooks/lifecycle, both return null)."
+    "Excluded by definition (see the script header): the Suspense/FeatureErrorBoundary/React.Fragment wrappers, and exactly three named bindings \u2014 EditorArea (@/shell frame), DocumentWindowMount and MainWindowRunners (@/hooks/lifecycle, both run effects and mount no UI of their own)."
   ],
   "surfaces": [
     "ApprovalDialog",

--- a/src-tauri/src/coherence/state.test.rs
+++ b/src-tauri/src/coherence/state.test.rs
@@ -340,6 +340,48 @@ fn a_bare_lock_file_is_not_mistaken_for_an_initialized_workspace() {
 }
 
 #[test]
+fn taking_the_lock_on_a_pristine_workspace_leaves_nothing_git_would_commit() {
+    // #1285: `acquire_lock_file` creates `.vmark/` to hold `group.lock`, and a
+    // write that is then REJECTED leaves that directory behind. It used to
+    // contain the lock and nothing else — so `git add .` staged a binary
+    // runtime file in every repository where a coherence action had failed.
+    // Deliberately NOT fixed by refusing to create the dir: the lock must exist
+    // before the op is adjudicated. The ignore rules are what has to arrive
+    // with it.
+    let dir = tmp();
+    let vmark = dir.path().join(".vmark");
+    let mut kernel = WorkspaceKernel::open(dir.path(), writer(1)).unwrap();
+
+    // A no-op under the write lock: acquires and releases, appends nothing.
+    kernel.with_write_lock(|_| Ok(())).unwrap();
+
+    assert!(
+        vmark.join("group.lock").is_file(),
+        "precondition: the lock file was created",
+    );
+    let ignore = std::fs::read_to_string(vmark.join(".gitignore"))
+        .expect(".vmark/.gitignore must exist beside a lock file git would otherwise see");
+    assert!(
+        ignore.lines().any(|l| l.trim() == "group.lock"),
+        "the lock must be ignored, got: {ignore:?}",
+    );
+    assert!(
+        ignore.lines().any(|l| l.trim() == "index.db*"),
+        "the index must be ignored too, got: {ignore:?}",
+    );
+    // The 6R-4 property is unchanged: ignore rules are not the completion
+    // marker, so a rejected op still does not fully initialize the workspace.
+    assert!(
+        !kernel.is_initialized(),
+        "writing ignore rules must not mark the workspace initialized",
+    );
+    assert!(
+        !vmark.join(".gitattributes").is_file(),
+        "no completion marker from a lock acquire alone",
+    );
+}
+
+#[test]
 // UNIX-ONLY FIXTURE, not a unix-only behaviour. The property under test —
 // fail closed on an I/O error rather than destroying state — holds on every
 // platform. What is unix-only is the way to PROVOKE it: these force the

--- a/src-tauri/src/coherence/state_write.rs
+++ b/src-tauri/src/coherence/state_write.rs
@@ -17,7 +17,7 @@ use std::fs;
 
 use super::state::WorkspaceKernel;
 use super::types::Envelope;
-use super::workspace_files::flock_exclusive;
+use super::workspace_files::{ensure_lock_ignore_rules, flock_exclusive};
 
 impl WorkspaceKernel {
     /// The single write path: durable ledger append, then index apply
@@ -187,6 +187,10 @@ impl WorkspaceKernel {
     fn acquire_lock_file(&self) -> Result<fs::File, String> {
         let vmark = self.root.join(".vmark");
         fs::create_dir_all(&vmark).map_err(|e| format!("group lock dir: {e}"))?;
+        // The ignore rules land with the LOCK, not with initialization (#1285)
+        // — this path creates `.vmark/` before the op is adjudicated, and a
+        // rejected op leaves it behind.
+        ensure_lock_ignore_rules(&vmark)?;
         flock_exclusive(&vmark)
     }
     /// Run `f` holding the exclusive cross-process workspace lock across its WHOLE

--- a/src-tauri/src/coherence/workspace_files.rs
+++ b/src-tauri/src/coherence/workspace_files.rs
@@ -47,6 +47,31 @@ pub(super) fn flock_exclusive(vmark: &Path) -> Result<fs::File, String> {
     Ok(file)
 }
 
+/// Give `.vmark/.gitignore` its runtime-file rules if the file is absent.
+///
+/// Called by `acquire_lock_file`, which creates `.vmark/` purely to hold
+/// `group.lock` BEFORE the operation is adjudicated (#1285). An op that is then
+/// rejected leaves that directory behind, and without these rules it holds one
+/// binary runtime file and nothing else — which `git add .` duly stages, in
+/// every repository a failed coherence action touched.
+///
+/// This is NOT initialization. The completion marker is `.gitattributes`,
+/// written last by `ensure_initialized`, so `is_fully_initialized` still
+/// reports false for a bare lock and 6R-4 holds unchanged.
+///
+/// Gated on the file being ABSENT rather than on having just created the
+/// directory, so a bare `.vmark` left by an older build is repaired on its next
+/// write too — one `is_file` per acquire, against the O(ledger) reconcile the
+/// caller performs on the same path.
+pub(super) fn ensure_lock_ignore_rules(vmark: &Path) -> Result<(), String> {
+    let ignore = vmark.join(".gitignore");
+    if ignore.is_file() {
+        return Ok(());
+    }
+    ensure_line(&ignore, "index.db*")?;
+    ensure_line(&ignore, "group.lock")
+}
+
 /// Is `.vmark` fully initialized? The marker rule alone is NOT a completion
 /// protocol (8th-review 8R-6): a checkout or hand-made workspace can carry
 /// `.gitattributes` while `.gitignore` and the ledger/snapshot dirs are missing,

--- a/src/components/Terminal/__tests__/useTerminalPosition.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalPosition.test.ts
@@ -7,6 +7,7 @@ import {
   oppositeTerminalPosition,
 } from "../useTerminalPosition";
 import type { EffectiveTerminalPosition } from "@/stores/uiStore";
+import { TERMINAL_MAX_RATIO } from "@/stores/uiStore";
 
 describe("computeTerminalPosition", () => {
   it.each([
@@ -72,9 +73,9 @@ describe("pixelsToRatio", () => {
     expect(pixelsToRatio(0, 1000)).toBe(0.1);
   });
 
-  it("clamps to 0.5 maximum", () => {
-    expect(pixelsToRatio(900, 1000)).toBe(0.5);
-    expect(pixelsToRatio(1000, 1000)).toBe(0.5);
+  it("clamps to the TERMINAL_MAX_RATIO maximum", () => {
+    expect(pixelsToRatio(900, 1000)).toBe(TERMINAL_MAX_RATIO);
+    expect(pixelsToRatio(1000, 1000)).toBe(TERMINAL_MAX_RATIO);
   });
 
   it("returns 0.4 when available dimension is 0", () => {
@@ -139,16 +140,18 @@ describe("pixelsToRatio — edge cases", () => {
   it("handles exact boundary values", () => {
     // 100/1000 = 0.1 (minimum)
     expect(pixelsToRatio(100, 1000)).toBeCloseTo(0.1);
-    // 500/1000 = 0.5 (maximum)
-    expect(pixelsToRatio(500, 1000)).toBeCloseTo(0.5);
-    // 800/1000 = 0.8 → clamped down to the 0.5 maximum
-    expect(pixelsToRatio(800, 1000)).toBeCloseTo(0.5);
+    // The cap itself, expressed in pixels, survives the round trip.
+    expect(pixelsToRatio(TERMINAL_MAX_RATIO * 1000, 1000)).toBeCloseTo(TERMINAL_MAX_RATIO);
+    // Anything above it is clamped down to the cap.
+    expect(pixelsToRatio((TERMINAL_MAX_RATIO + 0.1) * 1000, 1000)).toBeCloseTo(
+      TERMINAL_MAX_RATIO,
+    );
   });
 });
 
 describe("pixelsToRatio — additional precision", () => {
   it("handles very large pixel values", () => {
-    expect(pixelsToRatio(10000, 1000)).toBe(0.5);
+    expect(pixelsToRatio(10000, 1000)).toBe(TERMINAL_MAX_RATIO);
   });
 
   it("handles negative pixel values (clamped to 0.1)", () => {
@@ -156,7 +159,7 @@ describe("pixelsToRatio — additional precision", () => {
   });
 
   it("returns exact mid-range ratio", () => {
-    expect(pixelsToRatio(500, 1000)).toBeCloseTo(0.5);
+    expect(pixelsToRatio(400, 1000)).toBeCloseTo(0.4);
   });
 });
 
@@ -274,7 +277,13 @@ vi.mock("@/stores/settingsStore", () => {
   return { useSettingsStore: store };
 });
 
-vi.mock("@/stores/uiStore", () => {
+vi.mock("@/stores/uiStore", async () => {
+  // Take the geometry constants from the real module rather than restating
+  // them. Copied literals here read as production values while tracking
+  // nothing: this mock still said 0.5 after #1279 raised the cap to 0.8, so
+  // every assertion below was measuring a ceiling the app no longer has.
+  const actual =
+    await vi.importActual<typeof import("@/stores/uiStore")>("@/stores/uiStore");
   const sidebarVisible = false;
   const sidebarWidth = 260;
   const subscribers: ((s: unknown) => unknown)[] = [];
@@ -310,9 +319,9 @@ vi.mock("@/stores/uiStore", () => {
 
   return {
     useUIStore: store,
-    TERMINAL_MIN_HEIGHT: 100,
-    TERMINAL_MIN_WIDTH: 200,
-    TERMINAL_MAX_RATIO: 0.5,
+    TERMINAL_MIN_HEIGHT: actual.TERMINAL_MIN_HEIGHT,
+    TERMINAL_MIN_WIDTH: actual.TERMINAL_MIN_WIDTH,
+    TERMINAL_MAX_RATIO: actual.TERMINAL_MAX_RATIO,
   };
 });
 

--- a/src/components/Terminal/useTerminalPosition.ts
+++ b/src/components/Terminal/useTerminalPosition.ts
@@ -10,7 +10,7 @@
  *
  * Pixel dimensions are derived from `settingsStore.terminal.panelRatio`
  * multiplied by the available container dimension, clamped to the absolute
- * pixel floor and a proportional ceiling of TERMINAL_MAX_RATIO (50%). The
+ * pixel floor and a proportional ceiling of TERMINAL_MAX_RATIO (80%). The
  * available dimension subtracts the shell's whole side chrome — workspace rail
  * INCLUDED; omitting it sized the panel against 30px the editor did not have.
  *
@@ -79,7 +79,7 @@ export function computeTerminalPosition(
 
 /**
  * Compute pixel dimension from ratio, clamped to the absolute pixel floor and
- * a proportional ceiling of TERMINAL_MAX_RATIO (50% of the available space).
+ * a proportional ceiling of TERMINAL_MAX_RATIO (80% of the available space).
  * Exported so the settings dropdown's options can be proven un-clamped
  * (WI-1.2) against the real layout function rather than a restatement of it.
  */
@@ -97,7 +97,7 @@ export function ratioToPixels(
  */
 export function pixelsToRatio(pixels: number, availableDimension: number): number {
   if (availableDimension <= 0) return 0.4;
-  // Clamp ratio to 0.1–0.5 (TERMINAL_MAX_RATIO)
+  // Clamp ratio to 0.1–0.8 (TERMINAL_MAX_RATIO)
   return Math.min(TERMINAL_MAX_RATIO, Math.max(0.1, pixels / availableDimension));
 }
 
@@ -118,7 +118,7 @@ export function getAvailableDimension(
     // Takes the ALREADY-COMBINED width rather than re-deriving it from
     // sidebar state: this function used to add up its own answer and forgot
     // the 30px workspace rail, so a rail-enabled window sized the panel (and
-    // its 50% cap) against 30px it did not have.
+    // its ratio cap) against 30px it did not have.
     return windowW - sideWidth;
   }
   return windowH - TITLEBAR_HEIGHT - STATUSBAR_HEIGHT;

--- a/src/components/Terminal/useTerminalResize.test.ts
+++ b/src/components/Terminal/useTerminalResize.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useTerminalResize } from "./useTerminalResize";
-import { useUIStore } from "@/stores/uiStore";
+import { useUIStore, TERMINAL_MAX_RATIO } from "@/stores/uiStore";
 import type { EffectiveTerminalPosition } from "@/stores/uiStore";
 
 // Persisting the ratio on mouseup is a side effect the drag tests don't care
@@ -113,7 +113,7 @@ describe("toggleMaximize (WI-4.5 / F6)", () => {
 
     result.current.toggleMaximize();
 
-    expect(useUIStore.getState().terminalHeight).toBe(Math.round(AVAILABLE_V * 0.5));
+    expect(useUIStore.getState().terminalHeight).toBe(Math.round(AVAILABLE_V * TERMINAL_MAX_RATIO));
   });
 
   it("restores the STORED ratio on a second toggle", () => {
@@ -157,7 +157,7 @@ describe("toggleMaximize (WI-4.5 / F6)", () => {
     const { result } = mount("right");
 
     result.current.toggleMaximize();
-    expect(useUIStore.getState().terminalWidth).toBe(Math.round(AVAILABLE_H * 0.5));
+    expect(useUIStore.getState().terminalWidth).toBe(Math.round(AVAILABLE_H * TERMINAL_MAX_RATIO));
 
     result.current.toggleMaximize();
     expect(useUIStore.getState().terminalWidth).toBe(Math.round(AVAILABLE_H * 0.4));
@@ -187,20 +187,21 @@ describe("toggleMaximize (WI-4.5 / F6)", () => {
 
     expect(onResize).not.toHaveBeenCalled();
     // …but the geometry really did change, so the effect has something to react to.
-    expect(useUIStore.getState().terminalHeight).toBe(Math.round(AVAILABLE_V * 0.5));
+    expect(useUIStore.getState().terminalHeight).toBe(Math.round(AVAILABLE_V * TERMINAL_MAX_RATIO));
   });
 
   it("clamps a legacy over-cap stored ratio when restoring", () => {
-    // A ratio persisted before WI-1.2 could be 0.8; restoring to it would
-    // exceed the cap the layout enforces everywhere else.
-    settingsState.terminal.panelRatio = 0.8;
-    useUIStore.getState().setTerminalHeight(Math.round(AVAILABLE_V * 0.5));
+    // Restoring to a ratio above the cap would exceed what the layout enforces
+    // everywhere else. Stated relative to the cap: written as the literal 0.8
+    // it silently became a no-op the moment #1279 raised the cap to 0.8.
+    settingsState.terminal.panelRatio = TERMINAL_MAX_RATIO + 0.15;
+    useUIStore.getState().setTerminalHeight(Math.round(AVAILABLE_V * TERMINAL_MAX_RATIO));
     const { result } = mount("bottom");
 
     // Already at the cap → this toggle RESTORES.
     result.current.toggleMaximize();
 
-    expect(useUIStore.getState().terminalHeight).toBe(Math.round(AVAILABLE_V * 0.5));
+    expect(useUIStore.getState().terminalHeight).toBe(Math.round(AVAILABLE_V * TERMINAL_MAX_RATIO));
   });
 
   it("does nothing when the available dimension is zero", () => {
@@ -252,7 +253,7 @@ describe("double-click maximize through the real DOM event sequence (WI-4.5)", (
   it("survives a full double-click → maximize → double-click → restore cycle", () => {
     const { result } = renderHook(() => useTerminalResize("bottom"));
     const stored = Math.round(AVAILABLE_V * 0.4);
-    const capped = Math.round(AVAILABLE_V * 0.5);
+    const capped = Math.round(AVAILABLE_V * TERMINAL_MAX_RATIO);
 
     // First double-click: two clicks, then the dblclick handler.
     click(result);

--- a/src/components/Terminal/useTerminalResize.ts
+++ b/src/components/Terminal/useTerminalResize.ts
@@ -11,15 +11,20 @@
  *   - Grow sign flips per side: right/bottom grow on negative client delta;
  *     left/top grow on positive (their handle is on the far edge).
  *   - Sets document.body cursor during drag and disables text selection.
- *   - Caps the live size at 50% of available space (TERMINAL_MAX_RATIO); the
+ *   - Caps the live size at 80% of available space (TERMINAL_MAX_RATIO); the
  *     store setters only enforce the absolute pixel floor.
  *   - Calls onResize callback on every move to let the parent refit xterm.
  *   - On drag end, computes the ratio from final pixel / available dimension
  *     and persists it to settingsStore.
  *   - `toggleMaximize` (WI-4.5/F6) snaps the panel to the cap and back to the
- *     STORED ratio, without rewriting that ratio. The persisted size stops at
- *     50% on purpose (the editor must stay usable); the real need behind
- *     "I want 80%" is temporary, so this is a view toggle, not a setting.
+ *     STORED ratio, without rewriting that ratio.
+ *   - The cap was 50%, on the reasoning that a bigger panel is a temporary
+ *     need the maximize toggle covers. That reasoning did not survive contact:
+ *     the toggle snaps to the SAME constant, so "temporarily bigger" also
+ *     stopped at 50% and the escape hatch it justified never existed. Raised
+ *     to 80% in #1279, matching the range `clamp.ts` had been persisting all
+ *     along. The editor stays usable via TERMINAL_MIN_HEIGHT/WIDTH, which are
+ *     absolute pixel floors and bind first on a small window.
  *
  * @coordinates-with TerminalPanel.tsx — attaches handleResizeStart to the resize handle
  * @coordinates-with uiStore — updates terminalHeight / terminalWidth during drag
@@ -113,7 +118,7 @@ export function useTerminalResize(
         if (!isResizing.current) return;
 
         const ui = useUIStore.getState();
-        // Cap live drag at 50% of available space (TERMINAL_MAX_RATIO); the
+        // Cap live drag at 80% of available space (TERMINAL_MAX_RATIO); the
         // store setters only enforce the pixel floor.
         const available = getAvailableDimension(
           ui.effectiveTerminalPosition,

--- a/src/pages/settings/TerminalSettings.test.tsx
+++ b/src/pages/settings/TerminalSettings.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { TerminalSettings } from "./TerminalSettings";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { TERMINAL_MAX_RATIO } from "@/stores/uiStore";
 
 // list_available_shells / get_default_shell are invoked on mount.
 vi.mock("@tauri-apps/api/core", () => ({
@@ -159,21 +160,25 @@ describe("TerminalSettings panel size (WI-1.2)", () => {
     });
   });
 
-  it("offers nothing above 50%", () => {
+  it("offers the cap and nothing above it", () => {
+    // Derived from TERMINAL_MAX_RATIO, not spelled out: as literals ("not 60/70/80,
+    // yes 50") this test asserted the OLD ceiling and would have gone on passing
+    // while the dropdown silently lost every option #1279 added.
     render(<TerminalSettings />);
     const labels = Array.from(panelSizeSelect().options).map((o) => o.textContent);
-    expect(labels).not.toContain("60%");
-    expect(labels).not.toContain("70%");
-    expect(labels).not.toContain("80%");
-    expect(labels).toContain("50%");
+    expect(labels).toContain(`${Math.round(TERMINAL_MAX_RATIO * 100)}%`);
+    expect(labels).not.toContain(`${Math.round((TERMINAL_MAX_RATIO + 0.05) * 100)}%`);
   });
 
-  it("displays a legacy over-cap ratio as the cap, not as the stored number", () => {
+  it("displays an over-cap ratio as the cap, not as the stored number", () => {
     useSettingsStore.setState({
-      terminal: { ...useSettingsStore.getState().terminal, panelRatio: 0.8 },
+      terminal: {
+        ...useSettingsStore.getState().terminal,
+        panelRatio: TERMINAL_MAX_RATIO + 0.15,
+      },
     });
     render(<TerminalSettings />);
-    // The panel was already rendering at 50%; the dropdown now agrees.
-    expect(panelSizeSelect().value).toBe("0.5");
+    // The panel is already rendering at the cap; the dropdown must agree.
+    expect(panelSizeSelect().value).toBe(String(TERMINAL_MAX_RATIO));
   });
 });

--- a/src/pages/settings/__tests__/terminalDocDefaults.test.ts
+++ b/src/pages/settings/__tests__/terminalDocDefaults.test.ts
@@ -58,7 +58,7 @@ const DOCUMENTED_RANGES: Array<{
   documented: [number, number];
   actual: () => number[];
 }> = [
-  { row: "Panel Size", documented: [0.1, 0.5], actual: () => panelSizeOptions.map((o) => Number(o.value)) },
+  { row: "Panel Size", documented: [0.1, 0.8], actual: () => panelSizeOptions.map((o) => Number(o.value)) },
   { row: "Font Size", documented: [10, 24], actual: () => fontSizeOptions.map((o) => Number(o.value)) },
   { row: "Line Height", documented: [1.0, 2.0], actual: () => [...lineHeightValues] },
   { row: "Scrollback", documented: [1000, 50000], actual: () => scrollbackOptions.map((o) => Number(o.value)) },

--- a/src/pages/settings/terminalSettingsHelpers.test.ts
+++ b/src/pages/settings/terminalSettingsHelpers.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./terminalSettingsHelpers";
 import { ratioToPixels } from "@/components/Terminal/useTerminalPosition";
 import { TERMINAL_MAX_RATIO, TERMINAL_MIN_HEIGHT } from "@/stores/uiStore";
+import { CLAMP_RANGES } from "@/stores/settingsStore/clamp";
 
 describe("panelSizeOptions (WI-1.2)", () => {
   it("no option is silently clamped", () => {
@@ -48,13 +49,26 @@ describe("panelSizeOptions (WI-1.2)", () => {
     }
   });
 
-  it("snapToOption maps a legacy over-cap ratio to the cap", () => {
-    // A build before WI-1.2 could persist 0.6/0.7/0.8. The panel was ALWAYS
-    // rendering at the cap for those; the dropdown must now say so rather than
-    // display a number the layout never honored.
-    expect(snapToOption(0.8)).toBe(String(TERMINAL_MAX_RATIO));
-    expect(snapToOption(0.7)).toBe(String(TERMINAL_MAX_RATIO));
-    expect(snapToOption(0.6)).toBe(String(TERMINAL_MAX_RATIO));
+  it("snapToOption maps an over-cap ratio to the cap", () => {
+    // The panel ALWAYS renders at the cap for these; the dropdown must say so
+    // rather than display a number the layout never honored. Stated relative to
+    // the cap so raising it (#1279) does not quietly turn this into a no-op.
+    expect(snapToOption(TERMINAL_MAX_RATIO + 0.1)).toBe(String(TERMINAL_MAX_RATIO));
+    expect(snapToOption(0.95)).toBe(String(TERMINAL_MAX_RATIO));
+    expect(snapToOption(1)).toBe(String(TERMINAL_MAX_RATIO));
+  });
+
+  // #1279 — the persisted range and the layout cap disagreed: clamp.ts accepted
+  // panelRatio up to 0.8 while the layout, the drag and the dropdown all
+  // stopped at 0.5, so a stored 0.8 could never take effect. Whatever the cap
+  // is, these two must name the same number.
+  it("the layout cap equals the persisted panelRatio maximum", () => {
+    expect(TERMINAL_MAX_RATIO).toBe(CLAMP_RANGES.terminal?.panelRatio?.[1]);
+  });
+
+  it("the smallest offered option equals the persisted panelRatio minimum", () => {
+    const values = panelSizeOptions.map((o) => Number(o.value));
+    expect(Math.min(...values)).toBe(CLAMP_RANGES.terminal?.panelRatio?.[0]);
   });
 
   it("snapToOption still returns an exact preset unchanged", () => {

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -58,13 +58,21 @@ const TERMINAL_DEFAULT_WIDTH = 400;
 
 /**
  * Maximum share of the available dimension the terminal panel may occupy.
- * There is no fixed pixel ceiling — the cap is proportional (50% of the
+ * There is no fixed pixel ceiling — the cap is proportional (80% of the
  * window's available width/height). This is enforced by the viewport-aware
  * layers (useTerminalPosition for layout, useTerminalResize for drag), since
  * the store itself does not know the window size. The store setters below
  * only enforce the absolute pixel floor.
+ *
+ * This MUST equal `CLAMP_RANGES.terminal.panelRatio`'s maximum in
+ * `settingsStore/clamp.ts`, and `terminalSettingsHelpers.test.ts` pins that.
+ * They disagreed until #1279: the setting persisted up to 0.8 while these
+ * three layers clamped back to 0.5, so a stored 0.8 could never take effect
+ * and the dropdown offering it was a dead control. The editor side stays
+ * protected by TERMINAL_MIN_HEIGHT / TERMINAL_MIN_WIDTH, which are absolute
+ * pixel floors and bind before this ratio does on a small window.
  */
-export const TERMINAL_MAX_RATIO = 0.5;
+export const TERMINAL_MAX_RATIO = 0.8;
 
 /* ──────────────────────────── store factory ───────────────────────────── */
 

--- a/src/utils/markdownPipeline/__tests__/spec/specDeltas.json
+++ b/src/utils/markdownPipeline/__tests__/spec/specDeltas.json
@@ -1064,61 +1064,41 @@
    "exampleId": "gfmext-18",
    "path": "root.children[2]",
    "kind": "child-count",
-   "detail": "5 vs 3",
-   "vmarkValue": 5,
+   "detail": "1 vs 3",
+   "vmarkValue": 1,
    "referenceValue": 3,
    "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
+  },
+  {
+   "exampleId": "gfmext-18",
+   "path": "root.children[2].children[0]",
+   "kind": "attribute",
+   "detail": "value",
+   "vmarkValue": "This ~is ~ legit~ isn't ~ legit.",
+   "referenceValue": "This ",
+   "verdict": "extension",
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
   },
   {
    "exampleId": "gfmext-18",
    "path": "root.children[2].children[1]",
-   "kind": "type",
-   "detail": "subscript vs delete",
-   "vmarkValue": "subscript",
+   "kind": "missing",
+   "detail": "absent in document",
+   "vmarkValue": "__undefined__",
    "referenceValue": "delete",
    "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
-  },
-  {
-   "exampleId": "gfmext-18",
-   "path": "root.children[2].children[1].children[0]",
-   "kind": "attribute",
-   "detail": "value",
-   "vmarkValue": "is ",
-   "referenceValue": "is ~ legit",
-   "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
   },
   {
    "exampleId": "gfmext-18",
    "path": "root.children[2].children[2]",
-   "kind": "attribute",
-   "detail": "value",
-   "vmarkValue": " legit",
-   "referenceValue": " isn't ~ legit.",
-   "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
-  },
-  {
-   "exampleId": "gfmext-18",
-   "path": "root.children[2].children[3]",
    "kind": "missing",
-   "detail": "absent in source-position",
-   "vmarkValue": "subscript",
-   "referenceValue": "__undefined__",
+   "detail": "absent in document",
+   "vmarkValue": "__undefined__",
+   "referenceValue": "text",
    "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
-  },
-  {
-   "exampleId": "gfmext-18",
-   "path": "root.children[2].children[4]",
-   "kind": "missing",
-   "detail": "absent in source-position",
-   "vmarkValue": "text",
-   "referenceValue": "__undefined__",
-   "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
   },
   {
    "exampleId": "gfmext-18",
@@ -1128,7 +1108,7 @@
    "vmarkValue": 3,
    "referenceValue": 1,
    "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
   },
   {
    "exampleId": "gfmext-18",
@@ -1138,7 +1118,7 @@
    "vmarkValue": "This is not ~~~~",
    "referenceValue": "This is not ~~~~~one~~~~~ huge strikethrough.",
    "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
   },
   {
    "exampleId": "gfmext-18",
@@ -1148,7 +1128,7 @@
    "vmarkValue": "subscript",
    "referenceValue": "__undefined__",
    "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
   },
   {
    "exampleId": "gfmext-18",
@@ -1158,7 +1138,7 @@
    "vmarkValue": "text",
    "referenceValue": "__undefined__",
    "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
   },
   {
    "exampleId": "gfmext-18",
@@ -1168,7 +1148,7 @@
    "vmarkValue": 5,
    "referenceValue": 4,
    "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
   },
   {
    "exampleId": "gfmext-18",
@@ -1178,7 +1158,7 @@
    "vmarkValue": "subscript",
    "referenceValue": "delete",
    "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
   },
   {
    "exampleId": "gfmext-18",
@@ -1188,7 +1168,7 @@
    "vmarkValue": " ~~",
    "referenceValue": " ~~~three~~~",
    "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
   },
   {
    "exampleId": "gfmext-18",
@@ -1198,7 +1178,7 @@
    "vmarkValue": "subscript",
    "referenceValue": "__undefined__",
    "verdict": "extension",
-   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected."
+   "reason": "Tilde dialect: VMark reads single-tilde ~x~ as subscript (and ^x^ superscript); GFM's reference reads strikethrough (delete). Double-tilde strikethrough is unaffected. Since #1280 a ~ pair also requires no unescaped whitespace (Pandoc's rule), so `~is ~ legit~` stays plain text here where GFM makes it a delete."
   },
   {
    "exampleId": "gfmreg-10",

--- a/src/utils/markdownPipeline/__tests__/spec/specRoundtripDeltas.json
+++ b/src/utils/markdownPipeline/__tests__/spec/specRoundtripDeltas.json
@@ -58,7 +58,7 @@
       "inputValue": "shortcut",
       "outputValue": "full",
       "verdict": "normalization",
-      "reason": "Reference SPELLING widens on save: a shortcut/collapsed image or link reference is re-emitted in full form (`![alt][id]`). The reference itself now SURVIVES \u2014 main's fix stopped the old flattening that rewrote it inline and orphaned its definition \u2014 and mdast-util-to-markdown must use the full form whenever the label and the rendered alt text differ, which is exactly these examples. The rendered document and the resolved destination are unchanged; only the reference's spelling widens."
+      "reason": "Reference SPELLING widens on save: a shortcut/collapsed image or link reference is re-emitted in full form (`![alt][id]`). The reference itself now SURVIVES — main's fix stopped the old flattening that rewrote it inline and orphaned its definition — and mdast-util-to-markdown must use the full form whenever the label and the rendered alt text differ, which is exactly these examples. The rendered document and the resolved destination are unchanged; only the reference's spelling widens."
     },
     {
       "exampleId": "cm-300",
@@ -328,7 +328,7 @@
       "inputValue": 1,
       "outputValue": 2,
       "verdict": "defect",
-      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks \u2014 fixable corruption of the author's structure; ratcheted."
+      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks — fixable corruption of the author's structure; ratcheted."
     },
     {
       "exampleId": "cm-39",
@@ -338,7 +338,7 @@
       "inputValue": "foo\n\nbar",
       "outputValue": "foo",
       "verdict": "defect",
-      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks \u2014 fixable corruption of the author's structure; ratcheted."
+      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks — fixable corruption of the author's structure; ratcheted."
     },
     {
       "exampleId": "cm-39",
@@ -348,7 +348,7 @@
       "inputValue": "__undefined__",
       "outputValue": "paragraph",
       "verdict": "defect",
-      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks \u2014 fixable corruption of the author's structure; ratcheted."
+      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks — fixable corruption of the author's structure; ratcheted."
     },
     {
       "exampleId": "cm-407",
@@ -838,7 +838,7 @@
       "inputValue": 1,
       "outputValue": 0,
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "cm-484",
@@ -848,7 +848,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "cm-487",
@@ -858,7 +858,7 @@
       "inputValue": 1,
       "outputValue": 0,
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "cm-487",
@@ -868,7 +868,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "cm-517",
@@ -928,7 +928,7 @@
       "inputValue": "shortcut",
       "outputValue": "full",
       "verdict": "normalization",
-      "reason": "Reference SPELLING widens on save: a shortcut/collapsed image or link reference is re-emitted in full form (`![alt][id]`). The reference itself now SURVIVES \u2014 main's fix stopped the old flattening that rewrote it inline and orphaned its definition \u2014 and mdast-util-to-markdown must use the full form whenever the label and the rendered alt text differ, which is exactly these examples. The rendered document and the resolved destination are unchanged; only the reference's spelling widens."
+      "reason": "Reference SPELLING widens on save: a shortcut/collapsed image or link reference is re-emitted in full form (`![alt][id]`). The reference itself now SURVIVES — main's fix stopped the old flattening that rewrote it inline and orphaned its definition — and mdast-util-to-markdown must use the full form whenever the label and the rendered alt text differ, which is exactly these examples. The rendered document and the resolved destination are unchanged; only the reference's spelling widens."
     },
     {
       "exampleId": "cm-576",
@@ -938,7 +938,7 @@
       "inputValue": "collapsed",
       "outputValue": "full",
       "verdict": "normalization",
-      "reason": "Reference SPELLING widens on save: a shortcut/collapsed image or link reference is re-emitted in full form (`![alt][id]`). The reference itself now SURVIVES \u2014 main's fix stopped the old flattening that rewrote it inline and orphaned its definition \u2014 and mdast-util-to-markdown must use the full form whenever the label and the rendered alt text differ, which is exactly these examples. The rendered document and the resolved destination are unchanged; only the reference's spelling widens."
+      "reason": "Reference SPELLING widens on save: a shortcut/collapsed image or link reference is re-emitted in full form (`![alt][id]`). The reference itself now SURVIVES — main's fix stopped the old flattening that rewrote it inline and orphaned its definition — and mdast-util-to-markdown must use the full form whenever the label and the rendered alt text differ, which is exactly these examples. The rendered document and the resolved destination are unchanged; only the reference's spelling widens."
     },
     {
       "exampleId": "cm-585",
@@ -948,7 +948,7 @@
       "inputValue": "collapsed",
       "outputValue": "full",
       "verdict": "normalization",
-      "reason": "Reference SPELLING widens on save: a shortcut/collapsed image or link reference is re-emitted in full form (`![alt][id]`). The reference itself now SURVIVES \u2014 main's fix stopped the old flattening that rewrote it inline and orphaned its definition \u2014 and mdast-util-to-markdown must use the full form whenever the label and the rendered alt text differ, which is exactly these examples. The rendered document and the resolved destination are unchanged; only the reference's spelling widens."
+      "reason": "Reference SPELLING widens on save: a shortcut/collapsed image or link reference is re-emitted in full form (`![alt][id]`). The reference itself now SURVIVES — main's fix stopped the old flattening that rewrote it inline and orphaned its definition — and mdast-util-to-markdown must use the full form whenever the label and the rendered alt text differ, which is exactly these examples. The rendered document and the resolved destination are unchanged; only the reference's spelling widens."
     },
     {
       "exampleId": "cm-589",
@@ -958,7 +958,7 @@
       "inputValue": "shortcut",
       "outputValue": "full",
       "verdict": "normalization",
-      "reason": "Reference SPELLING widens on save: a shortcut/collapsed image or link reference is re-emitted in full form (`![alt][id]`). The reference itself now SURVIVES \u2014 main's fix stopped the old flattening that rewrote it inline and orphaned its definition \u2014 and mdast-util-to-markdown must use the full form whenever the label and the rendered alt text differ, which is exactly these examples. The rendered document and the resolved destination are unchanged; only the reference's spelling widens."
+      "reason": "Reference SPELLING widens on save: a shortcut/collapsed image or link reference is re-emitted in full form (`![alt][id]`). The reference itself now SURVIVES — main's fix stopped the old flattening that rewrote it inline and orphaned its definition — and mdast-util-to-markdown must use the full form whenever the label and the rendered alt text differ, which is exactly these examples. The rendered document and the resolved destination are unchanged; only the reference's spelling widens."
     },
     {
       "exampleId": "cm-638",
@@ -1289,13 +1289,53 @@
     },
     {
       "exampleId": "gfmext-18",
+      "path": "root.children[2]",
+      "kind": "child-count",
+      "detail": "3 vs 1",
+      "inputValue": 3,
+      "outputValue": 1,
+      "verdict": "extension",
+      "reason": "Tilde dialect: VMark does not implement GFM's single-tilde strikethrough — `~` opens a subscript, and since #1280 only when the span carries no unescaped whitespace. Tildes VMark reads as literal are escaped on output (`\\~`) so the document renders the same in VMark and in GFM; the stock ruler therefore reads a `delete` in the input where it reads plain text in the output. Double-tilde strikethrough is unaffected."
+    },
+    {
+      "exampleId": "gfmext-18",
+      "path": "root.children[2].children[0]",
+      "kind": "attribute",
+      "detail": "value",
+      "inputValue": "This ",
+      "outputValue": "This ~is ~ legit~ isn't ~ legit.",
+      "verdict": "extension",
+      "reason": "Tilde dialect: VMark does not implement GFM's single-tilde strikethrough — `~` opens a subscript, and since #1280 only when the span carries no unescaped whitespace. Tildes VMark reads as literal are escaped on output (`\\~`) so the document renders the same in VMark and in GFM; the stock ruler therefore reads a `delete` in the input where it reads plain text in the output. Double-tilde strikethrough is unaffected."
+    },
+    {
+      "exampleId": "gfmext-18",
+      "path": "root.children[2].children[1]",
+      "kind": "missing",
+      "detail": "absent in source-position",
+      "inputValue": "delete",
+      "outputValue": "__undefined__",
+      "verdict": "extension",
+      "reason": "Tilde dialect: VMark does not implement GFM's single-tilde strikethrough — `~` opens a subscript, and since #1280 only when the span carries no unescaped whitespace. Tildes VMark reads as literal are escaped on output (`\\~`) so the document renders the same in VMark and in GFM; the stock ruler therefore reads a `delete` in the input where it reads plain text in the output. Double-tilde strikethrough is unaffected."
+    },
+    {
+      "exampleId": "gfmext-18",
+      "path": "root.children[2].children[2]",
+      "kind": "missing",
+      "detail": "absent in source-position",
+      "inputValue": "text",
+      "outputValue": "__undefined__",
+      "verdict": "extension",
+      "reason": "Tilde dialect: VMark does not implement GFM's single-tilde strikethrough — `~` opens a subscript, and since #1280 only when the span carries no unescaped whitespace. Tildes VMark reads as literal are escaped on output (`\\~`) so the document renders the same in VMark and in GFM; the stock ruler therefore reads a `delete` in the input where it reads plain text in the output. Double-tilde strikethrough is unaffected."
+    },
+    {
+      "exampleId": "gfmext-18",
       "path": "root.children[3]",
       "kind": "child-count",
       "detail": "1 vs 3",
       "inputValue": 1,
       "outputValue": 3,
-      "verdict": "model-limit",
-      "reason": "Delimiter-run pathology (regression corpora): adversarial nested/unbalanced emphasis, strikethrough and tilde runs cannot be represented as distinct ProseMirror marks; the serializer emits its closest escaped spelling, whose re-parse differs at the boundaries. The text content survives; the adversarial delimiter structure does not."
+      "verdict": "extension",
+      "reason": "Tilde dialect: VMark does not implement GFM's single-tilde strikethrough — `~` opens a subscript, and since #1280 only when the span carries no unescaped whitespace. Tildes VMark reads as literal are escaped on output (`\\~`) so the document renders the same in VMark and in GFM; the stock ruler therefore reads a `delete` in the input where it reads plain text in the output. Double-tilde strikethrough is unaffected."
     },
     {
       "exampleId": "gfmext-18",
@@ -1304,8 +1344,8 @@
       "detail": "value",
       "inputValue": "This is not ~~~~~one~~~~~ huge strikethrough.",
       "outputValue": "This is not ~~~~",
-      "verdict": "model-limit",
-      "reason": "Delimiter-run pathology (regression corpora): adversarial nested/unbalanced emphasis, strikethrough and tilde runs cannot be represented as distinct ProseMirror marks; the serializer emits its closest escaped spelling, whose re-parse differs at the boundaries. The text content survives; the adversarial delimiter structure does not."
+      "verdict": "extension",
+      "reason": "Tilde dialect: VMark does not implement GFM's single-tilde strikethrough — `~` opens a subscript, and since #1280 only when the span carries no unescaped whitespace. Tildes VMark reads as literal are escaped on output (`\\~`) so the document renders the same in VMark and in GFM; the stock ruler therefore reads a `delete` in the input where it reads plain text in the output. Double-tilde strikethrough is unaffected."
     },
     {
       "exampleId": "gfmext-18",
@@ -1314,8 +1354,8 @@
       "detail": "absent in document",
       "inputValue": "__undefined__",
       "outputValue": "delete",
-      "verdict": "model-limit",
-      "reason": "Delimiter-run pathology (regression corpora): adversarial nested/unbalanced emphasis, strikethrough and tilde runs cannot be represented as distinct ProseMirror marks; the serializer emits its closest escaped spelling, whose re-parse differs at the boundaries. The text content survives; the adversarial delimiter structure does not."
+      "verdict": "extension",
+      "reason": "Tilde dialect: VMark does not implement GFM's single-tilde strikethrough — `~` opens a subscript, and since #1280 only when the span carries no unescaped whitespace. Tildes VMark reads as literal are escaped on output (`\\~`) so the document renders the same in VMark and in GFM; the stock ruler therefore reads a `delete` in the input where it reads plain text in the output. Double-tilde strikethrough is unaffected."
     },
     {
       "exampleId": "gfmext-18",
@@ -1324,8 +1364,8 @@
       "detail": "absent in document",
       "inputValue": "__undefined__",
       "outputValue": "text",
-      "verdict": "model-limit",
-      "reason": "Delimiter-run pathology (regression corpora): adversarial nested/unbalanced emphasis, strikethrough and tilde runs cannot be represented as distinct ProseMirror marks; the serializer emits its closest escaped spelling, whose re-parse differs at the boundaries. The text content survives; the adversarial delimiter structure does not."
+      "verdict": "extension",
+      "reason": "Tilde dialect: VMark does not implement GFM's single-tilde strikethrough — `~` opens a subscript, and since #1280 only when the span carries no unescaped whitespace. Tildes VMark reads as literal are escaped on output (`\\~`) so the document renders the same in VMark and in GFM; the stock ruler therefore reads a `delete` in the input where it reads plain text in the output. Double-tilde strikethrough is unaffected."
     },
     {
       "exampleId": "gfmext-18",
@@ -1334,8 +1374,8 @@
       "detail": "4 vs 5",
       "inputValue": 4,
       "outputValue": 5,
-      "verdict": "model-limit",
-      "reason": "Delimiter-run pathology (regression corpora): adversarial nested/unbalanced emphasis, strikethrough and tilde runs cannot be represented as distinct ProseMirror marks; the serializer emits its closest escaped spelling, whose re-parse differs at the boundaries. The text content survives; the adversarial delimiter structure does not."
+      "verdict": "extension",
+      "reason": "Tilde dialect: VMark does not implement GFM's single-tilde strikethrough — `~` opens a subscript, and since #1280 only when the span carries no unescaped whitespace. Tildes VMark reads as literal are escaped on output (`\\~`) so the document renders the same in VMark and in GFM; the stock ruler therefore reads a `delete` in the input where it reads plain text in the output. Double-tilde strikethrough is unaffected."
     },
     {
       "exampleId": "gfmext-18",
@@ -1344,8 +1384,8 @@
       "detail": "value",
       "inputValue": " ~~~three~~~",
       "outputValue": " ~~",
-      "verdict": "model-limit",
-      "reason": "Delimiter-run pathology (regression corpora): adversarial nested/unbalanced emphasis, strikethrough and tilde runs cannot be represented as distinct ProseMirror marks; the serializer emits its closest escaped spelling, whose re-parse differs at the boundaries. The text content survives; the adversarial delimiter structure does not."
+      "verdict": "extension",
+      "reason": "Tilde dialect: VMark does not implement GFM's single-tilde strikethrough — `~` opens a subscript, and since #1280 only when the span carries no unescaped whitespace. Tildes VMark reads as literal are escaped on output (`\\~`) so the document renders the same in VMark and in GFM; the stock ruler therefore reads a `delete` in the input where it reads plain text in the output. Double-tilde strikethrough is unaffected."
     },
     {
       "exampleId": "gfmext-18",
@@ -1354,8 +1394,8 @@
       "detail": "absent in document",
       "inputValue": "__undefined__",
       "outputValue": "delete",
-      "verdict": "model-limit",
-      "reason": "Delimiter-run pathology (regression corpora): adversarial nested/unbalanced emphasis, strikethrough and tilde runs cannot be represented as distinct ProseMirror marks; the serializer emits its closest escaped spelling, whose re-parse differs at the boundaries. The text content survives; the adversarial delimiter structure does not."
+      "verdict": "extension",
+      "reason": "Tilde dialect: VMark does not implement GFM's single-tilde strikethrough — `~` opens a subscript, and since #1280 only when the span carries no unescaped whitespace. Tildes VMark reads as literal are escaped on output (`\\~`) so the document renders the same in VMark and in GFM; the stock ruler therefore reads a `delete` in the input where it reads plain text in the output. Double-tilde strikethrough is unaffected."
     },
     {
       "exampleId": "gfmext-20",
@@ -1855,7 +1895,7 @@
       "inputValue": "$$a$$$$b$$",
       "outputValue": "$a$$$$b$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-17",
@@ -1865,7 +1905,7 @@
       "inputValue": "$$ Display ",
       "outputValue": "$Display ",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-17",
@@ -1875,7 +1915,7 @@
       "inputValue": "first $$ then",
       "outputValue": "first$ then",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-19",
@@ -1885,7 +1925,7 @@
       "inputValue": 4,
       "outputValue": 5,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-19",
@@ -1895,7 +1935,7 @@
       "inputValue": "math\n$$",
       "outputValue": "math",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-19",
@@ -1905,7 +1945,7 @@
       "inputValue": "__undefined__",
       "outputValue": "paragraph",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-2",
@@ -1915,7 +1955,7 @@
       "inputValue": "$$\\left( \\sum_{k=1}^n a_k b_k \\right)^2 \\leq \\left( \\sum_{k=1}^n a_k^2 \\right) \\left( \\sum_{k=1}^n b_k^2 \\right)$$",
       "outputValue": "$\\left( \\sum_{k=1}^n a_k b_k \\right)^2 \\leq \\left( \\sum_{k=1}^n a_k^2 \\right) \\left( \\sum_{k=1}^n b_k^2 \\right)$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-21",
@@ -1925,7 +1965,7 @@
       "inputValue": 1,
       "outputValue": 3,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-21",
@@ -1935,7 +1975,7 @@
       "inputValue": "This is display math:\n$$\n\\text{Hello $x^2$}\n$$\nAnd this is inline math:\n$\\text{Hello $x$ there!}$",
       "outputValue": "This is display math:",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-21",
@@ -1945,7 +1985,7 @@
       "inputValue": "__undefined__",
       "outputValue": "paragraph",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-21",
@@ -1955,7 +1995,7 @@
       "inputValue": "__undefined__",
       "outputValue": "paragraph",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-22",
@@ -1965,7 +2005,7 @@
       "inputValue": "Math environment contains y: $x {$ $ } $y$",
       "outputValue": "Math environment contains y: $x {$ $}$y$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -1975,7 +2015,7 @@
       "inputValue": "$$\\text{first $$ second}$",
       "outputValue": "$\\text{first $ second}$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -1985,7 +2025,7 @@
       "inputValue": "$$\\text{first $$ second}$$",
       "outputValue": "$\\text{first $ second}$$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -1995,7 +2035,7 @@
       "inputValue": "$$$\\text{first $$ second}$$",
       "outputValue": "$$$\\text{first $ second}$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -2005,7 +2045,7 @@
       "inputValue": "$$$$\\text{first $$ second}$$",
       "outputValue": "$$$$\\text{first $ second}$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-28",
@@ -2035,7 +2075,7 @@
       "inputValue": "$$$$",
       "outputValue": "$$\n$$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-31",
@@ -2265,7 +2305,7 @@
       "inputValue": "$$x$$$$$$y$$",
       "outputValue": "$x$$$$$$y$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-43",
@@ -2532,7 +2572,7 @@
       "inputValue": "$${a",
       "outputValue": "${a",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-5",
@@ -2542,7 +2582,7 @@
       "inputValue": " d$$",
       "outputValue": " d$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "mdx-1",
@@ -2602,7 +2642,7 @@
       "inputValue": 3,
       "outputValue": 0,
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-12",
@@ -2612,7 +2652,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-12",
@@ -2622,7 +2662,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-12",
@@ -2632,7 +2672,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-13",
@@ -2722,7 +2762,7 @@
       "inputValue": 2,
       "outputValue": 0,
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-28",
@@ -2732,7 +2772,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-28",
@@ -2742,7 +2782,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-31",
@@ -2762,7 +2802,7 @@
       "inputValue": 1,
       "outputValue": 2,
       "verdict": "normalization",
-      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark \u2014 which lacks the dialect \u2014 reads the spelling difference as a value change. VMark renders both identically."
+      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark — which lacks the dialect — reads the spelling difference as a value change. VMark renders both identically."
     },
     {
       "exampleId": "vmark-alert-note",
@@ -2772,7 +2812,7 @@
       "inputValue": "[!NOTE]\nSomething.",
       "outputValue": "[!NOTE]",
       "verdict": "normalization",
-      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark \u2014 which lacks the dialect \u2014 reads the spelling difference as a value change. VMark renders both identically."
+      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark — which lacks the dialect — reads the spelling difference as a value change. VMark renders both identically."
     },
     {
       "exampleId": "vmark-alert-note",
@@ -2782,7 +2822,7 @@
       "inputValue": "__undefined__",
       "outputValue": "paragraph",
       "verdict": "normalization",
-      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark \u2014 which lacks the dialect \u2014 reads the spelling difference as a value change. VMark renders both identically."
+      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark — which lacks the dialect — reads the spelling difference as a value change. VMark renders both identically."
     },
     {
       "exampleId": "vmark-cm-bare-list-marker",
@@ -2792,7 +2832,7 @@
       "inputValue": 1,
       "outputValue": 2,
       "verdict": "defect",
-      "reason": "Bare list marker through the ruler's eyes: stock remark reads the input as a setext heading and the serialized output as a paragraph plus an empty list \u2014 the rendered meaning changed across the roundtrip. Same defect family as the fidelity leg's bare-marker entry; fixable, ratcheted."
+      "reason": "Bare list marker through the ruler's eyes: stock remark reads the input as a setext heading and the serialized output as a paragraph plus an empty list — the rendered meaning changed across the roundtrip. Same defect family as the fidelity leg's bare-marker entry; fixable, ratcheted."
     },
     {
       "exampleId": "vmark-cm-bare-list-marker",
@@ -2802,7 +2842,7 @@
       "inputValue": "heading",
       "outputValue": "paragraph",
       "verdict": "defect",
-      "reason": "Bare list marker through the ruler's eyes: stock remark reads the input as a setext heading and the serialized output as a paragraph plus an empty list \u2014 the rendered meaning changed across the roundtrip. Same defect family as the fidelity leg's bare-marker entry; fixable, ratcheted."
+      "reason": "Bare list marker through the ruler's eyes: stock remark reads the input as a setext heading and the serialized output as a paragraph plus an empty list — the rendered meaning changed across the roundtrip. Same defect family as the fidelity leg's bare-marker entry; fixable, ratcheted."
     },
     {
       "exampleId": "vmark-cm-bare-list-marker",
@@ -2812,7 +2852,7 @@
       "inputValue": "__undefined__",
       "outputValue": "list",
       "verdict": "defect",
-      "reason": "Bare list marker through the ruler's eyes: stock remark reads the input as a setext heading and the serialized output as a paragraph plus an empty list \u2014 the rendered meaning changed across the roundtrip. Same defect family as the fidelity leg's bare-marker entry; fixable, ratcheted."
+      "reason": "Bare list marker through the ruler's eyes: stock remark reads the input as a setext heading and the serialized output as a paragraph plus an empty list — the rendered meaning changed across the roundtrip. Same defect family as the fidelity leg's bare-marker entry; fixable, ratcheted."
     },
     {
       "exampleId": "vmark-details-simple",
@@ -2822,7 +2862,7 @@
       "inputValue": "<details><summary>S</summary>",
       "outputValue": "<details>\n<summary>S</summary>",
       "verdict": "normalization",
-      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark \u2014 which lacks the dialect \u2014 reads the spelling difference as a value change. VMark renders both identically."
+      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark — which lacks the dialect — reads the spelling difference as a value change. VMark renders both identically."
     },
     {
       "exampleId": "vmark-nesting-details-in-list",
@@ -2832,7 +2872,7 @@
       "inputValue": "<details><summary>S</summary>",
       "outputValue": "<details>\n<summary>S</summary>",
       "verdict": "normalization",
-      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark \u2014 which lacks the dialect \u2014 reads the spelling difference as a value change. VMark renders both identically."
+      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark — which lacks the dialect — reads the spelling difference as a value change. VMark renders both identically."
     },
     {
       "exampleId": "vmark-toc-block",
@@ -2842,7 +2882,7 @@
       "inputValue": "[toc]",
       "outputValue": "[TOC]",
       "verdict": "normalization",
-      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark \u2014 which lacks the dialect \u2014 reads the spelling difference as a value change. VMark renders both identically."
+      "reason": "Dialect canonical spelling: VMark re-emits its dialect constructs in canonical form ([TOC] casing, <details> with newline-separated summary, alert marker on its own quote line); stock remark — which lacks the dialect — reads the spelling difference as a value change. VMark renders both identically."
     }
   ],
   "stability": [
@@ -2850,43 +2890,43 @@
       "exampleId": "cmreg-14",
       "pass1Sha256": "0287879e70ddc3dea8cbacc2e2b6c5fdb1af71f5294b04c425acbe5335a5fe8f",
       "pass2Sha256": "543a6931f0689714a3f062351d4abfa02b90dea346afff275cce6818b699d798",
-      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth \u2014 unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
+      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth — unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
     },
     {
       "exampleId": "gfmext-20",
       "pass1Sha256": "f0cb4b8d38329b96ceb51088a1261a283b2faf5229dad1590978fbc60e3baa22",
       "pass2Sha256": "1a4412bb4ddbedfec4a6131de210d9458380c855948bf1385b09dac44f3be699",
-      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth \u2014 unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
+      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth — unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
     },
     {
       "exampleId": "mdx-10",
       "pass1Sha256": "8a5fe0e2bf0147fa4a9d0f394ddc1a46e71539e1eb37cde64c8e01e52fefd977",
       "pass2Sha256": "30a12cbf9135fc30f3852c887c750a0d467e0e1e51e091dd77863804839ba780",
-      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth \u2014 unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
+      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth — unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
     },
     {
       "exampleId": "mdx-12",
       "pass1Sha256": "545c38b0922de19734fbffde62792c37c2aef6a3216cfa472449173165220f7d",
       "pass2Sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth \u2014 unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
+      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth — unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
     },
     {
       "exampleId": "mdx-13",
       "pass1Sha256": "cf3aca25260402f8ebbef37cdcb530338f33d23479f14313638a764543a49d42",
       "pass2Sha256": "538b7f4abb555f04486a35cbdedcb5bb46ff3b94b85e20ee0cd1f5800129c805",
-      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth \u2014 unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
+      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth — unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
     },
     {
       "exampleId": "mdx-27",
       "pass1Sha256": "ab520acc88337e6af1ea91544c7cfe1e278beae4fafac740e5cf11bb64b03124",
       "pass2Sha256": "14077a5501f7db1670d172bcfa613c69fc3b64eccd7d466a4abe5237e02307d0",
-      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth \u2014 unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
+      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth — unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
     },
     {
       "exampleId": "mdx-28",
       "pass1Sha256": "75a11da44c802486bc6f65640aa48a730f0f684c5c07a42ba3cd1735eb3fb070",
       "pass2Sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth \u2014 unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
+      "reason": "Serializer DEFECT (ratcheted for fixing): bracket-escape growth — unresolvable or escape-heavy link/reference brackets gain another escape layer on the second pass instead of reaching a fixed point. Real bug; fixing it deletes this entry."
     }
   ],
   "fidelity": [
@@ -2898,7 +2938,7 @@
       "inputValue": 1,
       "outputValue": 2,
       "verdict": "defect",
-      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks \u2014 fixable corruption of the author's structure; ratcheted."
+      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks — fixable corruption of the author's structure; ratcheted."
     },
     {
       "exampleId": "cm-39",
@@ -2908,7 +2948,7 @@
       "inputValue": "foo\n\nbar",
       "outputValue": "foo",
       "verdict": "defect",
-      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks \u2014 fixable corruption of the author's structure; ratcheted."
+      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks — fixable corruption of the author's structure; ratcheted."
     },
     {
       "exampleId": "cm-39",
@@ -2918,7 +2958,7 @@
       "inputValue": "__undefined__",
       "outputValue": "paragraph",
       "verdict": "defect",
-      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks \u2014 fixable corruption of the author's structure; ratcheted."
+      "reason": "Entity-newline injection: numeric entities for newlines (&#10;) serialize as REAL newlines, so one paragraph reparses as two blocks — fixable corruption of the author's structure; ratcheted."
     },
     {
       "exampleId": "cm-109",
@@ -3718,7 +3758,7 @@
       "inputValue": 1,
       "outputValue": 0,
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "cm-484",
@@ -3728,7 +3768,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "cm-487",
@@ -3738,7 +3778,7 @@
       "inputValue": 1,
       "outputValue": 0,
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "cm-487",
@@ -3748,7 +3788,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "cm-517",
@@ -3798,7 +3838,7 @@
       "inputValue": 1,
       "outputValue": 3,
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cm-638",
@@ -3808,7 +3848,7 @@
       "inputValue": 3,
       "outputValue": 1,
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cm-638",
@@ -3818,7 +3858,7 @@
       "inputValue": "break",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cm-638",
@@ -3828,7 +3868,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cm-638",
@@ -3838,7 +3878,7 @@
       "inputValue": "__undefined__",
       "outputValue": "break",
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cm-638",
@@ -3848,7 +3888,7 @@
       "inputValue": "__undefined__",
       "outputValue": "emphasis",
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cm-639",
@@ -3858,7 +3898,7 @@
       "inputValue": 1,
       "outputValue": 3,
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cm-639",
@@ -3868,7 +3908,7 @@
       "inputValue": 3,
       "outputValue": 1,
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cm-639",
@@ -3878,7 +3918,7 @@
       "inputValue": "break",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cm-639",
@@ -3888,7 +3928,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cm-639",
@@ -3898,7 +3938,7 @@
       "inputValue": "__undefined__",
       "outputValue": "break",
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cm-639",
@@ -3908,7 +3948,7 @@
       "inputValue": "__undefined__",
       "outputValue": "emphasis",
       "verdict": "model-limit",
-      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* \u2014 the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
+      "reason": "Emphasis spanning a hard line break: ProseMirror marks split at the break node, so *foo(break)bar* serializes as *foo*\\ then *bar* — the re-parse reads three inline nodes where the input had one emphasis span. The emphasized text survives; the single-span structure does not."
     },
     {
       "exampleId": "cmreg-8",
@@ -4575,7 +4615,7 @@
       "inputValue": 2,
       "outputValue": 1,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-10",
@@ -4585,7 +4625,7 @@
       "inputValue": "$x $",
       "outputValue": "$x $ x$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-10",
@@ -4595,7 +4635,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4605,7 +4645,7 @@
       "inputValue": 8,
       "outputValue": 1,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4615,7 +4655,7 @@
       "inputValue": "these are not math texts: ",
       "outputValue": "these are not math texts: $ y=x$, $y=x $, $\ny=x$ and $y=x\n$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4625,7 +4665,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4635,7 +4675,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4645,7 +4685,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4655,7 +4695,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4665,7 +4705,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4675,7 +4715,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4685,7 +4725,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4695,7 +4735,7 @@
       "inputValue": 2,
       "outputValue": 1,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4705,7 +4745,7 @@
       "inputValue": "The start of a line counts as whitespace ",
       "outputValue": "The start of a line counts as whitespace $2 +\n$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4715,7 +4755,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4725,7 +4765,7 @@
       "inputValue": 3,
       "outputValue": 2,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4735,7 +4775,7 @@
       "inputValue": "While displays can start with whitespace, {",
       "outputValue": "While displays can start with whitespace, {${\nthey should not allow inlines to do that $$2 +\n",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4745,7 +4785,7 @@
       "inputValue": "text",
       "outputValue": "inlineMath",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-12",
@@ -4755,7 +4795,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-18",
@@ -4765,7 +4805,7 @@
       "inputValue": "> z $$",
       "outputValue": "\n> z $$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-19",
@@ -4775,7 +4815,7 @@
       "inputValue": 3,
       "outputValue": 4,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-19",
@@ -4785,7 +4825,7 @@
       "inputValue": "not\n\nmath",
       "outputValue": "not\n\nmath\n",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-19",
@@ -4795,7 +4835,7 @@
       "inputValue": "__undefined__",
       "outputValue": "math",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-21",
@@ -4805,7 +4845,7 @@
       "inputValue": 4,
       "outputValue": 1,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-21",
@@ -4815,7 +4855,7 @@
       "inputValue": "And this is inline math:\n",
       "outputValue": "And this is inline math:\n$\\text{Hello $x$ there!}$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-21",
@@ -4825,7 +4865,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-21",
@@ -4835,7 +4875,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-21",
@@ -4845,7 +4885,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4855,7 +4895,7 @@
       "inputValue": 2,
       "outputValue": 1,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4865,7 +4905,7 @@
       "inputValue": "$\\text{first $",
       "outputValue": "$\\text{first $ second}$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4875,7 +4915,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4885,7 +4925,7 @@
       "inputValue": 2,
       "outputValue": 1,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4895,7 +4935,7 @@
       "inputValue": "$\\text{first $",
       "outputValue": "$\\text{first $ second}$$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4905,7 +4945,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4915,7 +4955,7 @@
       "inputValue": 2,
       "outputValue": 1,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4925,7 +4965,7 @@
       "inputValue": "$$$\\text{first ",
       "outputValue": "$$$\\text{first $ second}$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4935,7 +4975,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4945,7 +4985,7 @@
       "inputValue": 2,
       "outputValue": 1,
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4955,7 +4995,7 @@
       "inputValue": "$$$$\\text{first ",
       "outputValue": "$$$$\\text{first $ second}$",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-23",
@@ -4965,7 +5005,7 @@
       "inputValue": "text",
       "outputValue": "__undefined__",
       "verdict": "normalization",
-      "reason": "Math delimiter canonicalization: $$\u2026$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
+      "reason": "Math delimiter canonicalization: $$…$$ inline math re-emits with VMark's canonical dollar delimiters and pathological dollar runs re-delimit; the math VALUE the renderer typesets is unchanged."
     },
     {
       "exampleId": "math-31",
@@ -5572,7 +5612,7 @@
       "inputValue": 3,
       "outputValue": 0,
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-12",
@@ -5582,7 +5622,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-12",
@@ -5592,7 +5632,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-12",
@@ -5602,7 +5642,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-13",
@@ -5692,7 +5732,7 @@
       "inputValue": 2,
       "outputValue": 0,
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-28",
@@ -5702,7 +5742,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-28",
@@ -5712,7 +5752,7 @@
       "inputValue": "paragraph",
       "outputValue": "__undefined__",
       "verdict": "model-limit",
-      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct \u2014 URL included \u2014 is dropped on serialize. Honest, pinned data loss."
+      "reason": "Empty-text link: ProseMirror represents links as marks on text, so a link with no text has nothing to carry the mark and the whole construct — URL included — is dropped on serialize. Honest, pinned data loss."
     },
     {
       "exampleId": "mdx-31",
@@ -5783,16 +5823,6 @@
       "outputValue": "list",
       "verdict": "defect",
       "reason": "Bare list marker: serializing the repaired paragraph puts the lone '-' on its own line without escaping it, so the re-parse reads a paragraph plus an empty list where the input had one paragraph. Fixable serializer corruption; ratcheted."
-    },
-    {
-      "exampleId": "vmark-malformed-unterminated-math",
-      "path": "root.children[0]",
-      "kind": "attribute",
-      "detail": "value",
-      "inputValue": "\\int_0^1",
-      "outputValue": "\\int_0\\^1",
-      "verdict": "defect",
-      "reason": "Caret escape asymmetry: the serializer escapes ^ (VMark's superscript marker) in plain text as \\^, but the parser does not read \\^ as an escape, so a literal backslash accretes in the author's text on every roundtrip. Fixable escape asymmetry; ratcheted."
     }
   ]
 }

--- a/src/utils/markdownPipeline/plugins/customInline.test.ts
+++ b/src/utils/markdownPipeline/plugins/customInline.test.ts
@@ -49,6 +49,112 @@ describe("customInline remark plugin", () => {
     });
   });
 
+  // Pandoc's rule for `~sub~` / `^sup^`: the span may not contain unescaped
+  // whitespace. Without it, two numeric ranges in one paragraph pair with each
+  // other and swallow everything between them (#1280).
+  describe("whitespace rejects a single-character mark pair", () => {
+    it("leaves two numeric ranges literal instead of pairing them (#1280)", () => {
+      const mdast = parseMarkdownToMdast(
+        "Recommended sample: 4~6 files, including 1~2 difficult cases."
+      );
+
+      const para = mdast.children[0];
+      const children = (para as { children?: unknown[] })?.children ?? [];
+      expect(
+        children.find((c) => (c as { type?: string }).type === "subscript")
+      ).toBeUndefined();
+      expect(children.map((c) => (c as { value?: string }).value).join("")).toBe(
+        "Recommended sample: 4~6 files, including 1~2 difficult cases."
+      );
+    });
+
+    it("does not pair across a soft line break (#1280)", () => {
+      const mdast = parseMarkdownToMdast("- sample: 4~6 files:\n  one typical, and 1~2 hard.");
+
+      const listItem = (mdast.children[0] as { children?: unknown[] }).children?.[0];
+      const para = (listItem as { children?: unknown[] }).children?.[0];
+      const children = (para as { children?: unknown[] })?.children ?? [];
+      expect(
+        children.find((c) => (c as { type?: string }).type === "subscript")
+      ).toBeUndefined();
+    });
+
+    it("rejects the same shape for superscript", () => {
+      const mdast = parseMarkdownToMdast("the 2^nd draft and the 3^rd review");
+
+      const para = mdast.children[0];
+      const children = (para as { children?: unknown[] })?.children ?? [];
+      expect(
+        children.find((c) => (c as { type?: string }).type === "superscript")
+      ).toBeUndefined();
+    });
+
+    it("still parses compact H~2~O and x^2^", () => {
+      const sub = parseMarkdownToMdast("H~2~O is water");
+      const sup = parseMarkdownToMdast("E=mc^2^ holds");
+
+      const subChildren = (sub.children[0] as { children?: unknown[] }).children ?? [];
+      const supChildren = (sup.children[0] as { children?: unknown[] }).children ?? [];
+      expect(
+        subChildren.find((c) => (c as { type?: string }).type === "subscript")
+      ).toBeDefined();
+      expect(
+        supChildren.find((c) => (c as { type?: string }).type === "superscript")
+      ).toBeDefined();
+    });
+
+    it("does not constrain the two-character marks", () => {
+      const mdast = parseMarkdownToMdast("==a highlighted phrase== and ++an underlined one++");
+
+      const para = mdast.children[0];
+      const children = (para as { children?: unknown[] })?.children ?? [];
+      expect(
+        children.find((c) => (c as { type?: string }).type === "highlight")
+      ).toBeDefined();
+      expect(
+        children.find((c) => (c as { type?: string }).type === "underline")
+      ).toBeDefined();
+    });
+
+    it("round-trips a subscript the editor applied to a phrase", () => {
+      // The toolbar/shortcut can mark a multi-word selection. Serializing it as
+      // a bare `~a b~` would no longer re-parse, silently losing the mark.
+      const md = serializeMdastToMarkdown({
+        type: "root",
+        children: [
+          {
+            type: "paragraph",
+            children: [
+              { type: "subscript", children: [{ type: "text", value: "two words" }] },
+            ],
+          },
+        ],
+      } as never);
+
+      expect(md.trim()).toBe("~two\\ words~");
+
+      const reparsed = parseMarkdownToMdast(md);
+      const children = (reparsed.children[0] as { children?: unknown[] }).children ?? [];
+      const subNode = children.find((c) => (c as { type?: string }).type === "subscript");
+      expect(subNode).toBeDefined();
+      expect(
+        ((subNode as { children?: unknown[] }).children?.[0] as { value?: string }).value
+      ).toBe("two words");
+    });
+
+    it("skips a whitespace-bearing candidate and still finds a later valid pair", () => {
+      const mdast = parseMarkdownToMdast("range 4~6 then H~2~O");
+
+      const para = mdast.children[0];
+      const children = (para as { children?: unknown[] })?.children ?? [];
+      const subNode = children.find((c) => (c as { type?: string }).type === "subscript");
+      expect(subNode).toBeDefined();
+      expect(
+        ((subNode as { children?: unknown[] }).children?.[0] as { value?: string }).value
+      ).toBe("2");
+    });
+  });
+
   describe("superscript ^text^", () => {
     it("parses superscript syntax", () => {
       const mdast = parseMarkdownToMdast("E=mc^2^");

--- a/src/utils/markdownPipeline/plugins/customInline.ts
+++ b/src/utils/markdownPipeline/plugins/customInline.ts
@@ -9,10 +9,23 @@
  * Key decisions:
  *   - Serialization uses `unsafe` rules to control escaping. Double markers
  *     (`==`/`++`) escape via a "followed by same char" match; single markers
- *     (`^`/`~`) use a broad phrasing rule exempting their own construct, so a
+ *     (`^`/`~`) use a phrasing rule exempting their own construct, so a
  *     literal `x\^2\^` is never re-parsed as a real superscript (defect D4).
+ *   - The single-marker rules carry `before`/`after` guards so they fire only
+ *     where a marker could actually re-pair — a partner on either side with no
+ *     whitespace between, matching what the parser accepts since #1280.
+ *     Escaping every `^` put backslashes through LaTeX-ish prose
+ *     (`\sum_{k=1}\^n a_k\^2`) to prevent a pairing that cannot happen.
+ *   - `~`/`^` handlers escape spaces in their CONTENT (`~two\ words~`,
+ *     Pandoc's spelling). The parser refuses to pair across unescaped
+ *     whitespace, so a subscript the user applied to a phrase would otherwise
+ *     stop being one on reload.
  *   - Marker chars emitted by a handler are exempt from escaping via
  *     `notInConstruct`, so real superscripts/highlights keep their markers.
+ *   - remark-gfm adds its OWN blanket `~` rule, which this cannot narrow: a
+ *     tilde VMark reads as literal is still escaped on output. That is wanted
+ *     — cmark-gfm pairs single tildes across spaces, so an unescaped `4~6 …
+ *     1~2` would render struck through on GitHub.
  *
  * @coordinates-with customInlineTransform.ts — the parse-side tree transform
  * @coordinates-with parser.ts — always loaded (lightweight, common syntax)
@@ -74,8 +87,12 @@ export const remarkCustomInline: Plugin<[], Root> = function () {
 function customInlineToMarkdown(): ToMarkdownExtension {
   return {
     handlers: {
-      subscript: createMarkHandler("~", "subscript"),
-      superscript: createMarkHandler("^", "superscript"),
+      // The single-character marks escape spaces in their content. The parser
+      // refuses to pair `~`/`^` across unescaped whitespace (Pandoc's rule, see
+      // customInlineTransform.ts), so a subscript the user applied to a phrase
+      // would silently stop being a subscript on reload without this (#1280).
+      subscript: createMarkHandler("~", "subscript", { escapeSpaces: true }),
+      superscript: createMarkHandler("^", "superscript", { escapeSpaces: true }),
       highlight: createMarkHandler("==", "highlight"),
       underline: createMarkHandler("++", "underline"),
     },
@@ -85,6 +102,11 @@ function customInlineToMarkdown(): ToMarkdownExtension {
       {
         character: "~",
         inConstruct: "phrasing",
+        // Escape only when a `~` could actually re-pair: a later `~` with no
+        // whitespace between, which is exactly what the parser now requires.
+        // Escaping unconditionally put backslashes into every prose tilde —
+        // `4~6 files` became `4\~6 files` — for a pairing that cannot happen.
+        after: "[^\\s~]*~",
         notInConstruct: [
           "autolink",
           "destinationLiteral",
@@ -101,9 +123,13 @@ function customInlineToMarkdown(): ToMarkdownExtension {
       // mirrors the `~` rule above. Markers emitted BY the superscript handler
       // are exempt via notInConstruct, so real superscripts stay `^…^`.
       // Without this, `x\^2\^` (literal) round-trips to `x^2^` (real superscript).
+      // The `after` guard keeps LaTeX-ish prose readable: in
+      // `\sum_{k=1}^n a_k^2` neither caret can re-pair (whitespace intervenes),
+      // so neither is escaped.
       {
         character: "^",
         inConstruct: "phrasing",
+        after: "[^\\s^]*\\^",
         notInConstruct: [
           "autolink",
           "destinationLiteral",
@@ -114,6 +140,23 @@ function customInlineToMarkdown(): ToMarkdownExtension {
           "superscript",
         ],
       },
+      // The mirror of the two `after` guards above: escape a marker whose
+      // PARTNER precedes it, so an author's `x\^2\^` keeps both backslashes
+      // instead of being normalised to `x\^2^`. Two entries rather than one
+      // with both fields, because the condition is "a partner on either side",
+      // and a single entry would require both at once.
+      {
+        character: "~",
+        inConstruct: "phrasing",
+        before: "~[^\\s~]*",
+        notInConstruct: ["autolink", "destinationLiteral", "destinationRaw", "reference", "titleQuote", "titleApostrophe", "subscript"],
+      },
+      {
+        character: "^",
+        inConstruct: "phrasing",
+        before: "\\^[^\\s^]*",
+        notInConstruct: ["autolink", "destinationLiteral", "destinationRaw", "reference", "titleQuote", "titleApostrophe", "superscript"],
+      },
       // Escape marker sequences to prevent false parsing
       { character: "=", inConstruct: "phrasing", before: "[^=]", after: "=", notInConstruct: ["highlight"] },
       { character: "+", inConstruct: "phrasing", before: "[^+]", after: "\\+", notInConstruct: ["underline"] },
@@ -121,18 +164,26 @@ function customInlineToMarkdown(): ToMarkdownExtension {
   };
 }
 
-function createMarkHandler(marker: string, constructName: string): MarkHandler {
+function createMarkHandler(
+  marker: string,
+  constructName: string,
+  options: { escapeSpaces?: boolean } = {}
+): MarkHandler {
   return function (node: unknown, _parent: unknown, state: MarkHandlerState, info: { before: string; after: string }) {
     const tracker = state.createTracker(info);
     const exit = state.enter(constructName);
 
     let value = tracker.move(marker);
     const current = tracker.current();
-    value += state.containerPhrasing(node as { children: PhrasingContent[] }, {
+    const content = state.containerPhrasing(node as { children: PhrasingContent[] }, {
       ...current,
       before: marker,
       after: marker,
     });
+    // Spaces and tabs only. A newline escaped this way would serialize as a
+    // markdown hard break, which is not what a sub/superscript means; such a
+    // span is pathological and degrades to literal text on reparse instead.
+    value += options.escapeSpaces ? content.replace(/[ \t]/g, "\\$&") : content;
     value += tracker.move(marker);
 
     exit();

--- a/src/utils/markdownPipeline/plugins/customInlineTransform.ts
+++ b/src/utils/markdownPipeline/plugins/customInlineTransform.ts
@@ -10,32 +10,33 @@
  * (`parseMarksAcrossChildren`) for pairs remark split by parsing an inner mark
  * (e.g. `**bold**`) first.
  *
+ * Key decisions:
+ *   - Which markers form a pair is `markPairing.ts`'s question, not this one's.
+ *     BOTH passes here must ask it: applying the whitespace rule only in the
+ *     per-text-node scan let a `strong` node between two numeric ranges re-form
+ *     in the cross-node pass the very pair the first pass had refused (#1280).
+ *
+ * @coordinates-with markPairing.ts — MARKS, findMarkPair, the whitespace rule
  * @coordinates-with customInline.ts — the plugin + serialize handlers
  * @coordinates-with types.ts — Subscript, Superscript, Highlight, Underline
  * @module utils/markdownPipeline/plugins/customInlineTransform
  */
 import type { Root, PhrasingContent, Text } from "mdast";
 import type { Subscript, Superscript, Highlight, Underline } from "../types";
+import {
+  MARKS,
+  findMarkPair,
+  findMarkerIn,
+  spanIsPairable,
+  unescapeWhitespace,
+  type MarkDefinition,
+} from "./markPairing";
 
 export interface FromMarkdownExtension {
   transforms?: Array<(tree: Root) => void>;
 }
 
-interface MarkDefinition {
-  readonly name: "highlight" | "underline" | "superscript" | "subscript";
-  readonly marker: string;
-  readonly markerLen: number;
-  readonly skipDouble?: boolean;
-}
-
 const SKIP_NODE_TYPES = new Set(["inlineCode", "code", "math", "inlineMath", "html", "yaml"]);
-
-const MARKS: readonly MarkDefinition[] = [
-  { name: "highlight", marker: "==", markerLen: 2 },
-  { name: "underline", marker: "++", markerLen: 2 },
-  { name: "superscript", marker: "^", markerLen: 1 },
-  { name: "subscript", marker: "~", markerLen: 1, skipDouble: true },
-];
 
 type MarkName = "subscript" | "superscript" | "highlight" | "underline";
 
@@ -102,20 +103,6 @@ function parseMarksAcrossChildren(children: unknown[]): unknown[] {
   }
 }
 
-/** Index of the first usable marker in `text`, respecting `skipDouble`, or -1. */
-function findMarkerIn(text: string, mark: MarkDefinition, from: number): number {
-  let at = from;
-  while (at < text.length) {
-    const found = text.indexOf(mark.marker, at);
-    if (found === -1) return -1;
-    if (mark.skipDouble && mark.markerLen === 1 && text[found + 1] === mark.marker) {
-      at = found + 2;
-      continue;
-    }
-    return found;
-  }
-  return -1;
-}
 
 /** Wrap the first cross-node pair for `mark`, or null if none exists. */
 function tryWrapAcross(children: unknown[], mark: MarkDefinition): unknown[] | null {
@@ -125,6 +112,10 @@ function tryWrapAcross(children: unknown[], mark: MarkDefinition): unknown[] | n
     const openAt = findMarkerIn(open.value, mark, 0);
     if (openAt === -1) continue;
 
+    // The span can only grow as `j` advances, so whitespace already present in
+    // the opening node's tail rules out every closing candidate at once.
+    if (!spanIsPairable(open.value.slice(openAt + mark.markerLen), mark)) continue;
+
     for (let j = i + 1; j < children.length; j++) {
       const between = children[j];
       // A marker pair must not span code/math/raw-HTML — abort this opening.
@@ -132,10 +123,30 @@ function tryWrapAcross(children: unknown[], mark: MarkDefinition): unknown[] | n
       if (!isTextNode(between)) continue;
       const closeAt = findMarkerIn(between.value, mark, 0);
       if (closeAt === -1) continue;
+      // Same rule as the single-node scan, applied to everything the span
+      // would swallow — otherwise `4~6 **bold** and 1~2` pairs across the
+      // bold node that the per-text-node pass could not see (#1280).
+      const swallowed =
+        collectText(children.slice(i + 1, j)) + between.value.slice(0, closeAt);
+      if (!spanIsPairable(swallowed, mark)) break;
       return buildSpan(children, i, openAt, j, closeAt, mark);
     }
   }
   return null;
+}
+
+/** All text a candidate span would swallow, however deeply nested. */
+function collectText(nodes: unknown[]): string {
+  let out = "";
+  for (const node of nodes) {
+    if (isTextNode(node)) {
+      out += node.value;
+    } else if (node && typeof node === "object") {
+      const children = (node as { children?: unknown[] }).children;
+      if (Array.isArray(children)) out += collectText(children);
+    }
+  }
+  return out;
 }
 
 /** Build the children array with [i..j] wrapped into a `mark` node. */
@@ -183,48 +194,6 @@ function isSkippableNode(node: unknown): boolean {
   return typeof type === "string" && SKIP_NODE_TYPES.has(type);
 }
 
-function findMarkPair(
-  text: string,
-  mark: MarkDefinition,
-  fromIndex: number
-): { start: number; end: number } | null {
-  let startIdx = fromIndex;
-
-  while (startIdx < text.length) {
-    const foundStart = text.indexOf(mark.marker, startIdx);
-    if (foundStart === -1) return null;
-
-    // Skip if this is a double marker when skipDouble is set
-    if (mark.skipDouble && mark.markerLen === 1 && text[foundStart + 1] === mark.marker) {
-      startIdx = foundStart + 2;
-      continue;
-    }
-
-    // Find closing marker
-    let searchPos = foundStart + mark.markerLen;
-    while (searchPos < text.length) {
-      const closeIdx = text.indexOf(mark.marker, searchPos);
-      if (closeIdx === -1) break;
-
-      // Skip double markers when configured
-      if (mark.skipDouble && mark.markerLen === 1 && text[closeIdx + 1] === mark.marker) {
-        searchPos = closeIdx + 2;
-        continue;
-      }
-
-      // Valid closing marker found
-      if (closeIdx > foundStart + mark.markerLen) {
-        return { start: foundStart, end: closeIdx };
-      }
-      break;
-    }
-
-    // No valid closing marker, try next occurrence
-    startIdx = foundStart + 1;
-  }
-
-  return null;
-}
 
 function parseMarksInText(text: string): PhrasingContent[] {
   const result: PhrasingContent[] = [];
@@ -259,8 +228,12 @@ function parseMarksInText(text: string): PhrasingContent[] {
       result.push({ type: "text", value: text.slice(position, earliestStart) });
     }
 
-    // Add the mark node
-    const content = text.slice(earliestStart + earliestMark.markerLen, earliestEnd);
+    // Add the mark node. `\ ` inside a sub/superscript is Pandoc's way to write
+    // a deliberate space; the backslash is syntax, not content.
+    const rawContent = text.slice(earliestStart + earliestMark.markerLen, earliestEnd);
+    const content = earliestMark.noUnescapedWhitespace
+      ? unescapeWhitespace(rawContent)
+      : rawContent;
     const markNode = createMarkNode(earliestMark.name as MarkName, content);
     result.push(markNode);
 

--- a/src/utils/markdownPipeline/plugins/markPairing.ts
+++ b/src/utils/markdownPipeline/plugins/markPairing.ts
@@ -1,0 +1,136 @@
+/**
+ * Marker pairing rules for VMark's custom inline marks.
+ *
+ * Purpose: decides WHERE a `==highlight==` / `++underline++` / `^superscript^`
+ * / `~subscript~` span begins and ends. Split out of customInlineTransform.ts
+ * so that file stays under the size limit; it owns walking the tree and
+ * building nodes, this owns the question "is this pair of markers a pair".
+ *
+ * Key decisions:
+ *   - The SINGLE-character marks (`^`, `~`) refuse a span containing unescaped
+ *     whitespace, which is Pandoc's rule. Without it two numeric ranges in one
+ *     paragraph paired with each other and subscripted everything between them
+ *     (#1280). `\ ` is Pandoc's deliberate space and survives as content.
+ *   - A rejected candidate advances to the next CLOSING marker rather than
+ *     abandoning the opening, so `range 4~6 then H~2~O` still finds `~2~`.
+ *   - The two-character marks are exempt: `==a highlighted phrase==` spanning
+ *     words is their normal use.
+ *
+ * @coordinates-with customInlineTransform.ts — the only consumer
+ * @module utils/markdownPipeline/plugins/markPairing
+ */
+
+export interface MarkDefinition {
+  readonly name: "highlight" | "underline" | "superscript" | "subscript";
+  readonly marker: string;
+  readonly markerLen: number;
+  readonly skipDouble?: boolean;
+  /**
+   * Pandoc's rule for the single-character marks: a `~sub~` / `^sup^` span may
+   * not contain unescaped whitespace. Without it the two `~` in
+   * `4~6 files, including 1~2 cases` pair with each other and subscript
+   * everything between them (#1280) — and `2^nd … 3^rd` does the same. The
+   * two-character marks are deliberately exempt: `==a highlighted phrase==`
+   * spanning words is their normal use.
+   */
+  readonly noUnescapedWhitespace?: boolean;
+}
+
+
+export const MARKS: readonly MarkDefinition[] = [
+  { name: "highlight", marker: "==", markerLen: 2 },
+  { name: "underline", marker: "++", markerLen: 2 },
+  { name: "superscript", marker: "^", markerLen: 1, noUnescapedWhitespace: true },
+  { name: "subscript", marker: "~", markerLen: 1, skipDouble: true, noUnescapedWhitespace: true },
+];
+
+/**
+ * Does `span` contain whitespace that is not backslash-escaped? An odd run of
+ * backslashes escapes the character after it, so `a\ b` is a deliberate
+ * subscript space (Pandoc's spelling) while `a\\ b` is a literal backslash
+ * followed by a real space.
+ */
+function hasUnescapedWhitespace(span: string): boolean {
+  for (let i = 0; i < span.length; i++) {
+    if (!/\s/.test(span[i])) continue;
+    let backslashes = 0;
+    for (let j = i - 1; j >= 0 && span[j] === "\\"; j--) backslashes++;
+    if (backslashes % 2 === 0) return true;
+  }
+  return false;
+}
+
+/** Drop the backslash from `\<whitespace>` so the mark's text reads naturally. */
+export function unescapeWhitespace(span: string): string {
+  return span.replace(/\\(\s)/g, "$1");
+}
+
+/** Is this a valid span for `mark`, per its whitespace rule? */
+export function spanIsPairable(span: string, mark: MarkDefinition): boolean {
+  return !mark.noUnescapedWhitespace || !hasUnescapedWhitespace(span);
+}
+
+/** Index of the first usable marker in `text`, respecting `skipDouble`, or -1. */
+export function findMarkerIn(text: string, mark: MarkDefinition, from: number): number {
+  let at = from;
+  while (at < text.length) {
+    const found = text.indexOf(mark.marker, at);
+    if (found === -1) return -1;
+    if (mark.skipDouble && mark.markerLen === 1 && text[found + 1] === mark.marker) {
+      at = found + 2;
+      continue;
+    }
+    return found;
+  }
+  return -1;
+}
+
+export function findMarkPair(
+  text: string,
+  mark: MarkDefinition,
+  fromIndex: number
+): { start: number; end: number } | null {
+  let startIdx = fromIndex;
+
+  while (startIdx < text.length) {
+    const foundStart = text.indexOf(mark.marker, startIdx);
+    if (foundStart === -1) return null;
+
+    // Skip if this is a double marker when skipDouble is set
+    if (mark.skipDouble && mark.markerLen === 1 && text[foundStart + 1] === mark.marker) {
+      startIdx = foundStart + 2;
+      continue;
+    }
+
+    // Find closing marker
+    let searchPos = foundStart + mark.markerLen;
+    while (searchPos < text.length) {
+      const closeIdx = text.indexOf(mark.marker, searchPos);
+      if (closeIdx === -1) break;
+
+      // Skip double markers when configured
+      if (mark.skipDouble && mark.markerLen === 1 && text[closeIdx + 1] === mark.marker) {
+        searchPos = closeIdx + 2;
+        continue;
+      }
+
+      // Valid closing marker found
+      if (closeIdx > foundStart + mark.markerLen) {
+        // A span carrying unescaped whitespace is not a pair. Keep scanning:
+        // in `range 4~6 then H~2~O` the first two candidate closes are
+        // rejected, and the real `~2~` is still found on a later opening.
+        if (!spanIsPairable(text.slice(foundStart + mark.markerLen, closeIdx), mark)) {
+          searchPos = closeIdx + mark.markerLen;
+          continue;
+        }
+        return { start: foundStart, end: closeIdx };
+      }
+      break;
+    }
+
+    // No valid closing marker, try next occurrence
+    startIdx = foundStart + 1;
+  }
+
+  return null;
+}

--- a/website/guide/terminal.md
+++ b/website/guide/terminal.md
@@ -24,7 +24,7 @@ When you close the last session the panel hides but the session stays alive — 
 
 Each tab reflects the running program's title (set by tools that emit a terminal title, such as `vim` or `ssh`) unless you have manually renamed the session — a manual rename always wins. To rename, **double-click the tab**: `Enter` commits, `Escape` discards, and clicking away keeps what you typed. An empty name is ignored.
 
-**Maximizing:** the panel's persistent size stops at 50 % so the editor stays usable, but a **double-click on the resize handle** snaps it to that cap and a second double-click returns it to your saved size. This is a view toggle — it never changes the size you configured.
+**Maximizing:** the panel's size stops at 80 % of the available space so the editor stays reachable, and a **double-click on the resize handle** snaps it to that cap. A second double-click returns it to your saved size. This is a view toggle — it never changes the size you configured.
 
 **Open Terminal Here:** right-click any folder in the file explorer and choose **Open Terminal Here** to start a session in that directory. The new session opens there regardless of where your other sessions happen to be. At five sessions the item is greyed out.
 
@@ -180,7 +180,7 @@ Open **Settings → Terminal** to configure:
 
 | Setting | Range | Default | Platforms |
 |---------|-------|---------|-----------|
-| Panel Size | 10 % – 50 % of the available space, in 5 % steps | 40 % | All |
+| Panel Size | 10 % – 80 % of the available space, in 5 % steps | 40 % | All |
 | Font Size | 10 – 24 px | 13 px | All |
 | Line Height | 1.0 – 2.0 | 1.2 | All |
 | Copy on Select | On / Off | Off | All |
@@ -197,7 +197,7 @@ Open **Settings → Terminal** to configure:
 | Terminal bell | Off / Visual / Audible | Visual |
 | Minimum contrast | Off / WCAG AA (4.5:1) / WCAG AAA (7:1) / Maximum | WCAG AA (4.5:1) |
 
-Changes apply immediately to all open sessions. **Panel Size** stops at 50 % on purpose: the terminal shares its axis with the editor, and a larger persistent share would squeeze the document below a usable width. For a temporary full-height look, double-click the resize handle to maximize instead. **Mac Option as Meta** routes the macOS Option key as Meta in the integrated terminal so emacs, tmux, and similar tools see Alt-prefixed shortcuts (macOS only); it is on by default, so Option+Arrow does word movement rather than inserting accented characters. **Shell Integration** is available on macOS and Linux (hidden on Windows). **Remote Clipboard** is described below. **Scrollback** controls how many lines of output each session retains in its scroll history — higher values use more memory. **Screen Reader Mode** exposes terminal output to assistive technology such as VoiceOver; it is off by default for performance. **Terminal bell** chooses how a bell (BEL) is signalled — a visual background-activity mark on the session tab, a soft audible beep (which also flags a background session's tab so you can find it), or nothing. **Minimum contrast** lifts faint terminal text to a readable contrast ratio against its background; raise it for accessibility or set it to Off to disable the lift.
+Changes apply immediately to all open sessions. **Panel Size** goes up to 80 % of the available space. The editor keeps a minimum size in pixels, so it never disappears entirely no matter how large the terminal gets. Double-click the resize handle to jump straight to the maximum and back again without changing the stored size. **Mac Option as Meta** routes the macOS Option key as Meta in the integrated terminal so emacs, tmux, and similar tools see Alt-prefixed shortcuts (macOS only); it is on by default, so Option+Arrow does word movement rather than inserting accented characters. **Shell Integration** is available on macOS and Linux (hidden on Windows). **Remote Clipboard** is described below. **Scrollback** controls how many lines of output each session retains in its scroll history — higher values use more memory. **Screen Reader Mode** exposes terminal output to assistive technology such as VoiceOver; it is off by default for performance. **Terminal bell** chooses how a bell (BEL) is signalled — a visual background-activity mark on the session tab, a soft audible beep (which also flags a background session's tab so you can find it), or nothing. **Minimum contrast** lifts faint terminal text to a readable contrast ratio against its background; raise it for accessibility or set it to Off to disable the lift.
 
 ::: tip Font size and zoom
 `Mod + =` / `Mod + -` zoom in steps of 2 px, so the terminal font can land on a


### PR DESCRIPTION
Three reported issues, one commit each. Unrelated to each other, but `strict: true` serialises merges — three PRs would cost three full CI cycles to change 18 files.

## `#1280` — tilde ranges swallow the paragraph

`Recommended sample: 4~6 files, including 1~2 difficult cases.` rendered everything between the two ranges as subscript, soft line breaks included. `2^nd ... 3^rd` did the same for superscript — one defect, two markers.

`findMarkPair` accepted any later marker as a closing one. The single-character marks now apply Pandoc's rule: no unescaped whitespace inside the span. `H~2~O` and `x^2^` are unaffected; `==a highlighted phrase==` is deliberately exempt, since spanning words is its normal use.

Three things this needed beyond the one-line rule:

- **The cross-sibling pass takes the same rule.** Applying it only per-text-node let a `strong` node between the two ranges re-form, in the second pass, the exact pair the first pass had just refused.
- **Serialization escapes spaces** (`~two\ words~`, Pandoc's spelling). The toolbar can apply subscript to a multi-word selection; without this it would serialize as `~a b~`, stop re-parsing, and silently lose the mark on reload.
- **The `^` escape rule got `before`/`after` guards.** Once those carets stopped being superscripts, escaping every literal `^` put backslashes through ordinary LaTeX-ish prose — `\sum_{k=1}^n a_k^2` became `\sum_{k=1}\^n a_k\^2`. The rule now fires only where a marker could actually re-pair, which is exactly what the parser accepts. An author's `x\^2\^` still keeps both backslashes.

**One user-visible consequence, deliberate:** a tilde VMark now reads as literal is escaped on output, so saving the reporter's document writes `4\~6`. remark-gfm's blanket `~` rule cannot be narrowed from here, and narrowing it would be wrong anyway — cmark-gfm pairs single tildes across spaces, so an unescaped `4~6 … 1~2` renders struck through on GitHub. The backslash is what makes the file mean the same thing in both.

The spec ledgers are **re-measured via the documented triage dump**, not widened. `gfmext-18`'s records change shape (VMark reads that line as text where GFM reads a `delete`, instead of reading it as a subscript) and one fidelity declaration became stale and is deleted — the unterminated-math example round-trips now.

## `#1279` — terminal panel ceiling 50% → 80%

`TERMINAL_MAX_RATIO` was `0.5` while `CLAMP_RANGES.terminal.panelRatio` has always accepted `0.8`. A persisted `0.8` could be stored and never took effect: layout, drag and dropdown all clamped it back.

The `0.5` was deliberate, on the reasoning that a bigger panel is a temporary need the maximize toggle covers. That reasoning does not survive reading `toggleMaximize` — it snaps to the *same* constant, so "temporarily bigger" also stopped at 50% and the escape hatch it justified never existed. The editor stays protected by `TERMINAL_MIN_HEIGHT`/`WIDTH`, absolute pixel floors that bind first on a small window.

A test pins the two numbers together in both directions so they cannot drift apart again.

**Five tests were asserting against a hardcoded `0.5` standing in for "the cap".** `useTerminalPosition.test.ts` was the worst: it *mocked* `@/stores/uiStore` with a copied `TERMINAL_MAX_RATIO: 0.5`, so raising the real constant would have left it measuring a ceiling the app no longer has — silently, forever. It reads `importActual` now, and that is what exposed the other four.

## `#1285` — `.vmark/group.lock` is committable

`acquire_lock_file` creates `.vmark/` to hold `group.lock` *before* the operation is adjudicated. An op that is then rejected leaves that directory behind holding one binary runtime file and nothing else — which `git add .` duly stages, in every repository a failed coherence action touched.

The existing comment already recorded that a bare `.vmark/group.lock` can be left behind, and a test already pinned that it must not read as *initialized*. What neither covered is that it must not be *committable*.

The ignore rules now land with the lock. This is not initialization: the completion marker is `.gitattributes`, written last by `ensure_initialized`, so 6R-4 holds and `is_fully_initialized` still reports false for a bare lock. Gated on `.gitignore` being absent rather than on having just created the directory, so a bare `.vmark` from an older build is repaired on its next write too.

## Verification

- `pnpm check:all` — green (the run also caught two files crossing the 300-line limit; both **split**, not baselined: `markPairing.ts` extracted from `customInlineTransform.ts`, and the ignore-rule helper moved into `workspace_files.rs`, which already owns "the idempotent line-append used to maintain ignore rules")
- `cargo test` — 2,132 passed
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` — clean
- 2,812-example spec corpus green; `website/guide/terminal.md` updated with the terminal change

Closes #1280
Closes #1279
Closes #1285
