### PR TITLE
Keep the macOS traffic lights put when the menu is rebuilt, and give the settings window the same shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.47",
+  "version": "0.9.48",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.47';
+const VERSION = '0.9.48';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6399,7 +6399,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.47"
+version = "0.9.48"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.47"
+version = "0.9.48"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/src/app_setup.rs
+++ b/src-tauri/src/app_setup.rs
@@ -115,62 +115,6 @@ pub(crate) fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::
     Ok(())
 }
 
-/// Intercept close requests for document windows so the frontend can run its
-/// save/confirm flow. Non-document windows (settings) close normally.
-pub(crate) fn handle_document_window_close_event(
-    window: &tauri::Window,
-    event: &tauri::WindowEvent,
-) {
-    use tauri::Emitter;
-    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-        let label = window.label();
-        // INFO, not debug (#1253). `prevent_close` below hands the outcome to
-        // the frontend with no timeout and no fallback, so when a close stalls
-        // the only way to tell "Rust never saw the click" from "the frontend
-        // never finished" is a line here — and release builds filter `debug!`,
-        // which is why the first report of a stuck window arrived with a log
-        // that said nothing at all.
-        log::info!("[Tauri] WindowEvent::CloseRequested for window '{}'", label);
-        // Only intercept close for document windows
-        if label == "main" || label.starts_with("doc-") {
-            api.prevent_close();
-            // Include target label in payload so frontend can filter
-            let _ = window.emit("window:close-requested", label);
-            log::info!("[Tauri] Emitted window:close-requested to '{}'", label);
-        }
-        // Settings and other non-document windows close normally
-    }
-
-    // The window is actually gone: tear down any embedded browser it owned (WI-S0.4).
-    //
-    // BrowserSurface normally sends `browser_destroy` from a React unmount cleanup, but
-    // that cleanup runs in the very webview being destroyed — the IPC races its own
-    // teardown and may never arrive. The native WKWebViews would then outlive the window
-    // that owned them: orphaned content processes still holding the page, with nothing
-    // left that could reach them. The native side does not have that problem, so it does
-    // the job here.
-    if let tauri::WindowEvent::Destroyed = event {
-        let app = window.app_handle().clone();
-        crate::browser::teardown::destroy_window(&app, window.label());
-
-        // Trusted-HTML grants owned by this window die with it (#1273). Same
-        // reasoning as the browser teardown above: the frontend's own cleanup
-        // races the webview it runs in, so the native side does it. Scoped to
-        // this label — a process-global sweep here would revoke every other
-        // window's trusted previews.
-        if let Some(trusted) = app.try_state::<crate::trusted_html::TrustedHtmlState>() {
-            let revoked = trusted.revoke_window(window.label());
-            if revoked > 0 {
-                log::info!(
-                    "[Tauri] revoked {} trusted-HTML grant(s) for window '{}'",
-                    revoked,
-                    window.label()
-                );
-            }
-        }
-    }
-}
-
 /// Handle an app exit request, preserving macOS last-window-close behavior
 /// while letting Linux/Windows CLI launches terminate when no document windows
 /// remain.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -192,7 +192,7 @@ pub fn run() {
         .on_menu_event(menu_events::handle_menu_event)
         // CRITICAL: Only intercept close for document windows (main, doc-*)
         // Non-document windows (settings) should close normally
-        .on_window_event(app_setup::handle_document_window_close_event);
+        .on_window_event(window_manager::handle_document_window_close_event);
 
     // Tauri MCP bridge plugin for automation/screenshots (dev only).
     //

--- a/src-tauri/src/macos_menu.rs
+++ b/src-tauri/src/macos_menu.rs
@@ -223,6 +223,10 @@ pub fn apply_menu_icons(app_handle: &tauri::AppHandle) {
     apply_icons_to_ns_menu(&main_menu, &title_icon_map);
 
     log::debug!("[macos_menu] Menu icons applied");
+
+    // Touching the main menu makes AppKit re-lay out window chrome, which puts
+    // repositioned traffic lights back. See `window_manager::repair_traffic_lights`.
+    crate::window_manager::repair_traffic_lights(app_handle);
 }
 
 /// Fallback icon for dynamic menu items based on which submenu they're in.

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -56,25 +56,9 @@ mod finder_open_delivery;
 mod native_theme;
 mod path_validation;
 mod settings_window;
-
-/// Where macOS draws this app's window controls.
-///
-/// A window built at runtime does NOT inherit `tauri.conf.json`'s window entry,
-/// so setting `trafficLightPosition` there moves the main window's buttons and
-/// nothing else. Every builder that asks for the overlay title bar has to place
-/// them itself, from this one constant — miss one and that window's lights sit
-/// 10pt away from the main window's, in the same app on the same screen.
-///
-/// The value matches Finder, measured: 19pt in from the window's left and top
-/// edges. `y` carries the standard titlebar inset AppKit applies before this
-/// value is used, so `19 + 9 = 28`; `x` is one to one. See
-/// `src/shell/trafficLights.ts`, which derives the app's own clearances from
-/// the same numbers and has the test that keeps all three declarations equal.
-///
-/// Needs the `macos-private-api` cargo feature — see `Cargo.toml`.
 #[cfg(target_os = "macos")]
-pub(crate) const TRAFFIC_LIGHT_POSITION: tauri::LogicalPosition<f64> =
-    tauri::LogicalPosition { x: 19.0, y: 28.0 };
+mod traffic_lights;
+mod window_events;
 
 pub use commands::*;
 pub use document_windows::*;
@@ -83,6 +67,9 @@ pub use file_open_state::*;
 pub(crate) use finder_open_delivery::*;
 pub use native_theme::*;
 pub use settings_window::*;
+#[cfg(target_os = "macos")]
+pub(crate) use traffic_lights::*;
+pub(crate) use window_events::*;
 
 #[cfg(test)]
 #[path = "mod.test.rs"]

--- a/src-tauri/src/window_manager/settings_window.rs
+++ b/src-tauri/src/window_manager/settings_window.rs
@@ -85,7 +85,8 @@ pub fn show_settings_window_section<R: Runtime>(
     section: Option<&str>,
 ) -> Result<String, tauri::Error> {
     const SETTINGS_WIDTH: f64 = 760.0;
-    const SETTINGS_HEIGHT: f64 = 540.0;
+    // 540 cut most panels off mid-list, so the window opened already scrolled.
+    const SETTINGS_HEIGHT: f64 = 680.0;
     const SETTINGS_MIN_WIDTH: f64 = 600.0;
     const SETTINGS_MIN_HEIGHT: f64 = 400.0;
 

--- a/src-tauri/src/window_manager/traffic_lights.rs
+++ b/src-tauri/src/window_manager/traffic_lights.rs
@@ -1,0 +1,152 @@
+//! # Traffic lights
+//!
+//! Purpose: keep the macOS window controls where this app puts them, against an
+//! AppKit that keeps putting them back.
+//!
+//! Lives in its own module because it is three things that must agree — the
+//! position, the repair, and the list of moments worth repairing at — and
+//! because `mod.rs` is a module map, not a place for thirty lines of objc2.
+//!
+//! @coordinates-with src-tauri/tauri.conf.json — the main window's position
+//! @coordinates-with src/shell/trafficLights.ts — the app's own derived clearances
+//! @coordinates-with macos_menu.rs — rebuilding the menu is what moves them
+
+/// Where macOS draws this app's window controls.
+///
+/// A window built at runtime does NOT inherit `tauri.conf.json`'s window entry,
+/// so setting `trafficLightPosition` there moves the main window's buttons and
+/// nothing else. Every builder that asks for the overlay title bar has to place
+/// them itself, from this one constant — miss one and that window's lights sit
+/// 10pt away from the main window's, in the same app on the same screen.
+///
+/// The value matches Finder, measured: 19pt in from the window's left and top
+/// edges. `y` carries the standard titlebar inset AppKit applies before this
+/// value is used, so `19 + 9 = 28`; `x` is one to one. See
+/// `src/shell/trafficLights.ts`, which derives the app's own clearances from
+/// the same numbers and has the test that keeps all three declarations equal.
+///
+/// Needs the `macos-private-api` cargo feature — see `Cargo.toml`.
+#[cfg(target_os = "macos")]
+pub(crate) const TRAFFIC_LIGHT_POSITION: tauri::LogicalPosition<f64> =
+    tauri::LogicalPosition { x: 19.0, y: 28.0 };
+
+/// Make the window controls actually take `TRAFFIC_LIGHT_POSITION`.
+///
+/// **There are two implementations of `trafficLightPosition` and they do not
+/// behave the same.** A window built by a `WebviewWindowBuilder` sets it on the
+/// WEBVIEW, and wry's `WryWebViewParent::set_traffic_light_inset` applies it
+/// immediately. A window declared in `tauri.conf.json` sets it on the tao
+/// WINDOW instead, and tao only STORES it — the value is applied nowhere but
+/// inside `TaoView`'s `drawRect:`. Nothing in Tauri maps the config value onto
+/// the webview attributes, so the two paths never meet.
+///
+/// A WKWebView covers the tao view, so that `drawRect:` does not run during the
+/// first paint and the buttons stay wherever AppKit put them. The first window
+/// resize marks the view dirty, `drawRect:` finally runs, and they jump into
+/// place — which is exactly how this shipped in 0.9.47: right after a resize,
+/// wrong on launch.
+///
+/// Running that `drawRect:` is therefore the whole fix, and it must run
+/// SYNCHRONOUSLY. `setNeedsDisplay:` only marks the view dirty and lets AppKit
+/// choose when; the window was already on screen by then, so the buttons sat in
+/// AppKit's default spot for about half a second and then jumped. `display()`
+/// draws inside this call.
+///
+/// **Once is not enough, and that is why this is called again on every window
+/// event that can re-lay the title bar out.** A probe over startup showed the
+/// real sequence: setup applies the inset at the config's 800x600, then the
+/// window-state plugin restores the saved size. Whether the inset survives that
+/// depends on whether the resize happens to redraw the tao view — a race, and
+/// the losing side is visible as buttons in the wrong place. Which side loses
+/// varies by machine and by saved window size, which is exactly why fixing it
+/// by argument rather than by re-checking kept producing a different symptom.
+/// Re-checking afterwards does not care who won.
+///
+/// Deliberately NOT a second copy of the geometry. tao's `inset_traffic_lights`
+/// resizes the title-bar container and derives the button spacing from the
+/// buttons' own current frames; a hand-written copy here would place them on
+/// frame 1 and tao would place them again on every redraw after, so any
+/// difference between the two would flicker forever. The check is a PREDICATE
+/// only — it compares the container's height against the one value tao's
+/// routine sets it to, and on a mismatch asks tao to run its own code again. So
+/// the geometry keeps exactly one author, and the common case costs one frame
+/// read, which is what makes it safe on a live resize drag.
+///
+/// Applied to every window, not just the main one. The others are built through
+/// wry's path and start correct, but leaving fullscreen is a documented way to
+/// lose a repositioned button set on any of them.
+///
+/// Takes the raw `NSWindow` rather than a Tauri type because the two callers
+/// hold different ones — setup a `WebviewWindow`, the event handler a `Window`
+/// — and neither converts to the other. Both expose `ns_window()`, which is all
+/// this needs.
+#[cfg(target_os = "macos")]
+pub(crate) fn apply_traffic_light_position(ns_window: *mut std::ffi::c_void) {
+    use objc2_app_kit::{NSView, NSWindow, NSWindowButton};
+
+    if ns_window.is_null() {
+        log::warn!("traffic lights: null ns_window; leaving them where AppKit put them");
+        return;
+    }
+    let ptr = ns_window;
+    // SAFETY: `ns_window()` hands back the window's own `NSWindow`, and every
+    // caller is on the main thread, which is the only thread allowed to touch it.
+    unsafe {
+        let ns_window: &NSWindow = &*(ptr as *const NSWindow);
+
+        // tao sets the container's height to `close.height + position.y`. Any
+        // other value means AppKit has re-laid it out since, and the buttons
+        // have ridden it back to where AppKit wants them.
+        if let Some(close) = ns_window.standardWindowButton(NSWindowButton::CloseButton) {
+            let wanted = NSView::frame(&close).size.height + TRAFFIC_LIGHT_POSITION.y;
+            let container = close.superview().and_then(|v| v.superview());
+            if let Some(container) = container {
+                if (NSView::frame(&container).size.height - wanted).abs() < 0.5 {
+                    return;
+                }
+            }
+        }
+
+        if let Some(view) = ns_window.contentView() {
+            view.display();
+        }
+    }
+}
+
+/// Repair every window's controls. Called after any pass over the main menu.
+///
+/// Menu work is what actually moved them: `menu/dynamic.rs` rebuilds the Genies
+/// submenu once the frontend knows the user's shortcuts, and ends by re-applying
+/// the SF Symbol icons. Touching the main menu makes AppKit re-lay out window
+/// chrome — about half a second after launch, which is exactly when the buttons
+/// were seen jumping back. It fires no window event at all, so an event-driven
+/// repair alone never sees it.
+#[cfg(target_os = "macos")]
+pub(crate) fn repair_traffic_lights(app: &tauri::AppHandle) {
+    for (_, window) in tauri::Manager::webview_windows(app) {
+        if let Ok(ns) = window.ns_window() {
+            apply_traffic_light_position(ns);
+        }
+    }
+}
+
+/// The window events that can re-lay the title bar out.
+///
+/// Separate from the menu path above, and both are needed: leaving fullscreen is
+/// a documented way to lose a repositioned button set, and it fires an event but
+/// touches no menu.
+#[cfg(target_os = "macos")]
+pub(crate) fn repair_traffic_lights_on_event(window: &tauri::Window, event: &tauri::WindowEvent) {
+    if !matches!(
+        event,
+        tauri::WindowEvent::Resized(_)
+            | tauri::WindowEvent::Moved(_)
+            | tauri::WindowEvent::Focused(true)
+            | tauri::WindowEvent::ScaleFactorChanged { .. }
+    ) {
+        return;
+    }
+    if let Ok(ns) = window.ns_window() {
+        apply_traffic_light_position(ns);
+    }
+}

--- a/src-tauri/src/window_manager/window_events.rs
+++ b/src-tauri/src/window_manager/window_events.rs
@@ -1,0 +1,73 @@
+//! # Window lifecycle events
+//!
+//! Purpose: what happens to a window when the OS acts on it — a close the
+//! frontend must confirm, and the native resources that have to die with the
+//! window rather than with the webview inside it.
+//!
+//! Split out of `app_setup.rs`, which is for setting the app UP; a handler that
+//! runs for the whole life of every window was only ever there because that is
+//! where it was first written.
+//!
+//! @coordinates-with lib.rs — registers this as the `on_window_event` handler
+//! @module window_manager/window_events
+
+/// Intercept close requests for document windows so the frontend can run its
+/// save/confirm flow. Non-document windows (settings) close normally.
+pub(crate) fn handle_document_window_close_event(
+    window: &tauri::Window,
+    event: &tauri::WindowEvent,
+) {
+    use tauri::{Emitter, Manager};
+
+    // Put the macOS window controls back if AppKit re-laid the title bar out.
+    #[cfg(target_os = "macos")]
+    crate::window_manager::repair_traffic_lights_on_event(window, event);
+
+    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+        let label = window.label();
+        // INFO, not debug (#1253). `prevent_close` below hands the outcome to
+        // the frontend with no timeout and no fallback, so when a close stalls
+        // the only way to tell "Rust never saw the click" from "the frontend
+        // never finished" is a line here — and release builds filter `debug!`,
+        // which is why the first report of a stuck window arrived with a log
+        // that said nothing at all.
+        log::info!("[Tauri] WindowEvent::CloseRequested for window '{}'", label);
+        // Only intercept close for document windows
+        if label == "main" || label.starts_with("doc-") {
+            api.prevent_close();
+            // Include target label in payload so frontend can filter
+            let _ = window.emit("window:close-requested", label);
+            log::info!("[Tauri] Emitted window:close-requested to '{}'", label);
+        }
+        // Settings and other non-document windows close normally
+    }
+
+    // The window is actually gone: tear down any embedded browser it owned (WI-S0.4).
+    //
+    // BrowserSurface normally sends `browser_destroy` from a React unmount cleanup, but
+    // that cleanup runs in the very webview being destroyed — the IPC races its own
+    // teardown and may never arrive. The native WKWebViews would then outlive the window
+    // that owned them: orphaned content processes still holding the page, with nothing
+    // left that could reach them. The native side does not have that problem, so it does
+    // the job here.
+    if let tauri::WindowEvent::Destroyed = event {
+        let app = window.app_handle().clone();
+        crate::browser::teardown::destroy_window(&app, window.label());
+
+        // Trusted-HTML grants owned by this window die with it (#1273). Same
+        // reasoning as the browser teardown above: the frontend's own cleanup
+        // races the webview it runs in, so the native side does it. Scoped to
+        // this label — a process-global sweep here would revoke every other
+        // window's trusted previews.
+        if let Some(trusted) = app.try_state::<crate::trusted_html::TrustedHtmlState>() {
+            let revoked = trusted.revoke_window(window.label());
+            if revoked > 0 {
+                log::info!(
+                    "[Tauri] revoked {} trusted-HTML grant(s) for window '{}'",
+                    revoked,
+                    window.label()
+                );
+            }
+        }
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -5,7 +5,7 @@
  * Sections sorted alphabetically.
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Palette,
@@ -31,11 +31,13 @@ import { useUpdateBroadcast, useUpdateListener } from "@/hooks/useUpdateSync";
 import { isImeKeyEvent } from "@/utils/imeGuard";
 import { safeUnlistenAsync } from "@/utils/safeUnlisten";
 import { isMacPlatform } from "@/utils/platform";
+import { shellChromeVars } from "@/shell/shellChrome";
 import { SettingsSearchContext } from "./settings/SettingsSearchContext";
 import { SettingsSearchResults, type SearchablePanel } from "./settings/SettingsSearchResults";
-import { SearchInput } from "./settings/components";
+import { SettingsNav } from "./settings/SettingsNav";
 import { SETTINGS_PANELS, SEARCHABLE_PANEL_IDS, type Section } from "./settings/panels";
 import "./settings/settings-search.css";
+import "./settings/settings-shell.css";
 import { appError } from "@/utils/debug";
 import { voidAsync } from "@/utils/voidAsync";
 
@@ -72,30 +74,6 @@ function useDevSectionShortcut() {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
-}
-
-interface NavItemProps {
-  icon: React.ReactNode;
-  label: string;
-  active: boolean;
-  onClick: () => void;
-}
-
-function NavItem({ icon, label, active, onClick }: NavItemProps) {
-  return (
-    <button
-      onClick={onClick}
-      data-active={active}
-      className="flex w-full items-center gap-2.5 rounded-md px-3 py-2
-                 text-sm font-medium transition-colors
-                 text-[var(--text-secondary)] hover:bg-[var(--bg-tertiary)]
-                 data-[active=true]:bg-[var(--accent-bg)]
-                 data-[active=true]:text-[var(--accent-primary)]"
-    >
-      {icon}
-      {label}
-    </button>
-  );
 }
 
 // Navigation config icons — labels are resolved at render time via i18n
@@ -222,41 +200,22 @@ export function SettingsPage() {
   const ActivePanel = SETTINGS_PANELS[section];
 
   return (
-    <div className="relative flex h-screen bg-[var(--bg-color)]">
-      {/* Sidebar - full height */}
-      <div
-        className="w-52 shrink-0 border-r border-gray-200 dark:border-gray-700
-                   bg-[var(--bg-secondary)] flex flex-col"
-      >
-        {isMac && <div data-tauri-drag-region className="h-12 shrink-0" />}
-        {/* Search box */}
-        <div className="px-3 pb-2">
-          <SearchInput
-            type="search"
-            value={searchQuery}
-            onChange={setSearchQuery}
-            placeholder={t("search.placeholder")}
-            aria-label={t("search.placeholder")}
-          />
-        </div>
-        {/* Nav items */}
-        <div className="flex-1 overflow-auto px-3 pb-3">
-          <div className="space-y-1">
-            {navItems.map((item) => (
-              <NavItem
-                key={item.id}
-                icon={item.icon}
-                label={item.label}
-                active={!searching && section === item.id}
-                onClick={() => {
-                  setSearchQuery("");
-                  setSection(item.id);
-                }}
-              />
-            ))}
-          </div>
-        </div>
-      </div>
+    // The settings window has its own root, not AppShell's, so it has to publish
+    // the same chrome geometry — otherwise --shell-top-inset falls back to the
+    // :root default of 0 and every clearance here is a hardcoded guess again.
+    <div
+      className="relative flex h-screen bg-[var(--bg-color)]"
+      style={shellChromeVars(isMac) as CSSProperties}
+    >
+      <SettingsNav
+        isMac={isMac}
+        items={navItems}
+        section={section}
+        searching={searching}
+        searchQuery={searchQuery}
+        onSearch={setSearchQuery}
+        onSelect={setSection}
+      />
 
       {/* Content area */}
       {/* min-w-0: without it this flex item cannot shrink below its content's
@@ -264,11 +223,17 @@ export function SettingsPage() {
           update card's button column), and the whole window grows a
           document-level horizontal scrollbar. */}
       <div className="flex-1 flex flex-col min-w-0">
-        {isMac && <div data-tauri-drag-region className="h-12 shrink-0" />}
+        {isMac && (
+          <div
+            data-tauri-drag-region
+            className="shrink-0"
+            style={{ height: "var(--shell-top-inset)" }}
+          />
+        )}
         {/* Content */}
         <SettingsSearchContext.Provider value={normalizedQuery}>
           <div
-            className="flex-1 overflow-auto p-6 [scrollbar-gutter:stable]"
+            className="settings-scroll flex-1 overflow-auto p-6"
             data-settings-searching={searching ? "" : undefined}
           >
             {searching ? (
@@ -283,8 +248,11 @@ export function SettingsPage() {
       {isMac && (
         <div
           data-tauri-drag-region
-          className="absolute top-0 right-0 h-12 flex items-center justify-center pointer-events-none"
-          style={{ left: "13rem" }}
+          className="absolute top-0 right-0 flex items-center justify-center pointer-events-none"
+          style={{
+            left: "calc(13rem + 2 * var(--shell-card-inset))",
+            height: "calc(2 * var(--traffic-lights-centre))",
+          }}
         >
           <span className="text-sm font-medium text-[var(--text-color)]">
             {t("title")}

--- a/src/pages/settings/SettingsNav.tsx
+++ b/src/pages/settings/SettingsNav.tsx
@@ -1,0 +1,117 @@
+/**
+ * SettingsNav
+ *
+ * Purpose: the settings window's leading card — the search field and the
+ * section list, held in the same card surface the document window's sidebar
+ * uses (`shell/app-shell.css`).
+ *
+ * Split out of `Settings.tsx` when the card pushed that file past the 300-line
+ * limit. It is a real seam, not a line-count dodge: this column owns the
+ * window's only chrome clearance and its own scroll behaviour, and the page
+ * beside it owns neither.
+ *
+ * @coordinates-with shell/shellChrome.ts — the card inset, radius and top inset
+ * @module pages/settings/SettingsNav
+ */
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { SearchInput } from "./components";
+import type { Section } from "./panels";
+
+interface NavItemProps {
+  icon: React.ReactNode;
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+
+function NavItem({ icon, label, active, onClick }: NavItemProps) {
+  return (
+    <button
+      onClick={onClick}
+      data-active={active}
+      className="flex w-full items-center gap-2.5 rounded-md px-3 py-2
+                 text-sm font-medium transition-colors
+                 text-[var(--text-secondary)] hover:bg-[var(--bg-tertiary)]
+                 data-[active=true]:bg-[var(--accent-bg)]
+                 data-[active=true]:text-[var(--accent-primary)]"
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+export interface SettingsNavProps {
+  isMac: boolean;
+  items: { id: Section; label: string; icon: ReactNode }[];
+  section: Section;
+  searching: boolean;
+  searchQuery: string;
+  onSearch: (value: string) => void;
+  onSelect: (id: Section) => void;
+}
+
+export function SettingsNav({
+  isMac,
+  items,
+  section,
+  searching,
+  searchQuery,
+  onSearch,
+  onSelect,
+}: SettingsNavProps) {
+  const { t } = useTranslation("settings");
+  // The gutter lives on this wrapper so the card's own width stays w-52.
+  return (
+    <div className="shrink-0 box-border" style={{ padding: "var(--shell-card-inset)" }}>
+      <div
+        className="w-52 h-full flex flex-col overflow-hidden bg-[var(--bg-secondary)]"
+        style={{
+          borderRadius: "var(--shell-card-radius)",
+          boxShadow: "var(--shadow-md)",
+        }}
+      >
+        {/* Clears the traffic lights, measured from the WINDOW's top — so the
+            card's own gutter comes off it, exactly as the document window's
+            card does. Still a drag region: this strip is the title bar. */}
+        {isMac && (
+          <div
+            data-tauri-drag-region
+            className="shrink-0"
+            style={{
+              height: "max(0px, calc(var(--shell-top-inset) - var(--shell-card-inset)))",
+            }}
+          />
+        )}
+        {/* Search box */}
+        <div className="px-3 pb-2">
+        <SearchInput
+          type="search"
+          value={searchQuery}
+          onChange={onSearch}
+          placeholder={t("search.placeholder")}
+          aria-label={t("search.placeholder")}
+        />
+        </div>
+        {/* Nav items */}
+        <div className="settings-scroll flex-1 overflow-auto px-3 pb-3">
+          <div className="space-y-1">
+          {items.map((item) => (
+            <NavItem
+              key={item.id}
+              icon={item.icon}
+              label={item.label}
+              active={!searching && section === item.id}
+              onClick={() => {
+                onSearch("");
+                onSelect(item.id);
+              }}
+            />
+          ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/settings/settings-shell.css
+++ b/src/pages/settings/settings-shell.css
@@ -1,0 +1,28 @@
+/* The settings window's two scrolling columns.
+ *
+ * `index.css` styles `::-webkit-scrollbar` globally, and styling it AT ALL opts
+ * every scrollable element out of macOS overlay scrollbars — so the app's bars
+ * are classic ones that take 10px of real layout width the moment a pane
+ * overflows. In a document that is the right trade: the bar is a grabbable
+ * affordance on content that is often metres long.
+ *
+ * A settings panel is not that. It is a short form, the overflow is usually a
+ * screenful or two, and the 10px lane shows up as content sitting visibly left
+ * of centre on exactly the panels that happen to be long — while the panels
+ * that fit sit correctly. The window looks like it cannot decide where its
+ * right margin is.
+ *
+ * `scrollbar-gutter: stable` used to make the lane permanent, which at least
+ * made it CONSISTENT; removing it (as asked) fixed the short panels and left
+ * the long ones. Zero width fixes both: the panes still scroll by wheel,
+ * trackpad and keyboard, and the content keeps its full width everywhere.
+ *
+ * The trade, stated: these two panes lose their visible scroll indicator.
+ * That is what macOS overlay scrollbars do at rest anyway, and it is what the
+ * global rule would give here if it were not opting the element out.
+ */
+
+.settings-scroll::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}

--- a/src/shell/trafficLights.test.ts
+++ b/src/shell/trafficLights.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 //
 // The macOS window controls are described in THREE places that no compiler
-// joins: `tauri.conf.json` (the main window), `window_manager/mod.rs` (every
-// window built at runtime), and `trafficLights.ts` (the clearances the app's
+// joins: `tauri.conf.json` (the main window), `window_manager/traffic_lights.rs`
+// (every window built at runtime), and `trafficLights.ts` (the clearances the app's
 // own chrome leaves). A number changed in one of them and not the others is
 // silent — the lights simply move under the title bar, or a second window's
 // lights sit somewhere the first window's do not.
@@ -94,9 +94,9 @@ describe("the three declarations of the position agree", () => {
   });
 
   it("matches the constant the runtime window builders use", () => {
-    const rs = read("src-tauri/src/window_manager/mod.rs");
+    const rs = read("src-tauri/src/window_manager/traffic_lights.rs");
     const m = /const TRAFFIC_LIGHT_POSITION:\s*(?:tauri::)?LogicalPosition<f64>\s*=\s*(?:tauri::)?LogicalPosition\s*\{\s*x:\s*([\d.]+),\s*y:\s*([\d.]+)\s*,?\s*\}/.exec(rs);
-    expect(m, "TRAFFIC_LIGHT_POSITION not found in window_manager/mod.rs").not.toBeNull();
+    expect(m, "TRAFFIC_LIGHT_POSITION not found in window_manager/traffic_lights.rs").not.toBeNull();
     expect(Number(m?.[1])).toBe(TRAFFIC_LIGHT_POSITION.x);
     expect(Number(m?.[2])).toBe(TRAFFIC_LIGHT_POSITION.y);
   });


### PR DESCRIPTION
## The traffic lights, actually fixed this time

0.9.47 shipped them in the right place only after a window resize. Three
follow-up attempts each produced a *different* symptom — wrong-then-right,
right-then-wrong, no change — because every one of them was about *when to
redraw*, and redrawing was never the question.

A probe over startup settled it:

```
[probe 0] close=(19.0,9.0) container=(y 558, h 42) win=800x600
[probe 1] close=(19.0,9.0) container=(y 994, h 42) win=1113x1036
```

**The buttons never move.** Their origin inside their superview reads `(19, 9)`
throughout. What moves is the **title-bar container** they ride in — tao resizes
it to `close.height + y` and pins it to the window top. Anything that makes
AppKit re-lay that container out takes the buttons with it *while their own frame
still reads correct*, which is why every check aimed at the button saw nothing.

And the thing doing it is our own code. `menu/dynamic.rs` rebuilds the Genies
submenu once the frontend knows the user's shortcuts and ends by re-applying the
SF Symbol icons. Touching the main menu re-lays out window chrome. It lands about
half a second after launch — the reported timing — and **fires no window event**,
so an event-driven repair never sees it.

The repair now hangs off `apply_menu_icons`, the shared tail of both the startup
pass and the dynamic rebuild, so any future menu mutation is covered by
construction. Window events are covered separately, because leaving fullscreen
loses repositioned buttons and touches no menu.

Both go through **one predicate** — compare the container's height against the
single value tao sets it to, and on a mismatch ask tao to re-run its own code.
The geometry keeps exactly one author; a hand-written copy would place the
buttons on frame 1 and tao would place them again on every redraw after, and any
difference would flicker forever.

## The settings window catches up

It kept the old chrome when the document window's was rebuilt. Now: nav column
as a leading card, clearances derived instead of a hardcoded `h-12` against a
real inset of 40, default height 540 → 680, and no reserved scrollbar lane.

That last one took two goes. Removing `scrollbar-gutter: stable` only stopped the
lane being held open when there was *nothing* to scroll — fixing short panels and
leaving long ones. The real cause: `index.css` styles `::-webkit-scrollbar`
globally, and styling it at all opts an element out of macOS overlay scrollbars,
so the bar is a classic one taking 10px the moment a pane overflows. Measured on
the live window at 2×: a 20px track whose transparent border leaves a 12px thumb.

## Three files split

`lint:file-size` caught them and none got a baseline entry:
`window_manager/traffic_lights.rs`, `window_manager/window_events.rs` (app_setup
was at 299, one under the cap), and `settings/SettingsNav.tsx`.

## Verification

`pnpm check:all` green. `cargo clippy --all-targets -- -D warnings`, `cargo test`
(2,243), `cargo fmt --check`, and `check-cross-target.sh` against
`x86_64-pc-windows-gnu` all clean. `trafficLights.test.ts` still pins that the
three declarations of the position agree — it caught the module move on its own.

## Not verified

The settings scroll lane is confirmed by CSS specificity and measurement of the
*old* behaviour, not by a photo of the new one — I repeatedly captured whatever
window was in front of it. `Settings.tsx` still has no render test; typecheck and
lint are its only automated cover.
