### PR TITLE
docs(readme): chart only xiaolai/vmark; drop the abandoned vmark/vmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ pnpm check:all        # Lint + test + build
      endpoint goes dark again, it is in the history — `git log -- scripts/gen-star-history.mjs`. -->
 <a href="https://www.star-history.com/?repos=xiaolai%2Fvmark&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=xiaolai/vmark&type=date&theme=dark&legend=top-left&sealed_token=qzdaDwLsJGl7o5BrAqxdidzzZ9Lssj-5DZ7-xtI-ZHgWG62bS-F8X29gUh02TQSxHD0eypMRp182O6QuTgb7WUs6JjSUsZi7ILMKUi58RpjlMyDlkDA0w3Y9cvv_Xvr62WDFWLrR1Tbr2G-8d_UbtTheGN7ZQ07OUF8BIZBzpwu7eukr-OrsMSoxteZD" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=xiaolai/vmark&type=date&legend=top-left&sealed_token=qzdaDwLsJGl7o5BrAqxdidzzZ9Lssj-5DZ7-xtI-ZHgWG62bS-F8X29gUh02TQSxHD0eypMRp182O6QuTgb7WUs6JjSUsZi7ILMKUi58RpjlMyDlkDA0w3Y9cvv_Xvr62WDFWLrR1Tbr2G-8d_UbtTheGN7ZQ07OUF8BIZBzpwu7eukr-OrsMSoxteZD" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=xiaolai/vmark&type=date&theme=dark&legend=top-left&sealed_token=N2-lbst3zDsNkStcxyDIv9I8vk5Sgqx4pLFGil8mBhSJZs-UxObXFI6rSX9uPC2_Tv0jqTvVvwUsk3Kc3gRJNCXr9RL8XvRWqwjozm9Rrd8wfH3eWxMT6EdZoIiCIKPqIxbVxhKvOhyoLpKwQVwwOf6dFvTMJVb7FlJiX9vgZNMiKSP2dk5LIt8QOQsl" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=xiaolai/vmark&type=date&legend=top-left&sealed_token=N2-lbst3zDsNkStcxyDIv9I8vk5Sgqx4pLFGil8mBhSJZs-UxObXFI6rSX9uPC2_Tv0jqTvVvwUsk3Kc3gRJNCXr9RL8XvRWqwjozm9Rrd8wfH3eWxMT6EdZoIiCIKPqIxbVxhKvOhyoLpKwQVwwOf6dFvTMJVb7FlJiX9vgZNMiKSP2dk5LIt8QOQsl" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ pnpm check:all        # Lint + test + build
      tests, a subsetted font and the roughjs dependency) was deleted with this
      change rather than left running weekly for an asset nothing reads. If the
      endpoint goes dark again, it is in the history — `git log -- scripts/gen-star-history.mjs`. -->
-<a href="https://www.star-history.com/?repos=vmark%2Fvmark%2Cxiaolai%2Fvmark&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=xiaolai%2Fvmark&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=vmark/vmark%2Cxiaolai/vmark&type=date&theme=dark&legend=top-left&sealed_token=qzdaDwLsJGl7o5BrAqxdidzzZ9Lssj-5DZ7-xtI-ZHgWG62bS-F8X29gUh02TQSxHD0eypMRp182O6QuTgb7WUs6JjSUsZi7ILMKUi58RpjlMyDlkDA0w3Y9cvv_Xvr62WDFWLrR1Tbr2G-8d_UbtTheGN7ZQ07OUF8BIZBzpwu7eukr-OrsMSoxteZD" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=vmark/vmark%2Cxiaolai/vmark&type=date&legend=top-left&sealed_token=qzdaDwLsJGl7o5BrAqxdidzzZ9Lssj-5DZ7-xtI-ZHgWG62bS-F8X29gUh02TQSxHD0eypMRp182O6QuTgb7WUs6JjSUsZi7ILMKUi58RpjlMyDlkDA0w3Y9cvv_Xvr62WDFWLrR1Tbr2G-8d_UbtTheGN7ZQ07OUF8BIZBzpwu7eukr-OrsMSoxteZD" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=xiaolai/vmark&type=date&theme=dark&legend=top-left&sealed_token=qzdaDwLsJGl7o5BrAqxdidzzZ9Lssj-5DZ7-xtI-ZHgWG62bS-F8X29gUh02TQSxHD0eypMRp182O6QuTgb7WUs6JjSUsZi7ILMKUi58RpjlMyDlkDA0w3Y9cvv_Xvr62WDFWLrR1Tbr2G-8d_UbtTheGN7ZQ07OUF8BIZBzpwu7eukr-OrsMSoxteZD" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=xiaolai/vmark&type=date&legend=top-left&sealed_token=qzdaDwLsJGl7o5BrAqxdidzzZ9Lssj-5DZ7-xtI-ZHgWG62bS-F8X29gUh02TQSxHD0eypMRp182O6QuTgb7WUs6JjSUsZi7ILMKUi58RpjlMyDlkDA0w3Y9cvv_Xvr62WDFWLrR1Tbr2G-8d_UbtTheGN7ZQ07OUF8BIZBzpwu7eukr-OrsMSoxteZD" />
  </picture>
 </a>
 


### PR DESCRIPTION
`vmark/vmark` was mistyped into star-history.com's repo field and never existed — `gh api repos/vmark/vmark` returns 404. It still rendered: a legend row with a colour swatch and no series, beside the one repo that has data.

## Three URLs, two spellings

They don't encode alike, so a single find-and-replace would have left the link pointing at the old two-repo chart:

| Element | Before | After |
|---|---|---|
| `<a href>` | `repos=vmark%2Fvmark%2Cxiaolai%2Fvmark` | `repos=xiaolai%2Fvmark` |
| `<source>` dark | `repos=vmark/vmark%2Cxiaolai/vmark` | `repos=xiaolai/vmark` |
| `<img>` | `repos=vmark/vmark%2Cxiaolai/vmark` | `repos=xiaolai/vmark` |

## Re-verified after the change

Both variants return HTTP 200 against the sealed token — `theme=dark` (65,447 bytes) and light (65,441 bytes) — so the token is bound to the reader, not to the repo pair it was first issued with.