### PR TITLE
fix: hide the Linux print helper window behind the system dialog (fixes #1341)

### DIFF
--- a/scripts/check-ui-phase.sh
+++ b/scripts/check-ui-phase.sh
@@ -11,9 +11,10 @@
 # scripts/check-gha-phase.sh (rule 60 §3).
 #
 # The plan itself is maintainer-local (dev-docs/ is gitignored), so this
-# script asserts TREE state only — files, npm wiring, baselines, gate output —
-# and can run on any checkout that has the dev-docs folder for the fixture
-# assertions (phase 0's PNGs and reference doc live there).
+# script asserts TREE state only — files, npm wiring, baselines, gate output.
+# The fixture assertions under dev-docs/ (phase 0's PNGs and reference doc,
+# phase 4's design-system.md) run only where that folder exists, and
+# VMARK_UI_PHASE_NO_DEVDOCS=1 skips them explicitly — see has_devdocs.
 
 set -uo pipefail
 
@@ -68,6 +69,17 @@ assert_empty_list() {
   " 2>/dev/null; then ok "$label"; else fail "$label ($key in $file is not empty)"; fi
 }
 
+# dev-docs/ is maintainer-local (gitignored — AGENTS.md). The self-test sets
+# VMARK_UI_PHASE_NO_DEVDOCS=1 to force the absent branch: a sibling gate test
+# (clean-dev.test.mjs) fabricates fixtures under the REAL dev-docs/ in the
+# same vitest tier, so probing the directory mid-run is the read half of a
+# TOCTOU race — on a checkout where dev-docs/ is normally absent (CI, a fresh
+# worktree) the probe can see the transient fixture and then demand
+# maintainer files the fixture does not carry.
+has_devdocs() {
+  [[ "${VMARK_UI_PHASE_NO_DEVDOCS:-0}" != "1" && -d dev-docs ]]
+}
+
 case "$PHASE" in
   0)
     echo "Phase 0 — Instrument:"
@@ -94,16 +106,15 @@ case "$PHASE" in
     assert_cmd "lint:theme-contrast green" pnpm lint:theme-contrast
     assert_cmd "lint:ui-consistency green" pnpm lint:ui-consistency
     assert_cmd "lint:design-tokens green" pnpm lint:design-tokens
-    # dev-docs/ is maintainer-local (gitignored — AGENTS.md); the visual-QA
-    # fixtures exist only where the folder does. Same skip rule as phase 4.
-    if [[ -d dev-docs ]]; then
+    # Visual-QA fixtures exist only where dev-docs/ does — see has_devdocs.
+    if has_devdocs; then
       assert_file dev-docs/css-reference.md "visual-QA reference doc"
       assert_file dev-docs/e2e-testing.md "e2e harness runbook"
       for theme in white paper mint sepia night solarized; do
         assert_file "dev-docs/baselines/${theme}.png" "baseline screenshot ${theme}"
       done
     else
-      ok "dev-docs/ absent (CI runner) — visual-QA fixture checks skipped per AGENTS.md"
+      ok "visual-QA fixture checks skipped — dev-docs/ absent or disabled (AGENTS.md)"
     fi
     ;;
   1)
@@ -143,12 +154,11 @@ case "$PHASE" in
   4)
     echo "Phase 4 — Copy + semantics + docs:"
     assert_file src/services/dialogs/confirmAction.ts
-    # dev-docs/ is maintainer-local (gitignored — AGENTS.md): the folder does
-    # not exist on a CI runner, so the doc check applies only where it can.
-    if [[ -d dev-docs ]]; then
+    # The doc lives only where dev-docs/ does — see has_devdocs.
+    if has_devdocs; then
       assert_file dev-docs/design-system.md
     else
-      ok "dev-docs/ absent (CI runner) — design-system.md check skipped per AGENTS.md"
+      ok "design-system.md check skipped — dev-docs/ absent or disabled (AGENTS.md)"
     fi
     assert_cmd "lint:i18n green (casing/punctuation checks live there)" pnpm lint:i18n
     assert_cmd "lint:keybinding-manifest green (label parity)" pnpm lint:keybinding-manifest

--- a/scripts/check-ui-phase.test.mjs
+++ b/scripts/check-ui-phase.test.mjs
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, chmodSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,7 +25,15 @@ function run(...args) {
   return spawnSync("bash", ["scripts/check-ui-phase.sh", ...args], {
     cwd: REPO,
     encoding: "utf8",
-    env: { ...process.env, PATH: `${shimDir}:${process.env.PATH}` },
+    env: {
+      ...process.env,
+      PATH: `${shimDir}:${process.env.PATH}`,
+      // clean-dev.test.mjs fabricates fixtures under the REAL dev-docs/ in
+      // this same tier, so a `-d dev-docs` probe mid-run is a race with a
+      // sibling worker. Force the absent branch so the assertion set is
+      // deterministic on every machine class.
+      VMARK_UI_PHASE_NO_DEVDOCS: "1",
+    },
   });
 }
 
@@ -46,13 +54,54 @@ describe("check-ui-phase.sh", () => {
     const res = run("4");
     expect(res.status).toBe(0);
     expect(res.stdout).toContain("confirmAction.ts exists");
+    // Pins that the no-devdocs override took effect — without it this run
+    // would race clean-dev.test.mjs's fixture on any checkout where
+    // dev-docs/ is absent (CI, fresh worktrees).
+    expect(res.stdout).toContain("dev-docs/ absent or disabled");
+  });
+
+  // The override above never exercises the maintainer branch, so on a real
+  // maintainer tree run phases 0 and 4 once without it. The condition is
+  // dev-docs/README.md — the index AGENTS.md mandates — chosen because it is
+  // INDEPENDENT of every artifact these runs assert: deleting an asserted
+  // artifact fails the test rather than skipping it. No gate test fabricates
+  // README.md in the real repo (clean-dev.test.mjs creates only grills/
+  // fixtures; the followups tests build temp roots), and on a tree where
+  // README.md exists dev-docs/ itself is permanent, so nothing here races.
+  const MAINTAINER_TREE = existsSync(path.join(REPO, "dev-docs/README.md"));
+
+  function runMaintainer(phase) {
+    return spawnSync("bash", ["scripts/check-ui-phase.sh", phase], {
+      cwd: REPO,
+      encoding: "utf8",
+      // "0" explicitly: an override inherited from the caller's environment
+      // must not silently turn this into a second absent-branch run.
+      env: {
+        ...process.env,
+        PATH: `${shimDir}:${process.env.PATH}`,
+        VMARK_UI_PHASE_NO_DEVDOCS: "0",
+      },
+    });
+  }
+
+  it.runIf(MAINTAINER_TREE)("phase 4 maintainer branch asserts the real doc", () => {
+    const res = runMaintainer("4");
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("dev-docs/design-system.md exists");
+  });
+
+  it.runIf(MAINTAINER_TREE)("phase 0 maintainer branch asserts the visual-QA fixtures", () => {
+    const res = runMaintainer("0");
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("visual-QA reference doc exists");
+    expect(res.stdout).toContain("baseline screenshot night exists");
   });
 
   it("phase 0 reports every gate wiring assertion", () => {
     const res = run("0");
-    // The wiring half of phase 0 is landed; PNG fixtures may or may not exist
-    // on this machine (dev-docs is maintainer-local). Assert the assertions
-    // RAN, and that none of the wiring ones failed.
+    // The wiring half of phase 0 is landed; the run() override always skips
+    // the dev-docs fixture block (see run above). Assert the wiring
+    // assertions RAN, and that none of them failed.
     expect(res.stdout).toContain("lint:theme-contrast npm entry");
     expect(res.stdout).not.toMatch(/✗ .*npm entry/);
     expect(res.stdout).not.toMatch(/✗ .*registered/);

--- a/src-tauri/src/pdf_export/renderer/linux.rs
+++ b/src-tauri/src/pdf_export/renderer/linux.rs
@@ -189,9 +189,9 @@ fn path_to_file_url(path: &str) -> Result<String, CommandError> {
 
 /// Show the system print dialog for the rendered document.
 ///
-/// Settles once the dialog has been SHOWN. `webkit_print_operation_run_dialog`
-/// is where the user takes over, and like the other two platforms we cannot
-/// report what they choose to do there.
+/// Settles once the user has DISMISSED the dialog —
+/// `webkit_print_operation_run_dialog` blocks until they respond. Like the
+/// other two platforms we do not report what they chose to do there.
 pub(super) fn print_on_main_thread(
     app: &AppHandle,
     html_path: &str,
@@ -211,9 +211,16 @@ fn start_print(
     let label = format!("{LABEL_PREFIX}{}", uuid::Uuid::new_v4().simple());
     let file_url = path_to_file_url(html_path)?;
     let blank = "about:blank".parse().expect("about:blank parses");
-    // Visible: a print dialog floating over nothing is disorienting.
+    // Hidden, like the export path in `start()`. This window used to be
+    // visible on the theory that a print dialog floating over nothing is
+    // disorienting — but users read the raw-document window behind the
+    // dialog as a stray bug window (#1341), and macOS shows only the print
+    // panel. A hidden WebKitGTK webview provably still renders and prints:
+    // `start()` has always printed from a `.visible(false)` window. Do NOT
+    // unify this with Windows — there, `ShowPrintUI` draws the print UI
+    // INSIDE the webview window, so hiding it would hide the dialog itself.
     let window = WebviewWindowBuilder::new(app, &label, WebviewUrl::External(blank))
-        .visible(true)
+        .visible(false)
         .title("VMark Print")
         .build()
         .map_err(|e| window_error(&e.to_string()))?;
@@ -247,8 +254,9 @@ fn start_print(
                     return;
                 }
                 let op = PrintOperation::new(view);
-                // No parent window: passing the render window would tie the
-                // dialog's lifetime to a window the user may close under it.
+                // No parent window: the render window is hidden, and a
+                // transient parent that is never mapped gives the WM nothing
+                // to stack against — the dialog floats free, as it always has.
                 // Turbofish: `None` alone is ambiguous — the parameter is
                 // generic over `IsA<gtk::Window>` with nothing to infer from.
                 op.run_dialog(None::<&gtk::Window>);

--- a/src-tauri/src/pdf_export/renderer/mod.rs
+++ b/src-tauri/src/pdf_export/renderer/mod.rs
@@ -251,9 +251,11 @@ pub async fn print_document(app: AppHandle, html: String) -> Result<(), CommandE
 
     app.run_on_main_thread(move || {
         // Same sink contract as render: macOS settles synchronously because
-        // its panel is modal, while Windows and Linux settle once the dialog
-        // has been SHOWN. None of the three can detect what the user then does
-        // with it — that has always been the documented contract here.
+        // its panel is modal, Windows settles once the dialog has been SHOWN
+        // (ShowPrintUI is asynchronous), and Linux settles once the user has
+        // DISMISSED the dialog (run_dialog blocks until they respond). None
+        // of the three reports what the user chose — that has always been the
+        // documented contract here.
         #[cfg(target_os = "windows")]
         windows_print::print_on_main_thread(&app_clone, &temp_html_str, &temp_dir_str, sink_clone);
         #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary

- On Linux, Ctrl+P / File → Print showed the GTK print dialog plus a bare "VMark Print" window behind it displaying the raw rendered document, lingering until the user answered the dialog. That window is the print helper webview `start_print()` builds to load the export HTML — it was deliberately `.visible(true)` on the theory that a dialog floating over nothing is disorienting.
- Users read it as a stray bug window (#1341), and macOS shows only the print panel. The helper is now `.visible(false)`.
- Hiding is provably safe: the sibling export path — `start()` in the same file — has always rendered and printed to PDF from a `.visible(false)` WebKitGTK window. Windows is deliberately NOT unified: its `ShowPrintUI` draws the print UI inside the webview window, so a hidden window there would hide the dialog itself; the rewritten comment records that asymmetry.

Fixes #1341

## What Changed

- `src-tauri/src/pdf_export/renderer/linux.rs` — `start_print()` builds the helper window with `.visible(false)`; the adjacent comment now records why hidden is correct, why the old visible choice existed, and why Windows must stay visible. Three stale lifecycle comments corrected in the same pass (audit findings): the `print_on_main_thread` doc and the `mod.rs` sink-contract comment claimed Linux settles when the dialog is shown — `run_dialog` blocks, so it settles when the user dismisses it; and the parentless-dialog rationale claimed the user could close the helper window, which a hidden window makes impossible (the real reason: an unmapped window gives the WM nothing to stack a transient dialog against).
- `scripts/check-ui-phase.sh` + `scripts/check-ui-phase.test.mjs` — pre-existing gate flake hit while gating this branch, fixed in the same pass. `clean-dev.test.mjs` fabricates its fixture under the real `dev-docs/`, creating the folder itself on any checkout where it is absent (CI, fresh worktrees); `check-ui-phase.sh`'s `-d dev-docs` probe, running concurrently in a sibling vitest worker, saw the transient fixture and demanded `dev-docs/design-system.md`. This is the residual TOCTOU of 1d69b51ac, live on CI too. The self-test now forces the absent branch via `VMARK_UI_PHASE_NO_DEVDOCS=1` and pins that the override took effect; two `it.runIf` tests keyed on `dev-docs/README.md` — independent of every artifact they assert, so deletion fails rather than skips — keep the maintainer branch covered where the real tree exists.

## Codex Audit

Three fix-verify iterations, converged at zero findings.

- Iteration 1 (print fix): three stale lifecycle comments found and fixed (above). A "no regression test" finding was overruled — see Validation. A pre-existing spooling-lifetime concern (the helper closes as soon as `run_dialog` returns, while a confirmed print job may still be spooling) was judged orthogonal to this diff by the audit itself and is deferred to a follow-up issue rather than fixed blind: the correct fix branches on `PrintOperationResponse` and awaits `finished`/`failed` only after Print, and needs a Linux box with a delayed CUPS backend to verify.
- Iteration 2 (gate-race fix): two findings — lost maintainer-branch coverage and three newly inaccurate descriptions — both fixed.
- Iteration 3: one finding — the maintainer test was gated on the artifact it protects, so deleting it skipped the test instead of failing it. Rekeyed on the independent `dev-docs/README.md` marker, plus an explicit `VMARK_UI_PHASE_NO_DEVDOCS: "0"` in the maintainer runs and a phase-0 twin. Verified by mutation. Final verdict: zero findings.

## Validation

- `pnpm check:all` — pass (full run on the final tree).
- `pnpm check:predelta` — all 41 delta gates pass.
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — pass (rustfmt parses the cfg'd-out module, verifying syntax and formatting of the edit).
- Compile verification of `linux.rs` happens on CI's Linux `rust-test` leg: the module is cfg-gated `not(any(macos, windows))` and `webkit2gtk` is not in the dependency graph on this macOS machine, so no local cargo invocation can check it.
- No unit test is feasible for this change: it is a one-literal visibility flag on a GTK window whose behavior needs a display server and a print dialog. The sibling render path has no unit tests for the same reason — this is the repo's accepted boundary for untestable platform UI.
- The gate-race fix was mutation-verified both ways: 6/6 tests pass against a maintainer-shaped fixture tree; deleting `design-system.md` (README kept) fails the phase-4 maintainer test instead of skipping it; on a checkout without `dev-docs/` the two maintainer tests report skipped, and the forced absent branch is asserted.
- `website/guide/export.md` was checked: it already describes print as "opens the system print dialog" and never mentions the helper window — no doc change needed.

## Type of Change

- Bug fix
