### PR TITLE
docs(readme): drop the duplicate light <source> from the Star History picture

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ pnpm check:all        # Lint + test + build
        - fine-grained PATs EXPIRE. When this silently reverts to a "restricted"
          notice, the token has lapsed — reissue it at star-history.com.
 
+     The <picture> carries exactly two entries, and the pairing is not
+     cosmetic: the chart's background is OPAQUE (#fff light, #0d1117 dark), so
+     serving the light SVG to a dark reader puts a white slab with black text in
+     a dark README. Hence a dark <source> plus the light <img> as the fallback.
+     A third `prefers-color-scheme: light` <source> was dropped because its URL
+     was byte-identical to that <img> — that one really was redundant.
+
      There is NO fallback any more. The self-hosted generator that carried this
      chart through the outage (scripts/gen-star-history.mjs, its workflow, its
      tests, a subsetted font and the roughjs dependency) was deleted with this
@@ -112,7 +119,6 @@ pnpm check:all        # Lint + test + build
 <a href="https://www.star-history.com/?repos=vmark%2Fvmark%2Cxiaolai%2Fvmark&type=date&legend=top-left">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=vmark/vmark%2Cxiaolai/vmark&type=date&theme=dark&legend=top-left&sealed_token=qzdaDwLsJGl7o5BrAqxdidzzZ9Lssj-5DZ7-xtI-ZHgWG62bS-F8X29gUh02TQSxHD0eypMRp182O6QuTgb7WUs6JjSUsZi7ILMKUi58RpjlMyDlkDA0w3Y9cvv_Xvr62WDFWLrR1Tbr2G-8d_UbtTheGN7ZQ07OUF8BIZBzpwu7eukr-OrsMSoxteZD" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=vmark/vmark%2Cxiaolai/vmark&type=date&legend=top-left&sealed_token=qzdaDwLsJGl7o5BrAqxdidzzZ9Lssj-5DZ7-xtI-ZHgWG62bS-F8X29gUh02TQSxHD0eypMRp182O6QuTgb7WUs6JjSUsZi7ILMKUi58RpjlMyDlkDA0w3Y9cvv_Xvr62WDFWLrR1Tbr2G-8d_UbtTheGN7ZQ07OUF8BIZBzpwu7eukr-OrsMSoxteZD" />
    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=vmark/vmark%2Cxiaolai/vmark&type=date&legend=top-left&sealed_token=qzdaDwLsJGl7o5BrAqxdidzzZ9Lssj-5DZ7-xtI-ZHgWG62bS-F8X29gUh02TQSxHD0eypMRp182O6QuTgb7WUs6JjSUsZi7ILMKUi58RpjlMyDlkDA0w3Y9cvv_Xvr62WDFWLrR1Tbr2G-8d_UbtTheGN7ZQ07OUF8BIZBzpwu7eukr-OrsMSoxteZD" />
  </picture>
 </a>


### PR DESCRIPTION
The block carried **three URLs and only two distinct ones**.

| Element | URL |
|---|---|
| `<source>` dark | `…&theme=dark&sealed_token=…` |
| `<source>` light | **byte-identical to the `<img>` below it** |
| `<img>` fallback | `…&sealed_token=…` |

The light `<source>` selected nothing the fallback wouldn't already have served, so it's gone.

## The dark source stays, and is not the redundant one

It looks like the odd entry out, but star-history.com renders an **opaque** background rather than a transparent one:

|  | background | axes | series |
|---|---|---|---|
| light | `#fff` | `#000` | `#28a3dd` |
| dark | `#0d1117` | `#fff` | `#48dbfb` |

Dropping it would serve a white slab with black text to every reader on a dark GitHub theme. Verified by fetching both variants and diffing: they differ by exactly `theme=dark`.

That reasoning is now in the comment, because the pairing reads like boilerplate and the next person tidying this block will otherwise reach for the same line.