### PR TITLE
fix(open): keep the workspace when a file arrives from the system (#1330)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.51",
+  "version": "0.9.52",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/scripts/test-types-baseline.json
+++ b/scripts/test-types-baseline.json
@@ -73,7 +73,6 @@
   "src/hooks/useDocumentState.test.tsx": 2,
   "src/hooks/useDragDropOpen.test.ts": 3,
   "src/hooks/useExternalFileChanges.test.ts": 24,
-  "src/hooks/useFinderFileOpen.comprehensive.test.tsx": 11,
   "src/hooks/useFinderFileOpen.test.ts": 38,
   "src/hooks/useFormatsUpgradeNudge.test.ts": 1,
   "src/hooks/useGenieShortcuts.invokeGenie.test.ts": 3,

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.51",
+  "version": "0.9.52",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.51';
+const VERSION = '0.9.52';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5508,6 +5508,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-store"
 version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6440,6 +6456,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6415,7 +6415,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.51"
+version = "0.9.52"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.51"
+version = "0.9.52"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -133,6 +133,17 @@ rusqlite = { version = "0.40", features = ["bundled"] }
 unicode-normalization = "0.1"
 lopdf = { version = "0.44.0", default-features = false }
 
+# Windows and Linux start a FRESH process for every file-association
+# double-click; macOS does not (one process per bundle identifier, later opens
+# arrive as `RunEvent::Opened`). A second process shares this app's
+# localStorage, app-data directory and hot-exit session, so it corrupts the
+# running one rather than merely duplicating it — see `src/single_instance.rs`
+# and #1330. Official Tauri plugin, same workspace as every other
+# `tauri-plugin-*` here. Rust-only: it has no `@tauri-apps/*` counterpart, so
+# `lint:tauri-versions` correctly skips it.
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+tauri-plugin-single-instance = "2"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/src-tauri/src/file_open.rs
+++ b/src-tauri/src/file_open.rs
@@ -26,13 +26,11 @@ use crate::window_manager;
 
 #[cfg(target_os = "macos")]
 use crate::supported_files::is_openable_supported;
-// macOS-gated since the scope helpers moved to `fs_scope`. This was
-// unconditional because `allow_fs_read` needed `Manager` for
-// `asset_protocol_scope()` on every platform; that consumer now lives in
-// `fs_scope.rs`, leaving `handle_reopen`'s `get_webview_window` as the only
-// user here — and that is macOS-only. Unconditional is now an unused-import
-// ERROR on Linux/Windows, the exact mirror of the hazard this comment used to
-// warn about, and CI caught it on ubuntu and windows while macOS stayed green.
+// Unconditional, and it must stay that way: `record_ready_document_window` and
+// `route_file_opens` both reach for `get_webview_window` / `webview_windows` on
+// every platform. (An earlier revision had only macOS callers left here, and
+// gating it was correct THEN — re-deriving that from the caller list is the
+// check, not this comment.)
 use tauri::Manager;
 
 /// A file open request queued during cold start before the frontend is ready.
@@ -171,7 +169,18 @@ pub(crate) fn handle_finder_opened(app: &tauri::AppHandle, urls: Vec<tauri::Url>
         }
     }
 
-    let file_paths = opened.files;
+    route_file_opens(app, opened.files);
+}
+
+/// Route already-filtered file paths to a ready document window, queueing them
+/// for the next one when no window can take them yet.
+///
+/// Shared by the macOS `RunEvent::Opened` handler above and the Windows/Linux
+/// single-instance callback (`crate::single_instance`), which arrive at the
+/// same point by different roads — Finder hands macOS a URL list, Explorer
+/// hands a second `vmark` process an argv. Both then need the identical
+/// grouping, atomic decide, and emit-or-queue behaviour, so it lives once.
+pub(crate) fn route_file_opens(app: &tauri::AppHandle, file_paths: Vec<String>) {
     if file_paths.is_empty() {
         return;
     }
@@ -180,7 +189,7 @@ pub(crate) fn handle_finder_opened(app: &tauri::AppHandle, urls: Vec<tauri::Url>
     for path in &file_paths {
         crate::allow_fs_read(app, path);
     }
-    log::info!("[Finder] Opening {} file(s)", file_paths.len());
+    log::info!("[FileOpen] Opening {} file(s)", file_paths.len());
 
     let groups = window_manager::group_paths_by_workspace(&file_paths);
     for (workspace_key, paths) in groups {
@@ -208,18 +217,18 @@ pub(crate) fn handle_finder_opened(app: &tauri::AppHandle, urls: Vec<tauri::Url>
             window_manager::FileOpenOutcome::Queued { create_window } => {
                 if create_window {
                     if app.get_webview_window("main").is_none() {
-                        log::info!("[Finder] Queueing files, creating main window");
+                        log::info!("[FileOpen] Queueing files, creating main window");
                         if let Err(e) = window_manager::create_main_window(app, None) {
                             log::error!(
-                                "[Finder] Failed to create main window for queued opens: {}",
+                                "[FileOpen] Failed to create main window for queued opens: {}",
                                 e
                             );
                         }
                     } else {
-                        log::info!("[Finder] Queueing files until main window is ready");
+                        log::info!("[FileOpen] Queueing files until main window is ready");
                     }
                 } else {
-                    log::info!("[Finder] Queueing files (frontend not ready)");
+                    log::info!("[FileOpen] Queueing files (frontend not ready)");
                 }
             }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,6 +49,7 @@ mod secret_token;
 mod secure_store;
 mod shell_env;
 mod shell_integration;
+mod single_instance;
 mod supported_files;
 mod tab_transfer;
 mod task;
@@ -104,7 +105,25 @@ pub fn run() {
     text_substitution::disable_smart_substitutions();
 
     #[allow(unused_mut)]
-    let mut builder = tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    // FIRST, before every other plugin — Tauri's own guidance, and it is what
+    // makes the guard cheap: a duplicate launch is turned away before this
+    // process builds any state to turn away with.
+    //
+    // Off macOS only. macOS keeps one process per bundle identifier natively
+    // and routes later opens through `RunEvent::Opened`; on Windows and Linux
+    // every file-association double-click starts a fresh process that then
+    // shares one localStorage and one hot-exit session with the running app
+    // (#1330 — see `single_instance.rs`).
+    #[cfg(not(target_os = "macos"))]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+            single_instance::handle_second_launch(app, argv);
+        }));
+    }
+
+    builder = builder
         .plugin(
             tauri_plugin_log::Builder::new()
                 .targets([

--- a/src-tauri/src/single_instance.rs
+++ b/src-tauri/src/single_instance.rs
@@ -1,0 +1,139 @@
+//! Second-launch forwarding for Windows and Linux (#1330).
+//!
+//! Purpose: make an Explorer/desktop-launcher double-click reach the VMark that
+//! is ALREADY running, instead of starting a second one.
+//!
+//! macOS never needs this — the OS keeps one process per bundle identifier and
+//! delivers later opens to it as `RunEvent::Opened`. Windows and Linux have no
+//! such rule: every double-click on an associated file starts a fresh `vmark`
+//! process with the path in argv, which is why `app_setup::setup_app` reads
+//! `std::env::args()` at all.
+//!
+//! Key decisions:
+//!   - A SECOND PROCESS IS NOT MERELY REDUNDANT, IT IS DESTRUCTIVE. Its windows
+//!     carry the same labels (`main`, `doc-N`) under the same bundle
+//!     identifier, so its webview rehydrates the same `vmark-workspace:<label>`
+//!     localStorage and its backend shares one app-data directory and hot-exit
+//!     session with the process already running. Two processes then
+//!     read-modify-write one session and the last writer wins — the reporter's
+//!     symptom in #1330 was a window that showed their workspace tree and then
+//!     lost it. `AGENTS.md` records the same hazard from the other direction:
+//!     splitting the dev build's identifier was needed for exactly this reason.
+//!   - Forwarding argv routes the open through `file_open::route_file_opens`,
+//!     the SAME path macOS takes, rather than a second copy of the policy.
+//!   - A launch carrying no openable file still surfaces a window. Swallowing
+//!     it would make double-clicking the app icon look broken once a VMark is
+//!     already running.
+//!   - Window creation here is safe on the blocking path: the plugin delivers
+//!     this callback on the main thread's event loop (Windows: a hidden
+//!     message-only window's WndProc, created during `setup`), not inside a
+//!     WebView2 `WebMessageReceived` callback — which is the reentrancy case
+//!     `scripts/check-window-creation-thread.mjs` exists to catch.
+//!   - The instance is keyed on `app.config().identifier` (the plugin's Windows
+//!     mutex name and Linux DBus name), so `tauri dev` — which overrides the
+//!     identifier to `app.vmark.dev` — is a SEPARATE instance from an installed
+//!     release build. That falls out of the dev-profile split AGENTS.md already
+//!     describes; it is not a second mechanism to keep in sync.
+//!
+//! Known Linux exposure, stated rather than discovered later: the plugin's
+//! Linux backend builds its guard on the DBus SESSION bus and `.unwrap()`s that
+//! connection, so a session with no `DBUS_SESSION_BUS_ADDRESS` panics VMark at
+//! startup where it previously launched. In practice a Tauri app already needs
+//! GTK + WebKitGTK and therefore a desktop session, which always carries a
+//! session bus — but if a Linux "won't start at all" report ever arrives after
+//! this, look here FIRST. The Windows backend has no such dependency (a named
+//! mutex plus `WM_COPYDATA`), which is where #1330 was actually reported.
+//!
+//! @coordinates-with file_open.rs — `route_file_opens`, the shared destination
+//! @coordinates-with app_setup.rs — handles the FIRST launch's argv
+
+// Compiled on macOS too, deliberately: the plugin is registered only off
+// macOS, but gating the module out would take its unit tests with it — and
+// macOS is the platform this project develops and runs `cargo test` on.
+#![cfg_attr(target_os = "macos", allow(dead_code))]
+
+use tauri::Manager;
+
+use crate::{file_open, quit, supported_files, window_manager};
+
+/// Handle a second launch: route any openable files in `argv` to this
+/// instance, and surface a window either way.
+///
+/// `argv[0]` is the program path, exactly as `std::env::args()` yields it, so
+/// it is skipped for the same reason `app_setup` skips it.
+pub(crate) fn handle_second_launch(app: &tauri::AppHandle, argv: Vec<String>) {
+    let files = openable_files_from_argv(argv);
+    log::info!(
+        "[SingleInstance] second launch with {} file(s)",
+        files.len()
+    );
+
+    if files.is_empty() {
+        surface_a_window(app);
+        return;
+    }
+    // route_file_opens focuses the window it delivers to, so no extra surfacing.
+    file_open::route_file_opens(app, files);
+}
+
+/// The openable files a second launch is asking for.
+///
+/// `argv[0]` is dropped before the gate, not after: it is the program path,
+/// and a build whose own name ends in a registered extension would otherwise
+/// open the executable as a document.
+pub(crate) fn openable_files_from_argv(argv: Vec<String>) -> Vec<String> {
+    supported_files::filter_supported_args(argv.into_iter().skip(1))
+}
+
+/// Bring an existing document window forward, or create one when none is left.
+///
+/// The target is chosen by `finder_window_target` rather than by taking
+/// whatever `webview_windows()` yields first: that is a `HashMap`, so "first"
+/// differs between runs, and the last-focused window is what the user means.
+fn surface_a_window(app: &tauri::AppHandle) {
+    let live_labels: Vec<String> = app.webview_windows().keys().cloned().collect();
+    let target = {
+        let state = file_open::FILE_OPEN_STATE
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        state.finder_window_target(&live_labels)
+    };
+
+    // Fall back to any live document window: `finder_window_target` only
+    // returns listener-READY ones, and a window still booting is a better
+    // answer than building a second one beside it.
+    let label = target.or_else(|| {
+        live_labels
+            .iter()
+            .filter(|label| quit::is_document_window_label(label))
+            .min()
+            .cloned()
+    });
+
+    let Some(label) = label else {
+        log::info!("[SingleInstance] no document window left — creating one");
+        if let Err(error) = window_manager::create_main_window(app, None) {
+            log::error!("[SingleInstance] failed to create main window: {}", error);
+        }
+        return;
+    };
+
+    let Some(window) = app.get_webview_window(&label) else {
+        return;
+    };
+    // show + unminimize before focus, so a hidden or minimized window is
+    // actually revealed rather than silently focused off-screen.
+    if let Err(error) = window.show() {
+        log::warn!("[SingleInstance] show('{}') failed: {}", label, error);
+    }
+    if let Err(error) = window.unminimize() {
+        log::warn!("[SingleInstance] unminimize('{}') failed: {}", label, error);
+    }
+    if let Err(error) = window.set_focus() {
+        log::warn!("[SingleInstance] set_focus('{}') failed: {}", label, error);
+    }
+}
+
+#[cfg(test)]
+#[path = "single_instance.test.rs"]
+mod tests;

--- a/src-tauri/src/single_instance.test.rs
+++ b/src-tauri/src/single_instance.test.rs
@@ -1,0 +1,102 @@
+//! Tests for second-launch argv handling (#1330).
+//!
+//! Only the argv→files decision is unit-testable without a live app; the
+//! window-surfacing half needs a real `AppHandle`. That split is deliberate:
+//! the argv half is where a silent mistake hides (a dropped `skip(1)` opens the
+//! executable; a missing filter opens a `.exe` as a document), while the
+//! surfacing half fails loudly and visibly the first time anyone tries it.
+
+use super::openable_files_from_argv;
+
+/// Real files on disk — `filter_supported_args` calls `is_file()`, so a
+/// fabricated path would be rejected for the wrong reason and the test would
+/// pass no matter what the filter did.
+struct Fixture {
+    dir: std::path::PathBuf,
+}
+
+impl Fixture {
+    fn new(tag: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!("vmark-single-instance-{tag}"));
+        std::fs::create_dir_all(&dir).expect("create fixture dir");
+        Self { dir }
+    }
+
+    fn file(&self, name: &str) -> String {
+        let path = self.dir.join(name);
+        std::fs::write(&path, b"# doc\n").expect("write fixture file");
+        path.to_string_lossy().into_owned()
+    }
+
+    fn subdir(&self, name: &str) -> String {
+        let path = self.dir.join(name);
+        std::fs::create_dir_all(&path).expect("create fixture subdir");
+        path.to_string_lossy().into_owned()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn empty_argv_asks_for_nothing() {
+    assert!(openable_files_from_argv(Vec::new()).is_empty());
+}
+
+#[test]
+fn a_bare_launch_carries_no_files() {
+    // Double-clicking the app icon while VMark is already running.
+    assert!(openable_files_from_argv(vec!["C:/Program Files/VMark/vmark.exe".into()]).is_empty());
+}
+
+#[test]
+fn forwards_the_supported_files_after_argv0() {
+    let fx = Fixture::new("forwards");
+    let note = fx.file("note.md");
+    let data = fx.file("data.yaml");
+
+    let files =
+        openable_files_from_argv(vec!["/opt/vmark/vmark".into(), note.clone(), data.clone()]);
+
+    assert_eq!(files, vec![note, data]);
+}
+
+#[test]
+fn argv0_is_dropped_before_the_gate_not_after() {
+    // The regression a missing `skip(1)` produces. argv[0] is a REAL openable
+    // file here, so the filter alone cannot reject it — only the skip can. A
+    // contrived program name, but the failure it guards (opening the program
+    // itself as a document) is the same one a `.md`-suffixed launcher causes.
+    let fx = Fixture::new("argv0");
+    let program = fx.file("vmark.md");
+    let note = fx.file("note.md");
+
+    let files = openable_files_from_argv(vec![program, note.clone()]);
+
+    assert_eq!(files, vec![note]);
+}
+
+#[test]
+fn drops_paths_this_app_cannot_open() {
+    let fx = Fixture::new("drops");
+    let note = fx.file("note.md");
+    let binary = fx.file("installer.exe");
+    let folder = fx.subdir("a-folder");
+    let missing = fx.dir.join("gone.md").to_string_lossy().into_owned();
+
+    let files = openable_files_from_argv(vec![
+        "/opt/vmark/vmark".into(),
+        binary,
+        folder,
+        missing,
+        note.clone(),
+    ]);
+
+    // A directory is dropped rather than opened as a workspace: that matches
+    // the cold-start CLI path in `app_setup`, which filters argv identically.
+    // Changing it is a product decision, and it belongs in both places at once.
+    assert_eq!(files, vec![note]);
+}

--- a/src-tauri/src/window_manager/finder_open_delivery.rs
+++ b/src-tauri/src/window_manager/finder_open_delivery.rs
@@ -1,8 +1,12 @@
-//! Delivery of macOS Finder hot-open events to one document window.
+//! Delivery of a system file-open to one document window.
 //!
 //! Rust broadcasts the event because the frontend listens through Tauri's
 //! global event API. The payload carries the selected window label so every
 //! other document window can reject the broadcast.
+//!
+//! Reached from macOS `RunEvent::Opened` and from the Windows/Linux
+//! single-instance callback, both via `file_open::route_file_opens` — so this
+//! module is NOT macOS-only, whatever the `[Finder]` log prefixes suggest.
 
 use serde::Serialize;
 use tauri::{Emitter, Manager};

--- a/src-tauri/src/window_manager/finder_open_delivery.test.rs
+++ b/src-tauri/src/window_manager/finder_open_delivery.test.rs
@@ -1,20 +1,40 @@
-//! Tauri-runtime contract tests for Finder hot-open delivery.
+//! Tauri-runtime contract tests for system file-open delivery.
+//!
+//! Every item here is `cfg(not(target_os = "windows"))`. `tauri::test::
+//! MockRuntime` does not exist on Windows — Cargo.toml scopes tauri's `test`
+//! feature to `cfg(not(target_os = "windows"))` because the mock-runtime test
+//! binary dies at startup there with STATUS_ENTRYPOINT_NOT_FOUND — and an
+//! ungated caller does not fail at runtime, it fails to COMPILE, on the one
+//! target you cannot run locally.
+//!
+//! This file was protected by accident until #1330: the module it tests was
+//! `cfg(macos)`, so the Windows target never saw it. Sharing the delivery path
+//! with the Windows/Linux single-instance callback removed that accident, and
+//! `scripts/check-cross-target.sh` caught it in about a minute.
 
+#[cfg(not(target_os = "windows"))]
 use std::sync::mpsc;
+#[cfg(not(target_os = "windows"))]
 use std::time::Duration;
 
+#[cfg(not(target_os = "windows"))]
 use serde_json::Value;
+#[cfg(not(target_os = "windows"))]
 use tauri::Listener;
 
+#[cfg(not(target_os = "windows"))]
 use super::{focus_and_emit, focus_and_emit_with_fallback};
+#[cfg(not(target_os = "windows"))]
 use crate::PendingFileOpen;
 
+#[cfg(not(target_os = "windows"))]
 fn mock_app() -> tauri::App<tauri::test::MockRuntime> {
     tauri::test::mock_builder()
         .build(tauri::test::mock_context(tauri::test::noop_assets()))
         .expect("build mock app")
 }
 
+#[cfg(not(target_os = "windows"))]
 #[test]
 fn focus_and_emit_reveals_the_target_and_broadcasts_its_label() {
     let app = mock_app();
@@ -51,6 +71,7 @@ fn focus_and_emit_reveals_the_target_and_broadcasts_its_label() {
     assert_eq!(payload["target_window_label"], "doc-7");
 }
 
+#[cfg(not(target_os = "windows"))]
 #[test]
 fn focus_and_emit_returns_the_payload_when_the_target_vanished() {
     let app = mock_app();
@@ -66,6 +87,7 @@ fn focus_and_emit_returns_the_payload_when_the_target_vanished() {
     assert_eq!(failed[0].workspace_root.as_deref(), Some("/docs"));
 }
 
+#[cfg(not(target_os = "windows"))]
 #[test]
 fn vanished_target_retries_delivery_to_a_ready_fallback_window() {
     let app = mock_app();

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -11,7 +11,7 @@
 //! | Module | Owns |
 //! |---|---|
 //! | `file_open_state` | Finder/CLI open decisions, pending queue, workspace grouping |
-//! | `finder_open_delivery` | macOS hot-open focus, targeted emit, and retry fallback |
+//! | `finder_open_delivery` | Hot-open focus, targeted emit, and retry fallback |
 //! | `document_windows` | Document/main window construction, URLs, labels, dock-reopen pick |
 //! | `path_validation` | Security gates for frontend-supplied paths / workspace roots |
 //! | `commands` | `open_*_in_new_window`, `close_window`, quit commands |
@@ -51,7 +51,6 @@
 mod commands;
 mod document_windows;
 mod file_open_state;
-#[cfg(target_os = "macos")]
 mod finder_open_delivery;
 mod native_theme;
 mod path_validation;
@@ -63,7 +62,9 @@ mod window_events;
 pub use commands::*;
 pub use document_windows::*;
 pub use file_open_state::*;
-#[cfg(target_os = "macos")]
+// Not macOS-gated: `file_open::route_file_opens` is the shared destination for
+// BOTH macOS `RunEvent::Opened` and the Windows/Linux single-instance callback
+// (#1330), and this is where it delivers.
 pub(crate) use finder_open_delivery::*;
 pub use native_theme::*;
 pub use settings_window::*;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.51",
+  "version": "0.9.52",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/hooks/useFinderFileOpen.comprehensive.test.tsx
+++ b/src/hooks/useFinderFileOpen.comprehensive.test.tsx
@@ -28,17 +28,29 @@ const listenMock = vi.fn(
 );
 
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: (...args: unknown[]) => listenMock(...(args as [string, ListenHandler])),
+  listen: (eventName: string, handler: ListenHandler) => listenMock(eventName, handler),
 }));
 
-const invokeMock = vi.fn(() => Promise.resolve([]));
+// Every mock below is declared with its real signature. `vi.fn(() => null)`
+// infers a return type of exactly `null`, so `mockReturnValue({...})` is a type
+// ERROR the runtime never sees — the mock and its subject can then disagree
+// silently, which is the whole reason `pnpm lint:test-types` exists.
+const invokeMock = vi.fn<(command: string, args?: unknown) => Promise<unknown>>(
+  () => Promise.resolve([]),
+);
 vi.mock("@tauri-apps/api/core", () => ({
-  invoke: (...args: unknown[]) => invokeMock(...args),
+  // Tuple rest, not `(command, args?)`: naming the optional parameter forwards
+  // an explicit `undefined` for it, so a one-argument invoke is RECORDED as two
+  // and `toHaveBeenCalledWith("cmd")` stops matching. A tuple also satisfies
+  // TS2556, which is what an untyped `...args: unknown[]` spread violates.
+  invoke: (...args: [command: string, args?: unknown]) => invokeMock(...args),
 }));
 
-const mockReadTextFile = vi.fn(() => Promise.resolve("# Content"));
+const mockReadTextFile = vi.fn<(path: string) => Promise<string>>(() =>
+  Promise.resolve("# Content"),
+);
 vi.mock("@tauri-apps/plugin-fs", () => ({
-  readTextFile: (...args: unknown[]) => mockReadTextFile(...args),
+  readTextFile: (path: string) => mockReadTextFile(path),
 }));
 
 let mockWindowLabel = "main";
@@ -46,23 +58,29 @@ vi.mock("@/contexts/WindowContext", () => ({
   useWindowLabel: () => mockWindowLabel,
 }));
 
-const mockFindExistingTabForPath = vi.fn(() => null);
-const mockGetReplaceableTab = vi.fn(() => null);
+type ReplaceableTab = { tabId: string; filePath: string | null };
+const mockFindExistingTabForPath =
+  vi.fn<(windowLabel: string, path: string) => string | null>(() => null);
+const mockGetReplaceableTab =
+  vi.fn<(windowLabel: string) => ReplaceableTab | null>(() => null);
 vi.mock("@/services/tabs/replaceableTab", () => ({
-  getReplaceableTab: (...args: unknown[]) => mockGetReplaceableTab(...args),
-  findExistingTabForPath: (...args: unknown[]) => mockFindExistingTabForPath(...args),
+  getReplaceableTab: (windowLabel: string) => mockGetReplaceableTab(windowLabel),
+  findExistingTabForPath: (windowLabel: string, path: string) =>
+    mockFindExistingTabForPath(windowLabel, path),
 }));
 
-const mockOpenWorkspaceWithConfig = vi.fn(() => Promise.resolve());
+const mockOpenWorkspaceWithConfig =
+  vi.fn<(rootPath: string, options?: unknown) => Promise<unknown>>(() => Promise.resolve(null));
 vi.mock("@/services/workspaces/openWorkspaceWithConfig", () => ({
-  openWorkspaceWithConfig: (...args: unknown[]) => mockOpenWorkspaceWithConfig(...args),
+  openWorkspaceWithConfig: (...args: [rootPath: string, options?: unknown]) =>
+    mockOpenWorkspaceWithConfig(...args),
 }));
 
 const mockSetActiveTab = vi.fn();
 const mockCreateTab = vi.fn(() => "new-tab-id");
 const mockUpdateTabPath = vi.fn();
 const mockDetachTab = vi.fn();
-const mockGetActiveTab = vi.fn(() => null);
+const mockGetActiveTab = vi.fn<() => { id: string } | null>(() => null);
 vi.mock("@/stores/tabStore", () => ({
   useTabStore: {
     getState: () => ({
@@ -102,9 +120,17 @@ vi.mock("@/stores/documentStore", () => ({
 }));
 
 const mockAddFile = vi.fn();
+// Configurable, not pinned. This was hardcoded to `rootPath: null`, so the
+// whole suite only ever described a window with NO workspace — and the one
+// state where reusing the untitled tab destroys something (#1330) could not be
+// reached by any test here.
+let mockWorkspaceState: { rootPath: string | null; isWorkspaceMode: boolean } = {
+  rootPath: null,
+  isWorkspaceMode: false,
+};
 vi.mock("@/stores/workspaceStore", () => ({
   useWorkspaceStore: {
-    getState: () => ({ rootPath: null, isWorkspaceMode: false }),
+    getState: () => mockWorkspaceState,
   },
   useRecentFilesStore: {
     getState: () => ({ addFile: mockAddFile }),
@@ -119,9 +145,10 @@ vi.mock("@/utils/paths", () => ({
   isWithinRoot: (_root: string, path: string) => path.startsWith("/workspace/"),
 }));
 
-const mockWaitForRestoreComplete = vi.fn(() => Promise.resolve(true));
+const mockWaitForRestoreComplete =
+  vi.fn<(timeoutMs: number) => Promise<boolean>>(() => Promise.resolve(true));
 vi.mock("@/services/persistence/hotExit/hotExitCoordination", () => ({
-  waitForRestoreComplete: (...args: unknown[]) => mockWaitForRestoreComplete(...args),
+  waitForRestoreComplete: (timeoutMs: number) => mockWaitForRestoreComplete(timeoutMs),
   RESTORE_WAIT_TIMEOUT_MS: 5000,
 }));
 
@@ -146,6 +173,7 @@ describe("useFinderFileOpen", () => {
     mockReadTextFile.mockResolvedValue("# Content");
     mockFindExistingTabForPath.mockReturnValue(null);
     mockGetReplaceableTab.mockReturnValue(null);
+    mockWorkspaceState = { rootPath: null, isWorkspaceMode: false };
   });
 
   it("registers listener and fetches pending files on main window", async () => {
@@ -298,6 +326,75 @@ describe("useFinderFileOpen", () => {
     expect(mockOpenWorkspaceWithConfig).toHaveBeenCalledWith("/workspace", {
       windowLabel: "main",
     });
+  });
+
+  // #1330 — the reported scenario, end to end through the real branch resolver
+  // and dispatcher: File → Open Workspace leaves a window with a file tree and
+  // ONE clean untitled tab, and a double-click on a file from another folder
+  // used to consume that tab and re-root the window, so the tree disappeared
+  // with no tab left to navigate back from.
+  it("keeps the open workspace when a file from elsewhere arrives", async () => {
+    mockWorkspaceState = { rootPath: "/workspace", isWorkspaceMode: true };
+    mockGetReplaceableTab.mockReturnValue({ tabId: "empty-tab", filePath: null });
+
+    await act(async () => {
+      render(<TestComponent />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      // `isWithinRoot` is mocked to accept only /workspace/*, so this file is
+      // outside the open workspace — the same relation as C:\Users\…\Desktop
+      // against D:\notes in the report.
+      listenHandler!({
+        payload: { path: "/elsewhere/note.md", workspace_root: "/elsewhere" },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockOpenWorkspaceWithConfig).not.toHaveBeenCalled();
+    // The untitled tab is left alone too: it was never the window's only claim
+    // on the workspace, but consuming it would still have lost the user's tab.
+    expect(mockUpdateTabPath).not.toHaveBeenCalled();
+    expect(invokeMock).toHaveBeenCalledWith("open_workspace_in_new_window", {
+      workspaceRoot: "/elsewhere",
+      filePath: "/elsewhere/note.md",
+    });
+  });
+
+  it("still reuses the untitled tab for a file inside the open workspace", async () => {
+    // The other half of the guard: the fix must not push same-workspace opens
+    // into a new window. It lands here, and still does not re-root — the
+    // incoming root is the file's PARENT, a subfolder of the workspace.
+    mockWorkspaceState = { rootPath: "/workspace", isWorkspaceMode: true };
+    mockGetReplaceableTab.mockReturnValue({ tabId: "empty-tab", filePath: null });
+
+    await act(async () => {
+      render(<TestComponent />);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      listenHandler!({
+        payload: { path: "/workspace/sub/note.md", workspace_root: "/workspace/sub" },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockOpenWorkspaceWithConfig).not.toHaveBeenCalled();
+    expect(mockUpdateTabPath).toHaveBeenCalledWith("empty-tab", "/workspace/sub/note.md");
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "open_workspace_in_new_window",
+      expect.anything(),
+    );
   });
 
   it("creates new tab when no replaceable tab and same workspace", async () => {

--- a/src/hooks/useFinderFileOpen.ts
+++ b/src/hooks/useFinderFileOpen.ts
@@ -7,21 +7,11 @@ import { invoke } from "@tauri-apps/api/core";
 import { imeToast as toast } from "@/services/ime/imeToast";
 import i18n from "@/i18n";
 import { useWindowLabel } from "@/contexts/WindowContext";
-import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { useSettingsStore } from "@/stores/settingsStore";
-import { getReplaceableTab, findExistingTabForPath } from "@/services/tabs/replaceableTab";
-import { resolveFinderOpenBranch } from "@/services/navigation/finderOpenBranch";
 import { loadFileIntoTab } from "@/services/navigation/loadFileIntoTab";
-import {
-  activateExistingTab,
-  createNewTabForFile,
-  replaceTabWithFile,
-  withSizeGateAndIndicator,
-  type FinderBranchContext,
-} from "@/services/navigation/finderOpenBranches";
+import { dispatchFinderOpen } from "@/services/navigation/finderOpenDispatch";
+import type { FinderBranchContext } from "@/services/navigation/finderOpenBranches";
 import { waitForRestoreComplete, RESTORE_WAIT_TIMEOUT_MS } from "@/services/persistence/hotExit/hotExitCoordination";
 import { finderFileOpenWarn, finderFileOpenError } from "@/utils/debug";
-import { routeOpenBySize } from "@/services/navigation/largeFileRouting";
 import { commandErrorMessage } from "@/services/commands/commandError";
 
 export interface OpenFilePayload {
@@ -43,9 +33,12 @@ interface PendingFileOpen {
  * When the user opens a markdown file from Finder (double-click or "Open With"),
  * and the app is already running, this hook receives the file path and:
  * 1. Checks if there's an existing tab for this file -> activates it
- * 2. Checks if there's an empty (replaceable) tab -> loads file there
- * 3. If same workspace -> creates new tab in the current window
- * 4. Otherwise -> opens file in a new window (different workspace)
+ * 2. If the file belongs to this window's workspace (or rail mode is on) ->
+ *    lands it here, reusing an empty (replaceable) tab when there is one
+ * 3. Otherwise -> opens file in a new window (different workspace)
+ *
+ * Reusing the empty tab never re-roots the window; `resolveFinderOpenBranch`
+ * owns that decision and hands it down as `adoptWorkspace` (#1330).
  *
  * Every document window listens for targeted hot opens. The main window alone
  * fetches pending files queued during cold start.
@@ -82,98 +75,6 @@ export function useFinderFileOpen(): void {
       loadFileIntoTab,
     };
 
-    /**
-     * Branch 4 — different workspace, so open in a new window. The Rust
-     * command validates the path and extends the fs scope for the spawned
-     * window; it stays here because it touches no tab in THIS window.
-     */
-    const openFileInNewWindow = async (
-      path: string,
-      workspaceRoot: string | null,
-    ) => {
-      try {
-        if (workspaceRoot) {
-          await invoke("open_workspace_in_new_window", { workspaceRoot, filePath: path });
-        } else {
-          await invoke("open_file_in_new_window", { path });
-        }
-      } catch (error) {
-        finderFileOpenError("Failed to open in new window:", path, error);
-        toastOpenFailure(error);
-      }
-    };
-
-    /**
-     * Dispatch a file open request to the correct branch. Must be called
-     * via enqueueFileOpen() to ensure serialization. Branch SELECTION is the
-     * pure resolveFinderOpenBranch(); this function owns only the async
-     * size-gate, indicator lifecycle, and branch EXECUTION.
-     */
-    const processFileOpen = async (
-      path: string,
-      workspaceRoot: string | null,
-      finishDrainedBatch = false,
-    ) => {
-      const currentBranchCtx = finishDrainedBatch
-        ? { ...branchCtx, isCancelled: () => false }
-        : branchCtx;
-      // Pre-read size check: applies to every non-activate branch below.
-      // Refused files never create a tab or open a window; huge files confirm.
-      // (Existing-tab activation skips the read, so resolve the branch first.)
-      const branch = resolveFinderOpenBranch({
-        filePath: path,
-        existingTabId: findExistingTabForPath(windowLabel, path),
-        replaceableTabId: getReplaceableTab(windowLabel)?.tabId ?? null,
-        workspaceRailMode: useSettingsStore.getState().general.workspaceRailMode,
-        currentRoot: useWorkspaceStore.getState().rootPath,
-        incomingWorkspace: workspaceRoot,
-      });
-
-      if (branch.kind === "activate") {
-        activateExistingTab(currentBranchCtx, branch.tabId);
-        return;
-      }
-
-      switch (branch.kind) {
-        case "replace": {
-          await withSizeGateAndIndicator(currentBranchCtx, path, async () => {
-            // Re-check: the replaceable tab could have been claimed during the
-            // awaited size route. Fall back to a new tab if it is gone.
-            const tab = getReplaceableTab(windowLabel);
-            if (!tab) {
-              return createNewTabForFile(
-                currentBranchCtx,
-                path,
-                workspaceRoot,
-                !useWorkspaceStore.getState().rootPath,
-              );
-            }
-            return replaceTabWithFile(currentBranchCtx, tab, path, workspaceRoot);
-          });
-          return;
-        }
-        case "create": {
-          await withSizeGateAndIndicator(currentBranchCtx, path, () =>
-            createNewTabForFile(
-              currentBranchCtx,
-              path,
-              workspaceRoot,
-              branch.adoptWorkspace,
-            ),
-          );
-          return;
-        }
-        case "newWindow": {
-          // The remote window runs its own size route when its cold-start queue
-          // drains, so no tab is marked here — none exists in this window.
-          const route = await routeOpenBySize(path);
-          if (!route.proceed || (cancelled && !finishDrainedBatch)) return;
-          await openFileInNewWindow(path, workspaceRoot);
-          return;
-        }
-      }
-    };
-
     /** Enqueue a file open, serialized to prevent concurrent tab races */
     const enqueueFileOpen = (
       path: string,
@@ -181,7 +82,7 @@ export function useFinderFileOpen(): void {
       finishDrainedBatch = false,
     ) => {
       processingChainRef.current = processingChainRef.current
-        .then(() => processFileOpen(path, workspaceRoot, finishDrainedBatch))
+        .then(() => dispatchFinderOpen(branchCtx, path, workspaceRoot, finishDrainedBatch))
         .catch((error) => {
           finderFileOpenError("Failed to open file:", path, error);
         });

--- a/src/services/navigation/finderOpenBranch.test.ts
+++ b/src/services/navigation/finderOpenBranch.test.ts
@@ -37,7 +37,7 @@ describe("resolveFinderOpenBranch precedence", () => {
   it("replaces a clean untitled tab when no existing tab", () => {
     expect(
       resolveFinderOpenBranch(input({ replaceableTabId: "tab-empty" })),
-    ).toEqual({ kind: "replace", replaceableTabId: "tab-empty" });
+    ).toEqual({ kind: "replace", replaceableTabId: "tab-empty", adoptWorkspace: true });
   });
 
   it("always creates a new tab in rail mode (no workspace adoption)", () => {
@@ -46,6 +46,52 @@ describe("resolveFinderOpenBranch precedence", () => {
         input({ workspaceRailMode: true, currentRoot: "/ws", incomingWorkspace: "/other" }),
       ),
     ).toEqual({ kind: "create", adoptWorkspace: false });
+  });
+
+  // #1330 — the replaceable tab used to be checked ABOVE rail mode and above
+  // the workspace check, so reusing it silently re-pointed the window at the
+  // incoming file's folder. A window is not "empty" just because its only tab
+  // is an untitled one; it can still own the workspace the sidebar is showing.
+  it("reuses the clean untitled tab in rail mode WITHOUT adopting a workspace", () => {
+    expect(
+      resolveFinderOpenBranch(
+        input({
+          replaceableTabId: "tab-empty",
+          workspaceRailMode: true,
+          currentRoot: "/ws",
+          incomingWorkspace: "/other",
+        }),
+      ),
+    ).toEqual({ kind: "replace", replaceableTabId: "tab-empty", adoptWorkspace: false });
+  });
+
+  it("opens a new window rather than consuming the untitled tab of a workspace window", () => {
+    expect(
+      resolveFinderOpenBranch(
+        input({
+          filePath: "/other/file.md",
+          replaceableTabId: "tab-empty",
+          currentRoot: "/ws",
+          incomingWorkspace: "/other",
+        }),
+      ),
+    ).toEqual({ kind: "newWindow" });
+  });
+
+  it("reuses the untitled tab without re-rooting when the file is inside the workspace", () => {
+    // The incoming root is the file's PARENT — a subfolder of the workspace.
+    // Adopting it would narrow the sidebar to that subfolder.
+    mockIsWithinRoot.mockReturnValue(true);
+    expect(
+      resolveFinderOpenBranch(
+        input({
+          filePath: "/ws/sub/file.md",
+          replaceableTabId: "tab-empty",
+          currentRoot: "/ws",
+          incomingWorkspace: "/ws/sub",
+        }),
+      ),
+    ).toEqual({ kind: "replace", replaceableTabId: "tab-empty", adoptWorkspace: false });
   });
 
   it("creates a tab and adopts the incoming workspace when this window has none", () => {

--- a/src/services/navigation/finderOpenBranch.ts
+++ b/src/services/navigation/finderOpenBranch.ts
@@ -37,7 +37,7 @@ export function isSameWorkspace(
 
 export type FinderOpenBranch =
   | { kind: "activate"; tabId: string }
-  | { kind: "replace"; replaceableTabId: string }
+  | { kind: "replace"; replaceableTabId: string; adoptWorkspace: boolean }
   | { kind: "create"; adoptWorkspace: boolean }
   | { kind: "newWindow" };
 
@@ -57,26 +57,43 @@ export interface FinderOpenBranchInput {
 
 /**
  * Resolve the open branch. Precedence:
- *   1. existing tab    → activate
- *   2. replaceable tab → replace (reuse the clean untitled tab)
- *   3. rail mode       → always create a new tab in this window (no workspace
- *                        adoption — the rail owns workspace identity)
- *   4. same workspace  → create a new tab (adopting the incoming workspace when
- *                        this window has none)
- *   5. otherwise       → new window (different workspace)
+ *   1. existing tab   → activate
+ *   2. rail mode      → land in this window (no workspace adoption — the rail
+ *                       owns workspace identity)
+ *   3. same workspace → land in this window, adopting the incoming workspace
+ *                       only when this window has none
+ *   4. otherwise      → new window (different workspace)
+ *
+ * Within 2 and 3, a single clean untitled tab is reused instead of adding one.
+ *
+ * REUSING THAT TAB IS NOT A LICENCE TO RE-ROOT THE WINDOW (#1330). The
+ * replaceable-tab check used to sit at the top, above both the rail rule and
+ * the workspace check, and the replace path then opened the incoming
+ * workspace unconditionally — so double-clicking a file from another folder
+ * silently replaced the sidebar tree of a window whose only tab happened to be
+ * untitled. "One clean untitled tab" describes the TABS; it says nothing about
+ * whether the window owns a workspace, which is exactly the state a window is
+ * in right after File → Open Workspace.
  */
 export function resolveFinderOpenBranch(input: FinderOpenBranchInput): FinderOpenBranch {
   if (input.existingTabId) {
     return { kind: "activate", tabId: input.existingTabId };
   }
-  if (input.replaceableTabId) {
-    return { kind: "replace", replaceableTabId: input.replaceableTabId };
-  }
   if (input.workspaceRailMode) {
-    return { kind: "create", adoptWorkspace: false };
+    return landInThisWindow(input, false);
   }
   if (isSameWorkspace(input.filePath, input.currentRoot, input.incomingWorkspace)) {
-    return { kind: "create", adoptWorkspace: !input.currentRoot };
+    return landInThisWindow(input, !input.currentRoot);
   }
   return { kind: "newWindow" };
+}
+
+/** Reuse the lone clean untitled tab when there is one; otherwise add a tab. */
+function landInThisWindow(
+  input: FinderOpenBranchInput,
+  adoptWorkspace: boolean,
+): FinderOpenBranch {
+  return input.replaceableTabId
+    ? { kind: "replace", replaceableTabId: input.replaceableTabId, adoptWorkspace }
+    : { kind: "create", adoptWorkspace };
 }

--- a/src/services/navigation/finderOpenBranches.test.ts
+++ b/src/services/navigation/finderOpenBranches.test.ts
@@ -123,7 +123,7 @@ describe("media never reaches readTextFile", () => {
   });
 
   it("replace branch: a .mp4 replaces the clean tab as media", async () => {
-    const result = await replaceTabWithFile(ctx, { tabId: "t1" } as never, "/w/clip.mp4", null);
+    const result = await replaceTabWithFile(ctx, { tabId: "t1" } as never, "/w/clip.mp4", null, true);
 
     expect(mockReplaceTabWithMediaFile).toHaveBeenCalledWith("t1", "/w/clip.mp4");
     expect(mockLoadFileIntoTab).not.toHaveBeenCalled();
@@ -219,11 +219,37 @@ describe("cancellation", () => {
   it("stops the replace branch after the workspace open", async () => {
     const cancelled: FinderBranchContext = { ...ctx, isCancelled: () => true };
 
-    const result = await replaceTabWithFile(cancelled, { tabId: "t1" } as never, MD, "/w");
+    const result = await replaceTabWithFile(cancelled, { tabId: "t1" } as never, MD, "/w", true);
 
     expect(mockOpenWorkspaceWithConfig).toHaveBeenCalled();
     expect(mockLoadFileIntoTab).not.toHaveBeenCalled();
     expect(result).toBeNull();
+  });
+});
+
+// #1330 — the replace branch is reached for a window that already owns a
+// workspace (rail mode, or a file inside the current root). Adopting the
+// incoming root there re-points the sidebar at the file's folder and the user
+// loses the tree they were looking at, with no tab left to navigate back from.
+describe("replacing the untitled tab does not re-root the window", () => {
+  it("skips the workspace open when the branch says not to adopt", async () => {
+    await replaceTabWithFile(ctx, { tabId: "t1" } as never, MD, "/w/sub", false);
+
+    expect(mockOpenWorkspaceWithConfig).not.toHaveBeenCalled();
+    expect(mockLoadFileIntoTab).toHaveBeenCalledWith("t1", MD);
+  });
+
+  it("skips it for media too — the short-circuit must not smuggle it back in", async () => {
+    await replaceTabWithFile(ctx, { tabId: "t1" } as never, PNG, "/w/sub", false);
+
+    expect(mockOpenWorkspaceWithConfig).not.toHaveBeenCalled();
+    expect(mockReplaceTabWithMediaFile).toHaveBeenCalledWith("t1", PNG);
+  });
+
+  it("still adopts when the window has no workspace of its own", async () => {
+    await replaceTabWithFile(ctx, { tabId: "t1" } as never, MD, "/w", true);
+
+    expect(mockOpenWorkspaceWithConfig).toHaveBeenCalledWith("/w", { windowLabel: "main" });
   });
 });
 

--- a/src/services/navigation/finderOpenBranches.ts
+++ b/src/services/navigation/finderOpenBranches.ts
@@ -67,15 +67,21 @@ export function activateExistingTab(ctx: FinderBranchContext, tabId: string): vo
  * Branch 2 — a single clean untitled tab exists; load into it. On read failure
  * the tab is left untouched, so the user gets their blank tab back.
  *
+ * `adoptWorkspace` is the same guard `createNewTabForFile` carries, and it was
+ * missing here (#1330): this path opened `workspaceRoot` unconditionally, so
+ * reusing the untitled tab of a window that already had a workspace replaced
+ * that window's sidebar tree with the incoming file's folder.
+ *
  * Returns the tab id that received content, or null if nothing landed.
  */
 export async function replaceTabWithFile(
   ctx: FinderBranchContext,
   tab: ReplaceableTabInfo,
   path: string,
-  workspaceRoot: string | null
+  workspaceRoot: string | null,
+  adoptWorkspace: boolean
 ): Promise<string | null> {
-  if (workspaceRoot) {
+  if (adoptWorkspace && workspaceRoot) {
     await openWorkspaceWithConfig(workspaceRoot, { windowLabel: ctx.windowLabel });
   }
   if (ctx.isCancelled()) return null;

--- a/src/services/navigation/finderOpenDispatch.ts
+++ b/src/services/navigation/finderOpenDispatch.ts
@@ -1,0 +1,120 @@
+/**
+ * Purpose: Turn one system file-open request into the branch it should take,
+ * then run that branch. The policy half is the pure `resolveFinderOpenBranch`;
+ * this module owns only the async size-gate, the indicator lifecycle, and the
+ * branch EXECUTION.
+ *
+ * Split out of `useFinderFileOpen`, which was carrying the event plumbing
+ * (listen, queue-until-restore, serialize, drain the cold-start queue) AND this
+ * dispatch in one `useEffect` closure. Two responsibilities, and the dispatch
+ * half is the one with rules worth testing on its own.
+ *
+ * Key decisions:
+ *   - The branch's `adoptWorkspace` verdict is passed down, never re-derived.
+ *     Recomputing `!rootPath` at the call site re-adopts in rail mode, which
+ *     the resolver deliberately refuses (#1330).
+ *   - The replaceable tab is re-read AFTER the size route: it can be claimed
+ *     while that await is in flight, and loading into a tab that is no longer
+ *     the clean untitled one would overwrite a real document.
+ *
+ * @coordinates-with hooks/useFinderFileOpen.ts — the caller (event plumbing)
+ * @coordinates-with services/navigation/finderOpenBranch.ts — branch selection
+ * @coordinates-with services/navigation/finderOpenBranches.ts — branch execution
+ * @module services/navigation/finderOpenDispatch
+ */
+import { invoke } from "@tauri-apps/api/core";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { getReplaceableTab, findExistingTabForPath } from "@/services/tabs/replaceableTab";
+import { resolveFinderOpenBranch } from "@/services/navigation/finderOpenBranch";
+import {
+  activateExistingTab,
+  createNewTabForFile,
+  replaceTabWithFile,
+  withSizeGateAndIndicator,
+  type FinderBranchContext,
+} from "@/services/navigation/finderOpenBranches";
+import { routeOpenBySize } from "@/services/navigation/largeFileRouting";
+import { finderFileOpenError } from "@/utils/debug";
+
+/**
+ * Branch 4 — different workspace, so open in a new window. The Rust command
+ * validates the path and extends the fs scope for the spawned window.
+ */
+async function openFileInNewWindow(
+  ctx: FinderBranchContext,
+  path: string,
+  workspaceRoot: string | null,
+): Promise<void> {
+  try {
+    if (workspaceRoot) {
+      await invoke("open_workspace_in_new_window", { workspaceRoot, filePath: path });
+    } else {
+      await invoke("open_file_in_new_window", { path });
+    }
+  } catch (error) {
+    finderFileOpenError("Failed to open in new window:", path, error);
+    ctx.onOpenFailure(error);
+  }
+}
+
+/**
+ * Dispatch one file-open to its branch and execute it.
+ *
+ * `finishDrainedBatch` marks a batch the Rust queue has already destructively
+ * drained: it must land even if the hook unmounted mid-flight, because no
+ * replacement mount can fetch it again.
+ */
+export async function dispatchFinderOpen(
+  ctx: FinderBranchContext,
+  path: string,
+  workspaceRoot: string | null,
+  finishDrainedBatch = false,
+): Promise<void> {
+  const runCtx = finishDrainedBatch ? { ...ctx, isCancelled: () => false } : ctx;
+  const { windowLabel } = ctx;
+
+  // Pre-read size check: applies to every non-activate branch below.
+  // Refused files never create a tab or open a window; huge files confirm.
+  // (Existing-tab activation skips the read, so resolve the branch first.)
+  const branch = resolveFinderOpenBranch({
+    filePath: path,
+    existingTabId: findExistingTabForPath(windowLabel, path),
+    replaceableTabId: getReplaceableTab(windowLabel)?.tabId ?? null,
+    workspaceRailMode: useSettingsStore.getState().general.workspaceRailMode,
+    currentRoot: useWorkspaceStore.getState().rootPath,
+    incomingWorkspace: workspaceRoot,
+  });
+
+  switch (branch.kind) {
+    case "activate":
+      activateExistingTab(runCtx, branch.tabId);
+      return;
+
+    case "replace":
+      await withSizeGateAndIndicator(runCtx, path, async () => {
+        // Re-check: the replaceable tab could have been claimed during the
+        // awaited size route. Fall back to a new tab if it is gone.
+        const tab = getReplaceableTab(windowLabel);
+        return tab
+          ? replaceTabWithFile(runCtx, tab, path, workspaceRoot, branch.adoptWorkspace)
+          : createNewTabForFile(runCtx, path, workspaceRoot, branch.adoptWorkspace);
+      });
+      return;
+
+    case "create":
+      await withSizeGateAndIndicator(runCtx, path, () =>
+        createNewTabForFile(runCtx, path, workspaceRoot, branch.adoptWorkspace),
+      );
+      return;
+
+    case "newWindow": {
+      // The remote window runs its own size route when its cold-start queue
+      // drains, so no tab is marked here — none exists in this window.
+      const route = await routeOpenBySize(path);
+      if (!route.proceed || runCtx.isCancelled()) return;
+      await openFileInNewWindow(runCtx, path, workspaceRoot);
+      return;
+    }
+  }
+}

--- a/src/utils/openPolicy.test.ts
+++ b/src/utils/openPolicy.test.ts
@@ -173,7 +173,13 @@ describe("resolveOpenAction", () => {
       });
     });
 
-    it("returns replace_tab when file is outside workspace and replaceable tab exists", () => {
+    // #1330 — this used to assert replace_tab, which was the defect: every
+    // in-window action here carries the file's own folder as the new root, so
+    // reusing the untitled tab of a WORKSPACE window replaced the sidebar tree
+    // the user was looking at, leaving no tab to navigate back from. A lone
+    // clean untitled tab describes the TABS; it says nothing about whether the
+    // window owns a workspace, and right after File → Open Workspace it does.
+    it("opens a new window rather than re-rooting a workspace window", () => {
       const context: OpenActionContext = {
         filePath: "/other/folder/file.md",
         workspaceRoot: "/workspace/project",
@@ -185,8 +191,7 @@ describe("resolveOpenAction", () => {
       const result = resolveOpenAction(context);
 
       expect(result).toEqual({
-        action: "replace_tab",
-        tabId: "untitled-tab",
+        action: "open_workspace_in_new_window",
         filePath: "/other/folder/file.md",
         workspaceRoot: "/other/folder",
       });
@@ -252,7 +257,9 @@ describe("resolveOpenAction", () => {
       });
     });
 
-    it("returns create_tab (with resolved workspaceRoot) for file outside workspace when a replaceable tab exists", () => {
+    // #1330 — openInNewTab preserves the empty TAB; it never licensed
+    // re-rooting the window. In a workspace window the new window does both.
+    it("opens a new window for a file outside a workspace window", () => {
       const context: OpenActionContext = {
         filePath: "/other/folder/file.md",
         workspaceRoot: "/workspace/project",
@@ -265,7 +272,7 @@ describe("resolveOpenAction", () => {
       const result = resolveOpenAction(context);
 
       expect(result).toEqual({
-        action: "create_tab",
+        action: "open_workspace_in_new_window",
         filePath: "/other/folder/file.md",
         workspaceRoot: "/other/folder",
       });

--- a/src/utils/openPolicy/openRouting.ts
+++ b/src/utils/openPolicy/openRouting.ts
@@ -68,6 +68,13 @@ function routeRailMode(context: OpenActionContext): OpenActionResult {
  * Step 4 — route a file outside the current workspace. Resolves the file's own
  * folder as a workspace root and threads it through every action so ownership
  * never gets lost (the new-tab path carries the root so callers can claim it).
+ *
+ * Reusing this window is only on the table when the window owns NO workspace.
+ * Every in-window action here carries `newWorkspaceRoot`, and applying it
+ * re-roots the window — so for a window that already has a workspace, reuse
+ * means the user's sidebar tree is replaced by the opened file's folder
+ * (#1330). A window is not free just because its only tab is untitled: that is
+ * exactly the state right after File → Open Workspace.
  */
 function routeExternalFile(context: OpenActionContext): OpenActionResult {
   const newWorkspaceRoot = resolveWorkspaceRootForExternalFile(context.filePath);
@@ -75,17 +82,20 @@ function routeExternalFile(context: OpenActionContext): OpenActionResult {
     return { action: "no_op", reason: "cannot_resolve_workspace_root" };
   }
 
+  const windowOwnsWorkspace = Boolean(context.isWorkspaceMode && context.workspaceRoot);
+
   // fix(#946) — with "open in new tab" enabled, an external file that would
   // otherwise replace the clean untitled tab opens as a new tab instead, so the
   // empty tab is preserved. The resolved root travels with the action so the
   // caller can apply workspace ownership rather than attaching the file to the
   // current context.
-  if (context.replaceableTab && context.openInNewTab) {
+  if (context.replaceableTab && context.openInNewTab && !windowOwnsWorkspace) {
     return { action: "create_tab", filePath: context.filePath, workspaceRoot: newWorkspaceRoot };
   }
 
-  // Replaceable tab present: replace it instead of opening a new window.
-  if (context.replaceableTab) {
+  // Replaceable tab in a window with no workspace of its own: replace it
+  // instead of opening a new window.
+  if (context.replaceableTab && !windowOwnsWorkspace) {
     return {
       action: "replace_tab",
       tabId: context.replaceableTab.tabId,
@@ -94,7 +104,7 @@ function routeExternalFile(context: OpenActionContext): OpenActionResult {
     };
   }
 
-  // No replaceable tab: open in a new window.
+  // Nothing here can take the file without cost: open a new window.
   return {
     action: "open_workspace_in_new_window",
     filePath: context.filePath,

--- a/website/guide/workspace-management.md
+++ b/website/guide/workspace-management.md
@@ -201,6 +201,18 @@ Each VMark window can have its own independent workspace. This lets you work on 
 
 When you drag a markdown file from Finder and the current window already has unsaved work, VMark opens the file's project in a new window automatically.
 
+### Opening a file from outside the current workspace
+
+A window with a workspace open keeps that workspace. Opening a file that lives
+somewhere else — from Finder or Explorer, from `File > Open`, or from Recent
+Files — opens it in a **new window** rooted at its own folder, so the file tree
+you were working in stays where it is. Only a window with no workspace of its
+own takes the file in place.
+
+On Windows and Linux, double-clicking a file whose type is associated with
+VMark now hands it to the VMark you already have running instead of starting a
+second copy. macOS has always worked this way.
+
 ### Detaching Tabs into New Windows
 
 You can pull a tab out of its window to create a new one:


### PR DESCRIPTION
Closes #1330.

A window with a workspace open and one clean untitled tab lost its file tree
when a file from another folder was opened. Reported on Windows; the policy
defect is cross-platform.

## Two independent causes

**Reusing the untitled tab re-rooted the window.** "One clean untitled tab"
describes the *tabs*; it says nothing about whether the window owns a workspace
— and that is exactly the state a window is in right after `File > Open
Workspace`. The replaceable-tab check sat above both the rail-mode rule and the
workspace check in `resolveFinderOpenBranch`, and `replaceTabWithFile` then
opened the incoming workspace unconditionally, without the `adoptWorkspace`
guard its sibling `createNewTabForFile` already carried. `routeExternalFile` had
the same shape for `Cmd+O` and Open Recent.

Reuse is now scoped to the rail and same-workspace branches, the verdict is
passed down rather than re-derived, and a file from elsewhere opens in its own
window — already the behaviour when the window has any real tab.

**Windows and Linux start a fresh process per file-association double-click.**
That second process is not merely redundant: its windows carry the same labels
under the same bundle identifier, so it rehydrates the same
`vmark-workspace:<label>` localStorage and shares one app-data directory and
hot-exit session with the app already running — last writer wins.
`tauri-plugin-single-instance` now forwards its argv to the running instance and
exits, so the open takes the same route macOS takes via `RunEvent::Opened`.
macOS is unchanged; it has this natively.

Sharing that route meant un-gating `window_manager::finder_open_delivery` from
macOS-only, which exposed its `tauri::test` callers to the Windows target for
the first time. They are per-item `cfg(not(windows))` now, per AGENTS.md;
`check-cross-target.sh` caught it in about a minute.

## Behaviour change worth knowing

App closed, double-click a file from outside your last workspace: you now get
the restored workspace window *plus* a window for the file. That was already the
outcome for any workspace with remembered tabs — the no-tabs case was the odd
one out, and it avoided the second window by destroying the workspace instead.

## Residual risk, stated rather than discovered later

The plugin's Linux backend `.unwrap()`s its DBus **session** connection, so a
session with no `DBUS_SESSION_BUS_ADDRESS` would panic at startup where VMark
previously launched. It should never fire — Tauri needs GTK/WebKitGTK and
therefore a desktop session — but if a Linux "won't start at all" report arrives
after this, look there first. Documented at the top of `single_instance.rs`. The
Windows backend (named mutex + `WM_COPYDATA`) has no such dependency, and that
is where the bug was reported.

## Also here, because the work ran into them

- `useFinderFileOpen` crossed the 300-line gate, so branch dispatch moved to
  `services/navigation/finderOpenDispatch.ts`, leaving the hook the event
  plumbing it should have had.
- That hook's 494-line test file pinned `rootPath` to `null`, so no test in it
  could reach the broken state. It is configurable now, with two end-to-end
  tests for the reported scenario — both verified failing against the pre-fix
  code.
- Typing the mocks in that file took it from 11 baselined type errors to zero
  (`test-types-baseline` entry removed, not raised). `vi.fn(() => null)` infers
  a return type of exactly `null`, so every `mockReturnValue` on it was an error
  the runtime never sees.

## Verification

`pnpm check:all` green, `check-cross-target.sh` (Windows) green, host
`cargo clippy --all-targets -- -D warnings` green, `cargo fmt --check` green,
2,248 Rust tests, `cargo machete` clean, all 40 `check:predelta` gates green
after the version bump.

Version bumped to 0.9.52 in this PR rather than a standalone one, per
`.claude/rules/40-version-bump.md`.
