### PR TITLE
chore: bump version to 0.9.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.45",
+  "version": "0.9.46",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.45';
+const VERSION = '0.9.46';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6399,7 +6399,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.45"
+version = "0.9.46"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.45"
+version = "0.9.46"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/src/gha_workflow/action_fetch.rs
+++ b/src-tauri/src/gha_workflow/action_fetch.rs
@@ -91,17 +91,11 @@ pub fn parse_action_yml(yaml: &str) -> Result<ActionMetadata, String> {
     })
 }
 
-/// Result of a fetch — typed so the frontend can branch cleanly.
+/// Result of a fetch — typed so the frontend can branch cleanly. `metadata` is boxed because this is also `fetch_action_yml`'s `Err`, where an inline `ActionMetadata` rode on every error return (`clippy::result_large_err`); `Box<T>` serialises as `T`, so the wire is unchanged.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FetchResult {
     Ok {
-        /// Boxed to keep the ENUM small. `ActionMetadata` inlines two BTreeMaps
-        /// and four Options (~145 bytes), and this enum is also used as the
-        /// `Err` type of `fetch_action_yml` — where every byte of the unused
-        /// `Ok` variant is carried on the error path of every call
-        /// (`clippy::result_large_err`). `Box<T>` serialises exactly like `T`,
-        /// so the IPC wire format is unchanged.
         metadata: Box<ActionMetadata>,
         /// Whether the result came from cache (vs. fresh network fetch).
         from_cache: bool,

--- a/src-tauri/src/gha_workflow/action_fetch.rs
+++ b/src-tauri/src/gha_workflow/action_fetch.rs
@@ -96,7 +96,13 @@ pub fn parse_action_yml(yaml: &str) -> Result<ActionMetadata, String> {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FetchResult {
     Ok {
-        metadata: ActionMetadata,
+        /// Boxed to keep the ENUM small. `ActionMetadata` inlines two BTreeMaps
+        /// and four Options (~145 bytes), and this enum is also used as the
+        /// `Err` type of `fetch_action_yml` — where every byte of the unused
+        /// `Ok` variant is carried on the error path of every call
+        /// (`clippy::result_large_err`). `Box<T>` serialises exactly like `T`,
+        /// so the IPC wire format is unchanged.
+        metadata: Box<ActionMetadata>,
         /// Whether the result came from cache (vs. fresh network fetch).
         from_cache: bool,
     },
@@ -377,7 +383,7 @@ pub async fn fetch_metadata(app: &AppHandle, uses: &str, ttl_secs: u64) -> Fetch
     if let Some(p) = &cache {
         if let Some(metadata) = read_cache(p, ttl_secs) {
             return FetchResult::Ok {
-                metadata,
+                metadata: Box::new(metadata),
                 from_cache: true,
             };
         }
@@ -402,7 +408,7 @@ pub async fn fetch_metadata(app: &AppHandle, uses: &str, ttl_secs: u64) -> Fetch
     }
 
     FetchResult::Ok {
-        metadata,
+        metadata: Box::new(metadata),
         from_cache: false,
     }
 }

--- a/src-tauri/src/window_manager/file_open_state.rs
+++ b/src-tauri/src/window_manager/file_open_state.rs
@@ -217,7 +217,10 @@ pub fn decide_file_open_locked(
 /// section (caller passes the locked state). Returns the drained opens.
 pub fn mark_ready_and_drain(state: &mut FileOpenState) -> Vec<PendingFileOpen> {
     state.frontend_ready = true;
-    state.pending.drain(..).collect()
+    // `take`, not `drain(..).collect()`: draining every element into a fresh
+    // Vec of the same type allocates a second buffer and copies into it, when
+    // the existing buffer can simply be handed over (`clippy::drain_collect`).
+    std::mem::take(&mut state.pending)
 }
 
 #[cfg(test)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Patch bump for the #1313 tab-lifecycle fixes (#1314).

All five version files plus the regenerated `src-tauri/Cargo.lock`.

## What 0.9.46 ships

**#1313 — blank tab lifecycle.** Fresh launch now lands on the WelcomeScreen instead of a forced `Untitled-1`; opening a workspace closes the clean untitled tab it used to orphan. New Window is unchanged and still gets a blank tab — launching the app is ambiguous, choosing New Window is not.

**The startup-path debt behind it.** An independent audit of that change caught a data-loss bug in the fix itself (the replaceable tab was probed before the file reads and closed after, so the cleanliness verdict was stale — a user typing during a workspace load could have had their work closed), plus 13 pre-existing findings. Grouped by mechanism they were five classes, dominated by one: *a decision taken on one side of an `await` and acted on from the other*.

**Hot-exit dedup keyed on identity.** Untitled tabs were categorically exempt because dedup keyed on `file_path` — path was only ever a proxy for identity, and it doesn't exist for an unsaved document, so a repeated record was restored once per copy every recovery.

## Along the way

`WindowContext.tsx` 348 → 299 lines, pruned from the file-size baseline entirely (now under the project's 300-line limit). `restoreWorkspaceTabs` 83 → 43. No baseline raised, no threshold loosened, no test skipped — two caps moved down and one entry was removed.

Verified: `pnpm check:all` exit 0 — 35,659 app tests, 966 gate, 512 sidecar, 159 content-server.