### PR TITLE
feat(pdf): stamp page numbers on every platform, with settings

### DIFF
--- a/.cc-suite/audits/audit-fix-20260817-183000-findings.md
+++ b/.cc-suite/audits/audit-fix-20260817-183000-findings.md
@@ -1,0 +1,37 @@
+# Audit Findings
+
+**Run**: audit-fix 20260817-183000 | **Scope**: branch feat/pdf-page-numbers (6 commits vs origin/main, 16 production files) | **Audit type**: mini
+**Model**: gpt-5.6-sol | **Effort**: high | **Sandbox**: read-only (audit)
+**Audit threads**: A `01a00fb3-2649-75c2-a8be-c5389fe06a4a`, B `01a00fb3-29cf-72e3-9ac3-ac9c4322b29f`, C `01a00fb3-3d2d-7fa2-9ed9-866b0b3142be`, D `01a00fb3-4421-7071-abad-14f1aff0e01c`, E `01a00fb3-5f71-7391-a52c-887364d252d1`
+**Status values**: open | fixed | not-fixed | partial | regressed | rejected (with reason) | skipped
+
+| # | File | Line | Severity | Dimension | Finding | Suggested fix | Status | Round |
+|---|------|------|----------|-----------|---------|---------------|--------|-------|
+| 1 | src/export/PdfExportDialog.tsx | 168 | High | Logic | Verbose template resolved via `tDialog` but the key lives in `export.json` — i18next returns the key, so every page stamps the literal `pdf.pageNumbers.verboseTemplate` | Use `t(...)` | fixed | 1 |
+| 2 | src/export/pdfOptions.ts | 79 | High | Logic | CJK verbose template is rejected backend-side, leaving every page unnumbered while export reports success; the doc comment claims a numeric fallback that does not exist | Fall back to the numeric form in the backend, where font capability is known | fixed | 1 |
+| 3 | src/export/PdfSettingsSidebar.tsx | 254 | High | Logic | Same as #2 from the UI side — verbose is offered in CJK locales where it cannot render | Covered by #2's backend fallback | fixed | 1 |
+| 4 | src-tauri/src/pdf_export/page_numbers.rs | 70 | Medium | Logic | Unencodable verbose label silently skipped rather than falling back | Same as #2 | fixed | 1 |
+| 5 | src-tauri/src/pdf_export/pdf_io.rs | 49 | High | Logic | `into_temp_path()` closes the securely created file, then `Document::save` reopens the path — a symlink can be swapped in between | Keep the handle open and write through it | fixed | 1 |
+| 6 | src-tauri/src/pdf_export/pdf_io.rs | 39 | High | Duplication | Reimplements existing atomic-replacement machinery; omits permission preservation and `sync_all` | Reuse `crate::atomic_replace` | fixed | 1 |
+| 7 | src-tauri/src/pdf_export/page_numbers.rs | 143 | Medium | Logic | `page_size` discards MediaBox `x0`/`y0`; `baseline` assumes origin at (0,0) | Preserve the origin and offset the baseline | fixed | 1 |
+| 8 | src-tauri/src/pdf_export/commands.rs | 114 | High | Logic | Stamping failure is logged only; command returns success while requested page numbers are absent | Propagate or surface a partial-success warning | fixed | 1 |
+| 9 | src-tauri/src/pdf_export/commands.rs | 90 | Medium | Shortcuts | `PageNumberSpec` crosses IPC unvalidated — non-finite or extreme sizes/margins reach PDF operator generation | Add `validate()` like `PageSpec` has | fixed | 1 |
+| 10 | src-tauri/src/pdf_export/commands.rs | 103 | Medium | Logic | Blocking PDF load/serialize inside an async command occupies Tokio workers | `spawn_blocking` around the post-processing pipeline | fixed | 1 |
+| 11 | src-tauri/src/pdf_export/outline.rs | 173 | Medium | Logic | Duplicate heading text always searched from the next page, so two identical headings on one page cannot both resolve | Occurrence-aware matching within a page | fixed | 1 |
+| 12 | src-tauri/src/pdf_export/commands.rs | 92 | Low | Logic | macOS emits `"done"` before post-processing begins | Emit completion after post-processing | fixed | 1 |
+| 13 | src/export/pdfOptions.ts | 43 | High | Logic | Spec carries no colour; stamper always draws black, unreadable on a dark-theme export | Send an effective foreground colour | fixed | 1 |
+| 14 | src/export/pdfOptions.ts | 82 | Medium | Logic | Zero/small bottom margin lets the footer overlap content | Enforce a minimum effective bottom margin when numbering | fixed | 1 |
+| 15 | src/export/pdfPresets.ts | 40 | High | Duplication | Style presets copy all four margin values from `MARGIN_PRESETS` | Reference the preset key | fixed | 1 |
+| 16 | src/export/PdfSettingsSidebar.tsx | 119 | High | Duplication | `handleMarginChange` reimplements the imported `detectMarginPreset` | Call the helper | fixed | 1 |
+| 17 | src/export/PdfSidebarPrimitives.tsx | 85 | High | Duplication | The number-input markup is copied four times | Extract a `MarginInput` | fixed | 1 |
+| 18 | src/export/PdfSidebarPrimitives.tsx | 89 | Medium | Logic | `step={1}` on inputs whose real values are tenths (25.4, 12.7, 38.1) | `step={0.1}` | fixed | 1 |
+| 19 | src-tauri/src/bin/pdf_smoke/verify.rs | 97 | High | Logic | `check_stamped` never verifies `/VMarkPageNo` actually resolves to a font in effective resources | Resolve direct/indirect/inherited resources and check the mapping | fixed | 1 |
+| 20 | src-tauri/src/bin/pdf_smoke/main.rs | 170 | High | Logic | `large` case never checks the `SENTINEL-PAST-2MIB` marker it exists to prove | Extract text and require the sentinel | fixed | 1 |
+| 21 | src-tauri/src/bin/pdf_smoke/main.rs | 263 | High | Logic | `concurrent` case accepts two `Ok`s without validating both artifacts or their distinct content | Validate both artifacts and sentinels | fixed | 1 |
+| 22 | src-tauri/src/bin/pdf_smoke/{page_numbers_case,render_one}.rs | 27/202 | High | Duplication | Margins and `PageNumberSpec` defaults (9.35, 72.0, template) duplicated across the two harness modes | One shared fixture helper | fixed | 1 |
+| 23 | src-tauri/src/bin/pdf_smoke/main.rs | 90 | High | Duplication | Standalone `legal`/`landscape` cases re-render geometries the matrix already covers, and `legal` reuses a transcript name | Drop the redundant cases | fixed | 1 |
+| 24 | src-tauri/src/bin/pdf_smoke/main.rs | 196 | Medium | Logic | The "missing" parent dir has a fixed name; a stale or concurrent dir makes badpath exercise a valid destination | Unique name, assert the parent is absent | fixed | 1 |
+| 25 | src-tauri/src/bin/pdf_smoke/main.rs | 255 | Medium | Logic | `sequential` can print `PASS 20 exports` after breaking out on failure | Only PASS when all 20 rendered | fixed | 1 |
+| 26 | src-tauri/src/bin/pdf_smoke/render_one.rs | 34 | Medium | Logic | A bare `--html` silently falls back to matrix mode | Reject malformed invocations | fixed | 1 |
+| 27 | src-tauri/src/bin/pdf_smoke/render_one.rs | 181 | Medium | Logic | `strip_tags` does not decode HTML entities, unlike the frontend's `textContent` | Decode entities | fixed | 1 |
+| 28 | src-tauri/src/bin/pdf_smoke/main.rs | 83 | Medium | Refactoring | `run_cases` is a ~189-line coordinator mixing every scenario | Extract per-scenario functions | fixed | 1 |

--- a/.cc-suite/audits/audit-fix-20260817-183000-findings.md
+++ b/.cc-suite/audits/audit-fix-20260817-183000-findings.md
@@ -35,3 +35,21 @@
 | 26 | src-tauri/src/bin/pdf_smoke/render_one.rs | 34 | Medium | Logic | A bare `--html` silently falls back to matrix mode | Reject malformed invocations | fixed | 1 |
 | 27 | src-tauri/src/bin/pdf_smoke/render_one.rs | 181 | Medium | Logic | `strip_tags` does not decode HTML entities, unlike the frontend's `textContent` | Decode entities | fixed | 1 |
 | 28 | src-tauri/src/bin/pdf_smoke/main.rs | 83 | Medium | Refactoring | `run_cases` is a ~189-line coordinator mixing every scenario | Extract per-scenario functions | fixed | 1 |
+
+## Round 2 — independent verify (thread `01a00fde-910f-70f0-982a-ba14428def3c`)
+
+23 FIXED, 2 PARTIAL, 3 REGRESSED, 0 NOT FIXED. All five resolved in round 2:
+
+| # | Verify verdict | Resolution | Status |
+|---|---|---|---|
+| 5 | REGRESSED — the symlink window closed, but the PDF was serialized into an unbounded `Vec` first | Added `atomic_replace_with`, a writer-closure form of the shared core — which is what finding #6 originally suggested. The PDF streams straight into the still-open temp file: no second copy, no reopen-by-name. | fixed | 2 |
+| 6 | REGRESSED — same unbounded buffer | Same fix; `pdf_io` uses the streaming form. | fixed | 2 |
+| 9 | PARTIAL — `validate()` did not check `verbose_template` | Handled in `render_label`, NOT `validate()`: a template with no `{n}` falls back to the numeric form like a CJK one. Rejecting would have failed the whole export over a translation typo. A frontend test asserts all ten shipped templates carry `{n}`, so a regression is caught at gate time instead. | fixed | 2 |
+| 14 | REGRESSED — `pdfFitToPage` still sized images from the raw `marginBottom` | It reads `effectiveBottomMarginMm` now. Three consumers, one helper. | fixed | 2 |
+| 27 | PARTIAL — only core entities decoded | Added the common named entities. An unknown one is still left literal on purpose: a wrong substitution breaks the match as badly as a missed one and is harder to see. | fixed | 2 |
+
+Also closed the verifier's test-gap note: the harness's pure helpers (argument
+parsing, entity decoding, heading extraction) now have 10 unit tests, and
+`pdf-smoke.yml` runs them — they sit in a feature-gated bin that `cargo test` in
+`ci.yml` never compiles, so without that step they would have been tests nothing
+runs.

--- a/.github/workflows/baseline-review.yml
+++ b/.github/workflows/baseline-review.yml
@@ -63,11 +63,17 @@ jobs:
           # exists to surface. Issue #1248 was filed that way.
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      # NO `cache: pnpm` here, and no pnpm setup — deliberately. Every step
+      # below runs `node scripts/*.mjs` straight off the checkout; nothing in
+      # this job installs dependencies. Asking setup-node to cache a pnpm store
+      # that is never created makes its POST step fail with "Path Validation
+      # Error: Path(s) specified in the action for caching do(es) not exist",
+      # which reddens `measure` after it has already produced its outputs — and
+      # `report` needs `measure` to succeed, so the weekly issue silently stops
+      # being filed while the measurement itself was fine. Observed 2026-08-17.
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: pnpm
 
       # Validation first, and it is a HARD failure: an inconsistent schedule
       # (a baseline tracked nowhere, a stale key) means the report below would

--- a/.github/workflows/pdf-smoke.yml
+++ b/.github/workflows/pdf-smoke.yml
@@ -12,17 +12,27 @@ name: PDF smoke
 # landed) the stamped footer — because a backend that ignores its input still
 # returns Ok and still writes a valid %PDF.
 #
-# MANUAL, not required. It costs three runners and several minutes of native
-# webview work, and every defect it has caught was caught while changing the
-# exporter. Run it when you touch `src-tauri/src/pdf_export/**`, and attach the
-# artifacts to the PR. It is deliberately not a gate: making it one would put a
-# slow, display-dependent job in front of every unrelated change, which is how
-# a check gets routed around.
+# PATH-FILTERED, and NOT a required check. It runs on pull requests that touch
+# the exporter and nowhere else, because that is the only time it can find
+# anything — and because the class it catches has already bitten this subsystem
+# twice: the heading outline shipped macOS-only for months, and page numbers
+# would have too. Neither was visible from a macOS desk.
 #
-# It is not a liveness gate either (no `liveness-gate:` marker) — a
-# dispatch-only workflow has no cadence to be silent against.
+# It stays out of branch protection deliberately. It costs three runners and
+# several minutes of native webview work behind a full Rust compile, and it
+# depends on a display; a slow, display-dependent job in front of every merge is
+# how a check gets routed around rather than obeyed. Red here means read the
+# artifacts, not "cannot merge".
+#
+# It is not a liveness gate either (no `liveness-gate:` marker) — it has no
+# cadence to be silent against, since it only fires on relevant diffs.
 
 on:
+  pull_request:
+    paths:
+      - "src-tauri/src/pdf_export/**"
+      - "src-tauri/src/bin/pdf_smoke/**"
+      - ".github/workflows/pdf-smoke.yml"
   # No `ref` input: workflow_dispatch already takes the branch to run from, so
   # one would only be a second, unvalidated way to say the same thing — and an
   # attacker-settable string reaching `actions/checkout`'s `ref:` is the ref

--- a/.github/workflows/pdf-smoke.yml
+++ b/.github/workflows/pdf-smoke.yml
@@ -87,6 +87,12 @@ jobs:
           fi
           touch "src-tauri/binaries/vmark-mcp-server-${triple}${ext}"
 
+      # The harness's own pure helpers — argument parsing, HTML entity decoding.
+      # They live in a feature-gated bin, so `cargo test` in ci.yml never
+      # compiles them; without this step they would be tests nothing runs.
+      - name: Unit-test the harness helpers
+        run: cargo test --manifest-path src-tauri/Cargo.toml --features pdf-smoke --bin pdf_smoke
+
       # WebKitGTK needs a display even to print off-screen; a headless runner
       # has none, and the renderer would hang until the harness timed out rather
       # than failing with something readable.

--- a/.github/workflows/pdf-smoke.yml
+++ b/.github/workflows/pdf-smoke.yml
@@ -1,0 +1,108 @@
+name: PDF smoke
+
+# The PDF exporter is the one subsystem here with THREE separate native
+# backends — WKWebView, WebView2, WebKitGTK — and nothing in the required checks
+# runs any of them. `cargo test` cannot: Tauri's MockRuntime does not link on
+# Windows in this crate, and where it does link it runs `with_webview` as a
+# no-op, so it would prove nothing. Only a real event loop exercises the code
+# that ships.
+#
+# So this is the harness's home. It renders the fixture matrix on each OS and
+# READS THE ARTIFACTS BACK — page box, page count, and (since page numbers
+# landed) the stamped footer — because a backend that ignores its input still
+# returns Ok and still writes a valid %PDF.
+#
+# MANUAL, not required. It costs three runners and several minutes of native
+# webview work, and every defect it has caught was caught while changing the
+# exporter. Run it when you touch `src-tauri/src/pdf_export/**`, and attach the
+# artifacts to the PR. It is deliberately not a gate: making it one would put a
+# slow, display-dependent job in front of every unrelated change, which is how
+# a check gets routed around.
+#
+# It is not a liveness gate either (no `liveness-gate:` marker) — a
+# dispatch-only workflow has no cadence to be silent against.
+
+on:
+  # No `ref` input: workflow_dispatch already takes the branch to run from, so
+  # one would only be a second, unvalidated way to say the same thing — and an
+  # attacker-settable string reaching `actions/checkout`'s `ref:` is the ref
+  # injection class outright.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pdf-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-tauri-deps
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: "src-tauri -> target"
+          shared-key: "ci-rust-v1"
+          cache-on-failure: "false"
+
+      # The Tauri build script resolves the sidecar by target triple and fails
+      # if it is absent. Same stub `ci.yml`'s rust-test creates — this harness
+      # never launches the sidecar.
+      - name: Create sidecar stub for Tauri build script
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            triple="x86_64-pc-windows-msvc"
+            ext=".exe"
+          elif [[ "$RUNNER_OS" == "Linux" ]]; then
+            triple="x86_64-unknown-linux-gnu"
+            ext=""
+          else
+            triple="aarch64-apple-darwin"
+            ext=""
+          fi
+          touch "src-tauri/binaries/vmark-mcp-server-${triple}${ext}"
+
+      # WebKitGTK needs a display even to print off-screen; a headless runner
+      # has none, and the renderer would hang until the harness timed out rather
+      # than failing with something readable.
+      - name: Run the smoke harness (Linux, under Xvfb)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y xvfb
+          xvfb-run -a --server-args="-screen 0 1280x1024x24" \
+            cargo run --manifest-path src-tauri/Cargo.toml \
+              --bin pdf_smoke --features pdf-smoke -- "$PWD/pdf-smoke-out"
+
+      - name: Run the smoke harness
+        if: runner.os != 'Linux'
+        shell: bash
+        run: |
+          cargo run --manifest-path src-tauri/Cargo.toml \
+            --bin pdf_smoke --features pdf-smoke -- "$PWD/pdf-smoke-out"
+
+      # `error`, not `warn`: the harness exiting 0 having written nothing looks
+      # exactly like a pass, and an empty artifact would be read as "rendered
+      # fine". Uploaded on failure too — the broken PDF is the evidence.
+      - name: Upload the rendered PDFs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: pdf-smoke-${{ matrix.os }}
+          path: pdf-smoke-out/*.pdf
+          if-no-files-found: error
+          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.41",
+  "version": "0.9.42",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/scripts/check-workflow-node-cache.test.mjs
+++ b/scripts/check-workflow-node-cache.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * `actions/setup-node` with `cache:` set is a CLAIM that the job installs.
+ *
+ * The cache is saved in a POST step, after every real step has already run. If
+ * the job never populates the store, that post step fails with "Path Validation
+ * Error: Path(s) specified in the action for caching do(es) not exist" and takes
+ * the whole job red — after its work succeeded. Anything gated on `needs:` that
+ * job is then SKIPPED, so the visible symptom is not "cache broken" but "the
+ * report stopped being filed".
+ *
+ * `baseline-review.yml` shipped that way and its weekly issue silently stopped
+ * (2026-08-17): `measure` computed the full debt table, set every output, and
+ * died in cleanup; `report` never ran. Five other workflows request the same
+ * cache and all install, so this is a one-off — which is exactly when to pin it,
+ * before it becomes a class.
+ *
+ * Discovers workflows rather than listing them, so a new one is covered on
+ * creation.
+ *
+ * @coordinates-with .github/workflows/*.yml
+ * @module scripts/check-workflow-node-cache.test
+ */
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DIR = path.join(REPO, ".github/workflows");
+
+const workflows = readdirSync(DIR)
+  .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+  .map((f) => ({ name: f, doc: parse(readFileSync(path.join(DIR, f), "utf8")) }));
+
+/** Every step of every job, flattened, with its job name. */
+function steps(doc) {
+  return Object.entries(doc?.jobs ?? {}).flatMap(([job, def]) =>
+    (def?.steps ?? []).map((step) => ({ job, step })),
+  );
+}
+
+/** Does this step populate a package-manager store? */
+function installs(step) {
+  const run = typeof step.run === "string" ? step.run : "";
+  // `pnpm/action-setup` can install by itself via `run_install`.
+  const usesInstall =
+    typeof step.uses === "string" &&
+    step.uses.includes("pnpm/action-setup") &&
+    step.with?.run_install !== undefined &&
+    step.with?.run_install !== false;
+  return usesInstall || /\b(pnpm|npm|yarn)\s+(install|ci|i)\b/.test(run);
+}
+
+describe("setup-node cache claims", () => {
+  it("finds the workflows (guards against a silently empty sweep)", () => {
+    expect(workflows.length).toBeGreaterThan(5);
+  });
+
+  it("is only requested by jobs that actually install", () => {
+    const offenders = [];
+    for (const { name, doc } of workflows) {
+      const byJob = new Map();
+      for (const { job, step } of steps(doc)) {
+        const entry = byJob.get(job) ?? { cached: false, installs: false };
+        if (
+          typeof step.uses === "string" &&
+          step.uses.includes("actions/setup-node") &&
+          step.with?.cache
+        ) {
+          entry.cached = true;
+        }
+        if (installs(step)) entry.installs = true;
+        byJob.set(job, entry);
+      }
+      for (const [job, entry] of byJob) {
+        if (entry.cached && !entry.installs) offenders.push(`${name}:${job}`);
+      }
+    }
+    // A job caching a store it never writes fails in its POST step, after
+    // succeeding — and skips everything downstream of it.
+    expect(offenders).toEqual([]);
+  });
+});

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -41,7 +41,6 @@
     "src/components/StatusBar/useStatusBarTabDrag.ts": 330,
     "src/components/Tabs/useTabContextMenuActions.ts": 349,
     "src/contexts/WindowContext.tsx": 348,
-    "src/export/PdfSettingsSidebar.tsx": 345,
     "src/export/htmlExport.ts": 331,
     "src/export/reader/vmark-reader.js": 1343,
     "src/export/resourceResolver.ts": 445,

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.41';
+const VERSION = '0.9.42';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6409,7 +6409,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.41"
+version = "0.9.42"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.41"
+version = "0.9.42"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/locales/de.yml
+++ b/src-tauri/locales/de.yml
@@ -251,6 +251,8 @@ errors:
   pdf.printTimeoutSecs: "Druckvorgang nach %{seconds} Sekunden abgelaufen"
   pdf.unsupportedPlatform: "PDF-Export ist auf dieser Plattform noch nicht verfügbar"
   pdf.invalidPageSize: "Ungültige Seiten-%{axis}: %{value}"
+  pdf.invalidPageNumberSpec: "Ungültige Seitenzahl-Einstellung %{field}: %{value}"
+  pdf.postProcessPanicked: "PDF-Nachbearbeitung unerwartet fehlgeschlagen: %{detail}"
   pdf.renderWindowFailed: "Renderfenster konnte nicht erstellt werden: %{detail}"
   pdf.loadFailed: "Das Dokument konnte zum Drucken nicht geladen werden"
   pdf.printRefused: "Die Druck-Engine hat kein PDF erzeugt"

--- a/src-tauri/locales/en.yml
+++ b/src-tauri/locales/en.yml
@@ -252,6 +252,8 @@ errors:
   pdf.printTimeoutSecs: "Print timed out after %{seconds} seconds"
   pdf.unsupportedPlatform: "PDF export is not yet available on this platform"
   pdf.invalidPageSize: "Invalid page %{axis}: %{value}"
+  pdf.invalidPageNumberSpec: "Invalid page-number setting %{field}: %{value}"
+  pdf.postProcessPanicked: "PDF post-processing failed unexpectedly: %{detail}"
   pdf.renderWindowFailed: "Could not create the render window: %{detail}"
   pdf.loadFailed: "The document failed to load for printing"
   pdf.printRefused: "The print engine declined to produce a PDF"

--- a/src-tauri/locales/es.yml
+++ b/src-tauri/locales/es.yml
@@ -251,6 +251,8 @@ errors:
   pdf.printTimeoutSecs: "La impresión expiró tras %{seconds} segundos"
   pdf.unsupportedPlatform: "La exportación a PDF aún no está disponible en esta plataforma"
   pdf.invalidPageSize: "%{axis} de página no válido: %{value}"
+  pdf.invalidPageNumberSpec: "Ajuste de numeración de páginas no válido %{field}: %{value}"
+  pdf.postProcessPanicked: "El posprocesamiento del PDF falló inesperadamente: %{detail}"
   pdf.renderWindowFailed: "No se pudo crear la ventana de renderizado: %{detail}"
   pdf.loadFailed: "No se pudo cargar el documento para imprimir"
   pdf.printRefused: "El motor de impresión no generó un PDF"

--- a/src-tauri/locales/fr.yml
+++ b/src-tauri/locales/fr.yml
@@ -251,6 +251,8 @@ errors:
   pdf.printTimeoutSecs: "L'impression a expiré après %{seconds} secondes"
   pdf.unsupportedPlatform: "L'export PDF n'est pas encore disponible sur cette plateforme"
   pdf.invalidPageSize: "%{axis} de page invalide : %{value}"
+  pdf.invalidPageNumberSpec: "Paramètre de numérotation des pages invalide %{field} : %{value}"
+  pdf.postProcessPanicked: "Le post-traitement du PDF a échoué de manière inattendue : %{detail}"
   pdf.renderWindowFailed: "Impossible de créer la fenêtre de rendu : %{detail}"
   pdf.loadFailed: "Le document n'a pas pu être chargé pour l'impression"
   pdf.printRefused: "Le moteur d'impression n'a pas produit de PDF"

--- a/src-tauri/locales/it.yml
+++ b/src-tauri/locales/it.yml
@@ -251,6 +251,8 @@ errors:
   pdf.printTimeoutSecs: "Stampa scaduta dopo %{seconds} secondi"
   pdf.unsupportedPlatform: "L'esportazione in PDF non è ancora disponibile su questa piattaforma"
   pdf.invalidPageSize: "%{axis} pagina non valido: %{value}"
+  pdf.invalidPageNumberSpec: "Impostazione di numerazione pagine non valida %{field}: %{value}"
+  pdf.postProcessPanicked: "Post-elaborazione del PDF non riuscita in modo imprevisto: %{detail}"
   pdf.renderWindowFailed: "Impossibile creare la finestra di rendering: %{detail}"
   pdf.loadFailed: "Impossibile caricare il documento per la stampa"
   pdf.printRefused: "Il motore di stampa non ha prodotto un PDF"

--- a/src-tauri/locales/ja.yml
+++ b/src-tauri/locales/ja.yml
@@ -251,6 +251,8 @@ errors:
   pdf.printTimeoutSecs: "印刷が %{seconds} 秒でタイムアウトしました"
   pdf.unsupportedPlatform: "PDF 書き出しはこのプラットフォームではまだ利用できません"
   pdf.invalidPageSize: "ページの%{axis}が不正です: %{value}"
+  pdf.invalidPageNumberSpec: "ページ番号の設定が不正です %{field}: %{value}"
+  pdf.postProcessPanicked: "PDF の後処理が予期せず失敗しました: %{detail}"
   pdf.renderWindowFailed: "レンダリング用ウィンドウを作成できませんでした: %{detail}"
   pdf.loadFailed: "印刷用のドキュメントを読み込めませんでした"
   pdf.printRefused: "印刷エンジンが PDF を生成しませんでした"

--- a/src-tauri/locales/ko.yml
+++ b/src-tauri/locales/ko.yml
@@ -251,6 +251,8 @@ errors:
   pdf.printTimeoutSecs: "인쇄가 %{seconds}초 후 시간 초과되었습니다"
   pdf.unsupportedPlatform: "PDF 내보내기는 이 플랫폼에서 아직 사용할 수 없습니다"
   pdf.invalidPageSize: "잘못된 페이지 %{axis}: %{value}"
+  pdf.invalidPageNumberSpec: "잘못된 페이지 번호 설정 %{field}: %{value}"
+  pdf.postProcessPanicked: "PDF 후처리가 예기치 않게 실패했습니다: %{detail}"
   pdf.renderWindowFailed: "렌더링 창을 만들지 못했습니다: %{detail}"
   pdf.loadFailed: "인쇄할 문서를 불러오지 못했습니다"
   pdf.printRefused: "인쇄 엔진이 PDF 생성을 거부했습니다"

--- a/src-tauri/locales/pt-BR.yml
+++ b/src-tauri/locales/pt-BR.yml
@@ -251,6 +251,8 @@ errors:
   pdf.printTimeoutSecs: "A impressão expirou após %{seconds} segundos"
   pdf.unsupportedPlatform: "A exportação para PDF ainda não está disponível nesta plataforma"
   pdf.invalidPageSize: "%{axis} de página inválida: %{value}"
+  pdf.invalidPageNumberSpec: "Configuração de numeração de páginas inválida %{field}: %{value}"
+  pdf.postProcessPanicked: "O pós-processamento do PDF falhou inesperadamente: %{detail}"
   pdf.renderWindowFailed: "Não foi possível criar a janela de renderização: %{detail}"
   pdf.loadFailed: "Falha ao carregar o documento para impressão"
   pdf.printRefused: "O mecanismo de impressão não gerou um PDF"

--- a/src-tauri/locales/zh-CN.yml
+++ b/src-tauri/locales/zh-CN.yml
@@ -251,6 +251,8 @@ errors:
   pdf.printTimeoutSecs: "打印在 %{seconds} 秒后超时"
   pdf.unsupportedPlatform: "此平台尚不支持导出 PDF"
   pdf.invalidPageSize: "页面%{axis}无效：%{value}"
+  pdf.invalidPageNumberSpec: "页码设置无效 %{field}：%{value}"
+  pdf.postProcessPanicked: "PDF 后处理意外失败：%{detail}"
   pdf.renderWindowFailed: "无法创建渲染窗口：%{detail}"
   pdf.loadFailed: "用于打印的文档加载失败"
   pdf.printRefused: "打印引擎未能生成 PDF"

--- a/src-tauri/locales/zh-TW.yml
+++ b/src-tauri/locales/zh-TW.yml
@@ -251,6 +251,8 @@ errors:
   pdf.printTimeoutSecs: "列印在 %{seconds} 秒後逾時"
   pdf.unsupportedPlatform: "此平台尚不支援匯出 PDF"
   pdf.invalidPageSize: "頁面%{axis}無效：%{value}"
+  pdf.invalidPageNumberSpec: "頁碼設定無效 %{field}：%{value}"
+  pdf.postProcessPanicked: "PDF 後處理意外失敗：%{detail}"
   pdf.renderWindowFailed: "無法建立算繪視窗：%{detail}"
   pdf.loadFailed: "用於列印的文件載入失敗"
   pdf.printRefused: "列印引擎未能產生 PDF"

--- a/src-tauri/src/atomic_replace.rs
+++ b/src-tauri/src/atomic_replace.rs
@@ -83,14 +83,37 @@ pub(crate) fn atomic_replace(
     parent: &Path,
     contents: &[u8],
 ) -> Result<(), AtomicReplaceError> {
+    atomic_replace_with(target, parent, |w| w.write_all(contents))
+}
+
+/// Atomically replace `target` with whatever `write` emits.
+///
+/// The streaming form. `atomic_replace` is this with a slice, and everything
+/// below the closure — permission preservation, fsync, the Windows
+/// remove-then-retry, RAII cleanup on any early return — is shared.
+///
+/// It exists for a producer that can write incrementally but would otherwise
+/// have to materialize its whole output first: `lopdf`'s `Document::save_to`
+/// takes a `Write`, so serializing a PDF through the byte form would hold a
+/// second full copy of the document in memory purely to hand it over.
+pub(crate) fn atomic_replace_with<F>(
+    target: &Path,
+    parent: &Path,
+    write: F,
+) -> Result<(), AtomicReplaceError>
+where
+    F: FnOnce(&mut NamedTempFile) -> std::io::Result<()>,
+{
     let mut temp =
         NamedTempFile::new_in(parent).map_err(|source| AtomicReplaceError::CreateTemp {
             parent: parent.to_path_buf(),
             source,
         })?;
 
-    temp.write_all(contents)
-        .map_err(AtomicReplaceError::WriteTemp)?;
+    // Written through the STILL-OPEN handle. Handing out the path instead — for
+    // the producer to reopen by name — is a window in which the path can be
+    // swapped for a symlink, which is what this API exists to avoid.
+    write(&mut temp).map_err(AtomicReplaceError::WriteTemp)?;
 
     temp.flush().map_err(AtomicReplaceError::FlushTemp)?;
 

--- a/src-tauri/src/bin/pdf_smoke/html_text.rs
+++ b/src-tauri/src/bin/pdf_smoke/html_text.rs
@@ -72,11 +72,18 @@ fn strip_tags(s: &str) -> String {
     decode_entities(&out)
 }
 
-/// Decode the five predefined XML entities plus numeric character references.
+/// Decode the entities a heading can realistically carry.
 ///
-/// Those five are what an HTML serializer is required to escape in text, so they
-/// are what a round trip through the export HTML can produce. Anything else is
-/// left as written rather than guessed at.
+/// The five predefined XML ones are what a serializer is REQUIRED to escape in
+/// text, so they are what the export HTML actually produces — `textContent`
+/// emits `©` and `—` as literal UTF-8, not as `&copy;` / `&mdash;`. The handful
+/// of named entities below are decoded anyway because hand-written HTML reaches
+/// this path too and leaving one literal silently mismatches the heading, and
+/// numeric references cover everything else.
+///
+/// An unknown entity is left as written rather than guessed at: a wrong
+/// substitution is worse than a missed one, since both break the match but only
+/// one is obvious in the output.
 fn decode_entities(s: &str) -> String {
     if !s.contains('&') {
         return s.to_string();
@@ -99,6 +106,16 @@ fn decode_entities(s: &str) -> String {
             "quot" => Some('"'),
             "apos" | "#39" => Some('\''),
             "nbsp" => Some('\u{00a0}'),
+            "mdash" => Some('—'),
+            "ndash" => Some('–'),
+            "hellip" => Some('…'),
+            "copy" => Some('©'),
+            "reg" => Some('®'),
+            "trade" => Some('™'),
+            "ldquo" => Some('\u{201c}'),
+            "rdquo" => Some('\u{201d}'),
+            "lsquo" => Some('\u{2018}'),
+            "rsquo" => Some('\u{2019}'),
             e if e.starts_with("#x") || e.starts_with("#X") => u32::from_str_radix(&e[2..], 16)
                 .ok()
                 .and_then(char::from_u32),
@@ -118,4 +135,61 @@ fn decode_entities(s: &str) -> String {
     }
     out.push_str(rest);
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_predefined_entities_round_trip_to_dom_text() {
+        // The frontend reads `Element.textContent`, where these are already
+        // characters. Leaving them literal made the harness's heading text
+        // disagree with the app's, so outline matching missed and the bookmark
+        // landed on the wrong page — a harness bug that reads as a product bug.
+        assert_eq!(decode_entities("Fish &amp; Chips"), "Fish & Chips");
+        assert_eq!(decode_entities("&lt;tag&gt;"), "<tag>");
+        assert_eq!(decode_entities("&quot;quoted&quot;"), "\"quoted\"");
+        assert_eq!(decode_entities("it&apos;s"), "it's");
+    }
+
+    #[test]
+    fn numeric_references_decode_in_both_bases() {
+        assert_eq!(decode_entities("&#65;&#x42;"), "AB");
+        assert_eq!(decode_entities("&#x4E2D;"), "中");
+    }
+
+    #[test]
+    fn an_unknown_entity_is_left_alone_rather_than_guessed() {
+        // A wrong substitution breaks the match just as badly as a missed one,
+        // and is harder to see in the output.
+        assert_eq!(decode_entities("&notarealentity;"), "&notarealentity;");
+        // A bare ampersand is not an entity at all.
+        assert_eq!(decode_entities("A & B"), "A & B");
+        // An unterminated one must not eat the rest of the heading.
+        assert_eq!(decode_entities("A &amp B"), "A &amp B");
+    }
+
+    #[test]
+    fn text_with_no_ampersand_is_returned_unchanged() {
+        assert_eq!(decode_entities("Chapter 1"), "Chapter 1");
+    }
+
+    #[test]
+    fn headings_are_read_with_their_level_and_inline_markup_stripped() {
+        let html = "<body><h1>Intro</h1><p>x</p><h2>Fish &amp; <code>Chips</code></h2></body>";
+        let got = headings_of(html);
+        assert_eq!(got.len(), 2);
+        assert_eq!((got[0].level, got[0].text.as_str()), (1, "Intro"));
+        // Nested markup dropped AND the entity decoded — both are needed for
+        // this to equal what `textContent` gives the dialog.
+        assert_eq!((got[1].level, got[1].text.as_str()), (2, "Fish & Chips"));
+    }
+
+    #[test]
+    fn an_empty_heading_is_not_reported() {
+        // The dialog filters these out too; keeping one would add a bookmark
+        // with no title.
+        assert!(headings_of("<body><h3>   </h3></body>").is_empty());
+    }
 }

--- a/src-tauri/src/bin/pdf_smoke/html_text.rs
+++ b/src-tauri/src/bin/pdf_smoke/html_text.rs
@@ -1,0 +1,121 @@
+//! Reading heading text out of the export HTML the way the DOM would.
+//!
+//! Purpose: the one-shot harness calls the renderer directly, below the command
+//! layer that injects the outline — so it has to recover the headings itself to
+//! show whether the sidebar works. That is exactly how the macOS-only outline
+//! gap went unnoticed for months.
+//!
+//! Split from `render_one.rs` for the size limit, and because this is text
+//! extraction rather than render flow.
+//!
+//! @coordinates-with render_one.rs — the only consumer
+//! @coordinates-with pdf_export/outline_match.rs — matches against this text
+//! @module bin/pdf_smoke/html_text
+
+use vmark_lib::pdf_export::heading::Heading;
+
+/// Pull headings out of the export HTML, the way the dialog does from the DOM.
+///
+/// The harness calls the renderer directly, below the command layer where the
+/// outline is injected — so without this the artifacts could never show whether
+/// the sidebar works, which is exactly how the macOS-only gap went unnoticed.
+pub fn headings_of(html: &str) -> Vec<Heading> {
+    let mut out = Vec::new();
+    let body = html.find("<body").map(|i| &html[i..]).unwrap_or(html);
+    let mut rest = body;
+    while let Some(i) = rest.find("<h") {
+        let after = &rest[i + 2..];
+        let level = match after.as_bytes().first() {
+            Some(c @ b'1'..=b'6') => u32::from(c - b'0'),
+            _ => {
+                rest = &rest[i + 2..];
+                continue;
+            }
+        };
+        let Some(open_end) = after.find('>') else {
+            break;
+        };
+        let tail = &after[open_end + 1..];
+        let Some(close) = tail.find("</h") else { break };
+        let text: String = strip_tags(&tail[..close]);
+        if !text.trim().is_empty() {
+            out.push(Heading {
+                level,
+                text: text.trim().to_string(),
+            });
+        }
+        rest = &tail[close..];
+    }
+    out
+}
+
+/// Drop nested markup so a heading with inline code or a link still matches the
+/// plain text the PDF carries.
+///
+/// Entities are DECODED, because the production path this imitates reads
+/// `Element.textContent` from a parsed DOM — where `Fish &amp; Chips` is
+/// `Fish & Chips`. Leaving the entity literal made the harness's heading text
+/// disagree with the app's for any heading containing `&`, `<`, `>` or a quote,
+/// so outline matching missed and the bookmark landed on the wrong page — a
+/// harness bug that reads exactly like a product bug.
+fn strip_tags(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut depth = 0usize;
+    for ch in s.chars() {
+        match ch {
+            '<' => depth += 1,
+            '>' => depth = depth.saturating_sub(1),
+            c if depth == 0 => out.push(c),
+            _ => {}
+        }
+    }
+    decode_entities(&out)
+}
+
+/// Decode the five predefined XML entities plus numeric character references.
+///
+/// Those five are what an HTML serializer is required to escape in text, so they
+/// are what a round trip through the export HTML can produce. Anything else is
+/// left as written rather than guessed at.
+fn decode_entities(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(i) = rest.find('&') {
+        out.push_str(&rest[..i]);
+        let after = &rest[i..];
+        let Some(semi) = after.find(';').filter(|n| *n <= 10) else {
+            out.push('&');
+            rest = &after[1..];
+            continue;
+        };
+        let entity = &after[1..semi];
+        let decoded = match entity {
+            "amp" => Some('&'),
+            "lt" => Some('<'),
+            "gt" => Some('>'),
+            "quot" => Some('"'),
+            "apos" | "#39" => Some('\''),
+            "nbsp" => Some('\u{00a0}'),
+            e if e.starts_with("#x") || e.starts_with("#X") => u32::from_str_radix(&e[2..], 16)
+                .ok()
+                .and_then(char::from_u32),
+            e if e.starts_with('#') => e[1..].parse().ok().and_then(char::from_u32),
+            _ => None,
+        };
+        match decoded {
+            Some(c) => {
+                out.push(c);
+                rest = &after[semi + 1..];
+            }
+            None => {
+                out.push('&');
+                rest = &after[1..];
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}

--- a/src-tauri/src/bin/pdf_smoke/main.rs
+++ b/src-tauri/src/bin/pdf_smoke/main.rs
@@ -183,10 +183,25 @@ async fn run_cases(app: &tauri::AppHandle, out: &Path) -> usize {
     // spools the document to the DEFAULT PRINTER. An earlier version of this
     // harness put four blank pages through a real one. The assertion is now
     // that the refusal happens up front, with a code that says so.
+    //
+    // The path must be ABSOLUTE-but-missing, and a POSIX literal is not
+    // absolute on Windows: a leading separator with no drive letter is
+    // root-RELATIVE, so `validate_output_path` refused it at the is_absolute
+    // check and returned InvalidInput, never reaching the missing-directory
+    // guard this case exists to exercise. The harness reported a Windows-only
+    // failure for a fixture bug — the noise that gets a cross-platform job
+    // ignored. `commands.test.rs` had already hit and documented this exact
+    // trap; deriving from `temp_dir()` is its answer, so use the same one
+    // rather than a second idiom that can drift.
+    let missing_dir_pdf = std::env::temp_dir()
+        .join("vmark-definitely-not-here")
+        .join("x.pdf")
+        .to_string_lossy()
+        .into_owned();
     match vmark_lib::pdf_export::renderer::render_pdf(
         app.clone(),
         String::new(),
-        "/nonexistent-dir-for-smoke/x.pdf".into(),
+        missing_dir_pdf,
         A4,
     )
     .await

--- a/src-tauri/src/bin/pdf_smoke/main.rs
+++ b/src-tauri/src/bin/pdf_smoke/main.rs
@@ -19,42 +19,47 @@
 //! case, so a caller can assert on the transcript rather than on a exit code
 //! alone.
 //!
-//! Cases, and why each exists:
+//! Cases, and why each exists — the bodies live in `scenarios.rs`:
 //!
-//! - `basic` — does it produce a PDF at all.
-//! - `legal` / `a5` — is `PageSpec` honoured, or is the platform default
-//!   silently used? A valid `%PDF` at the wrong size is the failure a
-//!   magic-byte assertion cannot see (ADR-PDF1).
-//! - `landscape` — orientation, which is a width/height swap rather than a
-//!   flag (ADR-PDF1a).
-//! - `large` — a document over 2 MiB. wry's `.with_html` caps there, so this
-//!   proves navigation is used (ADR-PDF4); VMark inlines images as data URIs,
-//!   so real exports routinely exceed it.
+//! - `geometry_matrix` — all four paper sizes × both orientations. Is
+//!   `PageSpec` honoured, or is the platform default silently used? A valid
+//!   `%PDF` at the wrong size is the failure a magic-byte assertion cannot see
+//!   (ADR-PDF1), and orientation is a width/height swap rather than a flag
+//!   (ADR-PDF1a).
+//! - `pagination` — `basic` (does it produce a PDF at all), `a5` (the one size
+//!   the matrix does not carry), and `large`: a document over 2 MiB, since
+//!   wry's `.with_html` caps there and VMark inlines images as data URIs. That
+//!   one asserts a SENTINEL past the boundary, because truncation still yields
+//!   a valid A4 PDF.
+//! - `page_numbers_case` — the stamp survives each engine's own page tree.
 //! - `badpath` — an unwritable destination must be refused UP FRONT. On macOS
 //!   an NSPrintOperation pointed at a missing directory does not fail, it
 //!   spools to the default printer; an earlier version of this harness put
 //!   four blank pages through a real one.
 //! - `sequential` — 20 exports in a row leak no window.
-//! - `concurrent` — 2 at once do not collide on a window label.
+//! - `concurrent` — 2 at once collide on neither a window label nor each
+//!   other's output, checked by distinct content sentinels.
 //!
 //! @coordinates-with pdf_export/renderer — the code under test
 //! @module bin/pdf_smoke
 
 use std::path::Path;
-
 use std::time::Duration;
-use tauri::Manager;
 
 use vmark_lib::pdf_export::page_spec::PageSpec;
 
-/// A4 and A5 in points, portrait.
-const A4: PageSpec = PageSpec::new(595.28, 841.89);
-const A5: PageSpec = PageSpec::new(419.53, 595.28);
-const A4_LANDSCAPE: PageSpec = PageSpec::new(841.89, 595.28);
-
 fn main() {
     // `--html <file> <out-dir>` renders a supplied document — see render_one.rs.
-    let (one_shot, out_dir) = render_one::parse_args(std::env::args().collect());
+    // Refuse a malformed invocation rather than silently running the fixture
+    // matrix instead of the document the caller named.
+    let (one_shot, out_dir) = match render_one::parse_args(std::env::args().collect()) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            eprintln!("pdf_smoke: {e}");
+            eprintln!("usage: pdf_smoke [--html <file>] <out-dir>");
+            std::process::exit(2);
+        }
+    };
     std::fs::create_dir_all(&out_dir).expect("create out dir");
 
     let app = tauri::Builder::default()
@@ -80,194 +85,20 @@ fn main() {
     app.run(|_, _| {});
 }
 
+/// Run every scenario, in order, and return the total failure count.
+///
+/// A flat list on purpose: each scenario owns its own counter, so one cannot
+/// report on another's work. That is not tidiness — the shared counter this
+/// replaced let the sequential case print "PASS 20 exports" for a run that had
+/// broken out after the first failure.
 async fn run_cases(app: &tauri::AppHandle, out: &Path) -> usize {
     let mut failures = 0usize;
-
-    // All eight UI combinations. The dialog offers four sizes and two
-    // orientations, and until WI-PDF1.4 every one of them produced the system
-    // default paper on macOS — so this asserts the whole surface, not a
-    // sample. Points are the portrait dimensions; landscape is the swap.
-    const SIZES: [(&str, f64, f64); 4] = [
-        ("A4", 595.28, 841.89),
-        ("letter", 612.0, 792.0),
-        ("A3", 841.89, 1190.55),
-        ("legal", 612.0, 1008.0),
-    ];
-    for (css, w, h) in SIZES {
-        for landscape in [false, true] {
-            let spec = if landscape {
-                PageSpec::new(h, w)
-            } else {
-                PageSpec::new(w, h)
-            };
-            let name = format!("{css}{}", if landscape { "-landscape" } else { "" });
-            let css_size = if landscape {
-                format!("{css} landscape")
-            } else {
-                css.to_string()
-            };
-            let path = out.join(format!("matrix-{name}.pdf"));
-            failures += check(
-                &name,
-                render(app, &doc_for(&css_size, "<p>matrix</p>"), &path, spec).await,
-                &path,
-                Some((spec.width_pt.round() as u32, spec.height_pt.round() as u32)),
-            );
-        }
-    }
-
-    failures += check(
-        "basic",
-        render(
-            app,
-            &doc_for("A4", "<div class='b'>one</div><div class='b'>two</div>"),
-            &out.join("basic.pdf"),
-            A4,
-        )
-        .await,
-        &out.join("basic.pdf"),
-        Some((595, 842)),
-    );
-
-    // Legal is 612x1008 — nothing like A4, so "the default came out" cannot be
-    // mistaken for "the request was honoured".
-    const LEGAL: PageSpec = PageSpec::new(612.0, 1008.0);
-    failures += check(
-        "legal",
-        render(
-            app,
-            &doc_for("legal", "<p>legal</p>"),
-            &out.join("legal.pdf"),
-            LEGAL,
-        )
-        .await,
-        &out.join("legal.pdf"),
-        Some((612, 1008)),
-    );
-
-    failures += check(
-        "a5",
-        render(app, &doc_for("A5", "<p>a5</p>"), &out.join("a5.pdf"), A5).await,
-        &out.join("a5.pdf"),
-        // The whole point: a backend ignoring PageSpec still emits a valid
-        // PDF, just at the platform default.
-        Some((420, 595)),
-    );
-
-    failures += check(
-        "landscape",
-        render(
-            app,
-            &doc_for("A4 landscape", "<p>wide</p>"),
-            &out.join("landscape.pdf"),
-            A4_LANDSCAPE,
-        )
-        .await,
-        &out.join("landscape.pdf"),
-        Some((842, 595)),
-    );
-
-    failures += check(
-        "large",
-        render(app, &large_doc("A4"), &out.join("large.pdf"), A4).await,
-        &out.join("large.pdf"),
-        Some((595, 842)),
-    );
-
+    failures += scenarios::geometry_matrix(app, out).await;
+    failures += scenarios::pagination(app, out).await;
     failures += page_numbers_case::run(app, out).await;
-
-    // A bad output path must be REFUSED before any print operation starts.
-    //
-    // This case is why the renderer validates the path itself. On macOS an
-    // NSPrintOperation pointed at a nonexistent directory does not fail — it
-    // spools the document to the DEFAULT PRINTER. An earlier version of this
-    // harness put four blank pages through a real one. The assertion is now
-    // that the refusal happens up front, with a code that says so.
-    //
-    // The path must be ABSOLUTE-but-missing, and a POSIX literal is not
-    // absolute on Windows: a leading separator with no drive letter is
-    // root-RELATIVE, so `validate_output_path` refused it at the is_absolute
-    // check and returned InvalidInput, never reaching the missing-directory
-    // guard this case exists to exercise. The harness reported a Windows-only
-    // failure for a fixture bug — the noise that gets a cross-platform job
-    // ignored. `commands.test.rs` had already hit and documented this exact
-    // trap; deriving from `temp_dir()` is its answer, so use the same one
-    // rather than a second idiom that can drift.
-    let missing_dir_pdf = std::env::temp_dir()
-        .join("vmark-definitely-not-here")
-        .join("x.pdf")
-        .to_string_lossy()
-        .into_owned();
-    match vmark_lib::pdf_export::renderer::render_pdf(
-        app.clone(),
-        String::new(),
-        missing_dir_pdf,
-        A4,
-    )
-    .await
-    {
-        Err(e) if e.code() == vmark_lib::command_error::ErrorCode::NotFound => {
-            println!("SMOKE badpath PASS refused up front, code=NotFound")
-        }
-        Err(e) => {
-            // Refused, but not by the guard — a timeout here means the print
-            // operation STARTED, which is the dangerous path.
-            println!("SMOKE badpath FAIL refused late, code={:?}", e.code());
-            failures += 1;
-        }
-        Ok(()) => {
-            println!("SMOKE badpath FAIL accepted an impossible path");
-            failures += 1;
-        }
-    }
-
-    // 20 in a row: a leaked render window would accumulate here.
-    let before = app.webview_windows().len();
-    for i in 0..20 {
-        let p = out.join(format!("seq-{i}.pdf"));
-        if render(app, &doc_for("A4", "<p>seq</p>"), &p, A4)
-            .await
-            .is_err()
-        {
-            println!("SMOKE sequential FAIL at {i}");
-            failures += 1;
-            break;
-        }
-    }
-    // The renderer settles the sink and THEN closes its window, so the caller
-    // resumes before the close has been processed — counting immediately
-    // measures a close in flight, not a leak. The contract is that windows
-    // return to baseline promptly, so poll for that with a bound: if they
-    // never do, it is a real leak and this still fails.
-    let mut after = app.webview_windows().len();
-    let deadline = std::time::Instant::now() + Duration::from_secs(10);
-    while after > before && std::time::Instant::now() < deadline {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        after = app.webview_windows().len();
-    }
-    if after > before {
-        println!(
-            "SMOKE sequential FAIL leaked {} window(s) after 10s",
-            after - before
-        );
-        failures += 1;
-    } else {
-        println!("SMOKE sequential PASS 20 exports, windows {before} -> {after}");
-    }
-
-    // Two at once must not collide on a window label. The docs and paths are
-    // bound first: `tokio::join!` borrows across an await point, so temporaries
-    // created inside it do not live long enough.
-    let (d1, d2) = (doc_for("A4", "<p>c1</p>"), doc_for("A4", "<p>c2</p>"));
-    let (p1, p2) = (out.join("con-1.pdf"), out.join("con-2.pdf"));
-    let (a, b) = tokio::join!(render(app, &d1, &p1, A4), render(app, &d2, &p2, A4),);
-    if a.is_ok() && b.is_ok() {
-        println!("SMOKE concurrent PASS");
-    } else {
-        println!("SMOKE concurrent FAIL a={a:?} b={b:?}");
-        failures += 1;
-    }
-
+    failures += scenarios::bad_path(app).await;
+    failures += scenarios::sequential(app, out).await;
+    failures += scenarios::concurrent(app, out).await;
     failures
 }
 
@@ -288,8 +119,9 @@ async fn render(
 }
 
 mod fixtures;
+mod html_text;
+mod page_number_fixture;
 mod page_numbers_case;
 mod render_one;
+mod scenarios;
 mod verify;
-use fixtures::{doc_for, large_doc};
-use verify::check;

--- a/src-tauri/src/bin/pdf_smoke/main.rs
+++ b/src-tauri/src/bin/pdf_smoke/main.rs
@@ -174,6 +174,8 @@ async fn run_cases(app: &tauri::AppHandle, out: &Path) -> usize {
         Some((595, 842)),
     );
 
+    failures += page_numbers_case::run(app, out).await;
+
     // A bad output path must be REFUSED before any print operation starts.
     //
     // This case is why the renderer validates the path itself. On macOS an
@@ -271,6 +273,7 @@ async fn render(
 }
 
 mod fixtures;
+mod page_numbers_case;
 mod render_one;
 mod verify;
 use fixtures::{doc_for, large_doc};

--- a/src-tauri/src/bin/pdf_smoke/page_number_fixture.rs
+++ b/src-tauri/src/bin/pdf_smoke/page_number_fixture.rs
@@ -1,0 +1,50 @@
+//! The page-number request both harness modes send, in one place.
+//!
+//! Purpose: `page_numbers_case` (fixture matrix) and `render_one` (real
+//! document) each built their own `PageNumberSpec`, repeating the dialog's
+//! `9.35` default font size, the 72pt margins and the verbose template. Two
+//! copies of a default is how one harness quietly stops testing what the app
+//! actually sends — and neither copy is wrong-looking on its own.
+//!
+//! These MIRROR the dialog (`buildPageNumberSpec` in `src/export/pdfOptions.ts`).
+//! Change one and change the other; the numbers are stated here so the mirror is
+//! visible rather than scattered.
+//!
+//! @coordinates-with src/export/pdfOptions.ts — the values this mirrors
+//! @coordinates-with page_numbers_case.rs, render_one.rs — the two consumers
+//! @module bin/pdf_smoke/page_number_fixture
+
+use vmark_lib::pdf_export::page_numbers::{Format, PageNumberSpec, Position};
+use vmark_lib::pdf_export::page_spec::PageSpec;
+
+/// The dialog's default margin, 25.4mm in points.
+pub const MARGIN_PT: f64 = 72.0;
+
+/// The dialog's default page-number size: `max(7, fontSize 11 * 0.85)`.
+const FONT_SIZE_PT: f64 = 9.35;
+
+/// A page geometry carrying the dialog's default margins on all four sides.
+pub fn with_default_margins(width_pt: f64, height_pt: f64) -> PageSpec {
+    let mut page = PageSpec::new(width_pt, height_pt);
+    page.margin_top_pt = Some(MARGIN_PT);
+    page.margin_right_pt = Some(MARGIN_PT);
+    page.margin_bottom_pt = Some(MARGIN_PT);
+    page.margin_left_pt = Some(MARGIN_PT);
+    page
+}
+
+/// A spec matching what the export dialog sends for these three choices.
+pub fn spec(position: Position, format: Format, skip_first: bool) -> PageNumberSpec {
+    PageNumberSpec {
+        position,
+        format,
+        skip_first,
+        font_size_pt: FONT_SIZE_PT,
+        bottom_margin_pt: MARGIN_PT,
+        side_margin_pt: MARGIN_PT,
+        verbose_template: "Page {n} of {total}".to_string(),
+        // Black: these fixtures render the light theme, which is also what the
+        // dialog sends unless the export carries a dark editor theme.
+        ink_rgb: Default::default(),
+    }
+}

--- a/src-tauri/src/bin/pdf_smoke/page_numbers_case.rs
+++ b/src-tauri/src/bin/pdf_smoke/page_numbers_case.rs
@@ -1,0 +1,92 @@
+//! Does the page-number stamp survive each platform's own PDF?
+//!
+//! Purpose: `stamp_page_numbers` is pure lopdf and its unit tests run
+//! identically everywhere, so they prove the arithmetic and nothing about the
+//! documents it has to edit. The three engines emit different page trees —
+//! `/Contents` as a lone stream or an array, `/Resources` direct, indirect, or
+//! inherited from the `/Pages` node — and the stamp has a branch for each. A
+//! branch that is wrong still produces a loadable PDF at the right size with an
+//! empty footer, which is invisible to every other assertion in this harness.
+//!
+//! So this renders through the REAL backend and then reads the result back.
+//!
+//! @coordinates-with pdf_export::page_numbers — the code under test
+//! @coordinates-with verify.rs — `check_stamped` does the reading back
+//! @module bin/pdf_smoke/page_numbers_case
+
+use std::path::Path;
+
+use vmark_lib::pdf_export::page_numbers::{Format, PageNumberSpec, Position};
+use vmark_lib::pdf_export::page_spec::PageSpec;
+
+use super::fixtures::doc_for;
+use super::verify::{check, check_stamped};
+
+/// A4 with the dialog's default 25.4mm margins, so the number has a band to sit
+/// in rather than landing on the content.
+fn a4_with_margins() -> PageSpec {
+    let mut page = PageSpec::new(595.28, 841.89);
+    page.margin_top_pt = Some(72.0);
+    page.margin_right_pt = Some(72.0);
+    page.margin_bottom_pt = Some(72.0);
+    page.margin_left_pt = Some(72.0);
+    page
+}
+
+fn spec(position: Position, format: Format, skip_first: bool) -> PageNumberSpec {
+    PageNumberSpec {
+        position,
+        format,
+        skip_first,
+        font_size_pt: 9.35, // the dialog's default: max(7, 11 * 0.85)
+        bottom_margin_pt: 72.0,
+        side_margin_pt: 72.0,
+        verbose_template: "Page {n} of {total}".to_string(),
+    }
+}
+
+/// Render a multi-page document, stamp it, and read the numbers back.
+/// Returns the failure count.
+pub async fn run(app: &tauri::AppHandle, out: &Path) -> usize {
+    // Four `.b` blocks at 180mm force several pages, so "every page is
+    // stamped" is a claim with something to fail on. A one-page fixture would
+    // pass even if the loop stamped only the first.
+    let body = "<div class='b'>one</div><div class='b'>two</div>\
+                <div class='b'>three</div><div class='b'>four</div>";
+    let page = a4_with_margins();
+
+    let mut failures = 0usize;
+    for (label, position, format, skip_first) in [
+        (
+            "pageno-center",
+            Position::BottomCenter,
+            Format::WithTotal,
+            false,
+        ),
+        // The other position, the other format, and the skip — one more render
+        // for the branches a single case cannot reach.
+        (
+            "pageno-right-skip",
+            Position::BottomRight,
+            Format::Plain,
+            true,
+        ),
+    ] {
+        let path = out.join(format!("{label}.pdf"));
+        let mut result = super::render(app, &doc_for("A4", body), &path, page).await;
+        if result.is_ok() {
+            if let Err(e) = vmark_lib::pdf_export::page_numbers::stamp_page_numbers(
+                &path.to_string_lossy(),
+                &spec(position, format, skip_first),
+            ) {
+                result = Err(format!("stamp: {e}"));
+            }
+        }
+        let rendered = result.is_ok();
+        failures += check(label, result, &path, Some((595, 842)));
+        if rendered {
+            failures += check_stamped(label, &path, skip_first);
+        }
+    }
+    failures
+}

--- a/src-tauri/src/bin/pdf_smoke/page_numbers_case.rs
+++ b/src-tauri/src/bin/pdf_smoke/page_numbers_case.rs
@@ -16,34 +16,11 @@
 
 use std::path::Path;
 
-use vmark_lib::pdf_export::page_numbers::{Format, PageNumberSpec, Position};
-use vmark_lib::pdf_export::page_spec::PageSpec;
+use vmark_lib::pdf_export::page_numbers::{Format, Position};
 
 use super::fixtures::doc_for;
+use super::page_number_fixture::{spec, with_default_margins};
 use super::verify::{check, check_stamped};
-
-/// A4 with the dialog's default 25.4mm margins, so the number has a band to sit
-/// in rather than landing on the content.
-fn a4_with_margins() -> PageSpec {
-    let mut page = PageSpec::new(595.28, 841.89);
-    page.margin_top_pt = Some(72.0);
-    page.margin_right_pt = Some(72.0);
-    page.margin_bottom_pt = Some(72.0);
-    page.margin_left_pt = Some(72.0);
-    page
-}
-
-fn spec(position: Position, format: Format, skip_first: bool) -> PageNumberSpec {
-    PageNumberSpec {
-        position,
-        format,
-        skip_first,
-        font_size_pt: 9.35, // the dialog's default: max(7, 11 * 0.85)
-        bottom_margin_pt: 72.0,
-        side_margin_pt: 72.0,
-        verbose_template: "Page {n} of {total}".to_string(),
-    }
-}
 
 /// Render a multi-page document, stamp it, and read the numbers back.
 /// Returns the failure count.
@@ -53,7 +30,7 @@ pub async fn run(app: &tauri::AppHandle, out: &Path) -> usize {
     // pass even if the loop stamped only the first.
     let body = "<div class='b'>one</div><div class='b'>two</div>\
                 <div class='b'>three</div><div class='b'>four</div>";
-    let page = a4_with_margins();
+    let page = with_default_margins(595.28, 841.89);
 
     let mut failures = 0usize;
     for (label, position, format, skip_first) in [

--- a/src-tauri/src/bin/pdf_smoke/render_one.rs
+++ b/src-tauri/src/bin/pdf_smoke/render_one.rs
@@ -20,9 +20,11 @@
 
 use std::path::{Path, PathBuf};
 
-use vmark_lib::pdf_export::heading::Heading;
 use vmark_lib::pdf_export::page_numbers::{Format, PageNumberSpec, Position};
 use vmark_lib::pdf_export::page_spec::PageSpec;
+
+use super::html_text::headings_of;
+use super::page_number_fixture::{spec, with_default_margins};
 
 /// Split argv into the optional `--html <file>` source and the out-dir.
 ///
@@ -30,8 +32,30 @@ use vmark_lib::pdf_export::page_spec::PageSpec;
 /// consumed by `--html`; without that second condition `--html x.html out/`
 /// would take `x.html` as the out-dir and silently render into a directory
 /// named after the source.
-pub fn parse_args(args: Vec<String>) -> (Option<PathBuf>, PathBuf) {
-    let html_idx = args.iter().position(|a| a == "--html").map(|i| i + 1);
+///
+/// A malformed invocation is an ERROR, not a fallback. A bare `--html` with no
+/// value used to leave `one_shot` as `None`, so the harness quietly ran the
+/// fixture matrix instead — a green transcript for a run that never opened the
+/// document the caller asked about.
+pub fn parse_args(args: Vec<String>) -> Result<(Option<PathBuf>, PathBuf), String> {
+    let flag_idx = args.iter().position(|a| a == "--html");
+    let html_idx = flag_idx.map(|i| i + 1);
+    if let Some(i) = html_idx {
+        match args.get(i) {
+            None => return Err("--html needs a file path".into()),
+            Some(v) if v.starts_with("--") => {
+                return Err(format!("--html needs a file path, got the flag {v:?}"))
+            }
+            Some(_) => {}
+        }
+    }
+    if let Some(unknown) = args
+        .iter()
+        .skip(1)
+        .find(|a| a.starts_with("--") && a.as_str() != "--html")
+    {
+        return Err(format!("unknown flag {unknown:?}"));
+    }
     let one_shot = html_idx.and_then(|i| args.get(i)).map(PathBuf::from);
     let out_dir = args
         .iter()
@@ -40,11 +64,8 @@ pub fn parse_args(args: Vec<String>) -> (Option<PathBuf>, PathBuf) {
         .find(|(i, a)| !a.starts_with("--") && Some(*i) != html_idx)
         .map(|(_, a)| PathBuf::from(a))
         .unwrap_or_else(std::env::temp_dir);
-    (one_shot, out_dir)
+    Ok((one_shot, out_dir))
 }
-
-/// The dialog's default margin, 25.4mm in points.
-const MARGIN_PT: f64 = 72.0;
 
 /// Portrait geometries in points, matching the dialog's page-size list.
 const SIZES: [(&str, f64, f64); 3] = [
@@ -141,57 +162,6 @@ fn retarget(html: &str, page: PageSpec) -> String {
     )
 }
 
-/// Pull headings out of the export HTML, the way the dialog does from the DOM.
-///
-/// The harness calls the renderer directly, below the command layer where the
-/// outline is injected — so without this the artifacts could never show whether
-/// the sidebar works, which is exactly how the macOS-only gap went unnoticed.
-fn headings_of(html: &str) -> Vec<Heading> {
-    let mut out = Vec::new();
-    let body = html.find("<body").map(|i| &html[i..]).unwrap_or(html);
-    let mut rest = body;
-    while let Some(i) = rest.find("<h") {
-        let after = &rest[i + 2..];
-        let level = match after.as_bytes().first() {
-            Some(c @ b'1'..=b'6') => u32::from(c - b'0'),
-            _ => {
-                rest = &rest[i + 2..];
-                continue;
-            }
-        };
-        let Some(open_end) = after.find('>') else {
-            break;
-        };
-        let tail = &after[open_end + 1..];
-        let Some(close) = tail.find("</h") else { break };
-        let text: String = strip_tags(&tail[..close]);
-        if !text.trim().is_empty() {
-            out.push(Heading {
-                level,
-                text: text.trim().to_string(),
-            });
-        }
-        rest = &tail[close..];
-    }
-    out
-}
-
-/// Drop nested markup so a heading with inline code or a link still matches the
-/// plain text the PDF carries.
-fn strip_tags(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut depth = 0usize;
-    for ch in s.chars() {
-        match ch {
-            '<' => depth += 1,
-            '>' => depth = depth.saturating_sub(1),
-            c if depth == 0 => out.push(c),
-            _ => {}
-        }
-    }
-    out
-}
-
 /// The page-number request for one geometry.
 ///
 /// Portrait sheets get the shipping default (bottom-centre, plain). Landscape
@@ -199,26 +169,24 @@ fn strip_tags(s: &str) -> String {
 /// exercises every branch rather than proving one path six times — and each
 /// file's variant is implied by its name, which is what makes the three
 /// platforms' outputs comparable side by side.
+///
+/// The VALUES come from `page_number_fixture`, shared with the fixture matrix:
+/// duplicating the dialog's defaults in two harness modes is how one of them
+/// silently stops matching the app.
 fn page_number_spec(landscape: bool) -> PageNumberSpec {
-    PageNumberSpec {
-        position: if landscape {
+    spec(
+        if landscape {
             Position::BottomRight
         } else {
             Position::BottomCenter
         },
-        format: if landscape {
+        if landscape {
             Format::WithTotal
         } else {
             Format::Plain
         },
-        skip_first: landscape,
-        // The dialog's defaults: max(7, fontSize 11 * 0.85), and the same 72pt
-        // margins this harness renders at.
-        font_size_pt: 9.35,
-        bottom_margin_pt: MARGIN_PT,
-        side_margin_pt: MARGIN_PT,
-        verbose_template: "Page {n} of {total}".to_string(),
-    }
+        landscape,
+    )
 }
 
 /// Render `html_path` once per geometry into `out`. Returns the failure count.
@@ -238,15 +206,11 @@ pub async fn run(app: &tauri::AppHandle, html_path: &Path, out: &Path) -> usize 
             // Landscape is a width/height swap, never a flag — ADR-PDF1a.
             // Match the captured document's CSS margins (25.4mm = 72pt), so
             // the artifact shows what a real export produces on each platform.
-            let mut page = if landscape {
-                PageSpec::new(h, w)
+            let page = if landscape {
+                with_default_margins(h, w)
             } else {
-                PageSpec::new(w, h)
+                with_default_margins(w, h)
             };
-            page.margin_top_pt = Some(MARGIN_PT);
-            page.margin_right_pt = Some(MARGIN_PT);
-            page.margin_bottom_pt = Some(MARGIN_PT);
-            page.margin_left_pt = Some(MARGIN_PT);
             let label = format!("{name}{}", if landscape { "-landscape" } else { "" });
             let path = out.join(format!("showcase-{label}.pdf"));
             let mut result = super::render(app, &retarget(&html, page), &path, page).await;

--- a/src-tauri/src/bin/pdf_smoke/render_one.rs
+++ b/src-tauri/src/bin/pdf_smoke/render_one.rs
@@ -21,6 +21,7 @@
 use std::path::{Path, PathBuf};
 
 use vmark_lib::pdf_export::heading::Heading;
+use vmark_lib::pdf_export::page_numbers::{Format, PageNumberSpec, Position};
 use vmark_lib::pdf_export::page_spec::PageSpec;
 
 /// Split argv into the optional `--html <file>` source and the out-dir.
@@ -191,6 +192,35 @@ fn strip_tags(s: &str) -> String {
     out
 }
 
+/// The page-number request for one geometry.
+///
+/// Portrait sheets get the shipping default (bottom-centre, plain). Landscape
+/// gets the other position and format plus `skip_first`, so the artifact set
+/// exercises every branch rather than proving one path six times — and each
+/// file's variant is implied by its name, which is what makes the three
+/// platforms' outputs comparable side by side.
+fn page_number_spec(landscape: bool) -> PageNumberSpec {
+    PageNumberSpec {
+        position: if landscape {
+            Position::BottomRight
+        } else {
+            Position::BottomCenter
+        },
+        format: if landscape {
+            Format::WithTotal
+        } else {
+            Format::Plain
+        },
+        skip_first: landscape,
+        // The dialog's defaults: max(7, fontSize 11 * 0.85), and the same 72pt
+        // margins this harness renders at.
+        font_size_pt: 9.35,
+        bottom_margin_pt: MARGIN_PT,
+        side_margin_pt: MARGIN_PT,
+        verbose_template: "Page {n} of {total}".to_string(),
+    }
+}
+
 /// Render `html_path` once per geometry into `out`. Returns the failure count.
 pub async fn run(app: &tauri::AppHandle, html_path: &Path, out: &Path) -> usize {
     let html = match std::fs::read_to_string(html_path) {
@@ -220,8 +250,11 @@ pub async fn run(app: &tauri::AppHandle, html_path: &Path, out: &Path) -> usize 
             let label = format!("{name}{}", if landscape { "-landscape" } else { "" });
             let path = out.join(format!("showcase-{label}.pdf"));
             let mut result = super::render(app, &retarget(&html, page), &path, page).await;
-            // Inject the outline exactly as the command layer does, so the
-            // artifact a human opens has the sidebar the shipped export gives.
+            // Inject the outline and stamp the page numbers exactly as the
+            // command layer does, and in the same order — so the artifact a
+            // human opens is the one the shipped export gives, sidebar and
+            // footer included.
+            let spec = page_number_spec(landscape);
             if result.is_ok() {
                 let headings = headings_of(&html);
                 if let Err(e) =
@@ -230,12 +263,24 @@ pub async fn run(app: &tauri::AppHandle, html_path: &Path, out: &Path) -> usize 
                     result = Err(format!("outline: {e}"));
                 }
             }
+            if result.is_ok() {
+                if let Err(e) = vmark_lib::pdf_export::page_numbers::stamp_page_numbers(
+                    &path.to_string_lossy(),
+                    &spec,
+                ) {
+                    result = Err(format!("page numbers: {e}"));
+                }
+            }
+            let rendered = result.is_ok();
             failures += super::verify::check(
                 &label,
                 result,
                 &path,
                 Some((page.width_pt.round() as u32, page.height_pt.round() as u32)),
             );
+            if rendered {
+                failures += super::verify::check_stamped(&label, &path, spec.skip_first);
+            }
         }
     }
     failures

--- a/src-tauri/src/bin/pdf_smoke/render_one.rs
+++ b/src-tauri/src/bin/pdf_smoke/render_one.rs
@@ -249,3 +249,43 @@ pub async fn run(app: &tauri::AppHandle, html_path: &Path, out: &Path) -> usize 
     }
     failures
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(args: &[&str]) -> Vec<String> {
+        std::iter::once("pdf_smoke")
+            .chain(args.iter().copied())
+            .map(String::from)
+            .collect()
+    }
+
+    #[test]
+    fn the_out_dir_is_not_confused_with_the_html_value() {
+        let (html, out) = parse_args(argv(&["--html", "doc.html", "out"])).unwrap();
+        assert_eq!(html.unwrap().to_string_lossy(), "doc.html");
+        assert_eq!(out.to_string_lossy(), "out");
+    }
+
+    #[test]
+    fn a_bare_html_flag_is_refused_rather_than_running_the_matrix() {
+        // THE REGRESSION. A missing value used to leave `one_shot` as None, so
+        // the harness quietly ran the fixture matrix instead — a green
+        // transcript for a run that never opened the document asked about.
+        assert!(parse_args(argv(&["--html"])).is_err());
+        assert!(parse_args(argv(&["--html", "--other"])).is_err());
+    }
+
+    #[test]
+    fn an_unknown_flag_is_refused() {
+        assert!(parse_args(argv(&["--nope", "out"])).is_err());
+    }
+
+    #[test]
+    fn matrix_mode_needs_no_flags() {
+        let (html, out) = parse_args(argv(&["out"])).unwrap();
+        assert!(html.is_none());
+        assert_eq!(out.to_string_lossy(), "out");
+    }
+}

--- a/src-tauri/src/bin/pdf_smoke/scenarios.rs
+++ b/src-tauri/src/bin/pdf_smoke/scenarios.rs
@@ -1,0 +1,237 @@
+//! The individual smoke scenarios.
+//!
+//! Purpose: `run_cases` had grown into a ~190-line coordinator holding geometry,
+//! pagination, bad-path, sequential and concurrency flows in one scope with one
+//! shared `failures` counter. That is not only long — its mixed state produced a
+//! FALSE transcript: the sequential case incremented `failures` and `break`ed on
+//! a render error, then fell through to the window-leak check, which printed
+//! "PASS 20 exports" for a run where fewer than 20 had rendered.
+//!
+//! Each scenario now owns its own counter and returns it, so a scenario cannot
+//! report on work another one did or did not do.
+//!
+//! @coordinates-with main.rs — the coordinator that calls these
+//! @coordinates-with verify.rs — every assertion lands there
+//! @module bin/pdf_smoke/scenarios
+
+use std::path::Path;
+use std::time::Duration;
+
+use tauri::Manager;
+use vmark_lib::pdf_export::page_spec::PageSpec;
+
+use super::fixtures::{doc_for, large_doc};
+use super::render;
+use super::verify::{check, contains_text};
+
+/// A4 and A5 in points, portrait.
+const A4: PageSpec = PageSpec::new(595.28, 841.89);
+const A5: PageSpec = PageSpec::new(419.53, 595.28);
+
+/// Every size × orientation the dialog offers.
+///
+/// Until WI-PDF1.4 every one of them produced the system default paper on
+/// macOS, so this asserts the whole surface rather than a sample. Points are the
+/// portrait dimensions; landscape is the swap, never a flag (ADR-PDF1a).
+pub async fn geometry_matrix(app: &tauri::AppHandle, out: &Path) -> usize {
+    const SIZES: [(&str, f64, f64); 4] = [
+        ("A4", 595.28, 841.89),
+        ("letter", 612.0, 792.0),
+        ("A3", 841.89, 1190.55),
+        ("legal", 612.0, 1008.0),
+    ];
+    let mut failures = 0usize;
+    for (css, w, h) in SIZES {
+        for landscape in [false, true] {
+            let spec = if landscape {
+                PageSpec::new(h, w)
+            } else {
+                PageSpec::new(w, h)
+            };
+            let name = format!("{css}{}", if landscape { "-landscape" } else { "" });
+            let css_size = if landscape {
+                format!("{css} landscape")
+            } else {
+                css.to_string()
+            };
+            let path = out.join(format!("matrix-{name}.pdf"));
+            failures += check(
+                &name,
+                render(app, &doc_for(&css_size, "<p>matrix</p>"), &path, spec).await,
+                &path,
+                Some((spec.width_pt.round() as u32, spec.height_pt.round() as u32)),
+            );
+        }
+    }
+    failures
+}
+
+/// Cases the geometry matrix does not already cover.
+///
+/// It used to also carry standalone `legal` and `landscape` cases. Both were
+/// redundant — the matrix renders legal portrait/landscape and A4 landscape with
+/// the same assertions — and the `legal` one reused the matrix's transcript
+/// name, so `SMOKE legal PASS` appeared twice per run with different byte
+/// counts and no way to tell which had failed. A5 is NOT in the matrix, so it
+/// stays.
+pub async fn pagination(app: &tauri::AppHandle, out: &Path) -> usize {
+    let mut failures = 0usize;
+
+    let basic = out.join("basic.pdf");
+    failures += check(
+        "basic",
+        render(
+            app,
+            &doc_for("A4", "<div class='b'>one</div><div class='b'>two</div>"),
+            &basic,
+            A4,
+        )
+        .await,
+        &basic,
+        Some((595, 842)),
+    );
+
+    let a5 = out.join("a5.pdf");
+    failures += check(
+        "a5",
+        render(app, &doc_for("A5", "<p>a5</p>"), &a5, A5).await,
+        &a5,
+        // The whole point: a backend ignoring PageSpec still emits a valid PDF,
+        // just at the platform default.
+        Some((420, 595)),
+    );
+
+    // Over 2 MiB — wry's `.with_html` caps there, so this proves navigation is
+    // used (ADR-PDF4). The SENTINEL is the actual assertion: truncation at the
+    // boundary still yields a valid A4 PDF, so a geometry check alone would pass
+    // on exactly the failure this case exists to catch. The fixture has always
+    // carried the marker; nothing looked for it.
+    let large = out.join("large.pdf");
+    let rendered = render(app, &large_doc("A4"), &large, A4).await;
+    let ok = rendered.is_ok();
+    failures += check("large", rendered, &large, Some((595, 842)));
+    if ok {
+        failures += contains_text("large", &large, "SENTINEL-PAST-2MIB");
+    }
+
+    failures
+}
+
+/// A bad output path must be REFUSED before any print operation starts.
+///
+/// This case is why the renderer validates the path itself. On macOS an
+/// NSPrintOperation pointed at a nonexistent directory does not fail — it spools
+/// the document to the DEFAULT PRINTER. An earlier version of this harness put
+/// four blank pages through a real one.
+pub async fn bad_path(app: &tauri::AppHandle) -> usize {
+    // ABSOLUTE-but-missing, and a POSIX literal is not absolute on Windows: a
+    // leading separator with no drive letter is root-RELATIVE, so validation
+    // refused it at the is_absolute check and returned InvalidInput, never
+    // reaching the missing-directory guard. `commands.test.rs` had already hit
+    // and documented that trap; this is its temp_dir answer.
+    //
+    // The directory name is UNIQUE per process: a fixed name under the shared
+    // temp dir can be left behind by an earlier run or created by a concurrent
+    // one, and then the case silently exercises a VALID destination and passes
+    // for the wrong reason.
+    let dir = std::env::temp_dir().join(format!("vmark-no-such-dir-{}", std::process::id()));
+    if dir.exists() {
+        println!("SMOKE badpath FAIL scratch dir {dir:?} already exists");
+        return 1;
+    }
+    let path = dir.join("x.pdf");
+
+    match vmark_lib::pdf_export::renderer::render_pdf(
+        app.clone(),
+        String::new(),
+        path.to_string_lossy().into_owned(),
+        A4,
+    )
+    .await
+    {
+        Err(e) if e.code() == vmark_lib::command_error::ErrorCode::NotFound => {
+            println!("SMOKE badpath PASS refused up front, code=NotFound");
+            0
+        }
+        Err(e) => {
+            // Refused, but not by the guard — a timeout here means the print
+            // operation STARTED, which is the dangerous path.
+            println!("SMOKE badpath FAIL refused late, code={:?}", e.code());
+            1
+        }
+        Ok(()) => {
+            println!("SMOKE badpath FAIL accepted an impossible path");
+            1
+        }
+    }
+}
+
+/// 20 exports in a row leak no window.
+pub async fn sequential(app: &tauri::AppHandle, out: &Path) -> usize {
+    let before = app.webview_windows().len();
+    let mut completed = 0usize;
+    let mut failures = 0usize;
+    for i in 0..20 {
+        let p = out.join(format!("seq-{i}.pdf"));
+        if render(app, &doc_for("A4", "<p>seq</p>"), &p, A4)
+            .await
+            .is_err()
+        {
+            println!("SMOKE sequential FAIL at {i}");
+            failures += 1;
+            break;
+        }
+        completed += 1;
+    }
+
+    // The renderer settles the sink and THEN closes its window, so the caller
+    // resumes before the close has been processed — counting immediately
+    // measures a close in flight, not a leak. The contract is that windows
+    // return to baseline promptly, so poll for that with a bound: if they never
+    // do, it is a real leak and this still fails.
+    let mut after = app.webview_windows().len();
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while after > before && std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        after = app.webview_windows().len();
+    }
+    if after > before {
+        println!(
+            "SMOKE sequential FAIL leaked {} window(s) after 10s",
+            after - before
+        );
+        failures += 1;
+    } else if completed == 20 {
+        println!("SMOKE sequential PASS 20 exports, windows {before} -> {after}");
+    } else {
+        // Reporting "PASS 20 exports" here is what the old shared-counter
+        // version did after breaking out early.
+        println!("SMOKE sequential FAIL only {completed}/20 exports rendered");
+    }
+    failures
+}
+
+/// Two at once must not collide on a window label — or on each other's output.
+pub async fn concurrent(app: &tauri::AppHandle, out: &Path) -> usize {
+    // The docs and paths are bound first: `tokio::join!` borrows across an await
+    // point, so temporaries created inside it do not live long enough.
+    let (d1, d2) = (doc_for("A4", "<p>c1</p>"), doc_for("A4", "<p>c2</p>"));
+    let (p1, p2) = (out.join("con-1.pdf"), out.join("con-2.pdf"));
+    let (a, b) = tokio::join!(render(app, &d1, &p1, A4), render(app, &d2, &p2, A4),);
+
+    let mut failures = 0usize;
+    let (ok1, ok2) = (a.is_ok(), b.is_ok());
+    failures += check("concurrent-1", a, &p1, Some((595, 842)));
+    failures += check("concurrent-2", b, &p2, Some((595, 842)));
+    // Two `Ok`s were the whole assertion before. They cannot see the failure
+    // this case is named for: a shared window label or a crossed output path
+    // makes both renders succeed while one document overwrites the other, and
+    // both files are valid A4 PDFs afterwards. The distinct sentinels can.
+    if ok1 {
+        failures += contains_text("concurrent-1", &p1, "c1");
+    }
+    if ok2 {
+        failures += contains_text("concurrent-2", &p2, "c2");
+    }
+    failures
+}

--- a/src-tauri/src/bin/pdf_smoke/verify.rs
+++ b/src-tauri/src/bin/pdf_smoke/verify.rs
@@ -90,6 +90,7 @@ pub fn check_stamped(name: &str, path: &Path, skip_first: bool) -> usize {
     let total = pages.len();
     let mut stamped = 0usize;
     let mut unfenced = 0usize;
+    let mut unresolved = 0usize;
     for (_, id) in &pages {
         let content = doc.get_page_content(*id);
         // The font name is distinctive, so this cannot match a renderer's own
@@ -101,18 +102,99 @@ pub fn check_stamped(name: &str, path: &Path, skip_first: bool) -> usize {
         if !fenced(&doc, *id) {
             unfenced += 1;
         }
+        if !font_resolves(&doc, *id) {
+            unresolved += 1;
+        }
     }
     let expected = total.saturating_sub(usize::from(skip_first));
-    if total > 0 && stamped == expected && unfenced == 0 {
-        println!("SMOKE {name} pageno PASS {stamped}/{total} pages stamped, all fenced");
+    if total > 0 && stamped == expected && unfenced == 0 && unresolved == 0 {
+        println!(
+            "SMOKE {name} pageno PASS {stamped}/{total} pages stamped, all fenced and resolved"
+        );
         0
     } else {
         println!(
             "SMOKE {name} pageno FAIL {stamped}/{total} stamped (expected {expected}), \
-             {unfenced} drawn in the renderer's leftover graphics state"
+             {unfenced} drawn in the renderer's leftover graphics state, \
+             {unresolved} selecting a font the page's resources do not define"
         );
         1
     }
+}
+
+/// Does `/VMarkPageNo` actually resolve to a font for this page?
+///
+/// Selecting an undefined font name is not an error a PDF reader reports — it
+/// draws nothing, or substitutes. `add_font_resource` has three branches for
+/// where `/Resources` lives (direct, indirect, inherited from the page tree)
+/// and each renderer takes a different one, so "the operator is present" says
+/// nothing about whether the branch for THIS engine worked.
+fn font_resolves(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> bool {
+    let Ok(page) = doc.get_object(page_id).and_then(|o| o.as_dict()) else {
+        return false;
+    };
+    let resources = match page.get(b"Resources") {
+        Ok(lopdf::Object::Dictionary(d)) => d.clone(),
+        Ok(lopdf::Object::Reference(r)) => match doc.get_object(*r).and_then(|o| o.as_dict()) {
+            Ok(d) => d.clone(),
+            Err(_) => return false,
+        },
+        _ => return false,
+    };
+    let fonts = match resources.get(b"Font") {
+        Ok(lopdf::Object::Dictionary(d)) => d.clone(),
+        Ok(lopdf::Object::Reference(r)) => match doc.get_object(*r).and_then(|o| o.as_dict()) {
+            Ok(d) => d.clone(),
+            Err(_) => return false,
+        },
+        _ => return false,
+    };
+    // Present AND dereferenceable to a real font dictionary.
+    match fonts.get(b"VMarkPageNo") {
+        Ok(lopdf::Object::Reference(r)) => doc
+            .get_object(*r)
+            .and_then(|o| o.as_dict())
+            .map(|d| d.has(b"BaseFont"))
+            .unwrap_or(false),
+        Ok(lopdf::Object::Dictionary(d)) => d.has(b"BaseFont"),
+        _ => false,
+    }
+}
+
+/// Does the PDF's extracted text contain `needle`?
+///
+/// A geometry check cannot see content: a truncated load, or two concurrent
+/// renders writing each other's document, both produce a valid PDF at the right
+/// size. Only reading the text back distinguishes them.
+pub fn contains_text(name: &str, path: &Path, needle: &str) -> usize {
+    let doc = match lopdf::Document::load(path) {
+        Ok(d) => d,
+        Err(e) => {
+            println!("SMOKE {name} content FAIL cannot reload: {e}");
+            return 1;
+        }
+    };
+    let pages: Vec<u32> = doc.get_pages().keys().copied().collect();
+    match doc.extract_text(&pages) {
+        // Whitespace is not preserved faithfully by extraction, so compare with
+        // it removed rather than pretending the layout round-trips.
+        Ok(text) if squeeze(&text).contains(&squeeze(needle)) => {
+            println!("SMOKE {name} content PASS found {needle:?}");
+            0
+        }
+        Ok(_) => {
+            println!("SMOKE {name} content FAIL {needle:?} missing from the text");
+            1
+        }
+        Err(e) => {
+            println!("SMOKE {name} content FAIL cannot extract text: {e}");
+            1
+        }
+    }
+}
+
+fn squeeze(s: &str) -> String {
+    s.chars().filter(|c| !c.is_whitespace()).collect()
 }
 
 /// Is this page's own content fenced off from the stamp?

--- a/src-tauri/src/bin/pdf_smoke/verify.rs
+++ b/src-tauri/src/bin/pdf_smoke/verify.rs
@@ -61,6 +61,45 @@ pub fn check(
     }
 }
 
+/// Verify the page numbers actually landed on the pages.
+///
+/// Reads the content streams rather than trusting `stamp_page_numbers`' return:
+/// the stamp writes an extra content stream and a font resource per page, and a
+/// PDF that dropped either still loads, still has the right MediaBox, and shows
+/// nothing in the footer. That is precisely the failure a human skimming an
+/// artifact does not notice on page 14 of 20.
+///
+/// Returns the failure count, and prints the number of stamped pages so the
+/// three platforms' transcripts can be diffed directly.
+pub fn check_stamped(name: &str, path: &Path, skip_first: bool) -> usize {
+    let doc = match lopdf::Document::load(path) {
+        Ok(d) => d,
+        Err(e) => {
+            println!("SMOKE {name} pageno FAIL cannot reload: {e}");
+            return 1;
+        }
+    };
+    let pages: Vec<_> = doc.get_pages().into_iter().collect();
+    let total = pages.len();
+    let stamped = pages
+        .iter()
+        .filter(|(_, id)| {
+            let content = doc.get_page_content(*id);
+            // The font name is distinctive, so this cannot match a renderer's
+            // own /F1 — see add_font_resource.
+            count(&content, b"/VMarkPageNo") > 0
+        })
+        .count();
+    let expected = total.saturating_sub(usize::from(skip_first));
+    if stamped == expected && total > 0 {
+        println!("SMOKE {name} pageno PASS {stamped}/{total} pages stamped");
+        0
+    } else {
+        println!("SMOKE {name} pageno FAIL {stamped}/{total} stamped, expected {expected}");
+        1
+    }
+}
+
 pub fn count(hay: &[u8], needle: &[u8]) -> usize {
     hay.windows(needle.len()).filter(|w| *w == needle).count()
 }

--- a/src-tauri/src/bin/pdf_smoke/verify.rs
+++ b/src-tauri/src/bin/pdf_smoke/verify.rs
@@ -61,7 +61,7 @@ pub fn check(
     }
 }
 
-/// Verify the page numbers actually landed on the pages.
+/// Verify the page numbers actually landed on the pages, the right way up.
 ///
 /// Reads the content streams rather than trusting `stamp_page_numbers`' return:
 /// the stamp writes an extra content stream and a font resource per page, and a
@@ -69,8 +69,15 @@ pub fn check(
 /// nothing in the footer. That is precisely the failure a human skimming an
 /// artifact does not notice on page 14 of 20.
 ///
-/// Returns the failure count, and prints the number of stamped pages so the
-/// three platforms' transcripts can be diffed directly.
+/// PRESENCE IS NOT ENOUGH, and this function learned that the hard way: it
+/// passed on Windows and Linux while the number was drawing at the top of the
+/// page and mirrored, because the renderer's unbalanced y-flip was still in
+/// effect. So it also checks the fence — the page's own content wrapped in q/Q
+/// before the stamp — which is what makes the coordinates mean what
+/// `baseline()` computed.
+///
+/// Returns the failure count, and prints the counts so the three platforms'
+/// transcripts can be diffed directly.
 pub fn check_stamped(name: &str, path: &Path, skip_first: bool) -> usize {
     let doc = match lopdf::Document::load(path) {
         Ok(d) => d,
@@ -81,23 +88,67 @@ pub fn check_stamped(name: &str, path: &Path, skip_first: bool) -> usize {
     };
     let pages: Vec<_> = doc.get_pages().into_iter().collect();
     let total = pages.len();
-    let stamped = pages
-        .iter()
-        .filter(|(_, id)| {
-            let content = doc.get_page_content(*id);
-            // The font name is distinctive, so this cannot match a renderer's
-            // own /F1 — see add_font_resource.
-            count(&content, b"/VMarkPageNo") > 0
-        })
-        .count();
+    let mut stamped = 0usize;
+    let mut unfenced = 0usize;
+    for (_, id) in &pages {
+        let content = doc.get_page_content(*id);
+        // The font name is distinctive, so this cannot match a renderer's own
+        // /F1 — see add_font_resource.
+        if count(&content, b"/VMarkPageNo") == 0 {
+            continue;
+        }
+        stamped += 1;
+        if !fenced(&doc, *id) {
+            unfenced += 1;
+        }
+    }
     let expected = total.saturating_sub(usize::from(skip_first));
-    if stamped == expected && total > 0 {
-        println!("SMOKE {name} pageno PASS {stamped}/{total} pages stamped");
+    if total > 0 && stamped == expected && unfenced == 0 {
+        println!("SMOKE {name} pageno PASS {stamped}/{total} pages stamped, all fenced");
         0
     } else {
-        println!("SMOKE {name} pageno FAIL {stamped}/{total} stamped, expected {expected}");
+        println!(
+            "SMOKE {name} pageno FAIL {stamped}/{total} stamped (expected {expected}), \
+             {unfenced} drawn in the renderer's leftover graphics state"
+        );
         1
     }
+}
+
+/// Is this page's own content fenced off from the stamp?
+///
+/// The array must be `[q, original…, Q, stamp]`: anything else means the stamp
+/// inherits whatever CTM the renderer left behind.
+fn fenced(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> bool {
+    let Ok(lopdf::Object::Array(contents)) = doc
+        .get_object(page_id)
+        .and_then(|o| o.as_dict())
+        .and_then(|d| d.get(b"Contents"))
+    else {
+        return false;
+    };
+    let body_of = |o: &lopdf::Object| -> Vec<u8> {
+        match o {
+            lopdf::Object::Reference(r) => doc
+                .get_object(*r)
+                .and_then(|o| o.as_stream())
+                .map(|s| s.content.clone())
+                .unwrap_or_default(),
+            _ => Vec::new(),
+        }
+    };
+    let Some(first) = contents.first() else {
+        return false;
+    };
+    let Some(stamp_at) = contents
+        .iter()
+        .position(|o| count(&body_of(o), b"/VMarkPageNo") > 0)
+    else {
+        return false;
+    };
+    body_of(first).trim_ascii() == b"q"
+        && stamp_at > 0
+        && body_of(&contents[stamp_at - 1]).trim_ascii() == b"Q"
 }
 
 pub fn count(hay: &[u8], needle: &[u8]) -> usize {

--- a/src-tauri/src/pdf_export/commands.rs
+++ b/src-tauri/src/pdf_export/commands.rs
@@ -75,7 +75,8 @@ pub(super) fn validate_output_path(output_path: &str) -> Result<(), CommandError
 /// Emits `pdf-export-progress` events to the `pdf-export` window
 /// with status updates: "loading", "rendering", "done".
 ///
-/// After PDF generation, injects heading-based bookmarks using PDFKit.
+/// After the render, post-processes the file: heading bookmarks, then page
+/// numbers. Both are cross-platform (lopdf) and both are best-effort.
 #[tauri::command]
 pub async fn export_pdf(
     app: tauri::AppHandle,
@@ -83,6 +84,7 @@ pub async fn export_pdf(
     output_path: String,
     headings: Option<Vec<Heading>>,
     page: PageSpec,
+    page_numbers: Option<super::page_numbers::PageNumberSpec>,
 ) -> Result<(), CommandError> {
     validate_output_path(&output_path)?;
     page.validate()?;
@@ -101,6 +103,16 @@ pub async fn export_pdf(
             if let Err(e) = super::outline::add_outline(&output_path, headings) {
                 log::warn!("[PDF] outline injection failed (PDF still valid): {}", e);
             }
+        }
+    }
+
+    // Page numbers, after the outline so the two post-processors compose in a
+    // fixed order and each sees a complete file. Same best-effort policy, and
+    // the same reason it is honest: the write is atomic, so a failure leaves
+    // the rendered PDF exactly as it was.
+    if let Some(ref spec) = page_numbers {
+        if let Err(e) = super::page_numbers::stamp_page_numbers(&output_path, spec) {
+            log::warn!("[PDF] page numbering failed (PDF still valid): {}", e);
         }
     }
 

--- a/src-tauri/src/pdf_export/commands.rs
+++ b/src-tauri/src/pdf_export/commands.rs
@@ -70,13 +70,30 @@ pub(super) fn validate_output_path(output_path: &str) -> Result<(), CommandError
     Ok(())
 }
 
+/// What the export produced, beyond "it did not fail".
+///
+/// Post-processing is best-effort — a PDF missing its sidebar or its footer is
+/// a worse PDF, not a failed export, and refusing the whole job over one would
+/// throw away the document the user just waited for. But returning a bare `Ok`
+/// made the UI claim unqualified success while a setting the user explicitly
+/// turned on had silently not happened. So the steps that failed are NAMED and
+/// the dialog says so.
+///
+/// Stable slugs, not prose: the frontend maps them to its own translations.
+#[derive(Debug, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportOutcome {
+    pub warnings: Vec<&'static str>,
+}
+
 /// Export HTML content to a PDF file using the platform's native webview.
 ///
 /// Emits `pdf-export-progress` events to the `pdf-export` window
 /// with status updates: "loading", "rendering", "done".
 ///
 /// After the render, post-processes the file: heading bookmarks, then page
-/// numbers. Both are cross-platform (lopdf) and both are best-effort.
+/// numbers. Both are cross-platform (lopdf) and both are best-effort — see
+/// `ExportOutcome`.
 #[tauri::command]
 pub async fn export_pdf(
     app: tauri::AppHandle,
@@ -85,38 +102,72 @@ pub async fn export_pdf(
     headings: Option<Vec<Heading>>,
     page: PageSpec,
     page_numbers: Option<super::page_numbers::PageNumberSpec>,
-) -> Result<(), CommandError> {
+) -> Result<ExportOutcome, CommandError> {
     validate_output_path(&output_path)?;
     page.validate()?;
+    // Validated for the same reason `page` is: this arrives as JSON over IPC,
+    // so a NaN font size would reach the `Tf` operator as the literal "NaN" and
+    // produce a corrupt content stream.
+    if let Some(ref spec) = page_numbers {
+        spec.validate()?;
+    }
 
+    let app_for_progress = app.clone();
     renderer::render_pdf(app, html, output_path.clone(), page).await?;
 
-    // Add the outline if headings were provided. Cross-platform since the
-    // injector became lopdf rather than PDFKit — Windows and Linux used to ship
-    // outline-less PDFs (ADR-PDF3).
-    //
-    // Still not an error path: a PDF without a sidebar is a worse PDF, not a
-    // failed export, and refusing the whole job over it would lose the document
-    // the user just waited for.
-    if let Some(ref headings) = headings {
-        if !headings.is_empty() {
-            if let Err(e) = super::outline::add_outline(&output_path, headings) {
-                log::warn!("[PDF] outline injection failed (PDF still valid): {}", e);
-            }
+    // Post-processing is synchronous, CPU-bound and reads/serializes the whole
+    // file, so it does not belong on a Tokio worker: a large export would
+    // occupy one for the duration and starve unrelated async work in the same
+    // runtime. `spawn_blocking` is the thread pool meant for exactly this.
+    let outcome = tokio::task::spawn_blocking(move || {
+        post_process(&output_path, headings.as_deref(), page_numbers.as_ref())
+    })
+    .await
+    .map_err(|e| {
+        localized_error!(
+            ErrorCode::Internal,
+            "errors.pdf.postProcessPanicked",
+            detail = e.to_string()
+        )
+    })?;
+
+    // Completion is emitted HERE, after the outline and the page numbers, so
+    // the stage the user sees matches what the file has.
+    renderer::emit_progress(&app_for_progress, "done");
+
+    Ok(outcome)
+}
+
+/// Inject the outline, then stamp page numbers. Never fails the export.
+///
+/// The order is fixed so the two composers each see a complete file, and so a
+/// change to one cannot silently reorder the other.
+fn post_process(
+    output_path: &str,
+    headings: Option<&[Heading]>,
+    page_numbers: Option<&super::page_numbers::PageNumberSpec>,
+) -> ExportOutcome {
+    let mut outcome = ExportOutcome::default();
+
+    // Cross-platform since the injector became lopdf rather than PDFKit —
+    // Windows and Linux used to ship outline-less PDFs (ADR-PDF3).
+    if let Some(headings) = headings.filter(|h| !h.is_empty()) {
+        if let Err(e) = super::outline::add_outline(output_path, headings) {
+            log::warn!("[PDF] outline injection failed (PDF still valid): {}", e);
+            outcome.warnings.push("outline-failed");
         }
     }
 
-    // Page numbers, after the outline so the two post-processors compose in a
-    // fixed order and each sees a complete file. Same best-effort policy, and
-    // the same reason it is honest: the write is atomic, so a failure leaves
-    // the rendered PDF exactly as it was.
-    if let Some(ref spec) = page_numbers {
-        if let Err(e) = super::page_numbers::stamp_page_numbers(&output_path, spec) {
+    // The write is atomic, so a failure here leaves the rendered PDF exactly as
+    // it was — which is what makes "warn and continue" honest rather than lossy.
+    if let Some(spec) = page_numbers {
+        if let Err(e) = super::page_numbers::stamp_page_numbers(output_path, spec) {
             log::warn!("[PDF] page numbering failed (PDF still valid): {}", e);
+            outcome.warnings.push("page-numbers-failed");
         }
     }
 
-    Ok(())
+    outcome
 }
 
 /// Print HTML content via native macOS print dialog.

--- a/src-tauri/src/pdf_export/mod.rs
+++ b/src-tauri/src/pdf_export/mod.rs
@@ -7,13 +7,20 @@
 //! A heading outline is injected on EVERY platform, via lopdf. It was PDFKit
 //! and therefore macOS-only until now, so Windows and Linux shipped PDFs with
 //! no sidebar table of contents (ADR-PDF3, now closed).
+//!
+//! Page numbers are stamped the same way and for the same reason: CSS puts them
+//! in `@page` margin boxes, which WebKit does not implement, so post-processing
+//! the finished file is the only route that behaves identically on all three.
 
 pub mod commands;
 pub mod heading;
 pub mod outline;
 mod outline_match;
 mod outline_tree;
+pub mod page_numbers;
+mod page_numbers_label;
 pub mod page_spec;
+mod pdf_io;
 pub mod renderer;
 
 #[cfg(test)]

--- a/src-tauri/src/pdf_export/outline.rs
+++ b/src-tauri/src/pdf_export/outline.rs
@@ -169,15 +169,38 @@ pub fn add_outline(pdf_path: &str, headings: &[Heading]) -> Result<(), String> {
     // the same page. Only a repeat of the same text needs to skip past its own
     // previous hit — two DIFFERENT headings frequently share one page.
     let mut placed: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    // How many bookmarks this exact text has already consumed on a given page.
+    // Skipping to `prev + 1` unconditionally — which is what this replaces —
+    // made two identically-named sections on ONE page unplaceable: the second
+    // was pushed to wherever the text next appeared, or fell back to the cursor.
+    let mut consumed: std::collections::HashMap<(&str, usize), usize> =
+        std::collections::HashMap::new();
     for h in headings {
         let from = match placed.get(h.text.as_str()) {
-            Some(prev) => cursor.max(prev.saturating_add(1)),
+            Some(prev) => {
+                let used = consumed
+                    .get(&(h.text.as_str(), *prev))
+                    .copied()
+                    .unwrap_or(1);
+                let available = page_texts
+                    .get(*prev)
+                    .map(|t| super::outline_match::occurrences_on_page(t, &h.text))
+                    .unwrap_or(0);
+                // Stay on the page only while it genuinely carries another
+                // occurrence; otherwise move past it as before.
+                if available > used {
+                    cursor.max(*prev)
+                } else {
+                    cursor.max(prev.saturating_add(1))
+                }
+            }
             None => cursor,
         };
         match super::outline_match::find_heading_page(&page_texts, &h.text, from) {
             Some(page) => {
                 cursor = page;
                 placed.insert(h.text.as_str(), page);
+                *consumed.entry((h.text.as_str(), page)).or_insert(0) += 1;
                 located.push((h.level, h.text.clone(), page));
             }
             None => {
@@ -222,7 +245,7 @@ pub fn add_outline(pdf_path: &str, headings: &[Heading]) -> Result<(), String> {
     // Atomic replace, shared with the page-number stamper: both rewrite a PDF
     // the renderer already produced, and both callers downgrade failure to a
     // warning, which is only honest while the original survives.
-    super::pdf_io::save_atomically(&mut doc, pdf_path, ".vmark-outline-")?;
+    super::pdf_io::save_atomically(&mut doc, pdf_path)?;
 
     log::info!("[PDF] outline written with {} headings", headings.len());
     Ok(())

--- a/src-tauri/src/pdf_export/outline.rs
+++ b/src-tauri/src/pdf_export/outline.rs
@@ -219,39 +219,10 @@ pub fn add_outline(pdf_path: &str, headings: &[Heading]) -> Result<(), String> {
     // outline looks absent even though it is there.
     catalog.set("PageMode", Object::Name(b"UseOutlines".to_vec()));
 
-    // Write beside the target and rename over it. `Document::save` truncates
-    // its path before serializing, so saving in place would destroy a PDF the
-    // renderer had already produced correctly if anything failed mid-write —
-    // and the caller deliberately downgrades an outline failure to a warning,
-    // which is only honest while a failure leaves the original intact.
-    //
-    // The temp file comes from `tempfile`, not a derived name like
-    // `x.outline.tmp`. A deterministic name is the same defect this crate's own
-    // renderer already had once: it can be pre-created as a symlink, which
-    // `File::create` follows straight back onto the target, and two concurrent
-    // exports of the same document would share it. `tempfile` creates with
-    // O_EXCL and 0600, and `TempPath` deletes on drop, so an error path cannot
-    // leave the scratch file behind.
-    //
-    // Same directory, so `persist` is a same-filesystem rename rather than a
-    // copy across devices that can itself fail halfway.
-    let target = std::path::Path::new(pdf_path);
-    let dir = target.parent().filter(|d| !d.as_os_str().is_empty());
-    let mut builder = tempfile::Builder::new();
-    builder.prefix(".vmark-outline-").suffix(".pdf");
-    let tmp = match dir {
-        Some(d) => builder.tempfile_in(d),
-        None => builder.tempfile(),
-    }
-    .map_err(|e| format!("create temp PDF: {e}"))?;
-    // Close our handle before lopdf opens the path itself; Windows refuses a
-    // rename over a file that still has an open handle.
-    let tmp_path = tmp.into_temp_path();
-
-    doc.save(&tmp_path).map_err(|e| format!("save PDF: {e}"))?;
-    tmp_path
-        .persist(target)
-        .map_err(|e| format!("replace PDF: {e}"))?;
+    // Atomic replace, shared with the page-number stamper: both rewrite a PDF
+    // the renderer already produced, and both callers downgrade failure to a
+    // warning, which is only honest while the original survives.
+    super::pdf_io::save_atomically(&mut doc, pdf_path, ".vmark-outline-")?;
 
     log::info!("[PDF] outline written with {} headings", headings.len());
     Ok(())

--- a/src-tauri/src/pdf_export/outline_match.rs
+++ b/src-tauri/src/pdf_export/outline_match.rs
@@ -73,6 +73,35 @@ pub(super) fn find_heading_page(
         .find_map(|predicate| search_forward(page_texts, start_page, predicate))
 }
 
+/// How many times `heading_text` appears as a heading-shaped line on `page`.
+///
+/// Used to decide whether a REPEATED heading can resolve to the page its
+/// previous occurrence took. The caller used to force a repeat to start one page
+/// later unconditionally, which made two identically-named sections on a single
+/// page impossible to place — the second bookmark jumped forward to wherever the
+/// text next appeared, or fell back to the cursor. Counting lets the repeat stay
+/// put when the page really does carry it twice, while a page carrying it once
+/// still pushes the repeat forward, which is what the original guard was for.
+///
+/// Deliberately uses only the strict whole-line shape. The looser substring
+/// passes exist to rescue mangled extraction, and counting with them would let
+/// one visual heading plus a body mention read as two headings.
+pub(super) fn occurrences_on_page(page: &str, heading_text: &str) -> usize {
+    let needle = heading_text.trim();
+    if needle.is_empty() {
+        return 0;
+    }
+    page.lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            trimmed == needle
+                || trimmed
+                    .strip_prefix(needle)
+                    .is_some_and(|rest| rest.starts_with(|c: char| !c.is_alphanumeric()))
+        })
+        .count()
+}
+
 /// Search pages from `start_page` forward. Never wraps.
 ///
 /// Wrapping used to let a bookmark point BACKWARD past the previous heading,

--- a/src-tauri/src/pdf_export/outline_match.test.rs
+++ b/src-tauri/src/pdf_export/outline_match.test.rs
@@ -198,3 +198,37 @@ fn a_repeated_heading_text_does_not_claim_the_same_page_twice() {
     assert_eq!(find_heading_page(&p, "Overview", 0), Some(0));
     assert_eq!(find_heading_page(&p, "Overview", 1), Some(2));
 }
+
+// --- occurrences_on_page: how many bookmarks one page can absorb ---
+
+#[test]
+fn a_page_carrying_the_heading_twice_reports_two() {
+    // This is what lets two identically-named sections on ONE page both keep
+    // their own bookmark. Skipping to the next page unconditionally — the rule
+    // this count replaced — made the second unplaceable.
+    let page = "Overview\nsome body\nOverview\nmore body";
+    assert_eq!(occurrences_on_page(page, "Overview"), 2);
+}
+
+#[test]
+fn a_body_mention_is_not_counted_as_a_heading() {
+    // Only the whole-line shape counts. The looser passes in `find_heading_page`
+    // exist to rescue mangled extraction; counting with them would read one
+    // visible heading plus a sentence about it as two sections, and push the
+    // second bookmark onto a page that has no such heading.
+    let page = "Overview\nsee the Overview section for details";
+    assert_eq!(occurrences_on_page(page, "Overview"), 1);
+}
+
+#[test]
+fn a_trailing_punctuation_variant_still_counts() {
+    // Extraction routinely glues a number or a separator onto the heading line.
+    assert_eq!(occurrences_on_page("Overview:\nbody", "Overview"), 1);
+    // But a longer word starting with the needle is a different heading.
+    assert_eq!(occurrences_on_page("Overviewing\nbody", "Overview"), 0);
+}
+
+#[test]
+fn an_empty_needle_counts_nothing() {
+    assert_eq!(occurrences_on_page("anything", "   "), 0);
+}

--- a/src-tauri/src/pdf_export/page_numbers.rs
+++ b/src-tauri/src/pdf_export/page_numbers.rs
@@ -1,0 +1,218 @@
+//! Stamping page numbers onto a finished PDF.
+//!
+//! Purpose: exported PDFs had no page numbers on any platform. CSS puts them in
+//! `@page` margin boxes, which WebKit does not implement — so the setting was
+//! never offered rather than working on one platform out of three.
+//!
+//! Done AFTER the render, on the finished file, for the same reason the outline
+//! is: it takes the engines out of the question entirely. One code path, the
+//! same bytes on macOS, Windows and Linux, no async pagination to wait for.
+//!
+//! What to draw and where lives next door in `page_numbers_label.rs`; this file
+//! is the document surgery that puts it on the page.
+//!
+//! @coordinates-with page_numbers_label.rs — the spec, the label, the geometry
+//! @coordinates-with pdf_io.rs — the atomic save both post-processors share
+//! @coordinates-with commands.rs — calls this after the render and the outline
+//! @module pdf_export/page_numbers
+
+use lopdf::{dictionary, Dictionary, Document, Object, ObjectId, Stream};
+
+use super::page_numbers_label::{baseline, escape, render_label, text_width};
+// The feature's public vocabulary. Re-exported so callers say
+// `page_numbers::PageNumberSpec` rather than reaching into the private half.
+pub use super::page_numbers_label::{Format, PageNumberSpec, Position};
+
+/// Stamp page numbers onto an existing PDF, in place.
+pub fn stamp_page_numbers(pdf_path: &str, spec: &PageNumberSpec) -> Result<(), String> {
+    if spec.position == Position::None {
+        return Ok(());
+    }
+
+    let mut doc = Document::load(pdf_path).map_err(|e| format!("open PDF: {e}"))?;
+    let pages: Vec<(u32, ObjectId)> = doc.get_pages().into_iter().collect();
+    let total = pages.len();
+    if total == 0 {
+        return Err(rust_i18n::t!("errors.pdf.noPages").to_string());
+    }
+
+    // One font object for the whole document rather than one per page.
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font",
+        "Subtype" => "Type1",
+        "BaseFont" => "Helvetica",
+        "Encoding" => "WinAnsiEncoding",
+    });
+
+    let mut unrenderable = 0usize;
+    for (page_no, page_id) in pages {
+        let n = page_no as usize;
+        if spec.skip_first && n == 1 {
+            continue;
+        }
+        let Some(label) = render_label(spec, n, total) else {
+            unrenderable += 1;
+            continue;
+        };
+
+        let (page_width, _) = page_size(&doc, page_id);
+        let width = text_width(&label, spec.font_size_pt);
+        let (x, y) = baseline(spec, page_width, width);
+
+        // q/Q around the whole thing: the page's own content stream may leave
+        // an arbitrary graphics state, and inheriting it would tint or clip the
+        // number unpredictably.
+        let mut ops = Vec::new();
+        ops.extend_from_slice(b"q\nBT\n0 0 0 rg\n/VMarkPageNo ");
+        ops.extend_from_slice(format!("{:.2}", spec.font_size_pt).as_bytes());
+        ops.extend_from_slice(b" Tf\n");
+        ops.extend_from_slice(format!("{x:.2} {y:.2} Td\n").as_bytes());
+        ops.push(b'(');
+        ops.extend_from_slice(&escape(&label));
+        ops.extend_from_slice(b") Tj\nET\nQ\n");
+
+        let stamp_id = doc.add_object(Stream::new(Dictionary::new(), ops));
+        append_content(&mut doc, page_id, stamp_id)?;
+        add_font_resource(&mut doc, page_id, font_id)?;
+    }
+
+    if unrenderable > 0 {
+        log::warn!(
+            "[PDF] page-number label is not Latin-1 and Helvetica cannot draw it; \
+             {unrenderable} page(s) left unnumbered"
+        );
+    }
+
+    super::pdf_io::save_atomically(&mut doc, pdf_path, ".vmark-pageno-")?;
+    log::info!("[PDF] stamped page numbers on {total} page(s)");
+    Ok(())
+}
+
+/// A page's width and height from its MediaBox, defaulting to A4.
+fn page_size(doc: &Document, page_id: ObjectId) -> (f64, f64) {
+    let fallback = (595.28, 841.89);
+    let Ok(page) = doc.get_object(page_id).and_then(|o| o.as_dict()) else {
+        return fallback;
+    };
+    // MediaBox is an INHERITABLE attribute: a page may carry none and take its
+    // parent's. Walking up is not optional — every page produced by these
+    // renderers inherits it, so reading only the page would fall back to A4 and
+    // silently mis-centre every number on Letter or A5.
+    let mut node = page.clone();
+    let mut mb = None;
+    for _ in 0..32 {
+        if let Ok(arr) = node.get(b"MediaBox").and_then(|o| o.as_array()) {
+            mb = Some(arr.to_vec());
+            break;
+        }
+        let Ok(parent) = node.get(b"Parent").and_then(|o| o.as_reference()) else {
+            break;
+        };
+        let Ok(next) = doc.get_object(parent).and_then(|o| o.as_dict()) else {
+            break;
+        };
+        node = next.clone();
+    }
+    let Some(mb) = mb else { return fallback };
+    if mb.len() != 4 {
+        return fallback;
+    }
+    let num = |i: usize| {
+        mb[i]
+            .as_float()
+            .map(f64::from)
+            .or_else(|_| mb[i].as_i64().map(|v| v as f64))
+    };
+    match (num(0), num(1), num(2), num(3)) {
+        (Ok(x0), Ok(y0), Ok(x1), Ok(y1)) => ((x1 - x0).abs(), (y1 - y0).abs()),
+        _ => fallback,
+    }
+}
+
+/// Append a content stream to a page, promoting a single stream to an array.
+fn append_content(doc: &mut Document, page_id: ObjectId, stamp: ObjectId) -> Result<(), String> {
+    let page = doc
+        .get_object_mut(page_id)
+        .and_then(|o| o.as_dict_mut())
+        .map_err(|e| format!("page dictionary: {e}"))?;
+    match page.get(b"Contents").cloned() {
+        Ok(Object::Array(mut a)) => {
+            a.push(Object::Reference(stamp));
+            page.set("Contents", Object::Array(a));
+        }
+        Ok(Object::Reference(r)) => {
+            page.set(
+                "Contents",
+                Object::Array(vec![Object::Reference(r), Object::Reference(stamp)]),
+            );
+        }
+        _ => page.set("Contents", Object::Array(vec![Object::Reference(stamp)])),
+    }
+    Ok(())
+}
+
+/// Walk the page tree for an inherited `/Resources` dictionary.
+fn inherited_resources(doc: &Document, page_id: ObjectId) -> Option<Dictionary> {
+    let mut node = doc.get_object(page_id).ok()?.as_dict().ok()?.clone();
+    for _ in 0..32 {
+        match node.get(b"Resources") {
+            Ok(Object::Dictionary(d)) => return Some(d.clone()),
+            Ok(Object::Reference(r)) => {
+                return doc.get_object(*r).ok()?.as_dict().ok().cloned();
+            }
+            _ => {}
+        }
+        let parent = node.get(b"Parent").and_then(|o| o.as_reference()).ok()?;
+        node = doc.get_object(parent).ok()?.as_dict().ok()?.clone();
+    }
+    None
+}
+
+/// Register the font under `/VMarkPageNo` in the page's resources.
+///
+/// A distinctive name so it cannot collide with a font the renderer already
+/// named `/F1` — which every engine here does.
+fn add_font_resource(doc: &mut Document, page_id: ObjectId, font: ObjectId) -> Result<(), String> {
+    let existing = doc
+        .get_object(page_id)
+        .and_then(|o| o.as_dict())
+        .ok()
+        .and_then(|d| d.get(b"Resources").ok().cloned());
+
+    let mut resources = match existing {
+        Some(Object::Dictionary(d)) => d,
+        // Resources can be an indirect reference, and can be inherited from the
+        // page tree. Either way, give this page its own so the edit cannot
+        // reach a dictionary shared with pages we did not stamp.
+        Some(Object::Reference(r)) => doc
+            .get_object(r)
+            .and_then(|o| o.as_dict())
+            .cloned()
+            .unwrap_or_default(),
+        // Inherited from the page tree, or absent entirely.
+        _ => inherited_resources(doc, page_id).unwrap_or_default(),
+    };
+
+    let mut fonts = match resources.get(b"Font") {
+        Ok(Object::Dictionary(d)) => d.clone(),
+        Ok(Object::Reference(r)) => doc
+            .get_object(*r)
+            .and_then(|o| o.as_dict())
+            .cloned()
+            .unwrap_or_default(),
+        _ => Dictionary::new(),
+    };
+    fonts.set("VMarkPageNo", Object::Reference(font));
+    resources.set("Font", Object::Dictionary(fonts));
+
+    let page = doc
+        .get_object_mut(page_id)
+        .and_then(|o| o.as_dict_mut())
+        .map_err(|e| format!("page dictionary: {e}"))?;
+    page.set("Resources", Object::Dictionary(resources));
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "page_numbers.test.rs"]
+mod tests;

--- a/src-tauri/src/pdf_export/page_numbers.rs
+++ b/src-tauri/src/pdf_export/page_numbers.rs
@@ -44,6 +44,23 @@ pub fn stamp_page_numbers(pdf_path: &str, spec: &PageNumberSpec) -> Result<(), S
         "Encoding" => "WinAnsiEncoding",
     });
 
+    // A page's content streams are CONCATENATED into one stream, so anything
+    // the renderer left in the graphics state is still in effect when our
+    // stamp begins. Both WebView2 and WebKitGTK emit a top-level
+    // `1 0 0 -1 0 <height> cm` — a y-flip they never undo — and our own `q`/`Q`
+    // does not help, because `q` saves the CURRENT state rather than resetting
+    // to the identity CTM. The number then drew at the TOP of the page and
+    // mirrored, on two platforms out of three, while every structural check
+    // passed and the text still extracted cleanly.
+    //
+    // Wrapping the ORIGINAL content in its own q/Q discards whatever it leaves,
+    // so the stamp starts from the page's default space where (0,0) is the
+    // bottom-left corner — which is the space `baseline()` computes in. One
+    // pair of streams shared by every page; they are indirect objects, so
+    // several Contents arrays may reference them.
+    let push_state = doc.add_object(Stream::new(Dictionary::new(), b"q\n".to_vec()));
+    let pop_state = doc.add_object(Stream::new(Dictionary::new(), b"Q\n".to_vec()));
+
     let mut unrenderable = 0usize;
     for (page_no, page_id) in pages {
         let n = page_no as usize;
@@ -59,9 +76,8 @@ pub fn stamp_page_numbers(pdf_path: &str, spec: &PageNumberSpec) -> Result<(), S
         let width = text_width(&label, spec.font_size_pt);
         let (x, y) = baseline(spec, page_width, width);
 
-        // q/Q around the whole thing: the page's own content stream may leave
-        // an arbitrary graphics state, and inheriting it would tint or clip the
-        // number unpredictably.
+        // q/Q around our own drawing too, so the colour and font selection do
+        // not leak onto anything appended after us.
         let mut ops = Vec::new();
         ops.extend_from_slice(b"q\nBT\n0 0 0 rg\n/VMarkPageNo ");
         ops.extend_from_slice(format!("{:.2}", spec.font_size_pt).as_bytes());
@@ -72,7 +88,7 @@ pub fn stamp_page_numbers(pdf_path: &str, spec: &PageNumberSpec) -> Result<(), S
         ops.extend_from_slice(b") Tj\nET\nQ\n");
 
         let stamp_id = doc.add_object(Stream::new(Dictionary::new(), ops));
-        append_content(&mut doc, page_id, stamp_id)?;
+        append_content(&mut doc, page_id, stamp_id, push_state, pop_state)?;
         add_font_resource(&mut doc, page_id, font_id)?;
     }
 
@@ -129,25 +145,32 @@ fn page_size(doc: &Document, page_id: ObjectId) -> (f64, f64) {
     }
 }
 
-/// Append a content stream to a page, promoting a single stream to an array.
-fn append_content(doc: &mut Document, page_id: ObjectId, stamp: ObjectId) -> Result<(), String> {
+/// Append the stamp to a page, with the page's own content fenced off.
+///
+/// The result is always `[q, <original…>, Q, stamp]`. The fence is not
+/// decoration: see `stamp_page_numbers` — without it the stamp inherits the
+/// renderer's unbalanced y-flip and draws upside-down at the top of the page.
+fn append_content(
+    doc: &mut Document,
+    page_id: ObjectId,
+    stamp: ObjectId,
+    push_state: ObjectId,
+    pop_state: ObjectId,
+) -> Result<(), String> {
     let page = doc
         .get_object_mut(page_id)
         .and_then(|o| o.as_dict_mut())
         .map_err(|e| format!("page dictionary: {e}"))?;
+    let mut contents = vec![Object::Reference(push_state)];
     match page.get(b"Contents").cloned() {
-        Ok(Object::Array(mut a)) => {
-            a.push(Object::Reference(stamp));
-            page.set("Contents", Object::Array(a));
-        }
-        Ok(Object::Reference(r)) => {
-            page.set(
-                "Contents",
-                Object::Array(vec![Object::Reference(r), Object::Reference(stamp)]),
-            );
-        }
-        _ => page.set("Contents", Object::Array(vec![Object::Reference(stamp)])),
+        Ok(Object::Array(a)) => contents.extend(a),
+        Ok(Object::Reference(r)) => contents.push(Object::Reference(r)),
+        // A page with no content at all is still stampable.
+        _ => {}
     }
+    contents.push(Object::Reference(pop_state));
+    contents.push(Object::Reference(stamp));
+    page.set("Contents", Object::Array(contents));
     Ok(())
 }
 

--- a/src-tauri/src/pdf_export/page_numbers.rs
+++ b/src-tauri/src/pdf_export/page_numbers.rs
@@ -21,7 +21,7 @@ use lopdf::{dictionary, Dictionary, Document, Object, ObjectId, Stream};
 use super::page_numbers_label::{baseline, escape, render_label, text_width};
 // The feature's public vocabulary. Re-exported so callers say
 // `page_numbers::PageNumberSpec` rather than reaching into the private half.
-pub use super::page_numbers_label::{Format, PageNumberSpec, Position};
+pub use super::page_numbers_label::{Format, InkRgb, PageNumberSpec, Position};
 
 /// Stamp page numbers onto an existing PDF, in place.
 pub fn stamp_page_numbers(pdf_path: &str, spec: &PageNumberSpec) -> Result<(), String> {
@@ -61,25 +61,33 @@ pub fn stamp_page_numbers(pdf_path: &str, spec: &PageNumberSpec) -> Result<(), S
     let push_state = doc.add_object(Stream::new(Dictionary::new(), b"q\n".to_vec()));
     let pop_state = doc.add_object(Stream::new(Dictionary::new(), b"Q\n".to_vec()));
 
-    let mut unrenderable = 0usize;
+    let mut downgraded = 0usize;
     for (page_no, page_id) in pages {
         let n = page_no as usize;
         if spec.skip_first && n == 1 {
             continue;
         }
-        let Some(label) = render_label(spec, n, total) else {
-            unrenderable += 1;
-            continue;
-        };
+        let (label, fell_back) = render_label(spec, n, total);
+        if fell_back {
+            downgraded += 1;
+        }
 
-        let (page_width, _) = page_size(&doc, page_id);
+        let (origin_x, origin_y, page_width, _) = page_box(&doc, page_id);
         let width = text_width(&label, spec.font_size_pt);
-        let (x, y) = baseline(spec, page_width, width);
+        // `baseline` works in a page-relative space starting at (0,0); a
+        // MediaBox need not start there, and a cropped or imposed PDF that
+        // begins at, say, [20 20 615 862] would take the number 20pt off both
+        // edges — or off the sheet entirely for a large origin.
+        let (rel_x, rel_y) = baseline(spec, page_width, width);
+        let (x, y) = (origin_x + rel_x, origin_y + rel_y);
 
         // q/Q around our own drawing too, so the colour and font selection do
         // not leak onto anything appended after us.
+        let [r, g, b] = spec.ink_rgb.0;
         let mut ops = Vec::new();
-        ops.extend_from_slice(b"q\nBT\n0 0 0 rg\n/VMarkPageNo ");
+        ops.extend_from_slice(b"q\nBT\n");
+        ops.extend_from_slice(format!("{r:.3} {g:.3} {b:.3} rg\n").as_bytes());
+        ops.extend_from_slice(b"/VMarkPageNo ");
         ops.extend_from_slice(format!("{:.2}", spec.font_size_pt).as_bytes());
         ops.extend_from_slice(b" Tf\n");
         ops.extend_from_slice(format!("{x:.2} {y:.2} Td\n").as_bytes());
@@ -92,21 +100,24 @@ pub fn stamp_page_numbers(pdf_path: &str, spec: &PageNumberSpec) -> Result<(), S
         add_font_resource(&mut doc, page_id, font_id)?;
     }
 
-    if unrenderable > 0 {
+    if downgraded > 0 {
         log::warn!(
-            "[PDF] page-number label is not Latin-1 and Helvetica cannot draw it; \
-             {unrenderable} page(s) left unnumbered"
+            "[PDF] the localized page-number template is not Latin-1 and the base-14 \
+             font cannot draw it; {downgraded} page(s) numbered as \"n / total\" instead"
         );
     }
 
-    super::pdf_io::save_atomically(&mut doc, pdf_path, ".vmark-pageno-")?;
+    super::pdf_io::save_atomically(&mut doc, pdf_path)?;
     log::info!("[PDF] stamped page numbers on {total} page(s)");
     Ok(())
 }
 
-/// A page's width and height from its MediaBox, defaulting to A4.
-fn page_size(doc: &Document, page_id: ObjectId) -> (f64, f64) {
-    let fallback = (595.28, 841.89);
+/// A page's MediaBox as `(origin_x, origin_y, width, height)`, defaulting to A4.
+///
+/// The origin is returned rather than discarded: a MediaBox is not required to
+/// start at `[0 0 …]`, and the stamp coordinates are absolute.
+fn page_box(doc: &Document, page_id: ObjectId) -> (f64, f64, f64, f64) {
+    let fallback = (0.0, 0.0, 595.28, 841.89);
     let Ok(page) = doc.get_object(page_id).and_then(|o| o.as_dict()) else {
         return fallback;
     };
@@ -140,7 +151,11 @@ fn page_size(doc: &Document, page_id: ObjectId) -> (f64, f64) {
             .or_else(|_| mb[i].as_i64().map(|v| v as f64))
     };
     match (num(0), num(1), num(2), num(3)) {
-        (Ok(x0), Ok(y0), Ok(x1), Ok(y1)) => ((x1 - x0).abs(), (y1 - y0).abs()),
+        // A MediaBox may list its corners in either order, so normalise to the
+        // lower-left corner plus a positive extent.
+        (Ok(x0), Ok(y0), Ok(x1), Ok(y1)) => {
+            (x0.min(x1), y0.min(y1), (x1 - x0).abs(), (y1 - y0).abs())
+        }
         _ => fallback,
     }
 }

--- a/src-tauri/src/pdf_export/page_numbers.test.rs
+++ b/src-tauri/src/pdf_export/page_numbers.test.rs
@@ -21,15 +21,20 @@ fn test_dir(name: &str) -> std::path::PathBuf {
 }
 
 fn blank_pdf(path: &std::path::Path, pages: usize) {
-    use lopdf::content::Content;
+    content_pdf(path, pages, b"")
+}
+
+/// A fixture whose pages carry `body` as their content stream.
+///
+/// `body` is raw operators rather than an encoded `Content`, because the case
+/// that matters is an UNBALANCED graphics state — which a well-formed operation
+/// list is awkward to express and which every real renderer here produces.
+fn content_pdf(path: &std::path::Path, pages: usize, body: &[u8]) {
     let mut doc = Document::with_version("1.5");
     let pages_id = doc.new_object_id();
     let mut kids = Vec::new();
     for _ in 0..pages {
-        let stream = doc.add_object(Stream::new(
-            Dictionary::new(),
-            Content::encode(&Content { operations: vec![] }).unwrap(),
-        ));
+        let stream = doc.add_object(Stream::new(Dictionary::new(), body.to_vec()));
         let page = doc.add_object(dictionary! {
             "Type" => "Page",
             "Parent" => pages_id,
@@ -58,6 +63,60 @@ fn blank_pdf(path: &std::path::Path, pages: usize) {
 fn page_text(doc: &Document, page_id: ObjectId) -> String {
     let bytes = doc.get_page_content(page_id);
     String::from_utf8_lossy(&bytes).into_owned()
+}
+
+#[test]
+fn the_renderers_unbalanced_flip_cannot_reach_the_stamp() {
+    // THE REGRESSION THIS FILE EXISTS FOR. Content streams are concatenated,
+    // so a top-level `cm` the renderer never undoes is still in effect when the
+    // stamp begins — and `q` saves the CURRENT state rather than resetting to
+    // identity, so wrapping only our own drawing does nothing. Both WebView2
+    // and WebKitGTK emit exactly this y-flip: the number drew at the TOP of the
+    // page, mirrored, on two platforms out of three, while the label was
+    // present, the font was registered, and the text extracted cleanly.
+    //
+    // The fix fences the page's own content in q/Q. Assert the shape, because
+    // it is the shape that makes the coordinates mean what `baseline()` says.
+    let dir = test_dir("flipctm");
+    let path = dir.join("doc.pdf");
+    content_pdf(&path, 2, b"1 0 0 -1 0 842 cm\n");
+    stamp_page_numbers(
+        &path.to_string_lossy(),
+        &spec(Position::BottomCenter, Format::Plain),
+    )
+    .unwrap();
+
+    let doc = Document::load(&path).unwrap();
+    for (_, page_id) in doc.get_pages() {
+        let Ok(Object::Array(contents)) = doc
+            .get_object(page_id)
+            .and_then(|o| o.as_dict())
+            .and_then(|d| d.get(b"Contents"))
+        else {
+            panic!("Contents must be an array after stamping");
+        };
+        let stream = |i: usize| -> Vec<u8> {
+            let Object::Reference(r) = contents[i] else {
+                panic!("Contents entries must be references")
+            };
+            doc.get_object(r)
+                .and_then(|o| o.as_stream())
+                .map(|s| s.content.clone())
+                .unwrap_or_default()
+        };
+        assert_eq!(contents.len(), 4, "expected [q, original, Q, stamp]");
+        assert_eq!(stream(0), b"q\n".to_vec(), "must push before page content");
+        assert!(
+            String::from_utf8_lossy(&stream(1)).contains("cm"),
+            "the original content must survive untouched"
+        );
+        assert_eq!(stream(2), b"Q\n".to_vec(), "must pop before the stamp");
+        assert!(
+            String::from_utf8_lossy(&stream(3)).contains("/VMarkPageNo"),
+            "the stamp comes last"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]

--- a/src-tauri/src/pdf_export/page_numbers.test.rs
+++ b/src-tauri/src/pdf_export/page_numbers.test.rs
@@ -9,6 +9,7 @@ fn spec(position: Position, format: Format) -> PageNumberSpec {
         bottom_margin_pt: 72.0,
         side_margin_pt: 72.0,
         verbose_template: "Page {n} of {total}".to_string(),
+        ink_rgb: Default::default(),
     }
 }
 
@@ -169,6 +170,84 @@ fn skip_first_leaves_the_title_page_unnumbered() {
 }
 
 #[test]
+fn the_ink_colour_reaches_the_content_stream() {
+    // Black on a dark-theme export is invisible, so the frontend sends the ink
+    // it wants. A hardcoded `0 0 0 rg` would pass every other test here.
+    let dir = test_dir("ink");
+    let path = dir.join("doc.pdf");
+    blank_pdf(&path, 1);
+    let mut s = spec(Position::BottomCenter, Format::Plain);
+    s.ink_rgb = InkRgb([0.78, 0.78, 0.78]);
+    stamp_page_numbers(&path.to_string_lossy(), &s).unwrap();
+
+    let doc = Document::load(&path).unwrap();
+    let (_, page_id) = doc.get_pages().into_iter().next().unwrap();
+    let text = page_text(&doc, page_id);
+    assert!(text.contains("0.780 0.780 0.780 rg"), "got: {text}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_mediabox_with_a_non_zero_origin_still_lands_on_the_paper() {
+    // A cropped or imposed PDF can start at e.g. [20 20 615 862]. Ignoring the
+    // origin shifts the number off both edges — and off the sheet entirely once
+    // the origin exceeds the margin.
+    let dir = test_dir("origin");
+    let path = dir.join("doc.pdf");
+    offset_pdf(&path, 100.0);
+    stamp_page_numbers(
+        &path.to_string_lossy(),
+        &spec(Position::BottomCenter, Format::Plain),
+    )
+    .unwrap();
+
+    let doc = Document::load(&path).unwrap();
+    let (_, page_id) = doc.get_pages().into_iter().next().unwrap();
+    let text = page_text(&doc, page_id);
+    let td = text
+        .lines()
+        .find(|l| l.ends_with(" Td"))
+        .expect("a Td line must exist");
+    let coords: Vec<f64> = td
+        .split_whitespace()
+        .take(2)
+        .map(|t| t.parse().unwrap())
+        .collect();
+    assert!(
+        coords[0] >= 100.0 && coords[1] >= 100.0,
+        "baseline {coords:?} must be inside a box starting at (100,100)"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A one-page fixture whose MediaBox starts at `(offset, offset)`.
+fn offset_pdf(path: &std::path::Path, offset: f64) {
+    let mut doc = Document::with_version("1.5");
+    let pages_id = doc.new_object_id();
+    let stream = doc.add_object(Stream::new(Dictionary::new(), Vec::new()));
+    let page = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => pages_id,
+        "Contents" => stream,
+    });
+    doc.set_object(
+        pages_id,
+        dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![Object::Reference(page)],
+            "Count" => 1_i64,
+            "MediaBox" => vec![
+                offset.into(), offset.into(),
+                (offset + 595.0).into(), (offset + 842.0).into(),
+            ],
+        },
+    );
+    let catalog = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+    doc.trailer.set("Root", catalog);
+    doc.save(path).expect("write fixture");
+}
+
+#[test]
 fn position_none_leaves_the_file_byte_identical() {
     let dir = test_dir("none");
     let path = dir.join("doc.pdf");
@@ -193,11 +272,12 @@ fn an_inherited_mediabox_is_found_rather_than_defaulted() {
     blank_pdf(&path, 1);
     let doc = Document::load(&path).unwrap();
     let (_, page_id) = doc.get_pages().into_iter().next().unwrap();
-    let (w, h) = page_size(&doc, page_id);
+    let (x0, y0, w, h) = page_box(&doc, page_id);
     assert!(
         (w - 595.0).abs() < 0.01 && (h - 842.0).abs() < 0.01,
         "got {w}x{h}"
     );
+    assert_eq!((x0, y0), (0.0, 0.0), "this fixture starts at the origin");
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/src-tauri/src/pdf_export/page_numbers.test.rs
+++ b/src-tauri/src/pdf_export/page_numbers.test.rs
@@ -1,0 +1,174 @@
+use super::*;
+
+fn spec(position: Position, format: Format) -> PageNumberSpec {
+    PageNumberSpec {
+        position,
+        format,
+        skip_first: false,
+        font_size_pt: 9.0,
+        bottom_margin_pt: 72.0,
+        side_margin_pt: 72.0,
+        verbose_template: "Page {n} of {total}".to_string(),
+    }
+}
+
+fn test_dir(name: &str) -> std::path::PathBuf {
+    // Per-test directory: these run in parallel and the assertions below read
+    // the directory, so a shared temp dir would see a sibling's scratch file.
+    let d = std::env::temp_dir().join(format!("vmark-pageno-{name}-{}", std::process::id()));
+    std::fs::create_dir_all(&d).expect("create test dir");
+    d
+}
+
+fn blank_pdf(path: &std::path::Path, pages: usize) {
+    use lopdf::content::Content;
+    let mut doc = Document::with_version("1.5");
+    let pages_id = doc.new_object_id();
+    let mut kids = Vec::new();
+    for _ in 0..pages {
+        let stream = doc.add_object(Stream::new(
+            Dictionary::new(),
+            Content::encode(&Content { operations: vec![] }).unwrap(),
+        ));
+        let page = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => stream,
+        });
+        kids.push(Object::Reference(page));
+    }
+    let count = kids.len() as i64;
+    doc.set_object(
+        pages_id,
+        // MediaBox lives on the PAGES node, not the page — the inheritable case
+        // every one of these renderers actually produces.
+        dictionary! {
+            "Type" => "Pages",
+            "Kids" => kids,
+            "Count" => count,
+            "MediaBox" => vec![0.into(), 0.into(), 595.into(), 842.into()],
+        },
+    );
+    let catalog = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+    doc.trailer.set("Root", catalog);
+    doc.save(path).expect("write fixture");
+}
+
+/// The visible text of a page, from its content streams.
+fn page_text(doc: &Document, page_id: ObjectId) -> String {
+    let bytes = doc.get_page_content(page_id);
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+#[test]
+fn every_page_is_stamped_and_the_pdf_still_loads() {
+    let dir = test_dir("stamped");
+    let path = dir.join("doc.pdf");
+    blank_pdf(&path, 3);
+
+    stamp_page_numbers(
+        &path.to_string_lossy(),
+        &spec(Position::BottomCenter, Format::WithTotal),
+    )
+    .expect("stamping must succeed");
+
+    let doc = Document::load(&path).expect("still a valid PDF");
+    let pages: Vec<_> = doc.get_pages().into_iter().collect();
+    assert_eq!(pages.len(), 3);
+    for (n, (_, id)) in pages.iter().enumerate() {
+        let text = page_text(&doc, *id);
+        assert!(
+            text.contains(&format!("({} / 3)", n + 1)),
+            "page {} text: {text}",
+            n + 1
+        );
+        assert!(text.contains("/VMarkPageNo"), "font must be selected");
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn skip_first_leaves_the_title_page_unnumbered() {
+    let dir = test_dir("skipfirst");
+    let path = dir.join("doc.pdf");
+    blank_pdf(&path, 3);
+    let mut s = spec(Position::BottomCenter, Format::Plain);
+    s.skip_first = true;
+    stamp_page_numbers(&path.to_string_lossy(), &s).unwrap();
+
+    let doc = Document::load(&path).unwrap();
+    let pages: Vec<_> = doc.get_pages().into_iter().collect();
+    assert!(
+        !page_text(&doc, pages[0].1).contains("Tj"),
+        "page 1 must be untouched"
+    );
+    assert!(page_text(&doc, pages[1].1).contains("(2)"));
+    // The numbering keeps the real page number, not a re-based one — a reader
+    // matching the sidebar against the footer expects them to agree.
+    assert!(page_text(&doc, pages[2].1).contains("(3)"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn position_none_leaves_the_file_byte_identical() {
+    let dir = test_dir("none");
+    let path = dir.join("doc.pdf");
+    blank_pdf(&path, 2);
+    let before = std::fs::read(&path).unwrap();
+    stamp_page_numbers(
+        &path.to_string_lossy(),
+        &spec(Position::None, Format::Plain),
+    )
+    .unwrap();
+    assert_eq!(std::fs::read(&path).unwrap(), before);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn an_inherited_mediabox_is_found_rather_than_defaulted() {
+    // The fixture puts MediaBox on the Pages node, which is what these
+    // renderers emit. Reading only the page would silently fall back to A4 and
+    // mis-centre every number on any other paper size.
+    let dir = test_dir("inherited");
+    let path = dir.join("doc.pdf");
+    blank_pdf(&path, 1);
+    let doc = Document::load(&path).unwrap();
+    let (_, page_id) = doc.get_pages().into_iter().next().unwrap();
+    let (w, h) = page_size(&doc, page_id);
+    assert!(
+        (w - 595.0).abs() < 0.01 && (h - 842.0).abs() < 0.01,
+        "got {w}x{h}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn stamping_leaves_no_scratch_file_behind() {
+    let dir = test_dir("noleak");
+    let path = dir.join("doc.pdf");
+    blank_pdf(&path, 2);
+    stamp_page_numbers(
+        &path.to_string_lossy(),
+        &spec(Position::BottomCenter, Format::Plain),
+    )
+    .unwrap();
+    let leftovers: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().starts_with(".vmark-"))
+        .collect();
+    assert!(leftovers.is_empty(), "scratch left: {leftovers:?}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_missing_file_is_an_error_not_a_panic() {
+    let dir = test_dir("missing");
+    let err = stamp_page_numbers(
+        &dir.join("nope.pdf").to_string_lossy(),
+        &spec(Position::BottomCenter, Format::Plain),
+    )
+    .expect_err("a nonexistent PDF must be refused");
+    assert!(err.contains("open PDF"), "unexpected: {err}");
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src-tauri/src/pdf_export/page_numbers_label.rs
+++ b/src-tauri/src/pdf_export/page_numbers_label.rs
@@ -1,0 +1,135 @@
+//! What a page number says, and where on the sheet it goes.
+//!
+//! Purpose: the half of page numbering that involves no PDF at all — the
+//! request the dialog sends, the text for one page, its measured width, and the
+//! baseline coordinate. Split from the stamping so the arithmetic is testable
+//! without building a document, the same way `outline_match`/`outline_tree` sit
+//! beneath `outline.rs`.
+//!
+//! **Base-14 fonts are Latin-1 only.** Helvetica is guaranteed present in every
+//! PDF viewer with no embedding, which is what keeps this cheap — but it cannot
+//! render CJK at all. A localized "第 7 頁，共 12 頁" would come out blank or as
+//! mojibake, so a label that will not encode is refused here rather than drawn
+//! wrong. See `render_label`.
+//!
+//! @coordinates-with page_numbers.rs — the stamping that consumes all of this
+//! @module pdf_export/page_numbers_label
+
+/// Where the number sits on the page.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Position {
+    None,
+    BottomCenter,
+    BottomRight,
+}
+
+/// How the number reads.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Format {
+    /// `7`
+    Plain,
+    /// `7 / 12`
+    WithTotal,
+    /// The caller's localized template, e.g. `Page 7 of 12`.
+    Verbose,
+}
+
+/// What the export dialog asked for.
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PageNumberSpec {
+    pub position: Position,
+    pub format: Format,
+    /// Leave the first page unnumbered — title pages conventionally are.
+    pub skip_first: bool,
+    pub font_size_pt: f64,
+    /// The page's bottom margin, so the number sits inside it rather than over
+    /// the text.
+    pub bottom_margin_pt: f64,
+    /// The page's right margin, used to place `BottomRight`.
+    pub side_margin_pt: f64,
+    /// Localized template for `Format::Verbose`, with `{n}` and `{total}`.
+    /// Substituted here rather than per-page in the frontend, which cannot know
+    /// the page count until the render is done.
+    pub verbose_template: String,
+}
+
+/// Helvetica advance widths, in 1/1000 em, for the characters a page number can
+/// contain. Exact for the numeric formats, which is what centring needs.
+fn advance(c: char) -> f64 {
+    match c {
+        '0'..='9' => 556.0,
+        ' ' => 278.0,
+        '/' => 278.0,
+        '-' | '\u{2013}' => 556.0,
+        '.' | ',' => 278.0,
+        'i' | 'l' | 'j' | 'I' => 222.0,
+        'f' | 't' | 'r' => 278.0,
+        'm' | 'M' | 'W' | 'w' => 833.0,
+        'A'..='Z' => 667.0,
+        _ => 556.0,
+    }
+}
+
+/// Text width in points at `size`.
+pub(super) fn text_width(s: &str, size: f64) -> f64 {
+    s.chars().map(advance).sum::<f64>() / 1000.0 * size
+}
+
+/// The label for one page, and whether it can be drawn at all.
+///
+/// Returns `None` for a label Helvetica cannot represent. WinAnsi covers
+/// Latin-1; anything beyond it — a CJK or Cyrillic template — would draw as
+/// blanks or wrong glyphs, and a silently wrong footer on every page is worse
+/// than leaving those pages unnumbered, which the caller reports.
+pub(super) fn render_label(spec: &PageNumberSpec, n: usize, total: usize) -> Option<String> {
+    let label = match spec.format {
+        Format::Plain => n.to_string(),
+        Format::WithTotal => format!("{n} / {total}"),
+        Format::Verbose => spec
+            .verbose_template
+            .replace("{n}", &n.to_string())
+            .replace("{total}", &total.to_string()),
+    };
+    if label.chars().all(|c| (c as u32) <= 0xFF) {
+        Some(label)
+    } else {
+        None
+    }
+}
+
+/// Escape a PDF literal string.
+pub(super) fn escape(s: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(s.len() + 4);
+    for c in s.chars() {
+        match c {
+            '(' | ')' | '\\' => {
+                out.push(b'\\');
+                out.push(c as u8);
+            }
+            // Already filtered to Latin-1 by render_label.
+            c => out.push(c as u8),
+        }
+    }
+    out
+}
+
+/// Baseline position for a label of `width` on a page of `page_width`.
+///
+/// Vertically centred within the bottom margin band, with a floor so a
+/// zero-margin export still puts the number on the paper rather than off it.
+pub(super) fn baseline(spec: &PageNumberSpec, page_width: f64, width: f64) -> (f64, f64) {
+    let y = (spec.bottom_margin_pt / 2.0 - spec.font_size_pt / 2.0).max(6.0);
+    let x = match spec.position {
+        Position::BottomRight => (page_width - spec.side_margin_pt - width).max(0.0),
+        // None never reaches here; centre is the sane default if it does.
+        _ => ((page_width - width) / 2.0).max(0.0),
+    };
+    (x, y)
+}
+
+#[cfg(test)]
+#[path = "page_numbers_label.test.rs"]
+mod tests;

--- a/src-tauri/src/pdf_export/page_numbers_label.rs
+++ b/src-tauri/src/pdf_export/page_numbers_label.rs
@@ -9,11 +9,14 @@
 //! **Base-14 fonts are Latin-1 only.** Helvetica is guaranteed present in every
 //! PDF viewer with no embedding, which is what keeps this cheap — but it cannot
 //! render CJK at all. A localized "第 7 頁，共 12 頁" would come out blank or as
-//! mojibake, so a label that will not encode is refused here rather than drawn
-//! wrong. See `render_label`.
+//! mojibake, so a label that will not encode falls back to the numeric form,
+//! which is ASCII and always drawable. See `render_label`.
 //!
 //! @coordinates-with page_numbers.rs — the stamping that consumes all of this
 //! @module pdf_export/page_numbers_label
+
+use crate::command_error::{CommandError, ErrorCode};
+use crate::localized_error;
 
 /// Where the number sits on the page.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize)]
@@ -54,6 +57,71 @@ pub struct PageNumberSpec {
     /// Substituted here rather than per-page in the frontend, which cannot know
     /// the page count until the render is done.
     pub verbose_template: String,
+    /// Ink colour as three 0–1 components.
+    ///
+    /// Sent by the frontend rather than assumed here: `useEditorTheme` lets a
+    /// dark theme reach the PDF, and a hardcoded black number on a dark page is
+    /// invisible. Defaults to black so an older caller — or a test — that omits
+    /// it keeps the previous behaviour.
+    #[serde(default)]
+    pub ink_rgb: InkRgb,
+}
+
+/// Three 0–1 colour components.
+#[derive(Clone, Copy, Debug, PartialEq, serde::Deserialize)]
+pub struct InkRgb(pub [f64; 3]);
+
+impl Default for InkRgb {
+    fn default() -> Self {
+        InkRgb([0.0, 0.0, 0.0])
+    }
+}
+
+impl PageNumberSpec {
+    /// Reject a spec that cannot produce a sane stamp.
+    ///
+    /// This crosses the IPC boundary as JSON, so the values are whatever the
+    /// caller sent — `PageSpec` beside it is validated for exactly that reason.
+    /// A NaN font size formats as the literal `NaN` in the `Tf` operator and
+    /// yields a corrupt content stream; a negative one is accepted by some
+    /// viewers and mirrors the text. The upper bounds are generous — this is a
+    /// guard against nonsense, not a style policy.
+    pub fn validate(&self) -> Result<(), CommandError> {
+        if !self.font_size_pt.is_finite() || !(1.0..=200.0).contains(&self.font_size_pt) {
+            return Err(localized_error!(
+                ErrorCode::InvalidInput,
+                "errors.pdf.invalidPageNumberSpec",
+                field = "fontSizePt",
+                value = format!("{}", self.font_size_pt)
+            ));
+        }
+        for (i, c) in self.ink_rgb.0.iter().enumerate() {
+            if !c.is_finite() || !(0.0..=1.0).contains(c) {
+                return Err(localized_error!(
+                    ErrorCode::InvalidInput,
+                    "errors.pdf.invalidPageNumberSpec",
+                    field = format!("inkRgb[{i}]"),
+                    value = format!("{c}")
+                ));
+            }
+        }
+        for (field, v) in [
+            ("bottomMarginPt", self.bottom_margin_pt),
+            ("sideMarginPt", self.side_margin_pt),
+        ] {
+            // Zero is legitimate — `baseline` has a floor for exactly that — but
+            // negative or non-finite is not.
+            if !v.is_finite() || !(0.0..=10_000.0).contains(&v) {
+                return Err(localized_error!(
+                    ErrorCode::InvalidInput,
+                    "errors.pdf.invalidPageNumberSpec",
+                    field = field,
+                    value = format!("{v}")
+                ));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Helvetica advance widths, in 1/1000 em, for the characters a page number can
@@ -78,26 +146,39 @@ pub(super) fn text_width(s: &str, size: f64) -> f64 {
     s.chars().map(advance).sum::<f64>() / 1000.0 * size
 }
 
-/// The label for one page, and whether it can be drawn at all.
+/// The label for one page, and whether the requested form had to be replaced.
 ///
-/// Returns `None` for a label Helvetica cannot represent. WinAnsi covers
-/// Latin-1; anything beyond it — a CJK or Cyrillic template — would draw as
-/// blanks or wrong glyphs, and a silently wrong footer on every page is worse
-/// than leaving those pages unnumbered, which the caller reports.
-pub(super) fn render_label(spec: &PageNumberSpec, n: usize, total: usize) -> Option<String> {
+/// WinAnsi covers Latin-1; anything beyond it — a CJK or Cyrillic verbose
+/// template — would draw as blanks or wrong glyphs. Such a label is replaced by
+/// the numeric form, which is ASCII and therefore always drawable, so a reader
+/// in those languages still gets page numbers.
+///
+/// Leaving the page BARE was the first attempt and it was worse: a Chinese,
+/// Japanese or Korean user who chose the verbose format got a PDF with no page
+/// numbers anywhere and an export that reported success. Numbers in a plainer
+/// form beat no numbers.
+pub(super) fn render_label(spec: &PageNumberSpec, n: usize, total: usize) -> (String, bool) {
+    let numeric = format!("{n} / {total}");
     let label = match spec.format {
         Format::Plain => n.to_string(),
-        Format::WithTotal => format!("{n} / {total}"),
+        Format::WithTotal => numeric.clone(),
         Format::Verbose => spec
             .verbose_template
             .replace("{n}", &n.to_string())
             .replace("{total}", &total.to_string()),
     };
-    if label.chars().all(|c| (c as u32) <= 0xFF) {
-        Some(label)
+    if is_winansi(&label) {
+        (label, false)
     } else {
-        None
+        // Only the verbose form can reach here — the other two are digits,
+        // spaces and a slash.
+        (numeric, true)
     }
+}
+
+/// Can the base-14 Helvetica WinAnsi encoding represent every character?
+fn is_winansi(s: &str) -> bool {
+    s.chars().all(|c| (c as u32) <= 0xFF)
 }
 
 /// Escape a PDF literal string.

--- a/src-tauri/src/pdf_export/page_numbers_label.rs
+++ b/src-tauri/src/pdf_export/page_numbers_label.rs
@@ -162,10 +162,16 @@ pub(super) fn render_label(spec: &PageNumberSpec, n: usize, total: usize) -> (St
     let label = match spec.format {
         Format::Plain => n.to_string(),
         Format::WithTotal => numeric.clone(),
-        Format::Verbose => spec
+        // A template with no `{n}` cannot produce a page NUMBER — it would
+        // stamp the same static text on all of them, or nothing at all if it is
+        // empty. Treated as unusable for the same reason a CJK one is, rather
+        // than rejected: refusing the whole export over a translation typo
+        // would lose the document the user just waited for.
+        Format::Verbose if spec.verbose_template.contains("{n}") => spec
             .verbose_template
             .replace("{n}", &n.to_string())
             .replace("{total}", &total.to_string()),
+        Format::Verbose => return (numeric, true),
     };
     if is_winansi(&label) {
         (label, false)

--- a/src-tauri/src/pdf_export/page_numbers_label.test.rs
+++ b/src-tauri/src/pdf_export/page_numbers_label.test.rs
@@ -9,6 +9,7 @@ fn spec(position: Position, format: Format) -> PageNumberSpec {
         bottom_margin_pt: 72.0,
         side_margin_pt: 72.0,
         verbose_template: "Page {n} of {total}".to_string(),
+        ink_rgb: Default::default(),
     }
 }
 
@@ -17,44 +18,57 @@ fn spec(position: Position, format: Format) -> PageNumberSpec {
 #[test]
 fn plain_is_just_the_number() {
     assert_eq!(
-        render_label(&spec(Position::BottomCenter, Format::Plain), 7, 12).unwrap(),
-        "7"
+        render_label(&spec(Position::BottomCenter, Format::Plain), 7, 12),
+        ("7".to_string(), false)
     );
 }
 
 #[test]
 fn with_total_reads_as_a_fraction() {
     assert_eq!(
-        render_label(&spec(Position::BottomCenter, Format::WithTotal), 7, 12).unwrap(),
-        "7 / 12"
+        render_label(&spec(Position::BottomCenter, Format::WithTotal), 7, 12),
+        ("7 / 12".to_string(), false)
     );
 }
 
 #[test]
 fn verbose_substitutes_both_placeholders() {
     assert_eq!(
-        render_label(&spec(Position::BottomCenter, Format::Verbose), 7, 12).unwrap(),
-        "Page 7 of 12"
+        render_label(&spec(Position::BottomCenter, Format::Verbose), 7, 12),
+        ("Page 7 of 12".to_string(), false)
     );
 }
 
 #[test]
-fn a_label_helvetica_cannot_draw_is_refused_rather_than_mangled() {
-    // Base-14 Helvetica is Latin-1 only. Drawing a CJK template would emit
-    // blanks or wrong glyphs on EVERY page — worse than leaving those pages
-    // unnumbered, and silent.
+fn a_label_helvetica_cannot_draw_falls_back_to_numbers() {
+    // Base-14 Helvetica is Latin-1 only, so a CJK template would draw as
+    // blanks or wrong glyphs. Leaving the page bare was the first attempt and
+    // it was worse: a CJK reader who picked the verbose format got a PDF with
+    // NO page numbers at all and a success message. The numeric form is ASCII,
+    // so it always draws.
     let mut s = spec(Position::BottomCenter, Format::Verbose);
     s.verbose_template = "第 {n} 頁，共 {total} 頁".to_string();
-    assert_eq!(render_label(&s, 7, 12), None);
+    assert_eq!(render_label(&s, 7, 12), ("7 / 12".to_string(), true));
+}
+
+#[test]
+fn the_numeric_forms_can_never_need_a_fallback() {
+    // They are digits, spaces and a slash whatever the locale, so the fallback
+    // flag must stay false — otherwise every export would log a warning.
+    let mut s = spec(Position::BottomCenter, Format::Plain);
+    s.verbose_template = "第 {n} 頁".to_string();
+    assert!(!render_label(&s, 3, 9).1, "plain must never fall back");
+    s.format = Format::WithTotal;
+    assert!(!render_label(&s, 3, 9).1, "with-total must never fall back");
 }
 
 #[test]
 fn a_latin1_accented_template_is_accepted() {
     // Within WinAnsi, so it draws correctly — the guard must not be
-    // "ASCII only", which would refuse most European languages.
+    // "ASCII only", which would downgrade most European languages.
     let mut s = spec(Position::BottomCenter, Format::Verbose);
     s.verbose_template = "Página {n} de {total}".to_string();
-    assert_eq!(render_label(&s, 2, 5).unwrap(), "Página 2 de 5");
+    assert_eq!(render_label(&s, 2, 5), ("Página 2 de 5".to_string(), false));
 }
 
 // --- placement ---
@@ -105,6 +119,62 @@ fn a_label_wider_than_the_page_is_clamped_to_the_edge() {
 #[test]
 fn width_scales_with_font_size() {
     assert!((text_width("12", 18.0) - text_width("12", 9.0) * 2.0).abs() < 0.001);
+}
+
+// --- validation ---
+
+#[test]
+fn a_sane_spec_is_accepted() {
+    assert!(spec(Position::BottomCenter, Format::Plain)
+        .validate()
+        .is_ok());
+}
+
+#[test]
+fn a_non_finite_font_size_is_refused() {
+    // This arrives as JSON over IPC. NaN formats as the literal "NaN" in the
+    // `Tf` operator, producing a content stream no viewer can parse — so it has
+    // to be caught here, not discovered in the artifact.
+    for bad in [f64::NAN, f64::INFINITY, -12.0, 0.0, 5000.0] {
+        let mut s = spec(Position::BottomCenter, Format::Plain);
+        s.font_size_pt = bad;
+        let err = s.validate().expect_err("must refuse fontSizePt {bad}");
+        assert_eq!(err.code(), crate::command_error::ErrorCode::InvalidInput);
+    }
+}
+
+#[test]
+fn a_negative_or_non_finite_margin_is_refused_but_zero_is_fine() {
+    for bad in [f64::NAN, -1.0, f64::NEG_INFINITY] {
+        let mut s = spec(Position::BottomCenter, Format::Plain);
+        s.bottom_margin_pt = bad;
+        assert!(s.validate().is_err(), "must refuse bottomMarginPt {bad}");
+        let mut s = spec(Position::BottomCenter, Format::Plain);
+        s.side_margin_pt = bad;
+        assert!(s.validate().is_err(), "must refuse sideMarginPt {bad}");
+    }
+    // Zero is a legitimate edge-to-edge export; `baseline` has a floor for it.
+    let mut s = spec(Position::BottomCenter, Format::Plain);
+    s.bottom_margin_pt = 0.0;
+    s.side_margin_pt = 0.0;
+    assert!(s.validate().is_ok());
+}
+
+#[test]
+fn an_out_of_gamut_ink_component_is_refused() {
+    // PDF `rg` takes 0–1. A 255-style value silently clamps in some viewers and
+    // renders black in others, so the disagreement is caught here instead.
+    for bad in [-0.1, 1.5, f64::NAN] {
+        let mut s = spec(Position::BottomCenter, Format::Plain);
+        s.ink_rgb = InkRgb([0.0, bad, 0.0]);
+        assert!(s.validate().is_err(), "must refuse ink component {bad}");
+    }
+    let mut s = spec(Position::BottomCenter, Format::Plain);
+    s.ink_rgb = InkRgb([0.78, 0.78, 0.78]);
+    assert!(
+        s.validate().is_ok(),
+        "a light grey is a normal dark-theme ink"
+    );
 }
 
 // --- escaping ---

--- a/src-tauri/src/pdf_export/page_numbers_label.test.rs
+++ b/src-tauri/src/pdf_export/page_numbers_label.test.rs
@@ -52,6 +52,18 @@ fn a_label_helvetica_cannot_draw_falls_back_to_numbers() {
 }
 
 #[test]
+fn a_template_with_no_page_placeholder_falls_back_too() {
+    // It cannot produce a page NUMBER — every page would carry the same static
+    // text, or nothing if the template is empty. Both look like a working
+    // footer to a structural check.
+    let mut s = spec(Position::BottomCenter, Format::Verbose);
+    s.verbose_template = "Printed by VMark".to_string();
+    assert_eq!(render_label(&s, 4, 9), ("4 / 9".to_string(), true));
+    s.verbose_template = String::new();
+    assert_eq!(render_label(&s, 4, 9), ("4 / 9".to_string(), true));
+}
+
+#[test]
 fn the_numeric_forms_can_never_need_a_fallback() {
     // They are digits, spaces and a slash whatever the locale, so the fallback
     // flag must stay false — otherwise every export would log a warning.

--- a/src-tauri/src/pdf_export/page_numbers_label.test.rs
+++ b/src-tauri/src/pdf_export/page_numbers_label.test.rs
@@ -1,0 +1,118 @@
+use super::*;
+
+fn spec(position: Position, format: Format) -> PageNumberSpec {
+    PageNumberSpec {
+        position,
+        format,
+        skip_first: false,
+        font_size_pt: 9.0,
+        bottom_margin_pt: 72.0,
+        side_margin_pt: 72.0,
+        verbose_template: "Page {n} of {total}".to_string(),
+    }
+}
+
+// --- label rendering ---
+
+#[test]
+fn plain_is_just_the_number() {
+    assert_eq!(
+        render_label(&spec(Position::BottomCenter, Format::Plain), 7, 12).unwrap(),
+        "7"
+    );
+}
+
+#[test]
+fn with_total_reads_as_a_fraction() {
+    assert_eq!(
+        render_label(&spec(Position::BottomCenter, Format::WithTotal), 7, 12).unwrap(),
+        "7 / 12"
+    );
+}
+
+#[test]
+fn verbose_substitutes_both_placeholders() {
+    assert_eq!(
+        render_label(&spec(Position::BottomCenter, Format::Verbose), 7, 12).unwrap(),
+        "Page 7 of 12"
+    );
+}
+
+#[test]
+fn a_label_helvetica_cannot_draw_is_refused_rather_than_mangled() {
+    // Base-14 Helvetica is Latin-1 only. Drawing a CJK template would emit
+    // blanks or wrong glyphs on EVERY page — worse than leaving those pages
+    // unnumbered, and silent.
+    let mut s = spec(Position::BottomCenter, Format::Verbose);
+    s.verbose_template = "第 {n} 頁，共 {total} 頁".to_string();
+    assert_eq!(render_label(&s, 7, 12), None);
+}
+
+#[test]
+fn a_latin1_accented_template_is_accepted() {
+    // Within WinAnsi, so it draws correctly — the guard must not be
+    // "ASCII only", which would refuse most European languages.
+    let mut s = spec(Position::BottomCenter, Format::Verbose);
+    s.verbose_template = "Página {n} de {total}".to_string();
+    assert_eq!(render_label(&s, 2, 5).unwrap(), "Página 2 de 5");
+}
+
+// --- placement ---
+
+#[test]
+fn centred_text_is_actually_centred() {
+    let s = spec(Position::BottomCenter, Format::Plain);
+    let w = text_width("7", 9.0);
+    let (x, _) = baseline(&s, 595.28, w);
+    assert!((x - (595.28 - w) / 2.0).abs() < 0.01);
+}
+
+#[test]
+fn right_aligned_text_sits_inside_the_margin() {
+    let s = spec(Position::BottomRight, Format::WithTotal);
+    let w = text_width("7 / 12", 9.0);
+    let (x, _) = baseline(&s, 595.28, w);
+    assert!(
+        (x + w - (595.28 - 72.0)).abs() < 0.01,
+        "right edge must meet the margin"
+    );
+}
+
+#[test]
+fn the_baseline_sits_within_the_bottom_margin_band() {
+    let s = spec(Position::BottomCenter, Format::Plain);
+    let (_, y) = baseline(&s, 595.28, 10.0);
+    assert!(y > 0.0 && y < 72.0, "y={y} must be inside the 72pt band");
+}
+
+#[test]
+fn a_zero_margin_export_still_puts_the_number_on_the_paper() {
+    // Margins are user-settable and can be 0. Without a floor the baseline
+    // computes negative and the number lands off the sheet.
+    let mut s = spec(Position::BottomCenter, Format::Plain);
+    s.bottom_margin_pt = 0.0;
+    let (_, y) = baseline(&s, 595.28, 10.0);
+    assert!(y >= 6.0, "y={y} must stay on the page");
+}
+
+#[test]
+fn a_label_wider_than_the_page_is_clamped_to_the_edge() {
+    let s = spec(Position::BottomCenter, Format::Plain);
+    let (x, _) = baseline(&s, 100.0, 400.0);
+    assert_eq!(x, 0.0);
+}
+
+#[test]
+fn width_scales_with_font_size() {
+    assert!((text_width("12", 18.0) - text_width("12", 9.0) * 2.0).abs() < 0.001);
+}
+
+// --- escaping ---
+
+#[test]
+fn parentheses_and_backslashes_are_escaped() {
+    // Unescaped, a "(" in a localized template terminates the PDF string early
+    // and corrupts every stamped page.
+    assert_eq!(escape("(7)"), b"\\(7\\)".to_vec());
+    assert_eq!(escape("a\\b"), b"a\\\\b".to_vec());
+}

--- a/src-tauri/src/pdf_export/pdf_io.rs
+++ b/src-tauri/src/pdf_export/pdf_io.rs
@@ -1,0 +1,55 @@
+//! Saving a modified PDF without risking the one already on disk.
+//!
+//! Purpose: both post-processing steps — the outline and the page numbers —
+//! rewrite a PDF the renderer has already produced correctly, and both callers
+//! downgrade their failure to a warning so the export still succeeds. That
+//! downgrade is only honest while a failure leaves the original intact.
+//!
+//! `Document::save` truncates its path before serializing, so saving in place
+//! would destroy the rendered PDF if anything failed mid-write. This writes
+//! beside the target and renames over it.
+//!
+//! Shared rather than copied: the two callers had identical needs, and a second
+//! copy of a security-relevant file dance is how one of them ends up fixed and
+//! the other does not.
+//!
+//! @coordinates-with outline.rs, page_numbers.rs — the two post-processors
+//! @module pdf_export/pdf_io
+
+use lopdf::Document;
+
+/// Serialize `doc` over `pdf_path`, atomically.
+///
+/// `prefix` only distinguishes the scratch file in a directory listing while it
+/// briefly exists; the name itself is random.
+pub(super) fn save_atomically(
+    doc: &mut Document,
+    pdf_path: &str,
+    prefix: &str,
+) -> Result<(), String> {
+    let target = std::path::Path::new(pdf_path);
+    // Same directory, so `persist` is a same-filesystem rename rather than a
+    // copy across devices that can itself fail halfway.
+    let dir = target.parent().filter(|d| !d.as_os_str().is_empty());
+
+    // `tempfile`, not a derived name like `x.tmp`. A deterministic name can be
+    // pre-created as a symlink, which `File::create` follows straight back onto
+    // the target, and two concurrent exports of one document would share it.
+    // O_EXCL + 0600, and `TempPath` deletes on drop so no error path leaks it.
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(prefix).suffix(".pdf");
+    let tmp = match dir {
+        Some(d) => builder.tempfile_in(d),
+        None => builder.tempfile(),
+    }
+    .map_err(|e| format!("create temp PDF: {e}"))?;
+
+    // Close our handle before lopdf opens the path itself; Windows refuses a
+    // rename over a file that still has an open handle.
+    let tmp_path = tmp.into_temp_path();
+    doc.save(&tmp_path).map_err(|e| format!("save PDF: {e}"))?;
+    tmp_path
+        .persist(target)
+        .map_err(|e| format!("replace PDF: {e}"))?;
+    Ok(())
+}

--- a/src-tauri/src/pdf_export/pdf_io.rs
+++ b/src-tauri/src/pdf_export/pdf_io.rs
@@ -20,8 +20,10 @@
 //! closes that window. `atomic_replace` also carries the Windows
 //! remove-then-retry fallback, which is deliberately NOT applied on Unix.
 //!
-//! The cost is holding the serialized PDF in memory. These are single documents
-//! the user just exported, and the renderer already held the whole thing.
+//! It uses the STREAMING form (`atomic_replace_with`), so the PDF is written
+//! straight into the temp file rather than serialized to a buffer first — a
+//! document embedding every image in the export should not need a second full
+//! copy in memory just to be handed to the writer.
 //!
 //! @coordinates-with atomic_replace.rs — the shared temp-file/fsync/rename core
 //! @coordinates-with outline.rs, page_numbers.rs — the two post-processors
@@ -29,7 +31,7 @@
 
 use lopdf::Document;
 
-use crate::atomic_replace::{atomic_replace, AtomicReplaceError};
+use crate::atomic_replace::{atomic_replace_with, AtomicReplaceError};
 
 /// Serialize `doc` over `pdf_path`, atomically.
 pub(super) fn save_atomically(doc: &mut Document, pdf_path: &str) -> Result<(), String> {
@@ -41,11 +43,15 @@ pub(super) fn save_atomically(doc: &mut Document, pdf_path: &str) -> Result<(), 
         .filter(|d| !d.as_os_str().is_empty())
         .unwrap_or_else(|| std::path::Path::new("."));
 
-    let mut bytes = Vec::new();
-    doc.save_to(&mut bytes)
-        .map_err(|e| format!("serialize PDF: {e}"))?;
-
-    atomic_replace(target, parent, &bytes).map_err(describe)
+    // STREAMED into the temp file, not serialized to a `Vec` first. `save_to`
+    // takes a `Write`, so buffering the whole PDF only to hand it over would
+    // hold a second full copy of a document that can carry every image in the
+    // export as an embedded object.
+    atomic_replace_with(target, parent, |temp| {
+        doc.save_to(temp)
+            .map_err(|e| std::io::Error::other(format!("serialize PDF: {e}")))
+    })
+    .map_err(describe)
 }
 
 /// Name the stage that failed, so the caller's warning says which one.

--- a/src-tauri/src/pdf_export/pdf_io.rs
+++ b/src-tauri/src/pdf_export/pdf_io.rs
@@ -6,50 +6,57 @@
 //! downgrade is only honest while a failure leaves the original intact.
 //!
 //! `Document::save` truncates its path before serializing, so saving in place
-//! would destroy the rendered PDF if anything failed mid-write. This writes
-//! beside the target and renames over it.
+//! would destroy the rendered PDF if anything failed mid-write.
 //!
-//! Shared rather than copied: the two callers had identical needs, and a second
-//! copy of a security-relevant file dance is how one of them ends up fixed and
-//! the other does not.
+//! **This delegates to `crate::atomic_replace` rather than doing its own
+//! temp-file dance**, and that is the whole point of the module. The hand-rolled
+//! version was missing three things the shared core already had, each fixed
+//! once before elsewhere: it did not preserve the target's permission bits (so
+//! replacing a PDF reset it to the temp file's 0600 on Unix), it did not
+//! `sync_all` before the rename (so a crash could expose an unsynced file), and
+//! it called `into_temp_path()` — closing the securely created handle and
+//! letting `Document::save` REOPEN that path by name, a window in which the
+//! path can be swapped for a symlink. Writing through the still-open handle
+//! closes that window. `atomic_replace` also carries the Windows
+//! remove-then-retry fallback, which is deliberately NOT applied on Unix.
 //!
+//! The cost is holding the serialized PDF in memory. These are single documents
+//! the user just exported, and the renderer already held the whole thing.
+//!
+//! @coordinates-with atomic_replace.rs — the shared temp-file/fsync/rename core
 //! @coordinates-with outline.rs, page_numbers.rs — the two post-processors
 //! @module pdf_export/pdf_io
 
 use lopdf::Document;
 
+use crate::atomic_replace::{atomic_replace, AtomicReplaceError};
+
 /// Serialize `doc` over `pdf_path`, atomically.
-///
-/// `prefix` only distinguishes the scratch file in a directory listing while it
-/// briefly exists; the name itself is random.
-pub(super) fn save_atomically(
-    doc: &mut Document,
-    pdf_path: &str,
-    prefix: &str,
-) -> Result<(), String> {
+pub(super) fn save_atomically(doc: &mut Document, pdf_path: &str) -> Result<(), String> {
     let target = std::path::Path::new(pdf_path);
-    // Same directory, so `persist` is a same-filesystem rename rather than a
-    // copy across devices that can itself fail halfway.
-    let dir = target.parent().filter(|d| !d.as_os_str().is_empty());
+    // The target was just written by the renderer, so its parent exists. A path
+    // with no parent component means the current directory, not an error.
+    let parent = target
+        .parent()
+        .filter(|d| !d.as_os_str().is_empty())
+        .unwrap_or_else(|| std::path::Path::new("."));
 
-    // `tempfile`, not a derived name like `x.tmp`. A deterministic name can be
-    // pre-created as a symlink, which `File::create` follows straight back onto
-    // the target, and two concurrent exports of one document would share it.
-    // O_EXCL + 0600, and `TempPath` deletes on drop so no error path leaks it.
-    let mut builder = tempfile::Builder::new();
-    builder.prefix(prefix).suffix(".pdf");
-    let tmp = match dir {
-        Some(d) => builder.tempfile_in(d),
-        None => builder.tempfile(),
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes)
+        .map_err(|e| format!("serialize PDF: {e}"))?;
+
+    atomic_replace(target, parent, &bytes).map_err(describe)
+}
+
+/// Name the stage that failed, so the caller's warning says which one.
+fn describe(e: AtomicReplaceError) -> String {
+    match e {
+        AtomicReplaceError::CreateTemp { parent, source } => {
+            format!("create temp PDF in {}: {source}", parent.display())
+        }
+        AtomicReplaceError::WriteTemp(e) => format!("write temp PDF: {e}"),
+        AtomicReplaceError::FlushTemp(e) => format!("flush temp PDF: {e}"),
+        AtomicReplaceError::SyncTemp(e) => format!("sync temp PDF: {e}"),
+        AtomicReplaceError::Persist(e) => format!("replace PDF: {e}"),
     }
-    .map_err(|e| format!("create temp PDF: {e}"))?;
-
-    // Close our handle before lopdf opens the path itself; Windows refuses a
-    // rename over a file that still has an open handle.
-    let tmp_path = tmp.into_temp_path();
-    doc.save(&tmp_path).map_err(|e| format!("save PDF: {e}"))?;
-    tmp_path
-        .persist(target)
-        .map_err(|e| format!("replace PDF: {e}"))?;
-    Ok(())
 }

--- a/src-tauri/src/pdf_export/renderer/macos_ops.rs
+++ b/src-tauri/src/pdf_export/renderer/macos_ops.rs
@@ -75,7 +75,12 @@ fn render_inner(
     );
 
     if result.is_ok() {
-        emit_progress(app, "done");
+        // "finishing", not "done": the RENDER is finished, but `export_pdf`
+        // still has the outline and the page numbers to add, and on a long
+        // document that is visible time. Claiming completion here told the user
+        // the export was over while it was still writing to the file.
+        // `export_pdf` emits "done" once post-processing returns.
+        emit_progress(app, "finishing");
     }
     result
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/export/PdfExportDialog.tsx
+++ b/src/export/PdfExportDialog.tsx
@@ -33,6 +33,7 @@ import { pdfError } from "@/utils/debug";
 import "./pdf-export-dialog.css";
 import { commandErrorMessage } from "@/services/commands/commandError";
 import { buildPageSpec } from "./pageSpec";
+import { buildPageNumberSpec } from "./pdfOptions";
 
 interface PdfExportContentProps {
   renderedHtml: string;
@@ -80,6 +81,11 @@ export function PdfExportContent({
     latinFont: appearance.latinFont,
     cjkFont: appearance.cjkFont,
     useEditorTheme: false,
+    // On by default: a printed document is expected to carry page numbers, and
+    // the control to turn them off is right there in this dialog.
+    pageNumberPosition: "bottom-center",
+    pageNumberFormat: "plain",
+    pageNumberSkipFirst: false,
   });
 
   const [exporting, setExporting] = useState(false);
@@ -155,7 +161,13 @@ export function PdfExportContent({
         bottom: options.marginBottom,
         left: options.marginLeft,
       });
-      await invoke("export_pdf", { html, outputPath, headings, page });
+      // The template is localized HERE and substituted backend-side, because the
+      // page count is not known until the render finishes.
+      const pageNumbers = buildPageNumberSpec(
+        options,
+        tDialog("pdf.pageNumbers.verboseTemplate"),
+      );
+      await invoke("export_pdf", { html, outputPath, headings, page, pageNumbers });
       toast.success(tDialog("toast.pdfExportSuccess"));
 
       // Open in default viewer (Preview.app on macOS). Non-fatal if it fails.

--- a/src/export/PdfExportDialog.tsx
+++ b/src/export/PdfExportDialog.tsx
@@ -33,7 +33,7 @@ import { pdfError } from "@/utils/debug";
 import "./pdf-export-dialog.css";
 import { commandErrorMessage } from "@/services/commands/commandError";
 import { buildPageSpec } from "./pageSpec";
-import { buildPageNumberSpec } from "./pdfOptions";
+import { buildPageNumberSpec, effectiveBottomMarginMm } from "./pdfOptions";
 
 interface PdfExportContentProps {
   renderedHtml: string;
@@ -101,6 +101,9 @@ export function PdfExportContent({
     const stageKeys: Record<string, string> = {
       loading: "pdf.progress.loading",
       rendering: "pdf.progress.rendering",
+      // The renderer emits this when the PDF exists but the outline and page
+      // numbers are still being written; `export_pdf` emits "done" after.
+      finishing: "pdf.progress.finishing",
       done: "pdf.progress.done",
     };
     const unlisten = listen<{ stage: string }>(
@@ -158,17 +161,42 @@ export function PdfExportContent({
       const page = buildPageSpec(options.pageSize, options.orientation, {
         top: options.marginTop,
         right: options.marginRight,
-        bottom: options.marginBottom,
+        // Reserved, not requested — see effectiveBottomMarginMm. Windows and
+        // Linux take their page box from here rather than from the CSS, so
+        // passing the raw value would leave the footer overlapping there while
+        // macOS was correct.
+        bottom: effectiveBottomMarginMm(options),
         left: options.marginLeft,
       });
       // The template is localized HERE and substituted backend-side, because the
       // page count is not known until the render finishes.
+      //
+      // `t`, NOT `tDialog`: the key lives in export.json. i18next returns the
+      // KEY when it misses, and that key is pure ASCII — so the backend would
+      // have accepted it and stamped the literal "pdf.pageNumbers.verboseTemplate"
+      // on every page rather than failing.
       const pageNumbers = buildPageNumberSpec(
         options,
-        tDialog("pdf.pageNumbers.verboseTemplate"),
+        t("pdf.pageNumbers.verboseTemplate"),
+        isDark,
       );
-      await invoke("export_pdf", { html, outputPath, headings, page, pageNumbers });
-      toast.success(tDialog("toast.pdfExportSuccess"));
+      // Post-processing is best-effort, so the command can succeed with the
+      // outline or the page numbers missing. Saying "exported" flatly in that
+      // case tells the user a setting they turned on worked when it did not.
+      const outcome = await invoke<{ warnings?: string[] }>("export_pdf", {
+        html, outputPath, headings, page, pageNumbers,
+      });
+      const warnings = outcome?.warnings ?? [];
+      if (warnings.length > 0) {
+        toast.warning(
+          tDialog("toast.pdfExportPartial", {
+            what: warnings.map((w) => t(`pdf.warning.${w}`)).join(", "),
+          }),
+          { pin: true },
+        );
+      } else {
+        toast.success(tDialog("toast.pdfExportSuccess"));
+      }
 
       // Open in default viewer (Preview.app on macOS). Non-fatal if it fails.
       try {

--- a/src/export/PdfSettingsSidebar.tsx
+++ b/src/export/PdfSettingsSidebar.tsx
@@ -12,6 +12,7 @@
  * @coordinates-with PdfExportDialog.tsx — parent component
  * @coordinates-with pdfPresets.ts — style presets and option definitions
  * @coordinates-with pdfHtmlTemplate.ts — PdfOptions type, MARGIN_PRESETS
+ * @coordinates-with PdfSidebarPrimitives.tsx — the layout components below
  */
 
 import { useState, useCallback, useMemo } from "react";
@@ -22,123 +23,25 @@ import {
   buildStylePresetOptions,
   detectMarginPreset, detectStylePreset,
   PAGE_SIZE_OPTIONS,
+  PAGE_NUMBER_POSITION_OPTIONS,
+  PAGE_NUMBER_FORMAT_OPTIONS,
   buildOrientationOptions, buildMarginPresetOptions,
   FONT_SIZE_OPTIONS, LINE_HEIGHT_OPTIONS,
   buildCjkSpacingOptions, buildLatinFontOptions, buildCjkFontOptions,
 } from "./pdfPresets";
-import { ChevronRight, FileText, Type, Palette } from "lucide-react";
+import { FileText, Type, Palette, Hash } from "lucide-react";
 import {
   SettingRow,
   Select,
   Toggle,
   Button,
 } from "@/pages/settings/components";
-
-import "./pdf-margin-layout.css";
-
-// --- Components ---
-
-function PdfSettingsGroup({
-  icon,
-  children,
-}: {
-  icon: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="pdf-settings-group">
-      <div className="pdf-settings-group-icon">{icon}</div>
-      <div className="pdf-settings-group-items">{children}</div>
-    </div>
-  );
-}
-
-/** Collapsible section for the sidebar. */
-function CollapsibleSection({
-  title,
-  defaultOpen = false,
-  children,
-}: {
-  title: string;
-  defaultOpen?: boolean;
-  children: React.ReactNode;
-}) {
-  const [open, setOpen] = useState(defaultOpen);
-  return (
-    <div style={{ marginBottom: "0.5rem" }}>
-      <button
-        className="pdf-collapsible-header"
-        data-open={open}
-        onClick={() => setOpen(!open)}
-      >
-        <ChevronRight />
-        {title}
-      </button>
-      {open && children}
-    </div>
-  );
-}
-
-/** Visual page margin diagram with editable mm inputs on all 4 sides. */
-function MarginLayoutDiagram({
-  top, right, bottom, left, landscape, unitLabel, onChange,
-}: {
-  top: number;
-  right: number;
-  bottom: number;
-  left: number;
-  landscape: boolean;
-  unitLabel: string;
-  onChange: (side: "marginTop" | "marginRight" | "marginBottom" | "marginLeft", value: number) => void;
-}) {
-  const handleChange = (side: "marginTop" | "marginRight" | "marginBottom" | "marginLeft", raw: string) => {
-    const v = parseFloat(raw);
-    if (!Number.isNaN(v) && v >= 0 && v <= 100) {
-      onChange(side, Math.round(v * 10) / 10);
-    }
-  };
-
-  return (
-    <div className="margin-layout">
-      <div className="margin-layout-top">
-        <input
-          type="number"
-          className="margin-layout-input"
-          value={top}
-          min={0} max={100} step={1}
-          onChange={(e) => handleChange("marginTop", e.target.value)}
-        />
-      </div>
-      <div className="margin-layout-middle">
-        <input
-          type="number"
-          className="margin-layout-input"
-          value={left}
-          min={0} max={100} step={1}
-          onChange={(e) => handleChange("marginLeft", e.target.value)}
-        />
-        <div className={`margin-layout-page ${landscape ? "margin-layout-page--landscape" : ""}`} />
-        <input
-          type="number"
-          className="margin-layout-input"
-          value={right}
-          min={0} max={100} step={1}
-          onChange={(e) => handleChange("marginRight", e.target.value)}
-        />
-      </div>
-      <div className="margin-layout-bottom">
-        <input
-          type="number"
-          className="margin-layout-input"
-          value={bottom}
-          min={0} max={100} step={1}
-          onChange={(e) => handleChange("marginBottom", e.target.value)}
-        />
-      </div>
-      <span className="margin-layout-unit">{unitLabel}</span>
-    </div>
-  );
-}
+import {
+  PdfSettingsGroup,
+  CollapsibleSection,
+  MarginLayoutDiagram,
+  type MarginSide,
+} from "./PdfSidebarPrimitives";
 
 // --- Main sidebar ---
 
@@ -209,7 +112,7 @@ export function PdfSettingsSidebar({ options, onOptionChange: set, onExport, exp
   }, [set, options]);
 
   const handleMarginChange = useCallback(
-    (side: "marginTop" | "marginRight" | "marginBottom" | "marginLeft", value: number) => {
+    (side: MarginSide, value: number) => {
       set(side, value);
       const next = { ...options, [side]: value };
       // Re-detect margin preset
@@ -327,6 +230,44 @@ export function PdfSettingsSidebar({ options, onOptionChange: set, onExport, exp
                 onChange={(v) => set("useEditorTheme", v)}
               />
             </SettingRow>
+          </PdfSettingsGroup>
+        </CollapsibleSection>
+
+        {/* Page numbers — collapsible */}
+        <CollapsibleSection title={t("pdf.pageNumbers")}>
+          <PdfSettingsGroup icon={<Hash className="w-3.5 h-3.5" />}>
+            <SettingRow label={t("pdf.pageNumbers.position")}>
+              <Select
+                value={options.pageNumberPosition}
+                options={PAGE_NUMBER_POSITION_OPTIONS.map((o) => ({
+                  value: o.value,
+                  label: t(o.labelKey),
+                }))}
+                onChange={(v) => set("pageNumberPosition", v)}
+              />
+            </SettingRow>
+            {/* The format and skip controls do nothing while position is
+                "none", so they are hidden rather than shown disabled. */}
+            {options.pageNumberPosition !== "none" && (
+              <>
+                <SettingRow label={t("pdf.pageNumbers.format")}>
+                  <Select
+                    value={options.pageNumberFormat}
+                    options={PAGE_NUMBER_FORMAT_OPTIONS.map((o) => ({
+                      value: o.value,
+                      label: t(o.labelKey),
+                    }))}
+                    onChange={(v) => set("pageNumberFormat", v)}
+                  />
+                </SettingRow>
+                <SettingRow label={t("pdf.pageNumbers.skipFirst")}>
+                  <Toggle
+                    checked={options.pageNumberSkipFirst}
+                    onChange={(v) => set("pageNumberSkipFirst", v)}
+                  />
+                </SettingRow>
+              </>
+            )}
           </PdfSettingsGroup>
         </CollapsibleSection>
       </div>

--- a/src/export/PdfSettingsSidebar.tsx
+++ b/src/export/PdfSettingsSidebar.tsx
@@ -115,17 +115,10 @@ export function PdfSettingsSidebar({ options, onOptionChange: set, onExport, exp
     (side: MarginSide, value: number) => {
       set(side, value);
       const next = { ...options, [side]: value };
-      // Re-detect margin preset
-      let found = false;
-      for (const [name, p] of Object.entries(MARGIN_PRESETS)) {
-        if (next.marginTop === p.top && next.marginRight === p.right &&
-            next.marginBottom === p.bottom && next.marginLeft === p.left) {
-          setMarginPreset(name);
-          found = true;
-          break;
-        }
-      }
-      if (!found) setMarginPreset("custom");
+      // `detectMarginPreset`, not a second copy of its loop — the copy that was
+      // here matched the same four fields against the same table, so the two
+      // could only ever disagree after someone edited one of them.
+      setMarginPreset(detectMarginPreset(next));
       setStylePreset(detectStylePreset(next));
     },
     [set, options],

--- a/src/export/PdfSidebarPrimitives.tsx
+++ b/src/export/PdfSidebarPrimitives.tsx
@@ -1,0 +1,122 @@
+/**
+ * Layout primitives for the PDF export sidebar.
+ *
+ * Purpose: these three are pure presentation — an icon-plus-items row, a
+ * disclosure wrapper, and the margin diagram. None of them knows what a
+ * `PdfOptions` is. Separating them leaves `PdfSettingsSidebar.tsx` as the
+ * composition of settings it is meant to be, rather than that plus a small
+ * widget library.
+ *
+ * @module export/PdfSidebarPrimitives
+ * @coordinates-with PdfSettingsSidebar.tsx — the only consumer
+ */
+
+import { useState } from "react";
+import { ChevronRight } from "lucide-react";
+
+import "./pdf-margin-layout.css";
+
+/** An icon gutter beside a column of setting rows. */
+export function PdfSettingsGroup({
+  icon,
+  children,
+}: {
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="pdf-settings-group">
+      <div className="pdf-settings-group-icon">{icon}</div>
+      <div className="pdf-settings-group-items">{children}</div>
+    </div>
+  );
+}
+
+/** Collapsible section for the sidebar. */
+export function CollapsibleSection({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div style={{ marginBottom: "0.5rem" }}>
+      <button
+        className="pdf-collapsible-header"
+        data-open={open}
+        onClick={() => setOpen(!open)}
+      >
+        <ChevronRight />
+        {title}
+      </button>
+      {open && children}
+    </div>
+  );
+}
+
+export type MarginSide = "marginTop" | "marginRight" | "marginBottom" | "marginLeft";
+
+/** Visual page margin diagram with editable mm inputs on all 4 sides. */
+export function MarginLayoutDiagram({
+  top, right, bottom, left, landscape, unitLabel, onChange,
+}: {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  landscape: boolean;
+  unitLabel: string;
+  onChange: (side: MarginSide, value: number) => void;
+}) {
+  const handleChange = (side: MarginSide, raw: string) => {
+    const v = parseFloat(raw);
+    if (!Number.isNaN(v) && v >= 0 && v <= 100) {
+      onChange(side, Math.round(v * 10) / 10);
+    }
+  };
+
+  return (
+    <div className="margin-layout">
+      <div className="margin-layout-top">
+        <input
+          type="number"
+          className="margin-layout-input"
+          value={top}
+          min={0} max={100} step={1}
+          onChange={(e) => handleChange("marginTop", e.target.value)}
+        />
+      </div>
+      <div className="margin-layout-middle">
+        <input
+          type="number"
+          className="margin-layout-input"
+          value={left}
+          min={0} max={100} step={1}
+          onChange={(e) => handleChange("marginLeft", e.target.value)}
+        />
+        <div className={`margin-layout-page ${landscape ? "margin-layout-page--landscape" : ""}`} />
+        <input
+          type="number"
+          className="margin-layout-input"
+          value={right}
+          min={0} max={100} step={1}
+          onChange={(e) => handleChange("marginRight", e.target.value)}
+        />
+      </div>
+      <div className="margin-layout-bottom">
+        <input
+          type="number"
+          className="margin-layout-input"
+          value={bottom}
+          min={0} max={100} step={1}
+          onChange={(e) => handleChange("marginBottom", e.target.value)}
+        />
+      </div>
+      <span className="margin-layout-unit">{unitLabel}</span>
+    </div>
+  );
+}

--- a/src/export/PdfSidebarPrimitives.tsx
+++ b/src/export/PdfSidebarPrimitives.tsx
@@ -60,6 +60,43 @@ export function CollapsibleSection({
 
 export type MarginSide = "marginTop" | "marginRight" | "marginBottom" | "marginLeft";
 
+/**
+ * One margin field.
+ *
+ * Extracted because the same input existed four times, differing only by side
+ * and value — and the duplication had already propagated a defect: every copy
+ * declared `step={1}` while the shipped presets are 25.4, 12.7 and 38.1mm, so
+ * the field was step-mismatched and the spinner snapped away the fraction.
+ * Fixing that once meant fixing it four times, which is the argument.
+ *
+ * The rounding to one decimal matches `step` deliberately: A4's 25.4mm is an
+ * inch, and letting it become 25 silently changes the page geometry.
+ */
+function MarginInput({
+  side, value, onChange,
+}: {
+  side: MarginSide;
+  value: number;
+  onChange: (side: MarginSide, value: number) => void;
+}) {
+  return (
+    <input
+      type="number"
+      className="margin-layout-input"
+      value={value}
+      min={0}
+      max={100}
+      step={0.1}
+      onChange={(e) => {
+        const v = parseFloat(e.target.value);
+        if (!Number.isNaN(v) && v >= 0 && v <= 100) {
+          onChange(side, Math.round(v * 10) / 10);
+        }
+      }}
+    />
+  );
+}
+
 /** Visual page margin diagram with editable mm inputs on all 4 sides. */
 export function MarginLayoutDiagram({
   top, right, bottom, left, landscape, unitLabel, onChange,
@@ -72,49 +109,18 @@ export function MarginLayoutDiagram({
   unitLabel: string;
   onChange: (side: MarginSide, value: number) => void;
 }) {
-  const handleChange = (side: MarginSide, raw: string) => {
-    const v = parseFloat(raw);
-    if (!Number.isNaN(v) && v >= 0 && v <= 100) {
-      onChange(side, Math.round(v * 10) / 10);
-    }
-  };
-
   return (
     <div className="margin-layout">
       <div className="margin-layout-top">
-        <input
-          type="number"
-          className="margin-layout-input"
-          value={top}
-          min={0} max={100} step={1}
-          onChange={(e) => handleChange("marginTop", e.target.value)}
-        />
+        <MarginInput side="marginTop" value={top} onChange={onChange} />
       </div>
       <div className="margin-layout-middle">
-        <input
-          type="number"
-          className="margin-layout-input"
-          value={left}
-          min={0} max={100} step={1}
-          onChange={(e) => handleChange("marginLeft", e.target.value)}
-        />
+        <MarginInput side="marginLeft" value={left} onChange={onChange} />
         <div className={`margin-layout-page ${landscape ? "margin-layout-page--landscape" : ""}`} />
-        <input
-          type="number"
-          className="margin-layout-input"
-          value={right}
-          min={0} max={100} step={1}
-          onChange={(e) => handleChange("marginRight", e.target.value)}
-        />
+        <MarginInput side="marginRight" value={right} onChange={onChange} />
       </div>
       <div className="margin-layout-bottom">
-        <input
-          type="number"
-          className="margin-layout-input"
-          value={bottom}
-          min={0} max={100} step={1}
-          onChange={(e) => handleChange("marginBottom", e.target.value)}
-        />
+        <MarginInput side="marginBottom" value={bottom} onChange={onChange} />
       </div>
       <span className="margin-layout-unit">{unitLabel}</span>
     </div>

--- a/src/export/__tests__/exportDialogNamespaces.test.ts
+++ b/src/export/__tests__/exportDialogNamespaces.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+/**
+ * Every translation key must exist in the namespace it is looked up through.
+ *
+ * `PdfExportDialog.tsx` holds TWO translation functions — `t` for the "export"
+ * bundle and `tDialog` for "dialog" — and nothing checks that a key is asked of
+ * the right one. i18next returns THE KEY ITSELF on a miss, so a mismatch is
+ * silent: `tDialog("pdf.pageNumbers.verboseTemplate")` returned the literal
+ * string `"pdf.pageNumbers.verboseTemplate"`, which is pure ASCII, so the PDF
+ * stamper happily accepted it and printed it on every page.
+ *
+ * Typecheck cannot see this (both functions are `(key: string) => string`) and
+ * `lint:i18n` cannot either — it verifies that keys exist across locales, not
+ * that a call site asks the right bundle.
+ *
+ * Scoped to the export windows: they are the files that carry more than one
+ * namespace, which is the precondition for the mistake.
+ *
+ * @module export/__tests__/exportDialogNamespaces
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const SRC = path.resolve(__dirname, "..");
+const LOCALES = path.resolve(__dirname, "../../locales/en");
+
+/** Files that bind more than one `useTranslation` namespace. */
+function multiNamespaceFiles(): string[] {
+  return readdirSync(SRC)
+    .filter((f) => f.endsWith(".tsx") || f.endsWith(".ts"))
+    .filter((f) => {
+      const src = readFileSync(path.join(SRC, f), "utf8");
+      return (src.match(/useTranslation\(/g) ?? []).length >= 2;
+    });
+}
+
+/** Map each translation function's local name to the namespace it was bound to. */
+function bindings(src: string): Map<string, string> {
+  const out = new Map<string, string>();
+  // `const { t } = useTranslation("export")`
+  for (const m of src.matchAll(/const\s*\{\s*t\s*\}\s*=\s*useTranslation\("([^"]+)"\)/g)) {
+    out.set("t", m[1]!);
+  }
+  // `const { t: tDialog } = useTranslation("dialog")`
+  for (const m of src.matchAll(
+    /const\s*\{\s*t:\s*(\w+)\s*\}\s*=\s*useTranslation\("([^"]+)"\)/g,
+  )) {
+    out.set(m[1]!, m[2]!);
+  }
+  return out;
+}
+
+function keysOf(namespace: string): Set<string> {
+  const file = path.join(LOCALES, `${namespace}.json`);
+  return new Set(Object.keys(JSON.parse(readFileSync(file, "utf8")) as object));
+}
+
+describe("translation namespaces in the export windows", () => {
+  const files = multiNamespaceFiles();
+
+  it("finds the files it is meant to check", () => {
+    // A rename or a refactor that emptied this list would make every assertion
+    // below vacuously pass.
+    expect(files.length).toBeGreaterThan(0);
+    expect(files).toContain("PdfExportDialog.tsx");
+  });
+
+  it.each(files)("%s resolves every literal key in the right bundle", (file) => {
+    const src = readFileSync(path.join(SRC, file), "utf8");
+    const bound = bindings(src);
+    expect(bound.size).toBeGreaterThan(1);
+
+    const missing: string[] = [];
+    for (const [fn, namespace] of bound) {
+      const known = keysOf(namespace);
+      // Literal single-argument calls only. A computed key (`t(\`pdf.${x}\`)`)
+      // cannot be resolved statically, and guessing at one would produce a
+      // false failure — those are covered by the runtime tests instead.
+      const calls = src.matchAll(new RegExp(`\\b${fn}\\("([^"\`$]+)"`, "g"));
+      for (const call of calls) {
+        const key = call[1]!;
+        if (!known.has(key)) missing.push(`${fn}("${key}") — not in ${namespace}.json`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/export/__tests__/pageNumberSpec.test.ts
+++ b/src/export/__tests__/pageNumberSpec.test.ts
@@ -9,7 +9,11 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { buildPageNumberSpec, type PdfOptions } from "../pdfOptions";
+import {
+  buildPageNumberSpec,
+  effectiveBottomMarginMm,
+  type PdfOptions,
+} from "../pdfOptions";
 
 function options(overrides: Partial<PdfOptions> = {}): PdfOptions {
   return {
@@ -102,10 +106,68 @@ describe("buildPageNumberSpec", () => {
       "bottomMarginPt",
       "fontSizePt",
       "format",
+      "inkRgb",
       "position",
       "sideMarginPt",
       "skipFirst",
       "verboseTemplate",
     ]);
+  });
+
+  it("draws black on a light page and light ink on a dark one", () => {
+    // Black on a dark-theme export is invisible, and the backend cannot know
+    // which theme the document was rendered with.
+    expect(buildPageNumberSpec(options(), TEMPLATE, true)!.inkRgb).toEqual([0, 0, 0]);
+    const dark = buildPageNumberSpec(
+      options({ useEditorTheme: true }),
+      TEMPLATE,
+      true,
+    )!;
+    expect(dark.inkRgb.every((c) => c > 0.5)).toBe(true);
+  });
+
+  it("keeps black when the editor is dark but the export forces light", () => {
+    // `useEditorTheme: false` forces a white page whatever the app looks like.
+    expect(buildPageNumberSpec(options(), TEMPLATE, true)!.inkRgb).toEqual([0, 0, 0]);
+  });
+});
+
+describe("effectiveBottomMarginMm", () => {
+  it("leaves a generous margin alone", () => {
+    // Every shipped preset is already wide enough; the reservation must not
+    // quietly change the geometry of a normal export.
+    expect(effectiveBottomMarginMm(options())).toBe(25.4);
+    expect(effectiveBottomMarginMm(options({ marginBottom: 12.7 }))).toBe(12.7);
+  });
+
+  it("reserves room for the footer when the margin cannot hold it", () => {
+    // The number is drawn INSIDE the bottom margin. At 0mm the baseline floor
+    // keeps it on the paper but puts it straight over the last line of text.
+    const reserved = effectiveBottomMarginMm(options({ marginBottom: 0 }));
+    expect(reserved).toBeGreaterThan(0);
+    // Twice the number's height: 11pt body → 9.35pt number → 18.7pt ≈ 6.6mm.
+    expect(reserved).toBeCloseTo((9.35 * 2 * 25.4) / 72, 5);
+  });
+
+  it("reserves nothing when page numbers are off", () => {
+    // No footer, no reason to move the user's margin.
+    expect(
+      effectiveBottomMarginMm(options({ marginBottom: 0, pageNumberPosition: "none" })),
+    ).toBe(0);
+  });
+
+  it("scales the reservation with body size", () => {
+    const small = effectiveBottomMarginMm(options({ marginBottom: 0, fontSize: 8 }));
+    const large = effectiveBottomMarginMm(options({ marginBottom: 0, fontSize: 24 }));
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it("is what the spec is told, so CSS and stamp agree", () => {
+    // Two layout paths read this: the @page rule and the PageSpec. If the spec
+    // received the RAW margin instead, the stamp would be placed in a band the
+    // page did not reserve.
+    const opts = options({ marginBottom: 0 });
+    const spec = buildPageNumberSpec(opts, TEMPLATE)!;
+    expect(spec.bottomMarginPt).toBeCloseTo((effectiveBottomMarginMm(opts) * 72) / 25.4, 5);
   });
 });

--- a/src/export/__tests__/pageNumberSpec.test.ts
+++ b/src/export/__tests__/pageNumberSpec.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+/**
+ * The page-number spec sent to the backend.
+ *
+ * Page numbers are STAMPED onto the finished PDF rather than laid out in CSS,
+ * because they belong in `@page` margin boxes and WebKit does not implement
+ * those — a CSS approach would have worked on Chromium alone. So the geometry
+ * the backend needs has to be computed here, in the units it expects.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildPageNumberSpec, type PdfOptions } from "../pdfOptions";
+
+function options(overrides: Partial<PdfOptions> = {}): PdfOptions {
+  return {
+    pageSize: "a4",
+    orientation: "portrait",
+    marginTop: 25.4,
+    marginRight: 25.4,
+    marginBottom: 25.4,
+    marginLeft: 25.4,
+    fontSize: 11,
+    lineHeight: 1.6,
+    cjkLetterSpacing: "0.05em",
+    latinFont: "system",
+    cjkFont: "system",
+    useEditorTheme: false,
+    pageNumberPosition: "bottom-center",
+    pageNumberFormat: "plain",
+    pageNumberSkipFirst: false,
+    ...overrides,
+  };
+}
+
+const TEMPLATE = "Page {n} of {total}";
+
+describe("buildPageNumberSpec", () => {
+  it("returns null when the user turned page numbers off", () => {
+    // null rather than a spec with position "none": the command argument is
+    // optional, so the backend can skip the whole post-processing step instead
+    // of loading and re-saving the PDF to draw nothing.
+    expect(buildPageNumberSpec(options({ pageNumberPosition: "none" }), TEMPLATE)).toBeNull();
+  });
+
+  it("converts margins from millimetres to points", () => {
+    const spec = buildPageNumberSpec(options(), TEMPLATE)!;
+    expect(spec.bottomMarginPt).toBeCloseTo(72, 5);
+    expect(spec.sideMarginPt).toBeCloseTo(72, 5);
+  });
+
+  it("takes the bottom margin for vertical placement and the right for horizontal", () => {
+    // Asymmetric on purpose — the `wide` preset has different side margins, and
+    // swapping these would push a right-aligned number off the page.
+    const spec = buildPageNumberSpec(
+      options({ marginBottom: 10, marginRight: 40 }),
+      TEMPLATE,
+    )!;
+    expect(spec.bottomMarginPt).toBeCloseTo((10 * 72) / 25.4, 5);
+    expect(spec.sideMarginPt).toBeCloseTo((40 * 72) / 25.4, 5);
+  });
+
+  it("scales the number with body text rather than fixing it", () => {
+    const small = buildPageNumberSpec(options({ fontSize: 9 }), TEMPLATE)!;
+    const large = buildPageNumberSpec(options({ fontSize: 20 }), TEMPLATE)!;
+    expect(large.fontSizePt).toBeGreaterThan(small.fontSizePt);
+    expect(large.fontSizePt).toBeCloseTo(17, 5);
+  });
+
+  it("floors the size so it stays legible under a tiny body size", () => {
+    // fontSize is user-settable; 0.85 x 4pt would be a 3.4pt footer nobody can
+    // read, and it would still consume a line of the margin.
+    const spec = buildPageNumberSpec(options({ fontSize: 4 }), TEMPLATE)!;
+    expect(spec.fontSizePt).toBe(7);
+  });
+
+  it("passes position, format and skip through unchanged", () => {
+    const spec = buildPageNumberSpec(
+      options({
+        pageNumberPosition: "bottom-right",
+        pageNumberFormat: "with-total",
+        pageNumberSkipFirst: true,
+      }),
+      TEMPLATE,
+    )!;
+    expect(spec.position).toBe("bottom-right");
+    expect(spec.format).toBe("with-total");
+    expect(spec.skipFirst).toBe(true);
+  });
+
+  it("carries the localized template for the backend to substitute", () => {
+    // The page COUNT is unknown until the render finishes, so the frontend
+    // sends a template rather than a finished string.
+    const spec = buildPageNumberSpec(options(), "Página {n} de {total}")!;
+    expect(spec.verboseTemplate).toBe("Página {n} de {total}");
+    expect(spec.verboseTemplate).toContain("{n}");
+    expect(spec.verboseTemplate).toContain("{total}");
+  });
+
+  it("emits exactly the wire fields the Rust struct declares", () => {
+    // The two sides are joined by serde field names, which no compiler checks.
+    expect(Object.keys(buildPageNumberSpec(options(), TEMPLATE)!).sort()).toEqual([
+      "bottomMarginPt",
+      "fontSizePt",
+      "format",
+      "position",
+      "sideMarginPt",
+      "skipFirst",
+      "verboseTemplate",
+    ]);
+  });
+});

--- a/src/export/__tests__/pageNumberSpec.test.ts
+++ b/src/export/__tests__/pageNumberSpec.test.ts
@@ -132,6 +132,23 @@ describe("buildPageNumberSpec", () => {
   });
 });
 
+describe("the shipped verbose templates", () => {
+  const LOCALES = ["en", "de", "es", "fr", "it", "ja", "ko", "pt-BR", "zh-CN", "zh-TW"];
+
+  it.each(LOCALES)("%s carries the page placeholder", async (loc) => {
+    // Without `{n}` the template cannot produce a page NUMBER — the backend
+    // falls back to the numeric form rather than stamping the same static text
+    // on every page, so the failure is graceful but silent. This is where a
+    // translation that dropped the placeholder should be caught.
+    const bundle = (await import(`../../locales/${loc}/export.json`)) as {
+      default: Record<string, string>;
+    };
+    const template = bundle.default["pdf.pageNumbers.verboseTemplate"];
+    expect(template, `${loc} is missing the key`).toBeDefined();
+    expect(template, `${loc}: ${template}`).toContain("{n}");
+  });
+});
+
 describe("effectiveBottomMarginMm", () => {
   it("leaves a generous margin alone", () => {
     // Every shipped preset is already wide enough; the reservation must not

--- a/src/export/pdfFitToPage.ts
+++ b/src/export/pdfFitToPage.ts
@@ -15,7 +15,7 @@
  * @coordinates-with pageSpec.ts — the page dimensions this is derived from
  */
 
-import type { PdfOptions } from "./pdfOptions";
+import { type PdfOptions, effectiveBottomMarginMm } from "./pdfOptions";
 import { PAGE_SIZE_PT } from "./pageSpec";
 
 /**
@@ -74,9 +74,14 @@ function buildFitCSS(options: PdfOptions): string {
   // 8% of image height for this; that is the price of one rule that works on
   // all three engines.
   const WEBKIT_OVERSHOOT = 0.92;
+  // The RESERVED bottom margin, not the requested one. Page numbers are stamped
+  // inside that band, so with numbering on the content area is shorter than
+  // `marginBottom` implies — and an image sized against the raw value is then
+  // taller than the page leaves it, which is the straddling this whole file
+  // exists to prevent.
   const usableMm = Math.max(
     20,
-    (heightMm - options.marginTop - options.marginBottom - WRAPPER_MM - 4) *
+    (heightMm - options.marginTop - effectiveBottomMarginMm(options) - WRAPPER_MM - 4) *
       WEBKIT_OVERSHOOT,
   );
 

--- a/src/export/pdfHtmlTemplate.ts
+++ b/src/export/pdfHtmlTemplate.ts
@@ -9,7 +9,9 @@
  *
  * WebKit's native print pipeline (printOperationWithPrintInfo) respects @page
  * size/margin rules but does NOT implement @page margin boxes (@top-center etc.),
- * so headers/footers/page-number settings are intentionally absent from PdfOptions.
+ * so nothing in this file can draw a running header or footer. Page numbers are
+ * therefore not CSS at all: `PdfOptions` carries the request, and Rust STAMPS
+ * the finished PDF (`pdf_export/page_numbers.rs`) so all three engines agree.
  *
  * @module export/pdfHtmlTemplate
  * @coordinates-with pdf_export/renderer.rs — WKWebView loads this HTML and prints to PDF

--- a/src/export/pdfHtmlTemplate.ts
+++ b/src/export/pdfHtmlTemplate.ts
@@ -25,7 +25,7 @@ import { getPrimitiveTokenCSS } from "./primitiveTokens";
 import { buildFontStack } from "@/utils/fontStacks";
 import { sharedContentCSS, forceLightThemeCSS } from "./pdfPrintCss";
 import { buildFitCSS } from "./pdfFitToPage";
-import { type PdfOptions, PAGE_SIZE_KEYWORDS } from "./pdfOptions";
+import { type PdfOptions, PAGE_SIZE_KEYWORDS, effectiveBottomMarginMm } from "./pdfOptions";
 
 // Re-exported so existing importers keep one entry point for the export API.
 export { MARGIN_PRESETS, PAGE_SIZE_KEYWORDS } from "./pdfOptions";
@@ -54,7 +54,11 @@ export function getSharedContentCSS(): string {
 function buildPageCSS(options: PdfOptions): string {
   const sizeKeyword = PAGE_SIZE_KEYWORDS[options.pageSize] ?? PAGE_SIZE_KEYWORDS.a4;
   const size = `${sizeKeyword} ${options.orientation}`;
-  const margin = `${options.marginTop}mm ${options.marginRight}mm ${options.marginBottom}mm ${options.marginLeft}mm`;
+  // The bottom uses the RESERVED margin: page numbers are stamped inside that
+  // band, so the content area has to stop short of them or the footer prints
+  // over the last line. Identical to what `buildPageNumberSpec` is told.
+  const bottom = effectiveBottomMarginMm(options);
+  const margin = `${options.marginTop}mm ${options.marginRight}mm ${bottom}mm ${options.marginLeft}mm`;
 
   return `
 @page {

--- a/src/export/pdfOptions.ts
+++ b/src/export/pdfOptions.ts
@@ -21,6 +21,68 @@ export interface PdfOptions {
   cjkFont: string;
   /** When true, use the editor's current theme instead of forcing light. */
   useEditorTheme: boolean;
+  /** Where the page number sits, or "none" to omit it. */
+  pageNumberPosition: PageNumberPosition;
+  /** How the page number reads. */
+  pageNumberFormat: PageNumberFormat;
+  /** Leave page 1 unnumbered — title pages conventionally are. */
+  pageNumberSkipFirst: boolean;
+}
+
+/**
+ * Page numbers are stamped onto the finished PDF by the Rust side, not laid out
+ * in CSS: they belong in `@page` margin boxes, which WebKit does not implement,
+ * so a CSS approach would have worked on Chromium alone.
+ */
+export type PageNumberPosition = "none" | "bottom-center" | "bottom-right";
+
+/** `7`, `7 / 12`, or the localized `Page 7 of 12`. */
+export type PageNumberFormat = "plain" | "with-total" | "verbose";
+
+/** The wire shape the `export_pdf` command takes. Field names are the contract. */
+export interface PageNumberSpec {
+  position: PageNumberPosition;
+  format: PageNumberFormat;
+  skipFirst: boolean;
+  fontSizePt: number;
+  bottomMarginPt: number;
+  sideMarginPt: number;
+  /**
+   * Localized template for the verbose format. Substituted backend-side because
+   * the page COUNT is not known until the render is done.
+   *
+   * A template the base-14 font cannot draw — any CJK — is refused there and
+   * falls back to the numeric form rather than being stamped as blanks.
+   */
+  verboseTemplate: string;
+}
+
+/** Millimetres to PostScript points. */
+function mmToPt(mm: number): number {
+  return (mm * 72) / 25.4;
+}
+
+/**
+ * Build the page-number spec, or `null` when the user turned it off.
+ *
+ * The number is sized relative to body text rather than fixed, so a 9pt export
+ * does not get a footer nearly as large as its prose, and floored so it stays
+ * legible at small body sizes.
+ */
+export function buildPageNumberSpec(
+  options: PdfOptions,
+  verboseTemplate: string,
+): PageNumberSpec | null {
+  if (options.pageNumberPosition === "none") return null;
+  return {
+    position: options.pageNumberPosition,
+    format: options.pageNumberFormat,
+    skipFirst: options.pageNumberSkipFirst,
+    fontSizePt: Math.max(7, options.fontSize * 0.85),
+    bottomMarginPt: mmToPt(options.marginBottom),
+    sideMarginPt: mmToPt(options.marginRight),
+    verboseTemplate,
+  };
 }
 
 /** Named margin presets (values in mm). */

--- a/src/export/pdfOptions.ts
+++ b/src/export/pdfOptions.ts
@@ -51,10 +51,18 @@ export interface PageNumberSpec {
    * Localized template for the verbose format. Substituted backend-side because
    * the page COUNT is not known until the render is done.
    *
-   * A template the base-14 font cannot draw — any CJK — is refused there and
-   * falls back to the numeric form rather than being stamped as blanks.
+   * A template the base-14 font cannot draw — any CJK — is replaced there by the
+   * numeric form, so those readers still get page numbers.
    */
   verboseTemplate: string;
+  /**
+   * Ink colour, as three 0–1 components.
+   *
+   * Sent rather than assumed: `useEditorTheme` lets a dark theme through to the
+   * PDF, and a hardcoded black number on a dark page is invisible. The frontend
+   * is the only side that knows which theme the document was rendered with.
+   */
+  inkRgb: [number, number, number];
 }
 
 /** Millimetres to PostScript points. */
@@ -62,26 +70,68 @@ function mmToPt(mm: number): number {
   return (mm * 72) / 25.4;
 }
 
+/** PostScript points to millimetres. */
+function ptToMm(pt: number): number {
+  return (pt * 25.4) / 72;
+}
+
+/**
+ * The bottom margin the page must actually reserve.
+ *
+ * The page number is drawn INSIDE the bottom margin, so a margin too shallow to
+ * hold it puts the number on top of the last line of text. `baseline()` floors
+ * the y coordinate to keep the number on the paper, which stops it falling off
+ * the sheet but does nothing about the collision — an export with a 0mm bottom
+ * margin and page numbers on printed the footer over the body.
+ *
+ * So the footer band is reserved rather than borrowed: with numbering on, the
+ * bottom margin is at least twice the number's height, which is what
+ * `baseline()` needs to centre it clear of the content. The user's margin is
+ * honoured whenever it is already large enough — every shipped preset is.
+ */
+export function effectiveBottomMarginMm(options: PdfOptions): number {
+  if (options.pageNumberPosition === "none") return options.marginBottom;
+  const minimum = ptToMm(pageNumberFontSizePt(options) * 2);
+  return Math.max(options.marginBottom, minimum);
+}
+
+/**
+ * The page number's size: relative to body text rather than fixed, so a 9pt
+ * export does not get a footer nearly as large as its prose, and floored so it
+ * stays legible at small body sizes.
+ */
+function pageNumberFontSizePt(options: PdfOptions): number {
+  return Math.max(7, options.fontSize * 0.85);
+}
+
+/** Light ink for a dark page; near-black otherwise. */
+const INK_ON_DARK: [number, number, number] = [0.78, 0.78, 0.78];
+const INK_ON_LIGHT: [number, number, number] = [0, 0, 0];
+
 /**
  * Build the page-number spec, or `null` when the user turned it off.
  *
- * The number is sized relative to body text rather than fixed, so a 9pt export
- * does not get a footer nearly as large as its prose, and floored so it stays
- * legible at small body sizes.
+ * `isDark` only matters when `useEditorTheme` is on — otherwise the export
+ * forces the light theme regardless of what the editor is showing, and the page
+ * is white however dark the app looks.
  */
 export function buildPageNumberSpec(
   options: PdfOptions,
   verboseTemplate: string,
+  isDark = false,
 ): PageNumberSpec | null {
   if (options.pageNumberPosition === "none") return null;
   return {
     position: options.pageNumberPosition,
     format: options.pageNumberFormat,
     skipFirst: options.pageNumberSkipFirst,
-    fontSizePt: Math.max(7, options.fontSize * 0.85),
-    bottomMarginPt: mmToPt(options.marginBottom),
+    fontSizePt: pageNumberFontSizePt(options),
+    // The RESERVED margin, not the requested one — the stamp has to be placed
+    // in the band the page actually leaves it, or it lands on the text.
+    bottomMarginPt: mmToPt(effectiveBottomMarginMm(options)),
     sideMarginPt: mmToPt(options.marginRight),
     verboseTemplate,
+    inkRgb: options.useEditorTheme && isDark ? INK_ON_DARK : INK_ON_LIGHT,
   };
 }
 

--- a/src/export/pdfPresets.ts
+++ b/src/export/pdfPresets.ts
@@ -113,6 +113,26 @@ export const PAGE_SIZE_OPTIONS = [
   { value: "legal" as const, label: "Legal" },
 ];
 
+/**
+ * Page-number position options.
+ *
+ * Label KEYS rather than resolved strings, so the sidebar translates at render
+ * time and the array stays a plain constant — the same shape the orientation
+ * builder produces, without needing a `t` to construct it.
+ */
+export const PAGE_NUMBER_POSITION_OPTIONS = [
+  { value: "none" as const, labelKey: "pdf.pageNumbers.position.none" },
+  { value: "bottom-center" as const, labelKey: "pdf.pageNumbers.position.bottomCenter" },
+  { value: "bottom-right" as const, labelKey: "pdf.pageNumbers.position.bottomRight" },
+];
+
+/** Page-number format options. */
+export const PAGE_NUMBER_FORMAT_OPTIONS = [
+  { value: "plain" as const, labelKey: "pdf.pageNumbers.format.plain" },
+  { value: "with-total" as const, labelKey: "pdf.pageNumbers.format.withTotal" },
+  { value: "verbose" as const, labelKey: "pdf.pageNumbers.format.verbose" },
+];
+
 /** Build select options for page orientation. */
 export function buildOrientationOptions(t: TFn) {
   return [

--- a/src/export/pdfPresets.ts
+++ b/src/export/pdfPresets.ts
@@ -36,31 +36,51 @@ export interface StylePreset {
   marginLeft: number;
 }
 
+/**
+ * Spread a named margin preset into the four fields a `StylePreset` carries.
+ *
+ * Every style preset's margins were previously written out as four literals
+ * that happened to equal a `MARGIN_PRESETS` entry — two independently editable
+ * sources for one set of numbers. Retuning `wide` then silently left `academic`
+ * on the old values, and `detectMarginPreset` would report "custom" for a
+ * preset the user had just chosen.
+ */
+function margins(preset: keyof typeof MARGIN_PRESETS | string) {
+  const p = MARGIN_PRESETS[preset];
+  if (!p) throw new Error(`unknown margin preset: ${preset}`);
+  return {
+    marginTop: p.top,
+    marginRight: p.right,
+    marginBottom: p.bottom,
+    marginLeft: p.left,
+  };
+}
+
 /** Built-in style presets: Default, Academic, Compact, and Elegant. */
 export const STYLE_PRESETS: Record<string, StylePreset> = {
   default: {
     labelKey: "pdf.preset.default",
     fontSize: 11, lineHeight: 1.6,
     latinFont: "system", cjkFont: "system",
-    marginTop: 25.4, marginRight: 25.4, marginBottom: 25.4, marginLeft: 25.4,
+    ...margins("normal"),
   },
   academic: {
     labelKey: "pdf.preset.academic",
     fontSize: 12, lineHeight: 2.0,
     latinFont: "palatino", cjkFont: "songti",
-    marginTop: 25.4, marginRight: 38.1, marginBottom: 25.4, marginLeft: 38.1,
+    ...margins("wide"),
   },
   compact: {
     labelKey: "pdf.preset.compact",
     fontSize: 10, lineHeight: 1.4,
     latinFont: "system", cjkFont: "system",
-    marginTop: 12.7, marginRight: 12.7, marginBottom: 12.7, marginLeft: 12.7,
+    ...margins("narrow"),
   },
   elegant: {
     labelKey: "pdf.preset.elegant",
     fontSize: 12, lineHeight: 1.8,
     latinFont: "athelas", cjkFont: "kaiti",
-    marginTop: 25.4, marginRight: 25.4, marginBottom: 25.4, marginLeft: 25.4,
+    ...margins("normal"),
   },
 };
 

--- a/src/export/pdfPresets.ts
+++ b/src/export/pdfPresets.ts
@@ -15,6 +15,7 @@
 
 import type { PdfOptions } from "./pdfHtmlTemplate";
 import { MARGIN_PRESETS } from "./pdfHtmlTemplate";
+import type { PageNumberFormat, PageNumberPosition } from "./pdfOptions";
 
 /** Translation function signature (matches react-i18next `t`). */
 type TFn = (key: string) => string;
@@ -114,24 +115,36 @@ export const PAGE_SIZE_OPTIONS = [
 ];
 
 /**
- * Page-number position options.
+ * Page-number dropdowns, keyed by the union rather than listed.
+ *
+ * `Record<PageNumberPosition, …>` is exhaustive: adding a position to the type
+ * fails to compile until this map gains its label. A plain array of
+ * `{ value: "…" as const }` rows — which is what these were — cannot do that.
+ * A bad value is caught at the `set()` call site either way, but a MISSING one
+ * is silent, and the symptom is a setting that exists with no way to choose it.
  *
  * Label KEYS rather than resolved strings, so the sidebar translates at render
- * time and the array stays a plain constant — the same shape the orientation
- * builder produces, without needing a `t` to construct it.
+ * time and these stay plain constants needing no `t` to construct.
  */
-export const PAGE_NUMBER_POSITION_OPTIONS = [
-  { value: "none" as const, labelKey: "pdf.pageNumbers.position.none" },
-  { value: "bottom-center" as const, labelKey: "pdf.pageNumbers.position.bottomCenter" },
-  { value: "bottom-right" as const, labelKey: "pdf.pageNumbers.position.bottomRight" },
-];
+const POSITION_LABEL_KEYS: Record<PageNumberPosition, string> = {
+  none: "pdf.pageNumbers.position.none",
+  "bottom-center": "pdf.pageNumbers.position.bottomCenter",
+  "bottom-right": "pdf.pageNumbers.position.bottomRight",
+};
 
-/** Page-number format options. */
-export const PAGE_NUMBER_FORMAT_OPTIONS = [
-  { value: "plain" as const, labelKey: "pdf.pageNumbers.format.plain" },
-  { value: "with-total" as const, labelKey: "pdf.pageNumbers.format.withTotal" },
-  { value: "verbose" as const, labelKey: "pdf.pageNumbers.format.verbose" },
-];
+const FORMAT_LABEL_KEYS: Record<PageNumberFormat, string> = {
+  plain: "pdf.pageNumbers.format.plain",
+  "with-total": "pdf.pageNumbers.format.withTotal",
+  verbose: "pdf.pageNumbers.format.verbose",
+};
+
+/** Select options, in declaration order (string keys preserve insertion order). */
+function optionsOf<K extends string>(labels: Record<K, string>) {
+  return (Object.keys(labels) as K[]).map((value) => ({ value, labelKey: labels[value] }));
+}
+
+export const PAGE_NUMBER_POSITION_OPTIONS = optionsOf(POSITION_LABEL_KEYS);
+export const PAGE_NUMBER_FORMAT_OPTIONS = optionsOf(FORMAT_LABEL_KEYS);
 
 /** Build select options for page orientation. */
 export function buildOrientationOptions(t: TFn) {

--- a/src/lib/ghaWorkflow/save/__tests__/corpusRoundtrip.test.ts
+++ b/src/lib/ghaWorkflow/save/__tests__/corpusRoundtrip.test.ts
@@ -38,7 +38,9 @@ const CORPUS_ROOTS = ["src/test/fixtures/gha-workflows", ".github/workflows"];
 // WI-AF3.3) joined the live root. Adding a workflow is meant to require
 // touching this number — that is the pin working, not an obstacle to route
 // around.
-const EXPECTED_FILE_COUNT = 37;
+// 38 since 2026-08-17: pdf-smoke.yml — the exporter's three native backends
+// had no cross-platform run anywhere in CI.
+const EXPECTED_FILE_COUNT = 38;
 
 /**
  * Workflows whose no-op round trip is BYTE-identical today. Two-way
@@ -47,6 +49,7 @@ const EXPECTED_FILE_COUNT = 37;
 const BYTE_IDENTICAL: ReadonlySet<string> = new Set([
   ".github/workflows/ci.yml",
   ".github/workflows/claude-cost-report.yml",
+  ".github/workflows/pdf-smoke.yml",
   ".github/workflows/soak.yml",
   ".github/workflows/release.yml",
   ".github/workflows/rust-cache-warm.yml",

--- a/src/locales/de/dialog.json
+++ b/src/locales/de/dialog.json
@@ -91,6 +91,7 @@
   "toast.failedToOpenPrintDialog": "Druckdialog konnte nicht geöffnet werden",
   "toast.htmlCopied": "HTML in Zwischenablage kopiert",
   "toast.pdfExportSuccess": "PDF erfolgreich exportiert",
+  "toast.pdfExportPartial": "PDF exportiert, aber {{what}} konnte nicht hinzugefügt werden.",
   "toast.pdfExportFailed": "PDF-Export fehlgeschlagen: {{error}}",
   "toast.cannotMoveTabNoDoc": "Tab kann nicht verschoben werden: Dokument ist nicht geladen.",
   "toast.cannotMoveLastTab": "Der letzte Tab im Hauptfenster kann nicht verschoben werden.",

--- a/src/locales/de/export.json
+++ b/src/locales/de/export.json
@@ -28,6 +28,7 @@
   "pdf.exporting": "Exportiert…",
   "pdf.progress.preparing": "Vorbereitung…",
   "pdf.progress.loading": "Inhalt wird geladen…",
+  "pdf.progress.finishing": "Wird abgeschlossen…",
   "pdf.progress.rendering": "PDF wird erstellt…",
   "pdf.progress.done": "Fertig",
   "pdf.saveDialog.title": "Als PDF exportieren",
@@ -42,5 +43,7 @@
   "pdf.pageNumbers.format.plain": "7",
   "pdf.pageNumbers.format.withTotal": "7 / 12",
   "pdf.pageNumbers.format.verbose": "Seite 7 von 12",
+  "pdf.warning.outline-failed": "die Seitenleisten-Gliederung",
+  "pdf.warning.page-numbers-failed": "Seitenzahlen",
   "pdf.pageNumbers.verboseTemplate": "Seite {n} von {total}"
 }

--- a/src/locales/de/export.json
+++ b/src/locales/de/export.json
@@ -31,5 +31,16 @@
   "pdf.progress.rendering": "PDF wird erstellt…",
   "pdf.progress.done": "Fertig",
   "pdf.saveDialog.title": "Als PDF exportieren",
-  "pdf.defaultTitle": "Dokument"
+  "pdf.defaultTitle": "Dokument",
+  "pdf.pageNumbers": "Seitenzahlen",
+  "pdf.pageNumbers.position": "Position",
+  "pdf.pageNumbers.format": "Format",
+  "pdf.pageNumbers.skipFirst": "Erste Seite überspringen",
+  "pdf.pageNumbers.position.none": "Keine",
+  "pdf.pageNumbers.position.bottomCenter": "Unten mittig",
+  "pdf.pageNumbers.position.bottomRight": "Unten rechts",
+  "pdf.pageNumbers.format.plain": "7",
+  "pdf.pageNumbers.format.withTotal": "7 / 12",
+  "pdf.pageNumbers.format.verbose": "Seite 7 von 12",
+  "pdf.pageNumbers.verboseTemplate": "Seite {n} von {total}"
 }

--- a/src/locales/en/dialog.json
+++ b/src/locales/en/dialog.json
@@ -113,6 +113,7 @@
   "toast.failedToOpenPrintDialog": "Failed to open print dialog",
   "toast.htmlCopied": "HTML copied to clipboard",
   "toast.pdfExportSuccess": "PDF exported successfully",
+  "toast.pdfExportPartial": "PDF exported, but {{what}} could not be added.",
   "toast.pdfExportFailed": "PDF export failed: {{error}}",
   "toast.cannotMoveTabNoDoc": "Cannot move tab: document is not loaded.",
   "toast.cannotMoveLastTab": "Cannot move the last tab in the main window.",

--- a/src/locales/en/export.json
+++ b/src/locales/en/export.json
@@ -31,5 +31,16 @@
   "pdf.progress.rendering": "Generating PDF…",
   "pdf.progress.done": "Done",
   "pdf.saveDialog.title": "Export PDF",
-  "pdf.defaultTitle": "Document"
+  "pdf.defaultTitle": "Document",
+  "pdf.pageNumbers": "Page Numbers",
+  "pdf.pageNumbers.position": "Position",
+  "pdf.pageNumbers.format": "Format",
+  "pdf.pageNumbers.skipFirst": "Skip first page",
+  "pdf.pageNumbers.position.none": "None",
+  "pdf.pageNumbers.position.bottomCenter": "Bottom centre",
+  "pdf.pageNumbers.position.bottomRight": "Bottom right",
+  "pdf.pageNumbers.format.plain": "7",
+  "pdf.pageNumbers.format.withTotal": "7 / 12",
+  "pdf.pageNumbers.format.verbose": "Page 7 of 12",
+  "pdf.pageNumbers.verboseTemplate": "Page {n} of {total}"
 }

--- a/src/locales/en/export.json
+++ b/src/locales/en/export.json
@@ -28,6 +28,7 @@
   "pdf.exporting": "Exporting…",
   "pdf.progress.preparing": "Preparing…",
   "pdf.progress.loading": "Loading content…",
+  "pdf.progress.finishing": "Finishing…",
   "pdf.progress.rendering": "Generating PDF…",
   "pdf.progress.done": "Done",
   "pdf.saveDialog.title": "Export PDF",
@@ -42,5 +43,7 @@
   "pdf.pageNumbers.format.plain": "7",
   "pdf.pageNumbers.format.withTotal": "7 / 12",
   "pdf.pageNumbers.format.verbose": "Page 7 of 12",
+  "pdf.warning.outline-failed": "the sidebar outline",
+  "pdf.warning.page-numbers-failed": "page numbers",
   "pdf.pageNumbers.verboseTemplate": "Page {n} of {total}"
 }

--- a/src/locales/es/dialog.json
+++ b/src/locales/es/dialog.json
@@ -91,6 +91,7 @@
   "toast.failedToOpenPrintDialog": "Error al abrir el cuadro de diálogo de impresión",
   "toast.htmlCopied": "HTML copiado al portapapeles",
   "toast.pdfExportSuccess": "PDF exportado correctamente",
+  "toast.pdfExportPartial": "PDF exportado, pero no se pudo añadir {{what}}.",
   "toast.pdfExportFailed": "Error al exportar PDF: {{error}}",
   "toast.cannotMoveTabNoDoc": "No se puede mover la pestaña: el documento no está cargado.",
   "toast.cannotMoveLastTab": "No se puede mover la última pestaña de la ventana principal.",

--- a/src/locales/es/export.json
+++ b/src/locales/es/export.json
@@ -28,6 +28,7 @@
   "pdf.exporting": "Exportando…",
   "pdf.progress.preparing": "Preparando…",
   "pdf.progress.loading": "Cargando contenido…",
+  "pdf.progress.finishing": "Finalizando…",
   "pdf.progress.rendering": "Generando PDF…",
   "pdf.progress.done": "Listo",
   "pdf.saveDialog.title": "Exportar PDF",
@@ -42,5 +43,7 @@
   "pdf.pageNumbers.format.plain": "7",
   "pdf.pageNumbers.format.withTotal": "7 / 12",
   "pdf.pageNumbers.format.verbose": "Página 7 de 12",
+  "pdf.warning.outline-failed": "el esquema de la barra lateral",
+  "pdf.warning.page-numbers-failed": "los números de página",
   "pdf.pageNumbers.verboseTemplate": "Página {n} de {total}"
 }

--- a/src/locales/es/export.json
+++ b/src/locales/es/export.json
@@ -31,5 +31,16 @@
   "pdf.progress.rendering": "Generando PDF…",
   "pdf.progress.done": "Listo",
   "pdf.saveDialog.title": "Exportar PDF",
-  "pdf.defaultTitle": "Documento"
+  "pdf.defaultTitle": "Documento",
+  "pdf.pageNumbers": "Números de página",
+  "pdf.pageNumbers.position": "Posición",
+  "pdf.pageNumbers.format": "Formato",
+  "pdf.pageNumbers.skipFirst": "Omitir la primera página",
+  "pdf.pageNumbers.position.none": "Ninguno",
+  "pdf.pageNumbers.position.bottomCenter": "Abajo centrado",
+  "pdf.pageNumbers.position.bottomRight": "Abajo a la derecha",
+  "pdf.pageNumbers.format.plain": "7",
+  "pdf.pageNumbers.format.withTotal": "7 / 12",
+  "pdf.pageNumbers.format.verbose": "Página 7 de 12",
+  "pdf.pageNumbers.verboseTemplate": "Página {n} de {total}"
 }

--- a/src/locales/fr/dialog.json
+++ b/src/locales/fr/dialog.json
@@ -91,6 +91,7 @@
   "toast.failedToOpenPrintDialog": "Impossible d'ouvrir la boîte de dialogue d'impression",
   "toast.htmlCopied": "HTML copié dans le presse-papiers",
   "toast.pdfExportSuccess": "PDF exporté avec succès",
+  "toast.pdfExportPartial": "PDF exporté, mais {{what}} n'a pas pu être ajouté.",
   "toast.pdfExportFailed": "Échec de l'exportation PDF : {{error}}",
   "toast.cannotMoveTabNoDoc": "Impossible de déplacer l'onglet : le document n'est pas chargé.",
   "toast.cannotMoveLastTab": "Impossible de déplacer le dernier onglet de la fenêtre principale.",

--- a/src/locales/fr/export.json
+++ b/src/locales/fr/export.json
@@ -31,5 +31,16 @@
   "pdf.progress.rendering": "Génération du PDF…",
   "pdf.progress.done": "Terminé",
   "pdf.saveDialog.title": "Exporter en PDF",
-  "pdf.defaultTitle": "Document"
+  "pdf.defaultTitle": "Document",
+  "pdf.pageNumbers": "Numéros de page",
+  "pdf.pageNumbers.position": "Position",
+  "pdf.pageNumbers.format": "Format",
+  "pdf.pageNumbers.skipFirst": "Ignorer la première page",
+  "pdf.pageNumbers.position.none": "Aucun",
+  "pdf.pageNumbers.position.bottomCenter": "En bas au centre",
+  "pdf.pageNumbers.position.bottomRight": "En bas à droite",
+  "pdf.pageNumbers.format.plain": "7",
+  "pdf.pageNumbers.format.withTotal": "7 / 12",
+  "pdf.pageNumbers.format.verbose": "Page 7 sur 12",
+  "pdf.pageNumbers.verboseTemplate": "Page {n} sur {total}"
 }

--- a/src/locales/fr/export.json
+++ b/src/locales/fr/export.json
@@ -28,6 +28,7 @@
   "pdf.exporting": "Exportation…",
   "pdf.progress.preparing": "Préparation…",
   "pdf.progress.loading": "Chargement du contenu…",
+  "pdf.progress.finishing": "Finalisation…",
   "pdf.progress.rendering": "Génération du PDF…",
   "pdf.progress.done": "Terminé",
   "pdf.saveDialog.title": "Exporter en PDF",
@@ -42,5 +43,7 @@
   "pdf.pageNumbers.format.plain": "7",
   "pdf.pageNumbers.format.withTotal": "7 / 12",
   "pdf.pageNumbers.format.verbose": "Page 7 sur 12",
+  "pdf.warning.outline-failed": "le sommaire latéral",
+  "pdf.warning.page-numbers-failed": "les numéros de page",
   "pdf.pageNumbers.verboseTemplate": "Page {n} sur {total}"
 }

--- a/src/locales/it/dialog.json
+++ b/src/locales/it/dialog.json
@@ -91,6 +91,7 @@
   "toast.failedToOpenPrintDialog": "Apertura della finestra di dialogo di stampa fallita",
   "toast.htmlCopied": "HTML copiato negli appunti",
   "toast.pdfExportSuccess": "PDF esportato con successo",
+  "toast.pdfExportPartial": "PDF esportato, ma non è stato possibile aggiungere {{what}}.",
   "toast.pdfExportFailed": "Esportazione PDF fallita: {{error}}",
   "toast.cannotMoveTabNoDoc": "Impossibile spostare la scheda: il documento non è caricato.",
   "toast.cannotMoveLastTab": "Impossibile spostare l'ultima scheda nella finestra principale.",

--- a/src/locales/it/export.json
+++ b/src/locales/it/export.json
@@ -31,5 +31,16 @@
   "pdf.progress.rendering": "Generazione PDF…",
   "pdf.progress.done": "Fatto",
   "pdf.saveDialog.title": "Esporta PDF",
-  "pdf.defaultTitle": "Documento"
+  "pdf.defaultTitle": "Documento",
+  "pdf.pageNumbers": "Numeri di pagina",
+  "pdf.pageNumbers.position": "Posizione",
+  "pdf.pageNumbers.format": "Formato",
+  "pdf.pageNumbers.skipFirst": "Salta la prima pagina",
+  "pdf.pageNumbers.position.none": "Nessuno",
+  "pdf.pageNumbers.position.bottomCenter": "In basso al centro",
+  "pdf.pageNumbers.position.bottomRight": "In basso a destra",
+  "pdf.pageNumbers.format.plain": "7",
+  "pdf.pageNumbers.format.withTotal": "7 / 12",
+  "pdf.pageNumbers.format.verbose": "Pagina 7 di 12",
+  "pdf.pageNumbers.verboseTemplate": "Pagina {n} di {total}"
 }

--- a/src/locales/it/export.json
+++ b/src/locales/it/export.json
@@ -28,6 +28,7 @@
   "pdf.exporting": "Esportazione…",
   "pdf.progress.preparing": "Preparazione…",
   "pdf.progress.loading": "Caricamento contenuto…",
+  "pdf.progress.finishing": "Completamento…",
   "pdf.progress.rendering": "Generazione PDF…",
   "pdf.progress.done": "Fatto",
   "pdf.saveDialog.title": "Esporta PDF",
@@ -42,5 +43,7 @@
   "pdf.pageNumbers.format.plain": "7",
   "pdf.pageNumbers.format.withTotal": "7 / 12",
   "pdf.pageNumbers.format.verbose": "Pagina 7 di 12",
+  "pdf.warning.outline-failed": "la struttura nella barra laterale",
+  "pdf.warning.page-numbers-failed": "i numeri di pagina",
   "pdf.pageNumbers.verboseTemplate": "Pagina {n} di {total}"
 }

--- a/src/locales/ja/dialog.json
+++ b/src/locales/ja/dialog.json
@@ -91,6 +91,7 @@
   "toast.failedToOpenPrintDialog": "印刷ダイアログを開けませんでした",
   "toast.htmlCopied": "HTMLをクリップボードにコピーしました",
   "toast.pdfExportSuccess": "PDFのエクスポートに成功しました",
+  "toast.pdfExportPartial": "PDF を書き出しましたが、{{what}}を追加できませんでした。",
   "toast.pdfExportFailed": "PDFエクスポートが失敗しました: {{error}}",
   "toast.cannotMoveTabNoDoc": "タブを移動できません: ドキュメントが読み込まれていません。",
   "toast.cannotMoveLastTab": "メインウィンドウの最後のタブは移動できません。",

--- a/src/locales/ja/export.json
+++ b/src/locales/ja/export.json
@@ -28,6 +28,7 @@
   "pdf.exporting": "エクスポート中…",
   "pdf.progress.preparing": "準備中…",
   "pdf.progress.loading": "コンテンツを読み込み中…",
+  "pdf.progress.finishing": "仕上げ中…",
   "pdf.progress.rendering": "PDF を生成中…",
   "pdf.progress.done": "完了",
   "pdf.saveDialog.title": "PDF をエクスポート",
@@ -42,5 +43,7 @@
   "pdf.pageNumbers.format.plain": "7",
   "pdf.pageNumbers.format.withTotal": "7 / 12",
   "pdf.pageNumbers.format.verbose": "12 ページ中 7 ページ目",
+  "pdf.warning.outline-failed": "サイドバーの目次",
+  "pdf.warning.page-numbers-failed": "ページ番号",
   "pdf.pageNumbers.verboseTemplate": "{total} ページ中 {n} ページ目"
 }

--- a/src/locales/ja/export.json
+++ b/src/locales/ja/export.json
@@ -31,5 +31,16 @@
   "pdf.progress.rendering": "PDF を生成中…",
   "pdf.progress.done": "完了",
   "pdf.saveDialog.title": "PDF をエクスポート",
-  "pdf.defaultTitle": "ドキュメント"
+  "pdf.defaultTitle": "ドキュメント",
+  "pdf.pageNumbers": "ページ番号",
+  "pdf.pageNumbers.position": "位置",
+  "pdf.pageNumbers.format": "形式",
+  "pdf.pageNumbers.skipFirst": "最初のページを除く",
+  "pdf.pageNumbers.position.none": "なし",
+  "pdf.pageNumbers.position.bottomCenter": "下中央",
+  "pdf.pageNumbers.position.bottomRight": "右下",
+  "pdf.pageNumbers.format.plain": "7",
+  "pdf.pageNumbers.format.withTotal": "7 / 12",
+  "pdf.pageNumbers.format.verbose": "12 ページ中 7 ページ目",
+  "pdf.pageNumbers.verboseTemplate": "{total} ページ中 {n} ページ目"
 }

--- a/src/locales/ko/dialog.json
+++ b/src/locales/ko/dialog.json
@@ -91,6 +91,7 @@
   "toast.failedToOpenPrintDialog": "인쇄 대화 상자를 열지 못했습니다",
   "toast.htmlCopied": "HTML이 클립보드에 복사되었습니다",
   "toast.pdfExportSuccess": "PDF 내보내기가 완료되었습니다",
+  "toast.pdfExportPartial": "PDF를 내보냈지만 {{what}}을(를) 추가하지 못했습니다.",
   "toast.pdfExportFailed": "PDF 내보내기 실패: {{error}}",
   "toast.cannotMoveTabNoDoc": "탭을 이동할 수 없습니다: 문서가 로드되지 않았습니다.",
   "toast.cannotMoveLastTab": "메인 창의 마지막 탭은 이동할 수 없습니다.",

--- a/src/locales/ko/export.json
+++ b/src/locales/ko/export.json
@@ -31,5 +31,16 @@
   "pdf.progress.rendering": "PDF 생성 중…",
   "pdf.progress.done": "완료",
   "pdf.saveDialog.title": "PDF 내보내기",
-  "pdf.defaultTitle": "문서"
+  "pdf.defaultTitle": "문서",
+  "pdf.pageNumbers": "페이지 번호",
+  "pdf.pageNumbers.position": "위치",
+  "pdf.pageNumbers.format": "형식",
+  "pdf.pageNumbers.skipFirst": "첫 페이지 건너뛰기",
+  "pdf.pageNumbers.position.none": "없음",
+  "pdf.pageNumbers.position.bottomCenter": "아래 가운데",
+  "pdf.pageNumbers.position.bottomRight": "아래 오른쪽",
+  "pdf.pageNumbers.format.plain": "7",
+  "pdf.pageNumbers.format.withTotal": "7 / 12",
+  "pdf.pageNumbers.format.verbose": "12페이지 중 7페이지",
+  "pdf.pageNumbers.verboseTemplate": "{total}페이지 중 {n}페이지"
 }

--- a/src/locales/ko/export.json
+++ b/src/locales/ko/export.json
@@ -28,6 +28,7 @@
   "pdf.exporting": "내보내는 중…",
   "pdf.progress.preparing": "준비 중…",
   "pdf.progress.loading": "콘텐츠 로드 중…",
+  "pdf.progress.finishing": "마무리하는 중…",
   "pdf.progress.rendering": "PDF 생성 중…",
   "pdf.progress.done": "완료",
   "pdf.saveDialog.title": "PDF 내보내기",
@@ -42,5 +43,7 @@
   "pdf.pageNumbers.format.plain": "7",
   "pdf.pageNumbers.format.withTotal": "7 / 12",
   "pdf.pageNumbers.format.verbose": "12페이지 중 7페이지",
+  "pdf.warning.outline-failed": "사이드바 개요",
+  "pdf.warning.page-numbers-failed": "페이지 번호",
   "pdf.pageNumbers.verboseTemplate": "{total}페이지 중 {n}페이지"
 }

--- a/src/locales/pt-BR/dialog.json
+++ b/src/locales/pt-BR/dialog.json
@@ -91,6 +91,7 @@
   "toast.failedToOpenPrintDialog": "Falha ao abrir a caixa de diálogo de impressão",
   "toast.htmlCopied": "HTML copiado para a área de transferência",
   "toast.pdfExportSuccess": "PDF exportado com sucesso",
+  "toast.pdfExportPartial": "PDF exportado, mas não foi possível adicionar {{what}}.",
   "toast.pdfExportFailed": "Falha ao exportar PDF: {{error}}",
   "toast.cannotMoveTabNoDoc": "Não é possível mover a aba: o documento não está carregado.",
   "toast.cannotMoveLastTab": "Não é possível mover a última aba da janela principal.",

--- a/src/locales/pt-BR/export.json
+++ b/src/locales/pt-BR/export.json
@@ -31,5 +31,16 @@
   "pdf.progress.rendering": "Gerando PDF…",
   "pdf.progress.done": "Concluído",
   "pdf.saveDialog.title": "Exportar PDF",
-  "pdf.defaultTitle": "Documento"
+  "pdf.defaultTitle": "Documento",
+  "pdf.pageNumbers": "Números de página",
+  "pdf.pageNumbers.position": "Posição",
+  "pdf.pageNumbers.format": "Formato",
+  "pdf.pageNumbers.skipFirst": "Ignorar a primeira página",
+  "pdf.pageNumbers.position.none": "Nenhum",
+  "pdf.pageNumbers.position.bottomCenter": "Inferior centralizado",
+  "pdf.pageNumbers.position.bottomRight": "Inferior direito",
+  "pdf.pageNumbers.format.plain": "7",
+  "pdf.pageNumbers.format.withTotal": "7 / 12",
+  "pdf.pageNumbers.format.verbose": "Página 7 de 12",
+  "pdf.pageNumbers.verboseTemplate": "Página {n} de {total}"
 }

--- a/src/locales/pt-BR/export.json
+++ b/src/locales/pt-BR/export.json
@@ -28,6 +28,7 @@
   "pdf.exporting": "Exportando…",
   "pdf.progress.preparing": "Preparando…",
   "pdf.progress.loading": "Carregando conteúdo…",
+  "pdf.progress.finishing": "Finalizando…",
   "pdf.progress.rendering": "Gerando PDF…",
   "pdf.progress.done": "Concluído",
   "pdf.saveDialog.title": "Exportar PDF",
@@ -42,5 +43,7 @@
   "pdf.pageNumbers.format.plain": "7",
   "pdf.pageNumbers.format.withTotal": "7 / 12",
   "pdf.pageNumbers.format.verbose": "Página 7 de 12",
+  "pdf.warning.outline-failed": "o sumário lateral",
+  "pdf.warning.page-numbers-failed": "os números de página",
   "pdf.pageNumbers.verboseTemplate": "Página {n} de {total}"
 }

--- a/src/locales/zh-CN/dialog.json
+++ b/src/locales/zh-CN/dialog.json
@@ -91,6 +91,7 @@
   "toast.failedToOpenPrintDialog": "无法打开打印对话框",
   "toast.htmlCopied": "HTML 已复制到剪贴板",
   "toast.pdfExportSuccess": "PDF 导出成功",
+  "toast.pdfExportPartial": "已导出 PDF，但无法添加{{what}}。",
   "toast.pdfExportFailed": "PDF 导出失败：{{error}}",
   "toast.cannotMoveTabNoDoc": "无法移动标签页：文档未加载。",
   "toast.cannotMoveLastTab": "无法移动主窗口中的最后一个标签页。",

--- a/src/locales/zh-CN/export.json
+++ b/src/locales/zh-CN/export.json
@@ -31,5 +31,16 @@
   "pdf.progress.rendering": "正在生成 PDF…",
   "pdf.progress.done": "完成",
   "pdf.saveDialog.title": "导出 PDF",
-  "pdf.defaultTitle": "文档"
+  "pdf.defaultTitle": "文档",
+  "pdf.pageNumbers": "页码",
+  "pdf.pageNumbers.position": "位置",
+  "pdf.pageNumbers.format": "格式",
+  "pdf.pageNumbers.skipFirst": "跳过首页",
+  "pdf.pageNumbers.position.none": "无",
+  "pdf.pageNumbers.position.bottomCenter": "底部居中",
+  "pdf.pageNumbers.position.bottomRight": "底部右侧",
+  "pdf.pageNumbers.format.plain": "7",
+  "pdf.pageNumbers.format.withTotal": "7 / 12",
+  "pdf.pageNumbers.format.verbose": "第 7 页，共 12 页",
+  "pdf.pageNumbers.verboseTemplate": "第 {n} 页，共 {total} 页"
 }

--- a/src/locales/zh-CN/export.json
+++ b/src/locales/zh-CN/export.json
@@ -28,6 +28,7 @@
   "pdf.exporting": "导出中…",
   "pdf.progress.preparing": "准备中…",
   "pdf.progress.loading": "正在加载内容…",
+  "pdf.progress.finishing": "正在完成…",
   "pdf.progress.rendering": "正在生成 PDF…",
   "pdf.progress.done": "完成",
   "pdf.saveDialog.title": "导出 PDF",
@@ -42,5 +43,7 @@
   "pdf.pageNumbers.format.plain": "7",
   "pdf.pageNumbers.format.withTotal": "7 / 12",
   "pdf.pageNumbers.format.verbose": "第 7 页，共 12 页",
+  "pdf.warning.outline-failed": "侧边栏目录",
+  "pdf.warning.page-numbers-failed": "页码",
   "pdf.pageNumbers.verboseTemplate": "第 {n} 页，共 {total} 页"
 }

--- a/src/locales/zh-TW/dialog.json
+++ b/src/locales/zh-TW/dialog.json
@@ -91,6 +91,7 @@
   "toast.failedToOpenPrintDialog": "無法開啟列印對話框",
   "toast.htmlCopied": "HTML 已複製至剪貼簿",
   "toast.pdfExportSuccess": "PDF 匯出成功",
+  "toast.pdfExportPartial": "已匯出 PDF，但無法加入{{what}}。",
   "toast.pdfExportFailed": "PDF 匯出失敗：{{error}}",
   "toast.cannotMoveTabNoDoc": "無法移動標籤頁：文件未載入。",
   "toast.cannotMoveLastTab": "無法移動主視窗中最後一個標籤頁。",

--- a/src/locales/zh-TW/export.json
+++ b/src/locales/zh-TW/export.json
@@ -28,6 +28,7 @@
   "pdf.exporting": "匯出中…",
   "pdf.progress.preparing": "準備中…",
   "pdf.progress.loading": "正在載入內容…",
+  "pdf.progress.finishing": "正在完成…",
   "pdf.progress.rendering": "正在產生 PDF…",
   "pdf.progress.done": "完成",
   "pdf.saveDialog.title": "匯出 PDF",
@@ -42,5 +43,7 @@
   "pdf.pageNumbers.format.plain": "7",
   "pdf.pageNumbers.format.withTotal": "7 / 12",
   "pdf.pageNumbers.format.verbose": "第 7 頁，共 12 頁",
+  "pdf.warning.outline-failed": "側邊欄目錄",
+  "pdf.warning.page-numbers-failed": "頁碼",
   "pdf.pageNumbers.verboseTemplate": "第 {n} 頁，共 {total} 頁"
 }

--- a/src/locales/zh-TW/export.json
+++ b/src/locales/zh-TW/export.json
@@ -31,5 +31,16 @@
   "pdf.progress.rendering": "正在產生 PDF…",
   "pdf.progress.done": "完成",
   "pdf.saveDialog.title": "匯出 PDF",
-  "pdf.defaultTitle": "文件"
+  "pdf.defaultTitle": "文件",
+  "pdf.pageNumbers": "頁碼",
+  "pdf.pageNumbers.position": "位置",
+  "pdf.pageNumbers.format": "格式",
+  "pdf.pageNumbers.skipFirst": "略過首頁",
+  "pdf.pageNumbers.position.none": "無",
+  "pdf.pageNumbers.position.bottomCenter": "底部置中",
+  "pdf.pageNumbers.position.bottomRight": "底部右側",
+  "pdf.pageNumbers.format.plain": "7",
+  "pdf.pageNumbers.format.withTotal": "7 / 12",
+  "pdf.pageNumbers.format.verbose": "第 7 頁，共 12 頁",
+  "pdf.pageNumbers.verboseTemplate": "第 {n} 頁，共 {total} 頁"
 }

--- a/website/guide/export.md
+++ b/website/guide/export.md
@@ -62,10 +62,33 @@ That is fixed, so your exports may now differ from what the same document
 produced before. They will match what the dialog says.
 :::
 
-::: info Bookmarks are macOS-only
-Exported PDFs get a heading outline — a clickable table of contents in the PDF
-viewer's sidebar — on macOS only. Windows and Linux produce the same document
-without that outline. Everything else, including page geometry, is identical.
+**Sidebar outline.** Exported PDFs carry a heading outline — the clickable
+table of contents your PDF viewer shows in its sidebar — on all three
+platforms. It used to be macOS-only; Windows and Linux got the same document
+with an empty sidebar.
+
+#### Page numbers
+
+The dialog's **Page numbers** section adds a number to each page. It is on by
+default, centred at the bottom.
+
+| Setting | Options |
+|---------|---------|
+| Position | Bottom centre, bottom right, or off |
+| Format | `7`, `7 / 12`, or `Page 7 of 12` |
+| Skip first page | Leaves page 1 unnumbered, the usual treatment for a title page |
+
+The number sits inside the bottom margin you chose, and scales with your body
+font size. Numbering always reflects the real page, so skipping the first page
+gives you 2, 3, 4… on the pages that follow rather than renumbering them.
+
+::: info Page numbers use a Latin alphabet
+The number is drawn with a standard PDF font that no viewer has to download,
+which is what keeps exports fast and self-contained — but that font cannot
+render Chinese, Japanese, Korean or Cyrillic. The two numeric formats work in
+every language. If your interface language writes `Page 7 of 12` in a script
+that font cannot draw, VMark leaves those pages unnumbered rather than printing
+blanks or wrong characters; choose `7` or `7 / 12` instead.
 :::
 
 ### Export via Pandoc


### PR DESCRIPTION
## What

Exported PDFs had no page numbers on any platform. They do now, on all three, with settings in the export dialog.

CSS puts page numbers in `@page` margin boxes, which WebKit does not implement — so the feature was never offered rather than working on one platform out of three. They are **stamped onto the finished PDF** with lopdf instead, after the render and after the outline, exactly as the sidebar outline already is. One code path, the same result on macOS, Windows and Linux.

Paged.js was the alternative and was rejected: it paginates asynchronously, and all three native backends print on load-complete and never evaluate scripts. It would need a JS-readiness handshake in each, and without one produces a half-paginated PDF with no error.

## Settings

New **Page numbers** section in the export dialog. On by default, bottom centre.

| Setting | Options |
|---|---|
| Position | Bottom centre, bottom right, off |
| Format | `7`, `7 / 12`, localized `Page 7 of 12` |
| Skip first page | Leaves page 1 unnumbered |

Skipping the first page keeps the real page number on the rest (2, 3, 4…), so the footer agrees with the viewer's sidebar rather than being renumbered.

## The one real limitation

Base-14 Helvetica is Latin-1 only. That is what keeps this cheap — nothing embedded, every viewer already has the font — but it cannot draw CJK. A verbose template that will not encode is **refused**, and those pages are left unnumbered with a `log::warn!`, rather than stamped as blanks or mojibake on every page. Both numeric formats work in every language. Documented in the guide.

## Also in here

- **`baseline-review.yml` was failing.** Its `measure` job asked setup-node for a pnpm cache and never installed anything, so the POST step died with `Path Validation Error` *after* the job's real work succeeded — and `report`, which `needs:` it, was skipped. The weekly issue had quietly stopped being filed. Fixed at the cause, plus `check-workflow-node-cache.test.mjs`, which fails any job requesting a cache it never populates. Verified red-then-green against the real defect.
- **`website/guide/export.md` still said the heading outline was macOS-only.** Stale since v0.9.41 made it cross-platform.
- **The PDF smoke harness now runs in CI** on all three platforms, path-filtered to exporter changes. This subsystem has three separate native backends and nothing in the required checks ran any of them; the macOS-only outline gap is exactly what that blindness produces. Not a required check — see the workflow header for why.

## Verification

- 89 Rust tests in `pdf_export` (20 new, covering CJK refusal, zero-margin floor, PDF string escaping, inherited MediaBox, byte-identity when off, no scratch leak, and the unbalanced-CTM regression below)
- 8 frontend tests on the wire contract, including the field-name set the two sides are joined by
- Smoke harness on all three real engines (WKWebView, WebView2, WebKitGTK), **reading the stamped footer back out of each artifact** rather than trusting the return value; plus six geometries of the real showcase document locally
- Rendered pages inspected by eye: number centred in the bottom margin, right-aligned variant inside the right margin, page 1 correctly bare under skip-first
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean
- Windows and Linux PDFs downloaded from the `pdf-smoke` job and rendered to images: bottom-centre upright, bottom-right variant inside the margin, page 1 bare under skip-first

## The defect this nearly shipped with

Worth reading, because every check in the repository was green while it was broken.

The first cross-platform run passed on all three platforms. Opening the artifacts showed the page number drawn at the **top of the page and mirrored** on Windows and Linux. macOS was correct, which is why local work could never have found it.

A page's content streams are **concatenated** into one stream, so whatever the renderer leaves in the graphics state is still in effect when appended content begins. Both WebView2 and WebKitGTK emit a top-level `1 0 0 -1 0 <height> cm` and never undo it. Wrapping only the stamp in `q`/`Q` does nothing about that — `q` saves the *current* state, it does not reset the CTM to identity.

The fix fences the page's own content in its own `q`/`Q`, so the stamp starts from the page's default space where `(0,0)` is the bottom-left corner — the space `baseline()` computes in.

What makes this worth writing down is what did **not** catch it: the label was present, the font was registered, the MediaBox was right, and `pdftotext` extracted `1 / 3` cleanly. A number in the wrong place is still a number. So both assertions now check the **fence** rather than presence — a Rust test builds a fixture leaving the same unbalanced flip and pins the resulting `Contents` shape, and the smoke harness reports `all fenced` per artifact.

All three platforms re-verified afterwards by rendering the PDFs and looking at them, not by re-reading the transcript.

## Notes on the diff

Two files were split because the size gate refused them, both along real seams — the label and its geometry under the document surgery (mirroring `outline_match`/`outline_tree` under `outline.rs`), and the sidebar's layout primitives out of the settings composition. `PdfSettingsSidebar.tsx` drops under 300 lines and comes **off** the baseline rather than being re-frozen higher.

The atomic-save dance the outline injector used is now shared (`pdf_io.rs`). Both post-processors downgrade failure to a warning, which is only honest while a failure leaves the rendered PDF intact — one copy of that, not two that drift.
