### PR TITLE
ci: skip the app tiers on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,11 @@ jobs:
       - run: pnpm check:static
 
   fe-test:
+    # Docs-only PRs skip this tier. `fe-static` deliberately does NOT: it runs
+    # the markdown gates (lint:emdash scans every *.md, lint:keybinding-manifest
+    # reads website/guide/shortcuts.md), so prose still gets checked.
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
@@ -160,7 +165,11 @@ jobs:
           retention-days: 1
 
   fe-coverage:
-    needs: [fe-test]
+    # Docs-only PRs skip this tier. `fe-static` deliberately does NOT: it runs
+    # the markdown gates (lint:emdash scans every *.md, lint:keybinding-manifest
+    # reads website/guide/shortcuts.md), so prose still gets checked.
+    needs: [changes, fe-test]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -179,6 +188,11 @@ jobs:
         run: pnpm vitest --merge-reports=.vitest-reports --coverage
 
   fe-servers:
+    # Docs-only PRs skip this tier. `fe-static` deliberately does NOT: it runs
+    # the markdown gates (lint:emdash scans every *.md, lint:keybinding-manifest
+    # reads website/guide/shortcuts.md), so prose still gets checked.
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -187,6 +201,11 @@ jobs:
       - run: pnpm check:servers
 
   fe-build:
+    # Docs-only PRs skip this tier. `fe-static` deliberately does NOT: it runs
+    # the markdown gates (lint:emdash scans every *.md, lint:keybinding-manifest
+    # reads website/guide/shortcuts.md), so prose still gets checked.
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -200,6 +219,11 @@ jobs:
   # (issues #1176 / #1179, fixed twice in one week with no automated gate
   # watching). Separate job because it must NOT inherit src/test/setup.ts.
   webkit:
+    # Docs-only PRs skip this tier. `fe-static` deliberately does NOT: it runs
+    # the markdown gates (lint:emdash scans every *.md, lint:keybinding-manifest
+    # reads website/guide/shortcuts.md), so prose still gets checked.
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -242,21 +266,25 @@ jobs:
           BUILD: ${{ needs.fe-build.result }}
           WEBKIT: ${{ needs.webkit.result }}
         run: |
+          # `skipped` is a PASS. The app tiers are path-filtered off for a
+          # docs-only PR, and this job is a REQUIRED check under
+          # `enforce_admins` — so without this tolerance every prose PR would
+          # report failure here and could never be merged by anyone. The `rust`
+          # aggregate below has carried the same clause since it was written.
+          #
+          # `fe-static` is never skipped, so a group reporting `skipped` here
+          # always means the filter fired, never that a gate went missing.
           failed=0
           for pair in "fe-static:$STATIC" "fe-test:$TESTS" "fe-coverage:$COVERAGE" \
                       "fe-servers:$SERVERS" "fe-build:$BUILD" "webkit:$WEBKIT"; do
             name="${pair%%:*}"
             result="${pair#*:}"
-            if [ "$result" != "success" ]; then
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "$name: $result"
               failed=1
             fi
           done
           [ "$failed" -eq 0 ]
-          if [ "$WEBKIT" != "success" ]; then
-            echo "webkit: $WEBKIT"
-            exit 1
-          fi
 
   # Perf bench: on every run, src/bench/*.bench.ts must execute without error
   # so the suite can't silently rot. On PRs, additionally benches the base ref
@@ -266,6 +294,11 @@ jobs:
   # variance makes a hard gate cry wolf; the step summary carries the verdict.
   # Threshold and semantics: scripts/compare-bench.mjs (2.5x mean, 1 ms floor).
   bench:
+    # Docs-only PRs skip this tier. `fe-static` deliberately does NOT: it runs
+    # the markdown gates (lint:emdash scans every *.md, lint:keybinding-manifest
+    # reads website/guide/shortcuts.md), so prose still gets checked.
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -300,20 +333,48 @@ jobs:
         continue-on-error: true
         run: node scripts/compare-bench.mjs /tmp/bench-base.json /tmp/bench-current.json
 
-  # Detect if Rust code changed — skip rust-test for frontend-only PRs
+  # Detect if Rust code changed — skip rust-test for frontend-only PRs — and
+  # whether anything but PROSE changed, so a docs-only PR skips the app tiers.
+  #
+  # `predicate-quantifier: some-with-excludes` is load-bearing. Under the
+  # DEFAULT ('some') a file counts if it matches at least one pattern, so `'**'`
+  # would match everything and `code` would always be true — the filter would
+  # silently be a no-op that still looked wired up. `some-with-excludes` means
+  # "matches a positive pattern AND no negated one", independent of order.
+  # Verified present in the pinned SHA's action.yml before relying on it; an
+  # unknown input would have been ignored rather than rejected.
   changes:
     runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         id: filter
         with:
+          predicate-quantifier: 'some-with-excludes'
           filters: |
             rust:
               - 'src-tauri/**'
               - 'Cargo.lock'
+            # True when any changed file is NOT prose — i.e. false only for a
+            # docs-only PR. The exclusions are an explicit allowlist, not
+            # `!**/*.md`, and that distinction is the whole safety argument:
+            # there are 50 markdown files under src/, including the
+            # markdown-pipeline characterization corpus that round-trip tests
+            # READ at runtime. A blanket `!**/*.md` would skip the entire suite
+            # on precisely the change most able to break it. Nothing below is
+            # read by an app-tier test; the paths that ARE inputs
+            # (website/guide/shortcuts.md → lint:keybinding-manifest) belong to
+            # fe-static, which never skips.
+            code:
+              - '**'
+              - '!README.md'
+              - '!AGENTS.md'
+              - '!CLAUDE.md'
+              - '!.claude/**/*.md'
+              - '!website/**/*.md'
 
   rust-test:
     needs: [changes]

--- a/scripts/check-ci-docs-filter.test.mjs
+++ b/scripts/check-ci-docs-filter.test.mjs
@@ -1,0 +1,109 @@
+/**
+ * The docs-only path filter, and the two ways it can fail silently.
+ *
+ * A prose-only PR used to cost ~12 runner-minutes: four sharded test jobs, a
+ * coverage merge, two builds and a WebKit run, none of which read a markdown
+ * file. The Rust side already skipped correctly; the frontend never got the
+ * same treatment.
+ *
+ * Both failure modes here are silent, which is why they are asserted rather
+ * than reviewed:
+ *
+ *   1. SKIPPING TOO MUCH. There are 50 markdown files under `src/`, including
+ *      the markdown-pipeline characterization corpus that round-trip tests read
+ *      at RUNTIME. A `!**\/*.md` exclusion would skip the whole app tier on
+ *      exactly the change most able to break it, and every check would still be
+ *      green. So the exclusion list must be an explicit allowlist, and nothing
+ *      under `src/` may appear in it.
+ *
+ *   2. BLOCKING EVERY MERGE. `frontend` is a REQUIRED check under
+ *      `enforce_admins`. Path-filtering its groups without teaching it that
+ *      `skipped` is a pass makes every docs PR unmergeable — by anyone,
+ *      including the repo owner. The `rust` aggregate has always had that
+ *      clause; this asserts the frontend one does too.
+ *
+ * A third, quieter mode: `predicate-quantifier` must be `some-with-excludes`.
+ * Under the default `some`, a file counts if it matches ANY pattern, so `'**'`
+ * matches everything, `code` is always true, and the filter is a no-op that
+ * still looks wired up — no skipping, no failure, no signal.
+ *
+ * @coordinates-with .github/workflows/ci.yml
+ * @module scripts/check-ci-docs-filter.test
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const ci = parseYaml(readFileSync(path.join(REPO, ".github/workflows/ci.yml"), "utf8"));
+const jobs = ci.jobs;
+
+/** Tiers that read no markdown and may skip on a prose-only PR. */
+const SKIPPABLE = ["fe-test", "fe-coverage", "fe-servers", "fe-build", "webkit", "bench"];
+
+const filterStep = jobs.changes.steps.find((s) => String(s.uses ?? "").includes("paths-filter"));
+const filters = parseYaml(filterStep.with.filters);
+
+describe("CI docs-only path filter", () => {
+  it("uses some-with-excludes, without which the filter is a silent no-op", () => {
+    expect(filterStep.with["predicate-quantifier"]).toBe("some-with-excludes");
+  });
+
+  it("exposes `code` from the changes job", () => {
+    expect(jobs.changes.outputs.code).toContain("filter.outputs.code");
+  });
+
+  it("guards every skippable tier on `code`, and none of them lost a dependency", () => {
+    for (const job of SKIPPABLE) {
+      expect(jobs[job].if, `${job} is not guarded`).toBe("needs.changes.outputs.code == 'true'");
+      expect(jobs[job].needs, `${job} must depend on changes`).toContain("changes");
+    }
+    // fe-coverage merges the shards' blob reports; dropping fe-test from its
+    // needs while adding `changes` would make the coverage gate race the shards
+    // and silently pass on nothing.
+    expect(jobs["fe-coverage"].needs).toContain("fe-test");
+  });
+
+  it("never skips fe-static, which is what actually checks the prose", () => {
+    // lint:emdash scans every *.md and lint:keybinding-manifest reads
+    // website/guide/shortcuts.md. If this tier were filtered too, a docs PR
+    // would be verified by nothing at all.
+    expect(jobs["fe-static"].if).toBeUndefined();
+  });
+
+  it("treats `skipped` as a pass in the required frontend check", () => {
+    const run = jobs.frontend.steps.map((s) => String(s.run ?? "")).join("\n");
+    expect(run).toContain('!= "skipped"');
+    // The dead post-loop webkit re-check would `exit 1` on a skipped webkit and
+    // undo the tolerance above.
+    expect(run).not.toMatch(/if \[ "\$WEBKIT" != "success" \]/);
+  });
+
+  it("keeps src/ out of the prose allowlist — the corpus trap", () => {
+    const excludes = filters.code.filter((p) => p.startsWith("!"));
+    expect(excludes.length).toBeGreaterThan(0);
+    for (const e of excludes) {
+      expect(e, `${e} would skip tests that read src/ markdown at runtime`).not.toMatch(/(^!src\/|^!\*\*\/\*\.md$)/);
+    }
+    expect(filters.code).toContain("**"); // something must match, or nothing is ever code
+  });
+
+  it("classifies real paths the way the tiers assume", () => {
+    // Mirrors `some-with-excludes`: included iff it matches a positive pattern
+    // and no negated one. Kept deliberately simple — this is a guard on the
+    // ALLOWLIST's shape, not a reimplementation of picomatch.
+    const excluded = new Set(filters.code.filter((p) => p.startsWith("!")).map((p) => p.slice(1)));
+    const isProse = (f) =>
+      excluded.has(f) ||
+      [...excluded].some((e) => e.endsWith("/**/*.md") && f.startsWith(e.slice(0, -8)) && f.endsWith(".md"));
+
+    expect(isProse("README.md")).toBe(true);
+    expect(isProse("website/guide/shortcuts.md")).toBe(true);
+    // The one that matters: a corpus fixture is CODE, so the tests still run.
+    expect(isProse("src/utils/markdownPipeline/__tests__/characterization/corpus/02-lists.md")).toBe(false);
+    expect(isProse("src/main.tsx")).toBe(false);
+    expect(isProse("package.json")).toBe(false);
+  });
+});


### PR DESCRIPTION
A prose-only PR cost **~12 runner-minutes** and ~4 min wall clock — four sharded test jobs, a coverage merge, two builds and a WebKit run, none of which read a markdown file. Measured on #1310, a two-line token swap in `README.md`.

The Rust side already did this correctly: `changes` (dorny/paths-filter) gates `rust-test`/`rust-audit`, and the `rust` aggregate treats `skipped` as a pass. The frontend never got the same treatment. This extends the existing job rather than adding a mechanism.

| Job | Docs-only PR | Why |
|---|---|---|
| `fe-static` | **runs** | `lint:emdash` scans every `*.md`; `lint:keybinding-manifest` reads `website/guide/shortcuts.md` |
| `fe-test` ×4, `fe-coverage`, `fe-servers`, `fe-build`, `webkit`, `bench` | skip | read no markdown |

~12 runner-min → **~3**, and docs are still verified by the gates that actually read docs.

## Three silent failure modes, all asserted and mutation-verified

`scripts/check-ci-docs-filter.test.mjs` — 7 assertions. Each mutation below fails it:

**1. Skipping too much.** There are **50 markdown files under `src/`**, including the markdown-pipeline characterization corpus that round-trip tests read *at runtime*. A blanket markdown exclusion would skip the whole app tier on exactly the change most able to break it — and stay green. So the exclusion list is an explicit allowlist, and no entry may live under `src/`.

**2. Blocking every merge.** `frontend` is a required check under `enforce_admins`. Filtering its groups without teaching it that `skipped` is a pass makes every docs PR unmergeable *by anyone, including you*. It now carries the clause `rust` always had.

The dead post-loop webkit re-check went in the same edit — under `bash -e` it was unreachable, but it would have `exit 1`-ed on a skipped webkit and undone the tolerance.

**3. The filter becoming a no-op.** `predicate-quantifier: some-with-excludes` is load-bearing. Under the default `some`, a file counts if it matches *any* pattern, so `'**'` matches everything and `code` is always true — no skipping, no failure, no signal. I verified the input exists in the **pinned SHA's** `action.yml` before relying on it; an unrecognised input is ignored, not rejected.

## What this PR cannot verify about itself

It touches `ci.yml`, so it is not docs-only and will run the full set. **The skip is observable on the next prose-only PR** — worth watching that one land to confirm `code=false` and the tiers reporting `skipped`.