### PR TITLE
chore: bump version to 0.9.45

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.44",
+  "version": "0.9.45",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.44';
+const VERSION = '0.9.45';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6399,7 +6399,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.44"
+version = "0.9.45"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.44"
+version = "0.9.45"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Patch bump for the Windows Settings-window deadlock fix (#1303, closing #1301 and #1302).

All five version files plus the derived `src-tauri/Cargo.lock`:

| File | Field |
|---|---|
| `package.json` | `version` |
| `src-tauri/tauri.conf.json` | `version` |
| `src-tauri/Cargo.toml` | `version` |
| `server/mcp/package.json` | `version` |
| `server/mcp/src/cli.ts` | `VERSION` |
| `src-tauri/Cargo.lock` | `vmark` entry (regenerated) |

## What 0.9.45 ships

**Windows: opening Settings no longer hangs the app.** A Tauri command without `async` runs inline on the thread delivering the IPC message, which on Windows is inside WebView2's `WebMessageReceived` COM callback — and creating a webview there is the reentrancy case WebView2 forbids. Seven commands were affected, including `hot_exit_restore_multi_window`, which runs at startup when restoring a multi-window session.

Also in this release:

- `pnpm lint:window-thread` — a zero-tolerance gate so a window-creating command cannot ship synchronously again.
- Settings creation is now idempotent, and tab detach registers its payload before creating the window (two orderings that had relied on the blocking IPC loop for serialization).
- The spurious `Dropped binding view.toggleFitTables` warning no longer reaches users' production logs.
- `cargo audit` back to zero — five RUSTSEC advisories cleared by real dependency updates, no ignore entries.

## Standalone bump, not folded

`.claude/rules/40-version-bump.md` §4 prefers folding a bump into the feature PR. That was not available here: #1303 was already green and merged before the bump was requested, so `main` already carries the change being released — which is exactly the fallback case the rule names.
