### PR TITLE
fix(star-history): draw the data line as a hand, not as a plot

### DIFF
--- a/scripts/gen-star-history.mjs
+++ b/scripts/gen-star-history.mjs
@@ -123,10 +123,16 @@ function mulberry32(seed) {
  * chart.xkcd's wobble done geometrically, so it needs no SVG filter support
  * (feTurbulence inside <img> is spotty in some renderers). First and last
  * points stay exact so the line lands on the real values.
+ *
+ * Returns the wobbled points AND the index each ORIGINAL vertex landed at, so
+ * markers can be pinned to the drawn line rather than to the ideal one. At the
+ * amplitude the data line needs (see `HAND`) a dot placed at the true position
+ * sits visibly beside the stroke instead of on it.
  */
 function roughPoints(pts, rng, { step = 11, mag = 4.0 } = {}) {
   const sub = [pts[0]];
   const normals = [[0, 0]];
+  const anchors = [0];
   for (let i = 1; i < pts.length; i++) {
     const [x0, y0] = pts[i - 1];
     const [x1, y1] = pts[i];
@@ -138,13 +144,16 @@ function roughPoints(pts, rng, { step = 11, mag = 4.0 } = {}) {
       sub.push([x0 + (dx * j) / n, y0 + (dy * j) / n]);
       normals.push(nrm);
     }
+    anchors.push(sub.length - 1);
   }
   const raw = sub.map(() => (rng() - 0.5) * 2 * mag);
   raw[0] = 0;
   raw[raw.length - 1] = 0;
   // one smoothing pass so the wobble reads as a shaky hand, not as noise
   const off = raw.map((o, i) => (i === 0 || i === raw.length - 1 ? o : (raw[i - 1] + o + raw[i + 1]) / 3));
-  return sub.map(([x, y], i) => [x + normals[i][0] * off[i], y + normals[i][1] * off[i]]);
+  const out = sub.map(([x, y], i) => [x + normals[i][0] * off[i], y + normals[i][1] * off[i]]);
+  out.anchors = anchors;
+  return out;
 }
 
 const toPath = (pts) => pts.map(([x, y], i) => `${i ? "L" : "M"}${x.toFixed(1)},${y.toFixed(1)}`).join(" ");
@@ -181,8 +190,21 @@ export function render(series) {
   const x = (t) => M.left + ((t - t0) / (t1 - t0 || 1)) * iw;
   const y = (c) => M.top + ih - (c / yMax) * ih;
 
-  const linePts = roughPoints(series.map(([t, c]) => [x(t), y(c)]), rng);
-  const line = toPath(linePts);
+  // TWO strokes, wobbled independently — this is what makes a CURVE read as
+  // hand-drawn, and a single wobbled stroke does not. Wobble is only perceivable
+  // against a known-ideal shape: on the axes the eye holds a perfect straight
+  // line to compare against, so ±1px of tremor is obvious. A data curve has no
+  // such reference — any deviation just reads as "the data did that" — so the
+  // old single stroke looked plotted no matter how hard it was shaken, and
+  // raising the amplitude only misstated the numbers. Two nearly-parallel
+  // strokes that separate and rejoin is something no plotter produces, so it
+  // reads as a pen regardless of the underlying shape. rough.js works this way
+  // for the same reason.
+  const idealPts = series.map(([t, c]) => [x(t), y(c)]);
+  const strokeA = roughPoints(idealPts, rng, HAND);
+  const strokeB = roughPoints(idealPts, rng, HAND);
+  const line = toPath(strokeA);
+  const line2 = toPath(strokeB);
   const area = `${line} L${x(t1).toFixed(1)},${(M.top + ih).toFixed(1)} L${x(t0).toFixed(1)},${(M.top + ih).toFixed(1)} Z`;
 
   // hand-drawn axes with tick marks (no gridlines — matches the xkcd look)
@@ -206,9 +228,13 @@ export function render(series) {
     xLabels.push(`<text x="${xx.toFixed(1)}" y="${(H - M.bottom + 24).toFixed(1)}" text-anchor="middle" font-size="13" fill="#888">${fmtDate(t)}</text>`);
   }
 
-  // dots on the (downsampled) data points, like star-history.com's markers
-  const dots = series
-    .map(([t, c]) => `<circle cx="${x(t).toFixed(1)}" cy="${y(c).toFixed(1)}" r="2.6" fill="#fff" stroke="${ACCENT}" stroke-width="1.6"/>`)
+  // Dots on the (downsampled) data points, like star-history.com's markers —
+  // pinned to the DRAWN line, not the ideal one. At this amplitude a dot at the
+  // true position sits beside the stroke rather than on it, which reads as a
+  // rendering bug rather than as a marker.
+  const dots = strokeA.anchors
+    .map((i) => strokeA[i])
+    .map(([cx, cy]) => `<circle cx="${cx.toFixed(1)}" cy="${cy.toFixed(1)}" r="2.6" fill="#fff" stroke="${ACCENT}" stroke-width="1.6"/>`)
     .join("\n  ");
 
   const total = series[series.length - 1][1];
@@ -229,7 +255,8 @@ export function render(series) {
   <path d="${starPath(starCx, 22.5, 7.5)}" fill="${ACCENT}" class="star"/>
   <text x="${countRight.toFixed(1)}" y="28" text-anchor="end" font-size="15" fill="${ACCENT}">${total}</text>
   <path d="${area}" fill="url(#fill)"/>
-  <path d="${line}" fill="none" stroke="${ACCENT}" stroke-width="2.75" stroke-linejoin="round" stroke-linecap="round"/>
+  <path d="${line}" fill="none" stroke="${ACCENT}" stroke-width="2.2" stroke-linejoin="round" stroke-linecap="round"/>
+  <path d="${line2}" fill="none" stroke="${ACCENT}" stroke-width="1.7" stroke-linejoin="round" stroke-linecap="round" opacity="0.75"/>
   ${dots}
   ${axes.join("\n  ")}
   ${ticks.join("\n  ")}
@@ -240,6 +267,20 @@ export function render(series) {
 }
 
 const ACCENT = "#3b82f6"; // blue — pops on light and dark
+
+/**
+ * Wobble for the DATA line. Coarser and larger than the axes' (step 22 / mag
+ * 1.8): the axes are short and straight, where fine tremor reads; the data line
+ * is 716px of already-irregular polyline, where fine tremor reads as noise and
+ * a long, slow undulation reads as a hand. Paired with the second stroke in
+ * `render`, this is the whole hand-drawn effect.
+ *
+ * `mag` is a bound on how far the drawing may sit from the truth: ±5px on a
+ * 304px-tall plot is under 2% of the y-range. Raising it buys nothing — beyond
+ * the double stroke the eye stops reading "hand-drawn" and starts reading
+ * "wrong" — and it is the one knob here that trades accuracy for style.
+ */
+const HAND = { step: 26, mag: 5 };
 
 // Only fetch when RUN, never when imported: the test suite drives `render()`
 // directly, and an unguarded top-level `gh` call would make importing this

--- a/scripts/gen-star-history.test.mjs
+++ b/scripts/gen-star-history.test.mjs
@@ -141,16 +141,76 @@ describe("y-axis headroom", () => {
   );
 });
 
+/**
+ * What makes a CURVE read as hand-drawn — and why the previous test here passed
+ * while it did not.
+ *
+ * That test asserted a mean local deviation above 0.35px and was named "draws a
+ * visibly hand-drawn line". 0.35px is a quarter of the stroke's own half-width:
+ * the wobble it certified was drawn INSIDE the line and could not be seen. The
+ * chart shipped with hand-drawn axes and a data line that read as plotted, and
+ * every test was green. It also pinned the subdivision COUNT (`> 50`), which is
+ * an implementation detail — tuning the wobble coarser broke the test without
+ * changing the property.
+ *
+ * The mechanism it missed: wobble is only perceivable against a known-ideal
+ * shape. The axes have one — the eye holds a perfect straight line to compare
+ * against, so a fraction of a pixel of tremor is obvious. A data curve has no
+ * such reference, so any deviation reads as "the data did that" and raising the
+ * amplitude only misstates the numbers. What no plotter produces is TWO
+ * nearly-parallel strokes that separate and rejoin, which is why rough.js draws
+ * everything twice and why this now does too.
+ *
+ * So the assertions below are about the doubling and whether it escapes the
+ * stroke body — measurable things that track what the eye actually sees.
+ */
 describe("wobble", () => {
-  it("draws a visibly hand-drawn line, not a straight polyline", () => {
-    const svg = render(seriesOf(600));
-    const d = /<path d="(M[^"]+)" fill="none" stroke="#3b82f6"/.exec(svg)?.[1] ?? "";
-    const ys = [...d.matchAll(/[ML][\d.]+,([\d.]+)/g)].map((m) => +m[1]);
-    expect(ys.length).toBeGreaterThan(50);
-    // deviation of each point from the straight line through its neighbours
+  /** The accent-coloured data strokes, as point arrays. */
+  const dataStrokes = (svg) =>
+    [...svg.matchAll(/<path d="(M[^"]+)" fill="none" stroke="#3b82f6"/g)]
+      .map((m) => [...m[1].matchAll(/[ML](-?[\d.]+),(-?[\d.]+)/g)].map((p) => [+p[1], +p[2]]));
+
+  it("draws the data line as two independently wobbled strokes", () => {
+    const [a, b] = dataStrokes(render(seriesOf(600)));
+    expect(a.length).toBeGreaterThan(2);
+    expect(b).toHaveLength(a.length);
+    // Independent draws, not one path reused at a second width — a copy would
+    // render as a single thicker line and lose the entire effect.
+    expect(b).not.toEqual(a);
+  });
+
+  it("separates the two strokes by more than the stroke's own half-width", () => {
+    // The threshold is not a taste call: the wider stroke is 2.2px, so a
+    // separation under 1.1px keeps the second stroke buried inside the first and
+    // the doubling is invisible. Measured mean separation is ~1.39px, stable at
+    // 120 / 522 / 600 / 2000 stars — this asserts the mechanism survives, not a
+    // lucky number.
+    for (const n of [120, 600, 2000]) {
+      const [a, b] = dataStrokes(render(seriesOf(n)));
+      const sep = a.map(([ax, ay], i) => Math.hypot(ax - b[i][0], ay - b[i][1]));
+      const mean = sep.reduce((s, v) => s + v, 0) / sep.length;
+      expect(mean, `mean stroke separation at n=${n}`).toBeGreaterThan(1.1);
+    }
+  });
+
+  it("keeps the drawing within 2% of the y-range of the truth", () => {
+    // The other side of the same knob: this chart may look hand-drawn, but it
+    // still reports real numbers. `HAND.mag` is 5px against a 304px plot.
+    const [a] = dataStrokes(render(seriesOf(600)));
+    const ys = a.map(([, y]) => y);
     const dev = ys.slice(1, -1).map((y, i) => Math.abs(y - (ys[i] + ys[i + 2]) / 2));
-    const mean = dev.reduce((a, b) => a + b, 0) / dev.length;
-    expect(mean).toBeGreaterThan(0.35);
+    expect(Math.max(...dev)).toBeLessThan(0.02 * 304);
+  });
+
+  it("pins the markers to the drawn line, not to the ideal one", () => {
+    // A dot at the true position sits visibly beside a stroke wobbled this far,
+    // which reads as a rendering bug rather than as a marker.
+    const svg = render(seriesOf(600));
+    const [a] = dataStrokes(svg);
+    const onStroke = new Set(a.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`));
+    const dots = [...svg.matchAll(/<circle cx="([\d.]+)" cy="([\d.]+)"/g)].map((m) => `${m[1]},${m[2]}`);
+    expect(dots.length).toBeGreaterThan(5);
+    expect(dots.filter((d) => !onStroke.has(d))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
The chart's axes read as hand-drawn and its curve did not.

The curve **was** already being wobbled — harder than the axes, in fact (`mag` 4.0 vs 1.8). So the settings were never the problem.

**Wobble is only perceivable against a known-ideal shape.** On an axis the eye holds a perfect straight line to compare against, so a fraction of a pixel of tremor is obvious. A data curve offers no such reference — every deviation reads as *"the data did that"* — so no amount of shaking makes it look drawn, and raising the amplitude only misstates the numbers.

What no plotter produces is **two nearly-parallel strokes that separate and rejoin**. The data line is now drawn twice with independent wobble, which is how rough.js gets the same effect and for the same reason.

Measured mean separation between the strokes is **1.39px against a 2.2px stroke** (half-width 1.1px), stable at 120 / 522 / 600 / 2000 stars — so the doubling escapes the stroke body instead of hiding inside it. That is the number the new test asserts.

Markers are now pinned to the **drawn** line rather than the ideal one; at this amplitude a dot at the true position sits beside the stroke rather than on it.

## The test that should have caught this

`wobble > draws a visibly hand-drawn line` asserted a mean local deviation above **0.35px** — a quarter of the stroke's own half-width. The wobble it certified was drawn *inside* the line, where it cannot be seen. It also pinned the subdivision **count** (`> 50`), an implementation detail that broke on retuning while the property was unaffected.

Both are replaced by assertions about the doubling and whether it escapes the stroke.

## Verified by mutation, not just by green

| Mutation | Result |
|---|---|
| second stroke is a copy of the first | **kills 2 tests** |
| markers back at ideal positions | **kills 1 test** |
| revert only `HAND` to the old values | **survives — correctly** |

The third was checked by *rendering* it rather than assumed: the doubling alone still reads as hand-drawn at the old tuning, so the exact values are taste within a stated bound. Pinning them would freeze taste as though it were a property.

## Accuracy bound

`HAND.mag` is the one knob that trades accuracy for style: 5px on a 304px plot is under 2% of the y-range, and a test holds that bound.

Determinism is unchanged — both strokes draw from the same seeded PRNG, so identical star data still renders byte-identical SVG and the weekly refresh still commits only on real change.

**After merge this needs a `workflow_dispatch` on `Refresh Star History chart`**, or the README keeps showing the old chart until the Monday cron.