### PR TITLE
fix(fonts): measure the mono stack instead of trusting the cascade (v0.9.54)

### DIFF
--- a/.claude/rules/31-design-tokens.md
+++ b/.claude/rules/31-design-tokens.md
@@ -216,6 +216,47 @@ Icon SVG sizes (conventions, not tokens):
 | `--cjk-letter-spacing` | CJK character spacing | `0.05em` |
 | `--editor-width` | Max editor content width | `50em` |
 
+**A monospace font stack must be MEASURED, never assumed (#1334).** Reach for
+`verifiedMonoStack()` from `src/services/fonts/`, not `resolveMonoFontStack()`,
+anywhere the result feeds a character grid — the terminal, code blocks, Source
+mode.
+
+The CSS cascade is supposed to skip a family that is not installed. On
+WebKitGTK under a CJK locale it does not: fontconfig returns a best match for
+**any** family name rather than reporting no match, WebKit accepts it, and the
+cascade stops at the unmatched head family instead of reaching the generic
+behind it. Measured on Ubuntu 24.04.4 + `fonts-noto-cjk`, `'W' × 32` vs
+`'i' × 32` (how xterm.js sizes its cell):
+
+| stack | `LANG=C` | `LANG=zh_CN.UTF-8` |
+|---|---|---|
+| `"No Such Family XYZ", monospace` | 8 / 8 | **11 / 4 — proportional** |
+| `"JetBrains Mono", monospace` (absent) | 8 / 8 | **11 / 4 — proportional** |
+| `monospace` | 8 / 8 | 7 / 7 |
+
+`verifiedMonoStack` drops leading families until the remainder measures
+monospace — performing the cascade step the engine skipped — so an installed
+font is kept and an absent one degrades. Measured on the repro host: **9 of 16
+mono settings were broken before it, 0 after**, and it is a no-op under
+`LANG=C`.
+
+**Two plausible-sounding explanations for this bug were refuted by
+measurement**, so do not re-derive them: it is not that `ui-monospace` is
+unimplemented on GTK and "wins" the cascade (in a list it is skipped like any
+absent family), and it is not the GTK UI font shadowing the stack (setting
+`gtk-font-name` changes nothing). `ui-monospace` is still kept out of the Linux
+tail in `src/utils/fontStacks.ts` as hygiene — it means nothing there — while
+remaining on macOS, where it is the only way to reach SF Mono (`"SF Mono"` and
+`SFMono-Regular` do not match by family name; the real family is the hidden
+`.SF NS Mono`).
+
+**A font test that measures real fonts asserts nothing on a machine without the
+trigger.** The first guard written for this bug did exactly that and passed on
+macOS and on CI's Linux WebKit while the bug was live. `verifiedMonoStack`'s
+unit test injects the measurement, and its WebKit test constructs the failure
+with `sans-serif` — a generic that always resolves and is always proportional —
+so it can fail on any engine.
+
 **Note:** These tokens have static defaults in `:root` for print/SSR, but are dynamically updated by `useTheme.ts` based on user settings. For example, `--editor-line-height` defaults to `1.6` in CSS, but the user-facing default is `1.8` (set in `settingsStore.ts` as "Relaxed" and applied dynamically by `useTheme.ts`).
 
 ## Code/Syntax Tokens

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.53",
+  "version": "0.9.54",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -6,7 +6,7 @@
  * Part of: pnpm check:all
  */
 import { readFileSync } from "node:fs";
-import { globSync } from "node:fs";
+import { globSync, statSync } from "node:fs";
 
 import { pathToFileURL } from "node:url";
 
@@ -119,12 +119,37 @@ export function collectJsDefinedVars(source) {
   return names;
 }
 
+/**
+ * `globSync` restricted to regular files.
+ *
+ * Vitest's browser runner writes screenshot artifacts into a `__screenshots__`
+ * directory beside the test, named after the test FILE — so a directory whose
+ * name ends in `.ts` exists after any `*.webkit.test.ts` failure, and those
+ * directories are gitignored, i.e. expected on a developer machine. Feeding
+ * it to `readFileSync` threw an unhandled `EISDIR` and killed this gate with a
+ * raw Node stack trace, which reads as "the token checker is broken" rather than
+ * "you have a leftover artifact".
+ *
+ * @param {string} pattern
+ * @returns {string[]}
+ */
+export function globFiles(pattern) {
+  return globSync(pattern).filter((p) => {
+    try {
+      return statSync(p).isFile();
+    } catch {
+      // Raced with a delete, or a broken symlink. Not ours to read either way.
+      return false;
+    }
+  });
+}
+
 // Main guard: this module EXPORTS collectJsDefinedVars for tests, so importing
 // it must not run the checker. Without it the importer's argv leaked in —
 // vitest's "run" was treated as a CSS path and the import threw ENOENT.
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   const args = process.argv.slice(2);
-  const files = args.length ? args : globSync("src/**/*.css");
+  const files = args.length ? args : globFiles("src/**/*.css");
 
   const violations = [];
 
@@ -216,12 +241,12 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
     const definedVars = new Set();
     const defRe = /--[A-Za-z0-9-]+(?=\s*:)/g;
     // CSS definitions across all stylesheets
-    for (const file of globSync("src/**/*.css")) {
+    for (const file of globFiles("src/**/*.css")) {
       const content = readFileSync(file, "utf8");
       for (const m of content.matchAll(defRe)) definedVars.add(m[0]);
     }
     // JS-emitted tokens: setProperty("--x", ...) and "--x": value maps
-    for (const file of globSync("src/**/*.{ts,tsx}")) {
+    for (const file of globFiles("src/**/*.{ts,tsx}")) {
       const content = readFileSync(file, "utf8");
       for (const name of collectJsDefinedVars(content)) definedVars.add(name);
     }

--- a/scripts/check-design-tokens.test.ts
+++ b/scripts/check-design-tokens.test.ts
@@ -14,7 +14,10 @@
  * cannot return.
  */
 import { describe, it, expect } from "vitest";
-import { collectJsDefinedVars, findFocusRemovals } from "./check-design-tokens.mjs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectJsDefinedVars, findFocusRemovals, globFiles } from "./check-design-tokens.mjs";
 
 describe("collectJsDefinedVars", () => {
   it("collects setProperty() calls", () => {
@@ -142,5 +145,44 @@ describe("findFocusRemovals", () => {
   it("reports a line number for the finding", () => {
     const css = `.x { color: red; }\n\n${removal}`;
     expect(findFocusRemovals(css)[0].line).toBe(3);
+  });
+});
+
+describe("globFiles", () => {
+  // The gate globs `src/**/*.{ts,tsx}` and readFileSync's every hit. Vitest's
+  // browser runner writes screenshot artifacts into a `__screenshots__`
+  // directory named after the TEST FILE, so after any `*.webkit.test.ts`
+  // failure there is a DIRECTORY whose name ends in `.ts`. Those directories
+  // are gitignored — expected on a developer machine — and feeding one to
+  // readFileSync threw an unhandled EISDIR that killed the gate with a raw Node
+  // stack trace, reading as "the token checker is broken".
+  it("excludes a directory whose name ends in a source extension", () => {
+    const root = mkdtempSync(join(tmpdir(), "globfiles-"));
+    try {
+      writeFileSync(join(root, "real.ts"), "export {};");
+      mkdirSync(join(root, "__screenshots__"));
+      mkdirSync(join(root, "__screenshots__", "some.webkit.test.ts"));
+
+      const hits = globFiles(join(root, "**/*.{ts,tsx}"));
+
+      expect(hits).toContain(join(root, "real.ts"));
+      expect(hits.some((p: string) => p.endsWith("some.webkit.test.ts"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns every regular file that matches", () => {
+    const root = mkdtempSync(join(tmpdir(), "globfiles-"));
+    try {
+      writeFileSync(join(root, "a.ts"), "");
+      writeFileSync(join(root, "b.tsx"), "");
+      writeFileSync(join(root, "c.css"), "");
+      expect(globFiles(join(root, "**/*.{ts,tsx}")).sort()).toEqual(
+        [join(root, "a.ts"), join(root, "b.tsx")].sort(),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.53",
+  "version": "0.9.54",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.53';
+const VERSION = '0.9.54';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6415,7 +6415,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.53"
+version = "0.9.54"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.53"
+version = "0.9.54"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.53",
+  "version": "0.9.54",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/Terminal/createTerminalInstance.ts
+++ b/src/components/Terminal/createTerminalInstance.ts
@@ -12,6 +12,10 @@
  *     rollback cannot drift apart.
  *   - Option normalization lives in terminalOptions.ts, so this file reads as
  *     a lifecycle (acquire → wire → release) rather than option tuning.
+ *   - The mono font handed to xterm is MEASURED, never assumed. xterm sizes its
+ *     character cell from the advance of a `W`, so a stack that resolves to a
+ *     proportional font spaces the whole grid out — which is what WebKitGTK
+ *     does under a CJK locale (#1334). See services/fonts/verifiedMonoStack.
  *   - Each instance gets its own child div inside the parent container,
  *     initially hidden; the caller (useTerminalSessions) toggles visibility
  *     when switching sessions.
@@ -68,6 +72,9 @@ import {
   type TerminalInstanceSettings,
 } from "./terminalOptions";
 
+import { getRuntimePlatform } from "@/utils/platform";
+import { verifiedMonoStack } from "@/services/fonts/verifiedMonoStack";
+
 import "@xterm/xterm/css/xterm.css";
 
 // Re-exports kept for compatibility with existing imports/tests.
@@ -77,11 +84,16 @@ export { ATLAS_PAGE_LIMIT } from "./setupWebglRenderer";
  *  terminal creation (the var is already applied by then). Live mono-font
  *  changes are handled by terminalSessionStoreSync, which resolves the stack
  *  straight from the monoFont setting via resolveMonoFontStack (the CSS var
- *  lags inside the store subscriber). */
+ *  lags inside the store subscriber).
+ *
+ *  Both paths are MEASURED, not trusted. `--font-mono` is written by useTheme,
+ *  which already verifies it; the fallback verifies its own stack rather than
+ *  hardcoding a literal. A proportional font reaching xterm sizes every cell
+ *  from the advance of a `W` and spaces the whole grid out (#1334). */
 function resolveMonoFont(): string {
   const style = getComputedStyle(document.documentElement);
   const mono = style.getPropertyValue("--font-mono").trim();
-  return mono || "ui-monospace, SFMono-Regular, Menlo, Monaco, monospace";
+  return mono || verifiedMonoStack("system", getRuntimePlatform());
 }
 
 /** A fully-configured xterm.js terminal with its addons and container element. */

--- a/src/components/Terminal/terminalSessionStoreSync.ts
+++ b/src/components/Terminal/terminalSessionStoreSync.ts
@@ -13,6 +13,10 @@
  *     (not the --font-mono CSS var, which useTheme writes only in a later
  *     effect, so it would lag a monoFont-only change) (G6/WI-4.1). A monoFont
  *     change also re-fits and resizes the PTY, since cell width changes.
+ *     The stack is MEASURED before it is applied: on WebKitGTK under a CJK
+ *     locale the cascade stops at an unmatched family rather than falling
+ *     through to the generic, so what CSS resolves is not always monospace
+ *     (#1334). A proportional font here inflates every terminal cell.
  *   - Workspace-root changes inject a `cd` command into every alive PTY whose
  *     current cwd differs from the new root — the live OSC 7 cwd when known,
  *     else the spawn-time cwd (WI-2.2); PTY-less or exited sessions are skipped.
@@ -33,7 +37,8 @@ import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
 import { getActiveWorkspaceScope } from "@/services/workspaces/activeWorkspaceScope";
 import { buildXtermThemeForId } from "@/theme";
 import { useTabStore } from "@/stores/tabStore";
-import { resolveMonoFontStack } from "@/utils/fontStacks";
+import { getRuntimePlatform } from "@/utils/platform";
+import { verifiedMonoStack } from "@/services/fonts/verifiedMonoStack";
 import { fitAndResizePty } from "./fitAndResizePty";
 // Re-exported so existing importers (and tests) keep one obvious home for it.
 export type { SyncableSessionEntry } from "./terminalSessionTypes";
@@ -104,7 +109,7 @@ export function useUIStoreSync(
       // subscriber fires synchronously inside the store `set`, before useTheme's
       // effect writes --font-mono, so reading that CSS var here would yield the
       // PREVIOUS font on a monoFont-only change.
-      const newFont = resolveMonoFontStack(monoFont);
+      const newFont = verifiedMonoStack(monoFont, getRuntimePlatform());
       const sessions = sessionsRef.current;
       if (!sessions) return;
       for (const [, entry] of sessions) {

--- a/src/export/pdfHtmlTemplate.ts
+++ b/src/export/pdfHtmlTemplate.ts
@@ -23,6 +23,7 @@ import _katexCSSRaw from "katex/dist/katex.min.css?raw";
 import { embedKatexFonts } from "./katexFontEmbed";
 import { getPrimitiveTokenCSS } from "./primitiveTokens";
 import { buildFontStack } from "@/utils/fontStacks";
+import { getRuntimePlatform } from "@/utils/platform";
 import { sharedContentCSS, forceLightThemeCSS } from "./pdfPrintCss";
 import { buildFitCSS } from "./pdfFitToPage";
 import { type PdfOptions, PAGE_SIZE_KEYWORDS, effectiveBottomMarginMm } from "./pdfOptions";
@@ -116,6 +117,7 @@ function buildTypographyCSS(options: PdfOptions, themeCSS: string): string {
     options.latinFont,
     options.cjkFont,
     "system",
+    getRuntimePlatform(),
   );
   const fs = options.fontSize;
   const lh = options.lineHeight;

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -14,6 +14,7 @@ import {
   computeTypographyVars,
   computeCoreColorVars,
   computeModeColorVars,
+  type TypographyInput,
 } from "./useTheme";
 import type { ThemeColors } from "@/stores/settingsStore";
 
@@ -21,7 +22,7 @@ import type { ThemeColors } from "@/stores/settingsStore";
 // Typography vars computation
 // ---------------------------------------------------------------------------
 describe("computeTypographyVars", () => {
-  const baseTypography = {
+  const baseTypography: TypographyInput = {
     latinFont: "system",
     cjkFont: "system",
     monoFont: "system",
@@ -31,7 +32,22 @@ describe("computeTypographyVars", () => {
     cjkLetterSpacing: "0",
     editorWidth: 50,
     blockFontSize: "1",
+    platform: "macos",
   };
+
+  // #1334: --font-mono feeds the editor's code blocks, Source mode AND the
+  // terminal's xterm cell measurement. `ui-monospace` is not implemented on
+  // WebKitGTK, where it returns the proportional GTK UI font.
+  it("emits no ui-* generic in --font-mono on linux", () => {
+    const vars = computeTypographyVars({ ...baseTypography, platform: "linux" });
+    expect(vars["--font-mono"]).not.toMatch(/\bui-[a-z]+\b/);
+    expect(vars["--font-mono"]).toMatch(/(^|,\s*)monospace$/);
+  });
+
+  it("keeps ui-monospace in --font-mono on macOS", () => {
+    const vars = computeTypographyVars({ ...baseTypography, platform: "macos" });
+    expect(vars["--font-mono"]).toContain("ui-monospace");
+  });
 
   it("computes editor font size in px", () => {
     const vars = computeTypographyVars(baseTypography);

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -13,6 +13,13 @@
  * Key decisions:
  *   - Font stacks live in `@/utils/fontStacks` (leaf-pure); this hook composes
  *     them via `buildFontStack` into the `--font-sans`/`--font-mono` tokens
+ *   - This hook is where the PLATFORM and the ENGINE enter font resolution:
+ *     `buildFontStack` takes the platform as a parameter so it can stay pure,
+ *     and the `navigator` read happens here. `--font-mono` is then MEASURED
+ *     before it is written — on WebKitGTK under a CJK locale the cascade stops
+ *     at an unmatched family instead of falling through to the generic, so the
+ *     stack CSS would resolve is not always monospace (#1334). See
+ *     services/fonts/verifiedMonoStack.
  *   - Editor font size drives dependent tokens (line-height, padding, mono size)
  *   - Mermaid and code preview plugins notified of font size changes
  *   - Dark theme toggled via `.dark-theme` class on documentElement
@@ -40,6 +47,8 @@ import { refreshPreviews } from "@/plugins/codePreview/tiptap";
 import { applyTheme, themes as themeTokensCatalog } from "@/theme";
 import { computeCoreColorVars, computeModeColorVars } from "@/theme/legacyModeColors";
 import { buildFontStack } from "@/utils/fontStacks";
+import { getRuntimePlatform, type RuntimePlatform } from "@/utils/platform";
+import { verifiedMonoStack } from "@/services/fonts/verifiedMonoStack";
 import { syncNativeTheme } from "@/services/theme/nativeTheme";
 
 // Pure color computation moved to @/theme/legacyModeColors (ADR-014 home for
@@ -64,12 +73,28 @@ export type TypographyInput = {
   cjkLetterSpacing: string;
   editorWidth: number;
   blockFontSize: string;
+  /** Which monospace fallback the mono stack may use. Passed in so this stays
+   *  pure; the DOM read lives in `useTheme` itself. */
+  platform: RuntimePlatform;
+  /** The mono stack to emit, already MEASURED against this engine (#1334).
+   *  Optional because the pure computation cannot measure anything — when it is
+   *  absent the preferred stack is used, which is what every non-DOM caller
+   *  wants. `applyTypography` supplies it. */
+  verifiedMono?: string;
 };
 
 /** Compute typography CSS vars. Pure — no DOM access. */
 export function computeTypographyVars(input: TypographyInput): Record<string, string> {
   const { fontSize, lineHeight, blockSpacing, cjkLetterSpacing, editorWidth, blockFontSize } = input;
-  const { sans, mono } = buildFontStack(input.latinFont, input.cjkFont, input.monoFont);
+  const { sans, mono: preferredMono } = buildFontStack(
+    input.latinFont,
+    input.cjkFont,
+    input.monoFont,
+    input.platform,
+  );
+  // The stack the CASCADE would give is not always the stack the engine
+  // renders — see services/fonts/verifiedMonoStack (#1334).
+  const mono = input.verifiedMono ?? preferredMono;
 
   // Calculate absolute line-height for use with reduced font sizes
   const lineHeightPx = fontSize * lineHeight;
@@ -142,6 +167,8 @@ function applyTypography(
   applyVars(root, computeTypographyVars({
     latinFont, cjkFont, monoFont, fontSize, lineHeight,
     blockSpacing, cjkLetterSpacing, editorWidth, blockFontSize,
+    platform: getRuntimePlatform(),
+    verifiedMono: verifiedMonoStack(monoFont, getRuntimePlatform()),
   }));
 }
 

--- a/src/pages/settings/EditorSettings.tsx
+++ b/src/pages/settings/EditorSettings.tsx
@@ -38,6 +38,13 @@ const fontOptions = {
     { value: "monaco", label: "Monaco" },
     { value: "menlo", label: "Menlo" },
     { value: "consolas", label: "Consolas" },
+    // Linux distribution defaults (#1334) — without these a Linux user had no
+    // monospace family in the list that ships on their machine.
+    { value: "dejavu", label: "DejaVu Sans Mono" },
+    { value: "liberation", label: "Liberation Mono" },
+    { value: "ubuntumono", label: "Ubuntu Mono" },
+    { value: "notosansmono", label: "Noto Sans Mono" },
+    { value: "notosansmonocjk", label: "Noto Sans Mono CJK SC" },
     { value: "jetbrains", label: "JetBrains Mono" },
     { value: "firacode", label: "Fira Code" },
     { value: "saucecodepro", label: "SauceCodePro NFM" },

--- a/src/services/fonts/verifiedMonoStack.test.ts
+++ b/src/services/fonts/verifiedMonoStack.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+/**
+ * verifiedMonoStack — the drop-the-head algorithm (#1334).
+ *
+ * The measurement is INJECTED here rather than taken from a real engine. The
+ * previous guard for this bug measured real fonts, which meant it silently
+ * asserted nothing on any machine without a CJK locale — it passed on macOS and
+ * on CI while the bug was live. Driving the algorithm directly is the half that
+ * can always fail; `verifiedMonoStack.webkit.test.ts` covers the real engine.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { narrowToMonospace, resetMonoStackCache, verifiedMonoStack } from "./verifiedMonoStack";
+
+/** A fake engine where only the named families render monospace. */
+function engineWith(monospaceFamilies: string[]) {
+  return (candidate: string) => {
+    const head = candidate.split(",")[0].trim();
+    return monospaceFamilies.includes(head);
+  };
+}
+
+describe("narrowToMonospace", () => {
+  it("keeps the stack untouched when the head already renders monospace", () => {
+    const stack = '"JetBrains Mono", monospace';
+    expect(narrowToMonospace(stack, engineWith(['"JetBrains Mono"']))).toBe(stack);
+  });
+
+  // The reported case: the user's chosen family is not installed, and under a
+  // CJK locale fontconfig answers with a proportional face instead of letting
+  // the cascade reach the generic behind it.
+  it("drops a head family that does not render monospace", () => {
+    expect(
+      narrowToMonospace('"JetBrains Mono", monospace', engineWith(["monospace"])),
+    ).toBe("monospace");
+  });
+
+  it("drops families one at a time, keeping the first that works", () => {
+    expect(
+      narrowToMonospace(
+        'Consolas, "Courier New", monospace',
+        engineWith(['"Courier New"']),
+      ),
+    ).toBe('"Courier New", monospace');
+  });
+
+  it("falls back to the last family when nothing measures monospace", () => {
+    // No better answer exists — the generic is the engine's own fixed-pitch
+    // font. Returning the original stack instead would keep the broken head.
+    expect(narrowToMonospace('"A", "B", monospace', engineWith([]))).toBe("monospace");
+  });
+
+  it("returns the input unchanged when it is empty", () => {
+    expect(narrowToMonospace("", engineWith([]))).toBe("");
+  });
+
+  it("tolerates stray whitespace and empty entries", () => {
+    expect(
+      narrowToMonospace('  "A" ,  , monospace ', engineWith(["monospace"])),
+    ).toBe("monospace");
+  });
+
+  it("never returns a stack the engine rejected", () => {
+    // Guards the loop bound: an off-by-one that returned families[i-1] would
+    // hand back the very family that failed.
+    const engine = engineWith(["monospace"]);
+    const result = narrowToMonospace('"X", "Y", "Z", monospace', engine);
+    expect(engine(result)).toBe(true);
+  });
+
+  it("stops at the FIRST family that works, not the last", () => {
+    expect(
+      narrowToMonospace('"A", "B", monospace', engineWith(['"B"', "monospace"])),
+    ).toBe('"B", monospace');
+  });
+});
+
+describe("verifiedMonoStack", () => {
+  it("memoizes per preferred stack", () => {
+    resetMonoStackCache();
+    // Without a DOM every candidate reports monospace, so this asserts the
+    // caching path rather than the measurement.
+    const first = verifiedMonoStack("jetbrains", "linux");
+    const second = verifiedMonoStack("jetbrains", "linux");
+    expect(second).toBe(first);
+  });
+
+  it("emits no ui-* generic on linux", () => {
+    resetMonoStackCache();
+    expect(verifiedMonoStack("system", "linux")).not.toMatch(/\bui-[a-z]+\b/);
+  });
+
+  it("returns the preferred stack unmeasured when there is no DOM", () => {
+    // Node environment: nothing to measure. Downgrading on a guess would strip
+    // the user's font for no reason.
+    resetMonoStackCache();
+    expect(verifiedMonoStack("jetbrains", "linux")).toContain("JetBrains Mono");
+  });
+});
+
+describe("stackRendersMonospace without a DOM", () => {
+  it("reports true rather than downgrading blind", async () => {
+    const { stackRendersMonospace } = await import("./verifiedMonoStack");
+    expect(stackRendersMonospace('"Anything At All"')).toBe(true);
+  });
+
+  it("does not touch the document when there is none", () => {
+    // Regression guard: an unguarded document.createElement here would throw in
+    // the node tier, which is where most of this repo's suite runs.
+    expect(() => verifiedMonoStack("system", "macos")).not.toThrow();
+    expect(vi.isMockFunction(globalThis.document)).toBe(false);
+  });
+});

--- a/src/services/fonts/verifiedMonoStack.ts
+++ b/src/services/fonts/verifiedMonoStack.ts
@@ -1,0 +1,149 @@
+/**
+ * verifiedMonoStack
+ *
+ * Purpose: Return a monospace font stack that has been MEASURED to render
+ *   monospace in this engine, downgrading through the stack until one does.
+ *
+ * Why this exists, and why it measures instead of reasoning (#1334):
+ *
+ *   The CSS cascade is supposed to skip a family that is not installed. On
+ *   WebKitGTK under a CJK locale it does not. Measured on Ubuntu 24.04.4 with
+ *   `fonts-noto-cjk` and `LANG=zh_CN.UTF-8`, using the same `'W' x 32` vs
+ *   `'i' x 32` comparison xterm.js's CharSizeService uses:
+ *
+ *     stack                                LANG=C    LANG=zh_CN.UTF-8
+ *     `"No Such Family XYZ", monospace`    8 / 8     11 / 4  <- proportional
+ *     `"JetBrains Mono", monospace`        8 / 8     11 / 4  <- proportional
+ *     `monospace`                          8 / 8      7 / 7
+ *
+ *   fontconfig returns a best match for ANY family name rather than reporting
+ *   no match, and under a CJK locale that best match is a proportional CJK
+ *   face. WebKit accepts it, so the cascade STOPS at the unmatched head family
+ *   and never reaches the generic behind it.
+ *
+ *   The consequence is a terminal bug, not merely an ugly one: xterm.js sizes
+ *   its character cell from the advance of `W`, so a proportional font makes
+ *   every cell as wide as a `W` while narrow glyphs keep their own advance —
+ *   the whole grid renders spaced out, for Latin and CJK alike, under every
+ *   renderer. The editor's code blocks and Source mode read the same
+ *   `--font-mono` and are wrong with it.
+ *
+ * Key decisions:
+ *   - **Assert the property, do not model the cause.** Two earlier attempts at
+ *     this bug named a mechanism (`ui-monospace` is unimplemented on GTK; the
+ *     GTK UI font shadows the stack) and both were refuted by measurement. What
+ *     survives every explanation is the property the terminal actually needs:
+ *     the stack must render with a uniform advance. So that is what is checked.
+ *   - **Drop the head, then re-measure.** This performs the cascade step the
+ *     engine skipped, so a stack keeps the user's font when it is installed and
+ *     degrades one family at a time when it is not.
+ *   - Results are memoized per stack string. VMark ships no web fonts, so the
+ *     set of installed families does not change within a session.
+ *   - Without a DOM (node tests, SSR) the preferred stack is returned
+ *     unmeasured. There is nothing to measure and guessing would be worse.
+ *
+ * @coordinates-with utils/fontStacks.ts — supplies the preferred stack
+ * @coordinates-with hooks/useTheme.ts — writes the verified stack to --font-mono
+ * @coordinates-with components/Terminal/terminalSessionStoreSync.ts — live terminal font
+ * @module services/fonts/verifiedMonoStack
+ */
+import { resolveMonoFontStack } from "@/utils/fontStacks";
+import type { RuntimePlatform } from "@/utils/platform";
+
+/**
+ * Glyph count per sample. Matches xterm.js's `DomMeasureStrategyConstants`, so
+ * this measures the same quantity the terminal will later derive its cell from.
+ */
+const REPEAT = 32;
+
+/**
+ * Probe size in px. Deliberately larger than any UI font size: `offsetWidth` is
+ * an integer, and at small sizes the rounding gap between a wide and a narrow
+ * glyph can close enough to make a proportional font look uniform.
+ */
+const PROBE_PX = 32;
+
+/** Mean advance of `char` under `stack`, or null when there is no DOM. */
+function advance(stack: string, char: string): number | null {
+  if (typeof document === "undefined" || !document.body) return null;
+  const span = document.createElement("span");
+  span.setAttribute("aria-hidden", "true");
+  span.style.cssText =
+    "position:absolute;visibility:hidden;white-space:pre;font-kerning:none;";
+  span.style.fontSize = `${PROBE_PX}px`;
+  span.style.fontFamily = stack;
+  span.textContent = char.repeat(REPEAT);
+  document.body.appendChild(span);
+  const width = span.offsetWidth;
+  span.remove();
+  return width / REPEAT;
+}
+
+/**
+ * True when `stack` renders with a uniform advance — i.e. really monospace.
+ *
+ * Returns true when the engine cannot be measured, so a DOM-less caller keeps
+ * whatever it asked for rather than being silently downgraded.
+ */
+export function stackRendersMonospace(stack: string): boolean {
+  const wide = advance(stack, "W");
+  const narrow = advance(stack, "i");
+  if (wide === null || narrow === null) return true;
+  // A zero-width measurement means the span never laid out (detached document,
+  // display:none ancestor). That is "cannot measure", not "not monospace".
+  if (wide === 0 && narrow === 0) return true;
+  return wide === narrow;
+}
+
+const memo = new Map<string, string>();
+
+/**
+ * Drop leading families until the remainder renders monospace.
+ *
+ * Exported for tests, which inject `rendersMonospace` so the algorithm can be
+ * driven deterministically without depending on which fonts a machine happens
+ * to have installed — the exact dependency that let the previous version of
+ * this guard pass everywhere while the bug was live.
+ */
+export function narrowToMonospace(
+  stack: string,
+  rendersMonospace: (candidate: string) => boolean = stackRendersMonospace,
+): string {
+  const families = stack
+    .split(",")
+    .map((f) => f.trim())
+    .filter(Boolean);
+  if (!families.length) return stack;
+
+  for (let i = 0; i < families.length; i++) {
+    const candidate = families.slice(i).join(", ");
+    if (rendersMonospace(candidate)) return candidate;
+  }
+  // Nothing in the stack measured monospace, the bare generic included. Return
+  // the generic anyway: it is the engine's own idea of a fixed-pitch font and
+  // there is no better answer left.
+  return families[families.length - 1];
+}
+
+/**
+ * The monospace stack for a setting, verified against this engine.
+ *
+ * Prefer this over `resolveMonoFontStack` at any site that hands a font to
+ * something which assumes a character grid.
+ */
+export function verifiedMonoStack(
+  monoFont: string,
+  platform: RuntimePlatform,
+): string {
+  const preferred = resolveMonoFontStack(monoFont, platform);
+  const cached = memo.get(preferred);
+  if (cached !== undefined) return cached;
+  const verified = narrowToMonospace(preferred);
+  memo.set(preferred, verified);
+  return verified;
+}
+
+/** Clear the measurement cache. For tests. */
+export function resetMonoStackCache(): void {
+  memo.clear();
+}

--- a/src/services/fonts/verifiedMonoStack.webkit.test.ts
+++ b/src/services/fonts/verifiedMonoStack.webkit.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Real-WebKit tier — the mono stack must actually BE monospace (#1334).
+ *
+ * jsdom has no font engine, so it cannot see this class at all: every stack
+ * "resolves" and every measurement is zero.
+ *
+ * **The failure condition here is constructed, not borrowed from the host.**
+ * The previous version of this guard measured VMark's real stacks and asserted
+ * they came out monospace — which is true on any machine WITHOUT a CJK locale,
+ * so it passed on macOS and on CI's Linux WebKit while the bug was live. Green
+ * meant "not exercised". This version leads a stack with `sans-serif`: a
+ * generic that always resolves and is always proportional, on every engine and
+ * every font configuration. If `narrowToMonospace` stops working, this fails
+ * everywhere rather than only where someone happens to read Chinese.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  narrowToMonospace,
+  stackRendersMonospace,
+  verifiedMonoStack,
+} from "./verifiedMonoStack";
+import { getRuntimePlatform } from "@/utils/platform";
+
+describe("mono stack verification in real WebKit", () => {
+  it("measures a proportional generic as NOT monospace", () => {
+    // Guards the measurement itself. Without this, a probe that always reported
+    // "monospace" would make every assertion below vacuously true — which is
+    // exactly how the previous guard failed.
+    expect(stackRendersMonospace("sans-serif")).toBe(false);
+  });
+
+  it("measures a monospace generic as monospace", () => {
+    expect(stackRendersMonospace("monospace")).toBe(true);
+  });
+
+  it("drops a proportional head family it can actually see", () => {
+    // The constructed reproduction of the reported bug: a head family that
+    // resolves but is not monospace must not survive verification.
+    expect(narrowToMonospace("sans-serif, monospace")).toBe("monospace");
+  });
+
+  it("keeps a monospace head family", () => {
+    expect(narrowToMonospace("monospace, sans-serif")).toBe("monospace, sans-serif");
+  });
+
+  it("yields a monospace stack for every mono setting on this platform", () => {
+    const platform = getRuntimePlatform();
+    for (const key of ["system", "sfmono", "menlo", "consolas", "jetbrains", "dejavu"]) {
+      expect(stackRendersMonospace(verifiedMonoStack(key, platform))).toBe(true);
+    }
+  });
+});

--- a/src/utils/fontStacks.test.ts
+++ b/src/utils/fontStacks.test.ts
@@ -4,44 +4,49 @@
  *
  *   - Latin / CJK / mono stack resolution and fallbacks
  *   - Trailing-generic stripping so the CJK Font setting takes effect (#1056)
+ *   - No `ui-*` generic reaches Linux, where WebKitGTK resolves them to the
+ *     proportional GTK UI font (#1334)
  */
 
 import { describe, it, expect } from "vitest";
 import { buildFontStack, fontStacks, resolveMonoFontStack } from "./fontStacks";
+import type { RuntimePlatform } from "./platform";
+
+const PLATFORMS: RuntimePlatform[] = ["macos", "windows", "linux"];
 
 describe("buildFontStack", () => {
   it("resolves known latin font to its stack", () => {
-    const result = buildFontStack("athelas", "system", "system");
+    const result = buildFontStack("athelas", "system", "system", "macos");
     expect(result.sans).toContain("Athelas");
   });
 
   it("resolves known CJK font into the sans stack", () => {
-    const result = buildFontStack("system", "songti", "system");
+    const result = buildFontStack("system", "songti", "system", "macos");
     expect(result.sans).toContain("Songti SC");
   });
 
   it("resolves known mono font", () => {
-    const result = buildFontStack("system", "system", "jetbrains");
+    const result = buildFontStack("system", "system", "jetbrains", "macos");
     expect(result.mono).toContain("JetBrains Mono");
   });
 
   it("falls back to system for unknown latin font key", () => {
-    const result = buildFontStack("nonexistent", "system", "system");
+    const result = buildFontStack("nonexistent", "system", "system", "macos");
     expect(result.sans).toContain("system-ui");
   });
 
   it("falls back to system for unknown CJK font key", () => {
-    const result = buildFontStack("system", "nonexistent", "system");
+    const result = buildFontStack("system", "nonexistent", "system", "macos");
     expect(result.sans).toContain("PingFang SC");
   });
 
   it("falls back to system for unknown mono font key", () => {
-    const result = buildFontStack("system", "system", "nonexistent");
+    const result = buildFontStack("system", "system", "nonexistent", "macos");
     expect(result.mono).toContain("ui-monospace");
   });
 
   it("combines latin and CJK in the sans stack", () => {
-    const result = buildFontStack("georgia", "kaiti", "system");
+    const result = buildFontStack("georgia", "kaiti", "system", "macos");
     // Latin comes first, then CJK
     const latinIdx = result.sans.indexOf("Georgia");
     const cjkIdx = result.sans.indexOf("Kaiti SC");
@@ -53,7 +58,7 @@ describe("buildFontStack", () => {
   // the CJK stack. The Latin stack's trailing generic must be stripped so the
   // CJK fonts (and their own trailing generic) actually take effect.
   it("does not place a generic family between the Latin and CJK fonts", () => {
-    const result = buildFontStack("athelas", "songti", "system");
+    const result = buildFontStack("athelas", "songti", "system", "macos");
     const cjkIdx = result.sans.indexOf("Songti SC");
     // No "serif"/"sans-serif" token may appear before the first CJK font.
     const head = result.sans.slice(0, cjkIdx);
@@ -61,14 +66,14 @@ describe("buildFontStack", () => {
   });
 
   it("keeps the CJK stack's trailing generic as the overall fallback", () => {
-    const result = buildFontStack("athelas", "songti", "system");
+    const result = buildFontStack("athelas", "songti", "system", "macos");
     // Songti's stack ends in `serif`; that becomes the final fallback.
     expect(result.sans.trim().endsWith("serif")).toBe(true);
   });
 
   it("lets the CJK font category survive a serif Latin choice", () => {
     // Latin=Athelas (serif) must not force a sans-serif CJK font to serif.
-    const result = buildFontStack("athelas", "sourcehans", "system");
+    const result = buildFontStack("athelas", "sourcehans", "system", "macos");
     const cjkIdx = result.sans.indexOf("Source Han Sans SC");
     const head = result.sans.slice(0, cjkIdx);
     expect(head).not.toContain("serif");
@@ -78,7 +83,7 @@ describe("buildFontStack", () => {
 
   it("still resolves the Latin font for a system CJK selection", () => {
     // Stripping the trailing generic must not drop the named Latin fonts.
-    const result = buildFontStack("georgia", "system", "system");
+    const result = buildFontStack("georgia", "system", "system", "macos");
     expect(result.sans).toContain("Georgia");
     expect(result.sans).toContain("PingFang SC");
   });
@@ -86,16 +91,69 @@ describe("buildFontStack", () => {
 
 describe("resolveMonoFontStack", () => {
   it("resolves a known mono font key to its stack", () => {
-    expect(resolveMonoFontStack("jetbrains")).toContain("JetBrains Mono");
+    expect(resolveMonoFontStack("jetbrains", "macos")).toContain("JetBrains Mono");
   });
 
-  it("falls back to the system mono stack for an unknown key", () => {
-    expect(resolveMonoFontStack("nonexistent")).toBe(fontStacks.mono.system);
-    expect(resolveMonoFontStack("nonexistent")).toContain("ui-monospace");
+  it("falls back to the platform default for an unknown key", () => {
+    // Same result the "system" key gives — the pre-#1334 behaviour, which
+    // resolved an unknown key through `fontStacks.mono.system`.
+    for (const platform of PLATFORMS) {
+      expect(resolveMonoFontStack("nonexistent", platform)).toBe(
+        resolveMonoFontStack("system", platform),
+      );
+    }
   });
 
   it("matches the mono stack buildFontStack produces for the same key", () => {
-    expect(resolveMonoFontStack("sfmono")).toBe(buildFontStack("system", "system", "sfmono").mono);
+    for (const platform of PLATFORMS) {
+      expect(resolveMonoFontStack("sfmono", platform)).toBe(
+        buildFontStack("system", "system", "sfmono", platform).mono,
+      );
+    }
+  });
+
+  // #1334: `ui-monospace` is not implemented on WebKitGTK — it returns the GTK
+  // *UI* font (proportional) for every ui-* generic, and a generic always
+  // matches, so it wins the cascade. xterm.js then sizes its character cell
+  // from a proportional 'W' and the whole grid renders spaced out.
+  it("emits no ui-* generic on linux, for any mono key", () => {
+    for (const key of Object.keys(fontStacks.mono)) {
+      expect(resolveMonoFontStack(key, "linux")).not.toMatch(/\bui-[a-z]+\b/);
+    }
+  });
+
+  it("still ends in a monospace generic on linux, for any mono key", () => {
+    // Losing ui-monospace must not leave the stack without a fallback: the
+    // generic is the only reliable monospace on WebKitGTK, and it is what
+    // honours the desktop's own monospace choice.
+    for (const key of Object.keys(fontStacks.mono)) {
+      expect(resolveMonoFontStack(key, "linux")).toMatch(/(^|,\s*)monospace$/);
+    }
+  });
+
+  it("keeps ui-monospace on macOS — the only way to reach SF Mono in WebKit", () => {
+    // "SF Mono" and SFMono-Regular do not match by family name in WebKit (the
+    // real family is the hidden ".SF NS Mono"), so dropping ui-monospace
+    // everywhere would silently regress the primary platform to Menlo.
+    expect(resolveMonoFontStack("system", "macos")).toContain("ui-monospace");
+    expect(resolveMonoFontStack("sfmono", "macos")).toContain("ui-monospace");
+  });
+
+  it("keeps the chosen family ahead of the platform fallback", () => {
+    for (const platform of PLATFORMS) {
+      const stack = resolveMonoFontStack("jetbrains", platform);
+      expect(stack.indexOf("JetBrains Mono")).toBeLessThan(stack.indexOf("monospace"));
+    }
+  });
+
+  it("offers mono families that exist on a stock Linux desktop (#1334)", () => {
+    // Before this, every named option was macOS- or Windows-only or a font the
+    // user had to install, so a Linux user had nothing in the list to pick.
+    expect(fontStacks.mono).toHaveProperty("dejavu");
+    expect(fontStacks.mono).toHaveProperty("liberation");
+    expect(fontStacks.mono).toHaveProperty("ubuntumono");
+    expect(fontStacks.mono).toHaveProperty("notosansmono");
+    expect(fontStacks.mono).toHaveProperty("notosansmonocjk");
   });
 });
 

--- a/src/utils/fontStacks.ts
+++ b/src/utils/fontStacks.ts
@@ -6,15 +6,23 @@
  *   imports — leaf-pure per ADR-013 (`src/utils/`).
  *
  * Key decisions:
- *   - Latin, CJK, and mono families each carry a system fallback.
+ *   - Latin and CJK families each carry a system fallback; the mono table holds
+ *     NAMED families only and the platform tail supplies the fallback, because
+ *     which generic is safe depends on the OS (see `MONO_TAIL`).
  *   - The sans stack is `<latin>, <cjk>`; the Latin stack's trailing generic
  *     family is stripped first so CJK glyph resolution actually reaches the CJK
  *     fonts (issue #1056).
+ *   - Mono resolution takes the platform as a PARAMETER. The module stays
+ *     leaf-pure (ADR-013) — the `navigator` read happens at the call site.
+ *   - What this module returns is the PREFERRED stack. It is not verified, and
+ *     on WebKitGTK the engine does not always render it — callers that need a
+ *     real character grid go through `services/fonts/verifiedMonoStack`.
  *
  * @coordinates-with hooks/useTheme.ts — consumes these to emit CSS vars
  * @coordinates-with components/Terminal/terminalSessionStoreSync.ts — live mono sync
  * @module utils/fontStacks
  */
+import type { RuntimePlatform } from "./platform";
 
 export const fontStacks = {
   latin: {
@@ -33,36 +41,105 @@ export const fontStacks = {
     notoserif: '"Noto Serif CJK SC", "Source Han Serif SC", serif',
     sourcehans: '"Source Han Sans SC", "Noto Sans CJK SC", sans-serif',
   },
+  /**
+   * Monospace families — NAMED ONLY. The generic comes from `MONO_TAIL`, which
+   * picks the one that means something on the running platform.
+   *
+   * A name here is a PREFERENCE, not a promise: nothing guarantees the user has
+   * the font, and on WebKitGTK an absent family can still capture the cascade
+   * (#1334). `services/fonts/verifiedMonoStack` is what makes the result safe.
+   */
   mono: {
-    system: 'ui-monospace, "SF Mono", Menlo, Monaco, monospace',
-    // macOS system fonts
-    sfmono: '"SF Mono", ui-monospace, monospace',
-    monaco: 'Monaco, ui-monospace, monospace',
-    menlo: 'Menlo, ui-monospace, monospace',
-    // Cross-platform
-    consolas: 'Consolas, "Courier New", monospace',
+    /** No named family — take the platform's own monospace default. */
+    system: "",
+    // macOS system fonts. "SF Mono" does not resolve by family name in WebKit
+    // (its real family is the hidden ".SF NS Mono"), so on macOS this entry is
+    // satisfied by `ui-monospace` in the tail — which is the point of the tail.
+    sfmono: '"SF Mono"',
+    monaco: "Monaco",
+    menlo: "Menlo",
+    // Windows
+    consolas: 'Consolas, "Courier New"',
+    // Linux distribution defaults (#1334)
+    dejavu: '"DejaVu Sans Mono"',
+    liberation: '"Liberation Mono"',
+    ubuntumono: '"Ubuntu Mono"',
+    notosansmono: '"Noto Sans Mono"',
+    notosansmonocjk: '"Noto Sans Mono CJK SC"',
     // Popular coding fonts (Nerd Font versions for terminal icon support)
-    jetbrains: '"JetBrains Mono", ui-monospace, monospace',
-    firacode: '"Fira Code", ui-monospace, monospace',
-    saucecodepro: '"SauceCodePro Nerd Font Mono", "SauceCodePro NFM", ui-monospace, monospace',
-    ibmplexmono: '"IBM Plex Mono", ui-monospace, monospace',
-    hack: 'Hack, ui-monospace, monospace',
-    inconsolata: 'Inconsolata, ui-monospace, monospace',
+    jetbrains: '"JetBrains Mono"',
+    firacode: '"Fira Code"',
+    saucecodepro: '"SauceCodePro Nerd Font Mono", "SauceCodePro NFM"',
+    ibmplexmono: '"IBM Plex Mono"',
+    hack: "Hack",
+    inconsolata: "Inconsolata",
   },
 };
 
 /**
- * Resolve the monospace font stack for a given `monoFont` setting key. Pure —
- * no DOM access. This is the same mapping `buildFontStack` applies to the
- * editor's `--font-mono`, exposed on its own so the live terminal-font sync can
- * read the new font straight from the setting instead of round-tripping through
- * the CSS var (which `useTheme` only writes in a later effect).
+ * The fallback appended to every monospace stack, per platform.
+ *
+ * This is hygiene, NOT the fix for #1334 — that lives in
+ * `services/fonts/verifiedMonoStack`, which measures what the engine actually
+ * renders. Two explanations were tried here first and both were refuted by
+ * measurement on Ubuntu 24.04.4 / WebKitGTK 4.1; the note is kept because the
+ * refutations are the useful part:
+ *
+ *   - "`ui-monospace` is unimplemented on GTK, and a generic always matches, so
+ *     it wins the cascade." Half right. It IS unimplemented — WebKit's own GTK
+ *     expectations say so (`webkit.org/b/304535`) and alone it yields a
+ *     proportional font. But in a LIST it is skipped like an absent family:
+ *     `ui-monospace, monospace` measures 8/8 under `LANG=C`.
+ *   - "It only bites when the GTK UI font is a real installed family." Also
+ *     refuted: setting `gtk-font-name=DejaVu Sans 11` (confirmed read back from
+ *     `Gtk.Settings`) changed nothing.
+ *
+ * What actually triggers it is the LOCALE. Under `LANG=zh_CN.UTF-8` with
+ * `fonts-noto-cjk` installed, `"No Such Family XYZ", monospace` measures 11/4 —
+ * proportional — because fontconfig returns a best match for ANY family name
+ * instead of reporting no match, and WebKit accepts it, so the cascade never
+ * reaches the generic. `ui-monospace` is not special; any unmatched head family
+ * does it.
+ *
+ * So the tail is only worth keeping for what it plainly is: `ui-monospace` is
+ * the ONLY way to reach SF Mono in WebKit on macOS (measured — `"SF Mono"` and
+ * `SFMono-Regular` both fail to match by name, the real family being the hidden
+ * `.SF NS Mono`), and it means nothing on Linux, so it is not emitted there.
+ * Reordering alone never fixed the bug and must not be relied on to.
  */
-export function resolveMonoFontStack(monoFont: string): string {
-  return (
-    fontStacks.mono[monoFont as keyof typeof fontStacks.mono] ||
-    fontStacks.mono.system
-  );
+const MONO_TAIL: Record<RuntimePlatform, string> = {
+  // ui-monospace → SF Mono. Falls through to the generic (Menlo) if it ever
+  // stops resolving, which is what the old explicit chain resolved to anyway.
+  macos: "ui-monospace, monospace",
+  // WebView2 is Chromium; ui-monospace maps to the fixed-font preference.
+  windows: "ui-monospace, monospace",
+  // WebKitGTK: ui-monospace is unimplemented here, so emitting it is noise.
+  // The generic honours the desktop's own monospace choice, which is what the
+  // native terminal uses — but it is NOT a guarantee on its own; see
+  // services/fonts/verifiedMonoStack.
+  linux: "monospace",
+};
+
+/**
+ * Resolve the monospace font stack for a given `monoFont` setting key. Pure —
+ * no DOM access; pass `getRuntimePlatform()` from the call site. This is the
+ * same mapping `buildFontStack` applies to the editor's `--font-mono`, exposed
+ * on its own so the live terminal-font sync can read the new font straight from
+ * the setting instead of round-tripping through the CSS var (which `useTheme`
+ * only writes in a later effect).
+ *
+ * An unknown key resolves to the platform tail alone, i.e. exactly what the
+ * `system` key gives — the pre-#1334 behaviour, which fell back to `system`.
+ */
+export function resolveMonoFontStack(
+  monoFont: string,
+  platform: RuntimePlatform,
+): string {
+  const named =
+    fontStacks.mono[monoFont as keyof typeof fontStacks.mono] ??
+    fontStacks.mono.system;
+  const tail = MONO_TAIL[platform];
+  return named ? `${named}, ${tail}` : tail;
 }
 
 /**
@@ -108,11 +185,19 @@ function stripTrailingGenerics(stack: string): string {
   return parts.join(", ");
 }
 
-/** Build font stacks from font key selections. Pure — no DOM access. */
+/**
+ * Build font stacks from font key selections. Pure — no DOM access; pass
+ * `getRuntimePlatform()` from the call site.
+ *
+ * `platform` is required rather than defaulted: defaulting to "macos" is what
+ * `getRuntimePlatform`'s own doc warns against, and here it would hand a Linux
+ * user the `ui-monospace` stack this function exists to keep away from them.
+ */
 export function buildFontStack(
   latinFont: string,
   cjkFont: string,
-  monoFont: string
+  monoFont: string,
+  platform: RuntimePlatform
 ): { sans: string; mono: string } {
   const latinStack =
     fontStacks.latin[latinFont as keyof typeof fontStacks.latin] ||
@@ -120,15 +205,12 @@ export function buildFontStack(
   const cjkStack =
     fontStacks.cjk[cjkFont as keyof typeof fontStacks.cjk] ||
     fontStacks.cjk.system;
-  const monoStack =
-    fontStacks.mono[monoFont as keyof typeof fontStacks.mono] ||
-    fontStacks.mono.system;
 
   // Strip the Latin stack's trailing generic so CJK glyph resolution reaches
   // the CJK stack (#1056). The CJK stack keeps its own trailing generic, which
   // becomes the overall fallback.
   return {
     sans: `${stripTrailingGenerics(latinStack)}, ${cjkStack}`,
-    mono: monoStack,
+    mono: resolveMonoFontStack(monoFont, platform),
   };
 }

--- a/website/guide/settings.md
+++ b/website/guide/settings.md
@@ -65,7 +65,7 @@ Typography, display, editing behavior, and whitespace settings.
 |---------|-------------|---------|---------|
 | Latin Font | Font family for Latin (English) text | System Default | System Default, Athelas, Palatino, Georgia, Charter, Literata |
 | CJK Font | Font family for Chinese, Japanese, Korean text | System Default | System Default, PingFang SC, Songti SC, Kaiti SC, Noto Serif CJK, Source Han Sans |
-| Mono Font | Font family for code and monospace text | System Default | System Default, SF Mono, Monaco, Menlo, Consolas, JetBrains Mono, Fira Code, SauceCodePro NFM, IBM Plex Mono, Hack, Inconsolata |
+| Mono Font | Font family for code and monospace text — also used by the integrated terminal | System Default | System Default, SF Mono, Monaco, Menlo, Consolas, DejaVu Sans Mono, Liberation Mono, Ubuntu Mono, Noto Sans Mono, Noto Sans Mono CJK SC, JetBrains Mono, Fira Code, SauceCodePro NFM, IBM Plex Mono, Hack, Inconsolata |
 | Font Size | Base font size for editor content | 18px | 14px, 16px, 18px, 20px, 22px |
 | Line Height | Vertical spacing between lines | 1.8 (Relaxed) | 1.4 (Compact), 1.6 (Normal), 1.8 (Relaxed), 2.0 (Spacious), 2.2 (Extra) |
 | Block Spacing | Visual gap between block elements (headings, paragraphs, lists) measured in multiples of line height | 1x (Normal) | 0.5x (Tight), 1x (Normal), 1.5x (Relaxed), 2x (Spacious) |

--- a/website/guide/terminal.md
+++ b/website/guide/terminal.md
@@ -208,6 +208,13 @@ Open **Settings → Terminal** to configure:
 
 Changes apply immediately to all open sessions. **Panel Size** goes up to 80 % of the available space. The editor keeps a minimum size in pixels, so it never disappears entirely no matter how large the terminal gets. Double-click the resize handle to jump straight to the maximum and back again without changing the stored size. **Mac Option as Meta** routes the macOS Option key as Meta in the integrated terminal so emacs, tmux, and similar tools see Alt-prefixed shortcuts (macOS only); it is on by default, so Option+Arrow does word movement rather than inserting accented characters. **Shell Integration** is available on macOS and Linux (hidden on Windows). **Remote Clipboard** is described below. **Scrollback** controls how many lines of output each session retains in its scroll history — higher values use more memory. **Screen Reader Mode** exposes terminal output to assistive technology such as VoiceOver; it is off by default for performance. **Terminal bell** chooses how a bell (BEL) is signalled — a visual background-activity mark on the session tab, a soft audible beep (which also flags a background session's tab so you can find it), or nothing. **Minimum contrast** lifts faint terminal text to a readable contrast ratio against its background; raise it for accessibility or set it to Off to disable the lift.
 
+::: tip Terminal font family
+The terminal uses the **Mono Font** from **Settings → Editor**, not a font of
+its own, so changing it there restyles code blocks, Source mode and the terminal
+together. On Linux the System Default option follows your desktop's own
+monospace font, which is what your system terminal uses.
+:::
+
 ::: tip Font size and zoom
 `Mod + =` / `Mod + -` zoom in steps of 2 px, so the terminal font can land on a
 value the dropdown doesn't list (13 → 15 → 17 …). The dropdown shows whatever


### PR DESCRIPTION
Closes #1334. Companion to #1335, which fixes the locale half of the same report; the two touch different files and can land in either order.

## The bug

The integrated terminal rendered every character in an oversized cell on a Chinese-locale Ubuntu desktop — Latin and CJK alike, under every renderer, unaffected by the WebGL toggle or by fixing the locale.

The CSS cascade is supposed to skip a family that is not installed. **On WebKitGTK under a CJK locale it does not.** fontconfig returns a best match for *any* family name rather than reporting no match, WebKit accepts it, and the cascade stops at the unmatched head family instead of reaching the generic behind it.

Measured on Ubuntu 24.04.4 + `fonts-noto-cjk` + WebKitGTK 4.1, comparing the mean advance of `'W' × 32` against `'i' × 32` — the quantity xterm.js's `CharSizeService` derives its character cell from:

| stack | `LANG=C` | `LANG=zh_CN.UTF-8` |
|---|---|---|
| `"No Such Family XYZ", monospace` | 8 / 8 | **11 / 4 — proportional** |
| `"JetBrains Mono", monospace` (absent) | 8 / 8 | **11 / 4 — proportional** |
| `monospace` | 8 / 8 | 7 / 7 |

A proportional font makes every cell as wide as a `W` while narrow glyphs keep their own advance, so the whole grid spaces out. The editor's code blocks and Source mode read the same `--font-mono` and were wrong with it.

## The fix

`services/fonts/verifiedMonoStack` drops leading families until the remainder **measures** monospace — performing the cascade step the engine skipped. An installed font is kept; an absent one degrades.

Verified by running the shipped algorithm inside real WebKitGTK on the repro host, across all 16 mono settings:

| locale | broken before | broken after |
|---|---|---|
| `zh_CN.UTF-8` | **9 of 16** | **0** |
| `C` | 0 of 16 | 0 |

Installed families survive (`"DejaVu Sans Mono", monospace`, `"Ubuntu Mono", monospace`); absent ones fall back to the generic. It is a no-op where there is no bug.

## Why it asserts the property instead of modelling the cause

Two mechanisms were proposed for this bug and **measurement refuted both**:

- *"`ui-monospace` is unimplemented on GTK, and a generic always matches, so it wins the cascade."* Half right. It **is** unimplemented — WebKit's own GTK expectations say so (`webkit.org/b/304535`) and alone it yields a proportional font. But in a *list* it is skipped like any absent family: `ui-monospace, monospace` measures 8/8 under `LANG=C`.
- *"It only bites when the GTK UI font is a real installed family."* Also refuted — setting `gtk-font-name=DejaVu Sans 11`, confirmed read back from `Gtk.Settings`, changed nothing.

What survived every explanation is the property the terminal actually needs: a uniform advance. So that is what is checked. `ui-monospace` is still kept out of the Linux tail as hygiene — it means nothing there — while staying on macOS, where it is the only route to SF Mono (`"SF Mono"` and `SFMono-Regular` do not match by family name; the real family is the hidden `.SF NS Mono`). Reordering alone never fixed this and is not relied on.

Also adds the Linux distro families to the Mono Font picker, which previously offered a Linux user nothing that ships on their machine.

## The test that had to be replaced

An earlier attempt at this shipped a real-WebKit test asserting VMark's stacks measure monospace, including a case named *"when the chosen family is not installed"*. **It passed on macOS and on CI's Linux WebKit while the bug was live** — neither has a CJK locale, so the precondition was absent and the assertion could not fail. Green meant "not exercised".

The replacement constructs its own failure condition instead of borrowing one from the host: it leads a stack with `sans-serif`, a generic that always resolves and is always proportional on every engine and every font configuration. Confirmed RED by disabling the mechanism — it fails on macOS, where the original could not. The unit test injects the measurement entirely, so the algorithm is driven deterministically.

## Drive-by, in its own commit

`check-design-tokens` globs `src/**/*.{ts,tsx}` and `readFileSync`s every hit. Vitest's browser runner writes screenshot artifacts into a `__screenshots__` directory **named after the test file**, so after any `*.webkit.test.ts` failure there is a directory whose name ends in `.ts` — and those directories are gitignored, i.e. expected on a developer machine. One of them threw an unhandled `EISDIR` and killed the gate with a raw Node stack trace. Any failing browser test arms it; I hit it writing this PR. `globFiles()` filters to regular files, pinned by a test that builds the exact shape.

`pnpm check:all` green, `pnpm test:browser` green (54 tests).
