### PR TITLE
fix(terminal): set LC_CTYPE=UTF-8 on macOS only, advertise truecolor

### DIFF
--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -103,7 +103,7 @@
     "src/components/Tabs/useTabContextMenuActions.test.ts": 840,
     "src/components/Terminal/TerminalContextMenu.test.tsx": 889,
     "src/components/Terminal/createTerminalInstance.test.ts": 1116,
-    "src/components/Terminal/spawnPty.test.ts": 832,
+    "src/components/Terminal/spawnPty.test.ts": 815,
     "src/components/Terminal/terminalKeyHandler.test.ts": 862,
     "src/contexts/WindowContext.test.tsx": 1557,
     "src/export/resourceResolver.test.ts": 1084,

--- a/src/components/Terminal/spawnPty.test.ts
+++ b/src/components/Terminal/spawnPty.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   resolveTerminalCwd,
   spawnPty,
@@ -55,6 +55,14 @@ import { useDocumentStore } from "@/stores/documentStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { invoke } from "@tauri-apps/api/core";
 import { spawn } from "@/lib/pty";
+
+/** Override navigator.platform for the duration of a test (#1334 gates the
+ *  macOS-only LC_CTYPE on it). Restored in an afterEach below. */
+function setPlatform(value: string) {
+  Object.defineProperty(navigator, "platform", { value, configurable: true });
+}
+const originalPlatform = navigator.platform;
+afterEach(() => setPlatform(originalPlatform));
 
 describe("resolveTerminalCwd", () => {
   beforeEach(() => {
@@ -413,37 +421,11 @@ describe("spawnPty shell selection", () => {
     expect(spawnCallEnv.env.VMARK_WORKSPACE).toBe("/my/workspace");
   });
 
-  it("sets TERM_PROGRAM env to WezTerm so CLI tools recognize the host (ADR-006)", async () => {
-    vi.mocked(useSettingsStore.getState).mockReturnValue({
-      terminal: { shell: "" },
-    } as ReturnType<typeof useSettingsStore.getState>);
-
-    await spawnPty({ term: mockTerm, onExit: vi.fn(), disposed: () => false });
-
-    const spawnCallEnv = vi.mocked(spawn).mock.calls[0][2] as { env: Record<string, string> };
-    // Impersonation per ADR-006: WezTerm is in Claude Code's CSI-u allowlist; "vmark" isn't.
-    expect(spawnCallEnv.env.TERM_PROGRAM).toBe("WezTerm");
-  });
-
-  it("does not set EDITOR (T1) — the vmark shim is opt-in, macOS-only, and non-blocking", async () => {
-    // `EDITOR=vmark` was set unconditionally on every OS. The shim is opt-in
-    // and admin-gated, so the default state is `vmark: command not found` —
-    // and even when installed, `open -b app.vmark` returns immediately, so
-    // `git commit` aborts with "empty commit message". Setting nothing lets
-    // the user's real $EDITOR (inherited from their login shell rc) win.
-    vi.mocked(useSettingsStore.getState).mockReturnValue({
-      terminal: { shell: "" },
-    } as ReturnType<typeof useSettingsStore.getState>);
-
-    await spawnPty({ term: mockTerm, onExit: vi.fn(), disposed: () => false });
-
-    const spawnCallEnv = vi.mocked(spawn).mock.calls[0][2] as { env: Record<string, string> };
-    expect(spawnCallEnv.env).not.toHaveProperty("EDITOR");
-  });
-
-  it("preserves the WezTerm impersonation and the rest of the env contract after dropping EDITOR", async () => {
-    // Regression guard for WI-1.1: removing EDITOR must not disturb any other
-    // key. ADR-006's TERM_PROGRAM impersonation is the one that matters most.
+  it("hands the shell exactly the base env buildBaseTerminalEnv built", async () => {
+    // The seam, not the contract: which variables are set and why is
+    // terminalSpawnEnv's own test. What this pins is that spawnPty passes that
+    // env through to spawn() intact, with the workspace root threaded in.
+    setPlatform("MacIntel");
     vi.mocked(useSettingsStore.getState).mockReturnValue({
       terminal: { shell: "" },
     } as ReturnType<typeof useSettingsStore.getState>);
@@ -462,6 +444,7 @@ describe("spawnPty shell selection", () => {
     expect(spawnCallEnv.env).toEqual({
       TERM: "xterm-256color",
       TERM_PROGRAM: "WezTerm",
+      COLORTERM: "truecolor",
       LC_CTYPE: "UTF-8",
       PATH: "/usr/local/bin:/bin",
       VMARK_WORKSPACE: "/my/workspace",

--- a/src/components/Terminal/spawnPty.ts
+++ b/src/components/Terminal/spawnPty.ts
@@ -11,30 +11,9 @@
  *     (get_default_shell: getpwuid → $SHELL → /bin/sh). Only absolute paths
  *     are accepted; relative paths are rejected to prevent PATH/CWD hijack.
  *   - If the configured shell fails to spawn, retries with system default.
- *   - Sets TERM_PROGRAM=WezTerm (impersonation) so CLI tools with terminal
- *     allowlists (Claude Code's /terminal-setup, etc.) recognize the host as a
- *     CSI-u-capable terminal. WezTerm chosen for lowest side-effect risk among
- *     the four recognized values. See dev-docs/decisions/ADR-006-terminal-program-identity.md.
- *     Do NOT change to "vmark" — third-party tools will fall through to a
- *     generic "unknown terminal" path. The impersonation is kept honest by
- *     terminalKeyHandler.ts, which translates Shift+Enter into the matching
- *     CSI-u sequence ("\x1b[13;2u") that real WezTerm sends.
- *   - Does NOT set EDITOR (T1/D1). It used to be forced to "vmark" on every
- *     platform, which could never work: the `vmark` shim is opt-in, macOS-only
- *     and admin-gated, so the default state is `vmark: command not found`; and
- *     even when installed the shim runs `open -b app.vmark "$@"` without `-W`,
- *     so it returns immediately and `git commit` aborts with "empty commit
- *     message". Leaving EDITOR unset lets the value from the user's login shell
- *     rc win. Restoring it requires a real blocking `vmark --wait` protocol
- *     (an IPC handshake, VS Code's `code --wait` design) — tracked separately.
- *   - Injects login shell PATH via get_login_shell_path Tauri command so CLI
- *     tools (node, claude, etc.) are discoverable — macOS GUI apps have minimal
- *     PATH by default. Fallback PATH is platform-aware (Windows vs Unix).
- *   - Sets LC_CTYPE=UTF-8 because macOS GUI apps have minimal env; without it
- *     the shell defaults to C locale and tools emit "?" for CJK characters.
- *     LC_CTYPE (not LANG) avoids overriding the user's full locale.
- *   - Sets VMARK_WORKSPACE when a workspace is open, enabling shell scripts
- *     to access the workspace root.
+ *   - The environment handed to the shell is built by
+ *     terminalSpawnEnv.buildBaseTerminalEnv — every variable and the reason
+ *     for it lives there, next to the code that sets it.
  *   - The disposed() callback lets the caller abort if the session was removed
  *     while the async spawn was in flight.
  *   - Watermark-based flow control pauses the PTY when xterm.js's parser can't
@@ -58,7 +37,11 @@ import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
 import { getActiveWorkspaceScope } from "@/services/workspaces/activeWorkspaceScope";
 import { getParentDir } from "@/utils/paths/paths";
 import { terminalLog } from "@/utils/debug";
-import { resolveLoginShellPath, buildShellSpawnConfig } from "./terminalSpawnEnv";
+import {
+  resolveLoginShellPath,
+  buildShellSpawnConfig,
+  buildBaseTerminalEnv,
+} from "./terminalSpawnEnv";
 
 /**
  * Resolve terminal working directory:
@@ -205,24 +188,7 @@ export async function spawnPty(options: SpawnOptions): Promise<IPty> {
   if (disposed()) throw new Error("disposed before spawn");
   const workspaceRoot = resolveTerminalWorkspaceRoot();
 
-  const env: Record<string, string> = {
-    // Ensure consistent color capabilities in xterm.js; Tauri GUI apps may not inherit terminal env vars.
-    TERM: "xterm-256color",
-    // Impersonate WezTerm so CLI tools with terminal allowlists (Claude Code's
-    // /terminal-setup, etc.) recognize the host. See ADR-006. Do NOT change to "vmark".
-    TERM_PROGRAM: "WezTerm",
-    // NOTE: EDITOR is deliberately absent — see the header's "Key decisions".
-    // macOS GUI apps launched from Dock/Spotlight have minimal environment —
-    // set UTF-8 encoding so the shell and tools handle CJK/multibyte correctly.
-    // LC_CTYPE (not LANG) to only affect encoding without overriding the user's locale.
-    LC_CTYPE: "UTF-8",
-    // Inject login shell PATH so CLI tools (node, claude, etc.) are on PATH,
-    // matching system terminal behavior on macOS GUI apps.
-    PATH: loginPath,
-  };
-  if (workspaceRoot) {
-    env.VMARK_WORKSPACE = workspaceRoot;
-  }
+  const env = buildBaseTerminalEnv(loginPath, workspaceRoot);
   // Observability (T1): make "why doesn't `git commit` open VMark?" answerable
   // from a dev-mode log instead of guesswork. Once per session, not per bell.
   terminalLog(

--- a/src/components/Terminal/terminalSpawnEnv.test.ts
+++ b/src/components/Terminal/terminalSpawnEnv.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
-import { resolveLoginShellPath, buildShellSpawnConfig } from "./terminalSpawnEnv";
+import {
+  resolveLoginShellPath,
+  buildShellSpawnConfig,
+  buildBaseTerminalEnv,
+} from "./terminalSpawnEnv";
 
 const mockInvoke = vi.mocked(invoke);
 
@@ -151,5 +155,67 @@ describe("buildShellSpawnConfig (WI-3.3)", () => {
     mockInvoke.mockResolvedValue({ env: {}, args: "--rcfile /x" });
     const result = await buildShellSpawnConfig({}, "/bin/bash", true);
     expect(result.args).toEqual([]);
+  });
+});
+
+describe("buildBaseTerminalEnv", () => {
+  const originalPlatform = navigator.platform;
+  afterEach(() => setPlatform(originalPlatform));
+
+  it("states the terminal's identity and colour capability", () => {
+    const env = buildBaseTerminalEnv("/usr/bin", undefined);
+    expect(env.TERM).toBe("xterm-256color");
+    // ADR-006: CLI tools with terminal allowlists (Claude Code's
+    // /terminal-setup) enable CSI-u only for terminals they recognize.
+    expect(env.TERM_PROGRAM).toBe("WezTerm");
+  });
+
+  it("advertises 24-bit colour on every platform (#1334)", () => {
+    // xterm.js renders SGR 38;2;r;g;b, but with COLORTERM empty a CLI tool has
+    // no way to know that and downgrades to the 256-colour palette.
+    for (const platform of ["MacIntel", "Linux x86_64", "Win32"]) {
+      setPlatform(platform);
+      expect(buildBaseTerminalEnv("/usr/bin", undefined).COLORTERM).toBe("truecolor");
+    }
+  });
+
+  it("passes the login shell PATH through", () => {
+    expect(buildBaseTerminalEnv("/opt/homebrew/bin:/usr/bin", undefined).PATH).toBe(
+      "/opt/homebrew/bin:/usr/bin",
+    );
+  });
+
+  // #1334: "UTF-8" is a locale name on Darwin (/usr/share/locale/UTF-8) and is
+  // NOT one on glibc. Exporting it on Linux replaced a perfectly good inherited
+  // locale with an invalid one, so every child calling setlocale() failed —
+  // "locale: Cannot set LC_CTYPE to default locale: No such file or directory",
+  // and `manpath: can't set the locale` on every prompt.
+  it.each([
+    ["MacIntel", true],
+    ["Linux x86_64", false],
+    ["Win32", false],
+  ])("platform=%s → sets LC_CTYPE=UTF-8: %s", (platform, expected) => {
+    setPlatform(platform);
+    const env = buildBaseTerminalEnv("/usr/bin", undefined);
+    if (expected) expect(env.LC_CTYPE).toBe("UTF-8");
+    else expect(env).not.toHaveProperty("LC_CTYPE");
+  });
+
+  it("exposes the workspace root only when one is open", () => {
+    expect(buildBaseTerminalEnv("/usr/bin", "/my/workspace").VMARK_WORKSPACE).toBe(
+      "/my/workspace",
+    );
+    expect(buildBaseTerminalEnv("/usr/bin", undefined)).not.toHaveProperty(
+      "VMARK_WORKSPACE",
+    );
+  });
+
+  it("never sets EDITOR (T1/D1)", () => {
+    // Forcing EDITOR=vmark could never work — the shim is opt-in, macOS-only,
+    // and returns immediately, so `git commit` aborts with an empty message.
+    for (const platform of ["MacIntel", "Linux x86_64", "Win32"]) {
+      setPlatform(platform);
+      expect(buildBaseTerminalEnv("/usr/bin", "/ws")).not.toHaveProperty("EDITOR");
+    }
   });
 });

--- a/src/components/Terminal/terminalSpawnEnv.ts
+++ b/src/components/Terminal/terminalSpawnEnv.ts
@@ -1,9 +1,10 @@
 /**
  * terminalSpawnEnv
  *
- * Purpose: Spawn-config helpers for spawnPty — login-shell PATH resolution and
- * per-shell shell-integration config. Extracted to keep spawnPty.ts focused on
- * the spawn lifecycle.
+ * Purpose: Spawn-config helpers for spawnPty — the base environment every
+ * terminal session gets, login-shell PATH resolution, and per-shell
+ * shell-integration config. Extracted to keep spawnPty.ts focused on the spawn
+ * lifecycle.
  *
  * Integration contributes ENV AND ARGS, not env alone (WI-3.3): zsh is hooked
  * through ZDOTDIR, but bash has no environment hook that applies to
@@ -13,6 +14,7 @@
  * @module components/Terminal/terminalSpawnEnv
  */
 import { invoke } from "@tauri-apps/api/core";
+import { isMacPlatform } from "@/utils/platform";
 
 /**
  * Fetch the login shell PATH so CLI tools (node, claude, etc.) are
@@ -32,6 +34,67 @@ export async function resolveLoginShellPath(): Promise<string> {
   return isWindows
     ? "C:\\Windows\\System32;C:\\Windows;C:\\Windows\\System32\\WindowsPowerShell\\v1.0"
     : "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+}
+
+/**
+ * The environment every terminal session starts from, before shell integration
+ * layers its own overrides on top. `CommandBuilder` on the Rust side sets these
+ * OVER the inherited process environment rather than replacing it, so anything
+ * absent here is whatever the user's desktop session already exported.
+ *
+ * What is here and why:
+ *
+ *   - `TERM=xterm-256color` — Tauri GUI apps may inherit no terminal env at
+ *     all, so state the colour capability xterm.js actually has.
+ *   - `TERM_PROGRAM=WezTerm` — impersonation, so CLI tools with terminal
+ *     allowlists (Claude Code's `/terminal-setup`, etc.) recognize the host as
+ *     a CSI-u-capable terminal. WezTerm has the lowest side-effect risk of the
+ *     four recognized values. See
+ *     dev-docs/decisions/ADR-006-terminal-program-identity.md. Do NOT change
+ *     this to "vmark" — third-party tools fall through to a degraded "unknown
+ *     terminal" path. terminalKeyHandler.ts keeps the impersonation honest by
+ *     translating Shift+Enter into the CSI-u sequence real WezTerm sends.
+ *   - `COLORTERM=truecolor` — xterm.js renders SGR 38;2;r;g;b, but with
+ *     COLORTERM empty a CLI tool has no way to know that and downgrades to the
+ *     256-colour palette (#1334).
+ *   - `PATH` — the login shell's PATH, so node/claude/etc. are discoverable.
+ *     macOS GUI apps launched from the Dock have a minimal PATH.
+ *   - `LC_CTYPE=UTF-8`, **macOS only** — a GUI app there inherits almost no
+ *     environment, and without this the shell falls back to the C locale and
+ *     tools emit "?" for CJK. LC_CTYPE rather than LANG, so only the encoding
+ *     is affected and the user's full locale is left alone.
+ *
+ *     The macOS gate is the fix for #1334: the bare name "UTF-8" is a locale on
+ *     Darwin (/usr/share/locale/UTF-8) and is NOT one on glibc. Exporting it on
+ *     Linux replaced a perfectly good inherited locale with an invalid one, so
+ *     every child calling setlocale() failed — "locale: Cannot set LC_CTYPE to
+ *     default locale: No such file or directory", plus `manpath: can't set the
+ *     locale` on every prompt. Off macOS the session's own LANG/LC_* are
+ *     inherited, which is already correct.
+ *   - `VMARK_WORKSPACE` — the workspace root, when one is open, so shell
+ *     scripts can find it.
+ *
+ * `EDITOR` is deliberately ABSENT (T1/D1). It used to be forced to "vmark" on
+ * every platform, which could never work: the `vmark` shim is opt-in,
+ * macOS-only and admin-gated, so the default state is `vmark: command not
+ * found`; and even when installed it runs `open -b app.vmark "$@"` without
+ * `-W`, returning immediately, so `git commit` aborts with "empty commit
+ * message". Leaving it unset lets the user's login-shell value win. Restoring
+ * it needs a real blocking `vmark --wait` protocol — tracked separately.
+ */
+export function buildBaseTerminalEnv(
+  loginPath: string,
+  workspaceRoot: string | undefined,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    TERM: "xterm-256color",
+    TERM_PROGRAM: "WezTerm",
+    COLORTERM: "truecolor",
+    PATH: loginPath,
+  };
+  if (isMacPlatform()) env.LC_CTYPE = "UTF-8";
+  if (workspaceRoot) env.VMARK_WORKSPACE = workspaceRoot;
+  return env;
 }
 
 /** Everything a shell needs at spawn time beyond its executable path. */

--- a/website/guide/terminal.md
+++ b/website/guide/terminal.md
@@ -132,7 +132,8 @@ VMark sets these environment variables in every terminal session:
 | `TERM_PROGRAM` | `WezTerm` |
 | `VMARK_WORKSPACE` | Workspace root path (when a folder is open) |
 | `PATH` | Full login shell PATH (same as your system terminal) |
-| `LC_CTYPE` | `UTF-8` |
+| `COLORTERM` | `truecolor` |
+| `LC_CTYPE` | `UTF-8` — **macOS only** |
 
 `TERM_PROGRAM` reports `WezTerm`, not `vmark`, and that is deliberate. Several
 CLI tools — Claude Code's `/terminal-setup` among them — enable
@@ -143,6 +144,14 @@ identifies as the allowlisted terminal whose behavior it matches most closely.
 Changing this value to `vmark` would silently break Shift+Enter and other
 modified-key sequences in those tools. See
 [ADR-006](https://github.com/xiaolai/vmark/blob/main/dev-docs/decisions/ADR-006-terminal-program-identity.md).
+
+`LC_CTYPE=UTF-8` is set on **macOS only**. A GUI app launched from the Dock or
+Spotlight inherits almost no environment there, so without it the shell falls
+back to the C locale and tools print `?` for CJK text. The bare name `UTF-8` is
+a locale on macOS and is *not* one on Linux, so setting it there would replace a
+perfectly good inherited locale with an invalid one — every program that calls
+`setlocale()` would complain. On Linux and Windows your desktop session's own
+`LANG` / `LC_*` are inherited unchanged.
 
 VMark deliberately does **not** set `EDITOR`. Your own `$EDITOR` — whatever your
 shell config exports — is what `git commit`, `crontab -e`, and friends will


### PR DESCRIPTION
Refs #1334. This is the **locale half only** — the font half is held back, see below.

## `LC_CTYPE=UTF-8` is a macOS locale name, not a glibc one

`UTF-8` is a locale on Darwin (`/usr/share/locale/UTF-8`) and is not one on glibc. VMark exported it into every PTY unconditionally, so on Linux it replaced the desktop session's perfectly good inherited locale with an invalid one, and every child that calls `setlocale()` failed — exactly what the reporter pasted:

```
locale: Cannot set LC_CTYPE to default locale: No such file or directory
manpath: can't set the locale; make sure $LC_* and $LANG are correct
```

The macOS rationale is unchanged and still holds there: a GUI app launched from the Dock inherits almost no environment, and without `LC_CTYPE` the shell falls back to the C locale and tools emit `?` for CJK. Off macOS the session's own `LANG`/`LC_*` are already correct, so the fix is to set nothing.

Also sets `COLORTERM=truecolor` on every platform — xterm.js renders `SGR 38;2;r;g;b`, but with `COLORTERM` empty a CLI tool has no way to know and downgrades to the 256-colour palette.

`spawnPty.ts` was sitting exactly at the 300-line cap, so the env literal moved to `terminalSpawnEnv.buildBaseTerminalEnv()` — where that module's stated purpose puts it, and which gives the env contract a directly testable unit instead of only an assertion on what reached `spawn()`. Both file-size baselines ratchet **down**.

Tests cover `LC_CTYPE` per platform (confirmed RED un-gated), `COLORTERM`, `PATH`, `VMARK_WORKSPACE`, and the continued absence of `EDITOR`. `pnpm check:all` green.

## Why the font fix is not in this PR

The issue also reports oversized character cells. An earlier revision of this PR carried a font-stack change with a root-cause claim that **turned out to be wrong**, so it has been pulled out rather than merged on a bad explanation.

What was claimed: `ui-monospace` leads VMark's mono stack, WebKitGTK does not implement the `ui-*` generics, and since a generic always matches it won the cascade and resolved to a proportional font.

What measurement on real WebKitGTK 4.1 / Ubuntu 24.04.4 actually shows — `'W' x 32` vs `'i' x 32`, the way xterm.js's `CharSizeService` measures:

| stack | `LANG=C` | `LANG=zh_CN.UTF-8` |
|---|---|---|
| `ui-monospace, "SF Mono", Menlo, Monaco, monospace` (old default) | 8 / 8 — fine | **11 / 4 — proportional** |
| `monospace` (proposed fix) | 8 / 8 | 7 / 7 — fine |
| `"No Such Family XYZ", monospace` | 8 / 8 | **11 / 4 — proportional** |
| `"JetBrains Mono", monospace` (font absent) | 8 / 8 | **11 / 4 — proportional** |

Two things follow, and both contradict the original write-up:

1. **It is not about `ui-monospace`.** An arbitrary absent family name reproduces it identically. Under a CJK locale, fontconfig returns a best match for *any* unmatched family — a proportional CJK face — and WebKit accepts it, so the cascade stops before it ever reaches `monospace`. Under `LANG=C` the same name falls through and the stack resolves correctly. **The trigger is the locale, not the generic.**
2. **The proposed fix was therefore incomplete.** It repairs the default (`monoFont: "system"`, which is the reported case), but every *named* option that the user does not have installed — `sfmono`, `monaco`, `menlo`, `consolas`, `jetbrains` and the rest, i.e. most of the list on Linux — still puts an unmatched name at the head and still reproduces.

The font work needs to guarantee that nothing unresolvable reaches the head of the stack on Linux, which is a different and larger change. It will come as its own PR, with the repro below as its gate.

## Note on the test that gave false confidence

The pulled revision added a real-WebKit test asserting the resolved stack measures as monospace, including a case named "when the chosen family is not installed". It passed on macOS and on CI's Linux WebKit — because **neither environment has a CJK locale or Noto CJK fonts installed**, so the precondition was absent and the assertion could not fail. A green result there meant "not exercised", not "correct".

The reproduction now exists on a host with Ubuntu 24.04.4, `zh_CN.UTF-8` generated, `fonts-noto-cjk`, and WebKitGTK `2.52.3-0ubuntu0.24.04.1` — matching the reporter's environment. Any future font test has to run with that locale active, or it is measuring nothing.
