### PR TITLE
fix: preserve viewport across cv-idle toggles in large WYSIWYG docs (fixes #1340)

### DIFF
--- a/.claude/hooks/gha-tdd-guard.test.mjs
+++ b/.claude/hooks/gha-tdd-guard.test.mjs
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { rmdirSync, mkdirSync, writeFileSync, rmSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 // Vitest runs with cwd = repo root; import.meta.url is a virtual URL under the
@@ -28,10 +28,14 @@ function runGuard(payload) {
 const write = (file_path) => ({ tool_name: "Write", tool_input: { file_path } });
 
 // Temp fixtures created under a real in-scope dir so the guard's filesystem
-// checks (isFile on the sibling candidate) hit real paths.
-const DIR_AS_TEST = join(REPO, "src/lib/browser/__guardspec_dir__.test.ts");
+// checks (isFile on the sibling candidate) hit real paths. Names carry the
+// pid so two concurrent vitest invocations on one checkout (a manual
+// test:gates beside a running check:predelta) never create or delete each
+// other's probes.
+const TAG = `__guardspec_${process.pid}__`;
+const DIR_AS_TEST = join(REPO, `src/lib/browser/${TAG}_dir.test.ts`);
 const TESTS_DIR = join(REPO, "src/lib/browser/__tests__");
-const TESTS_FILE = join(TESTS_DIR, "__guardspec_sub__.test.ts");
+const TESTS_FILE = join(TESTS_DIR, `${TAG}_sub.test.ts`);
 
 beforeAll(() => {
   mkdirSync(DIR_AS_TEST, { recursive: true }); // a DIRECTORY named like a test
@@ -43,7 +47,16 @@ beforeAll(() => {
 
 afterAll(() => {
   rmSync(DIR_AS_TEST, { recursive: true, force: true });
-  rmSync(TESTS_DIR, { recursive: true, force: true });
+  // File-precise, then a NON-recursive rmdir: mkdirSync(recursive) succeeds
+  // on a pre-existing __tests__/ too, and a recursive rm here would silently
+  // delete any real tests that directory had acquired. rmdir refuses a
+  // non-empty directory, which is exactly the safe outcome.
+  rmSync(TESTS_FILE, { force: true });
+  try {
+    rmdirSync(TESTS_DIR);
+  } catch {
+    // non-empty or already gone — leave it alone
+  }
 });
 
 describe("gha-tdd-guard — pass-through (not our business)", () => {
@@ -96,7 +109,7 @@ describe("gha-tdd-guard — scope + allow-list", () => {
   });
 
   it("allows a scoped source when the test lives in __tests__/", () => {
-    expect(runGuard(write("src/lib/browser/__guardspec_sub__.ts")).status).toBe(0);
+    expect(runGuard(write(`src/lib/browser/${TAG}_sub.ts`)).status).toBe(0);
   });
 
   it("allows the test file itself", () => {
@@ -115,7 +128,7 @@ describe("gha-tdd-guard — scope + allow-list", () => {
 describe("gha-tdd-guard — directory named like a test does not satisfy the gate", () => {
   it("blocks when the sibling test path is a DIRECTORY, not a file", () => {
     // isFile() must reject a directory named foo.test.ts.
-    expect(runGuard(write("src/lib/browser/__guardspec_dir__.ts")).status).toBe(2);
+    expect(runGuard(write(`src/lib/browser/${TAG}_dir.ts`)).status).toBe(2);
   });
 });
 

--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -173,6 +173,28 @@ export function globFiles(pattern) {
   });
 }
 
+/**
+ * `readFileSync` with `globFiles`' race contract carried through to the read:
+ * the stat filter above cannot close the window between glob and read, and a
+ * scanned file CAN vanish inside it — `gha-tdd-guard.test.mjs` writes probe
+ * `*.test.ts` files into `src/lib/browser/` and deletes them while the gates
+ * tier runs this CLI against the real tree (the same transient that gave
+ * `check-scripts-parity` a ~25% flake rate before its single-snapshot fix).
+ * A vanished file is "not ours to read", exactly like a raced delete at stat
+ * time; anything other than ENOENT still throws.
+ *
+ * @param {string} file
+ * @returns {string | null} contents, or null when the file no longer exists
+ */
+export function readScannedFile(file) {
+  try {
+    return readFileSync(file, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
 // Main guard: this module EXPORTS collectJsDefinedVars for tests, so importing
 // it must not run the checker. Without it the importer's argv leaked in —
 // vitest's "run" was treated as a CSS path and the import threw ENOENT.
@@ -181,6 +203,16 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   const fileArgs = args.filter((a) => !a.startsWith("--"));
   const fixtureMode = fileArgs.length > 0;
   const files = fixtureMode ? fileArgs : globFiles("src/**/*.css");
+
+  // Explicit fixture arguments are claims, not discoveries: a mistyped or
+  // missing path must fail LOUD (readFileSync throws here, before any scan),
+  // and their contents are captured NOW so even a deletion mid-run cannot
+  // demote them to a quiet skip. Only glob-discovered paths get
+  // readScannedFile's ENOENT tolerance.
+  const fixtureContents = fixtureMode
+    ? new Map(files.map((f) => [f, readFileSync(f, "utf8")]))
+    : new Map();
+  const readTree = (file) => fixtureContents.get(file) ?? readScannedFile(file);
 
   const violations = [];
 
@@ -227,7 +259,8 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   ];
 
   for (const file of files) {
-    const content = readFileSync(file, "utf8");
+    const content = readTree(file);
+    if (content === null) continue;
 
     for (const focus of findFocusRemovals(content)) {
       violations.push({
@@ -277,17 +310,20 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
     const defRe = /--[A-Za-z0-9-]+(?=\s*:)/g;
     // CSS definitions across all stylesheets (and any fixture files given)
     for (const file of [...globFiles("src/**/*.css"), ...files]) {
-      const content = readFileSync(file, "utf8");
+      const content = readTree(file);
+      if (content === null) continue;
       for (const m of content.matchAll(defRe)) definedVars.add(m[0]);
     }
     // JS-emitted tokens: setProperty("--x", ...) and "--x": value maps
     for (const file of globFiles("src/**/*.{ts,tsx}")) {
-      const content = readFileSync(file, "utf8");
+      const content = readTree(file);
+      if (content === null) continue;
       for (const name of collectJsDefinedVars(content)) definedVars.add(name);
     }
     const useRe = /var\(\s*(--[A-Za-z0-9-]+)\s*\)/g; // no-fallback uses only
     for (const file of files) {
-      const content = readFileSync(file, "utf8");
+      const content = readTree(file);
+      if (content === null) continue;
       for (const m of content.matchAll(useRe)) {
         const name = m[1];
         if (definedVars.has(name)) continue;
@@ -315,10 +351,13 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
     const rgbaFindings = [];
     const declaredKeyframes = new Set();
     for (const file of [...globFiles("src/**/*.css"), ...(fixtureMode ? files : [])]) {
-      for (const name of collectKeyframes(readFileSync(file, "utf8"))) declaredKeyframes.add(name);
+      const keyframeSource = readTree(file);
+      if (keyframeSource === null) continue;
+      for (const name of collectKeyframes(keyframeSource)) declaredKeyframes.add(name);
     }
     for (const file of files) {
-      const content = readFileSync(file, "utf8");
+      const content = readTree(file);
+      if (content === null) continue;
       if (!COLOR_EXCLUDE.some((re) => re.test(file))) {
         rgbaFindings.push(...findColorFnLiterals(content, file));
       }
@@ -336,9 +375,10 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
     // C2g — className literals, tree mode only (the TSX surface).
     const classNameFindings = fixtureMode
       ? []
-      : globFiles("src/**/*.{ts,tsx}").flatMap((file) =>
-          findClassNameLiterals(readFileSync(file, "utf8"), file),
-        );
+      : globFiles("src/**/*.{ts,tsx}").flatMap((file) => {
+          const source = readTree(file);
+          return source === null ? [] : findClassNameLiterals(source, file);
+        });
 
     // Identity-baseline comparison for C2b + C2g: new entries and stale
     // entries both fail (house rule — record the win).
@@ -394,7 +434,8 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
       const useRe = /var\(\s*(--[A-Za-z0-9-]+)/g;
       const quotedRe = /["'`](--[A-Za-z0-9-]+)["'`]/g;
       for (const file of [...globFiles("src/**/*.css"), ...globFiles("src/**/*.{ts,tsx}")]) {
-        const content = readFileSync(file, "utf8");
+        const content = readTree(file);
+        if (content === null) continue;
         for (const m of content.matchAll(useRe)) consumedVars.add(m[1]);
         for (const m of content.matchAll(quotedRe)) consumedVars.add(m[1]);
       }

--- a/scripts/check-design-tokens.test.ts
+++ b/scripts/check-design-tokens.test.ts
@@ -19,7 +19,42 @@ import { describe, it, expect } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { collectJsDefinedVars, findFocusRemovals, globFiles } from "./check-design-tokens.mjs";
+import {
+  collectJsDefinedVars,
+  findFocusRemovals,
+  globFiles,
+  readScannedFile,
+} from "./check-design-tokens.mjs";
+
+describe("readScannedFile", () => {
+  // Carries globFiles' race contract through to the read: a scanned file CAN
+  // vanish between glob and read (gha-tdd-guard.test.mjs deletes its probe
+  // *.test.ts files under src/ while the gates tier runs this CLI against the
+  // real tree). ENOENT means "no longer ours to read"; everything else is a
+  // real failure and must stay loud.
+  it("returns contents for a file that exists", () => {
+    const root = mkdtempSync(join(tmpdir(), "design-tokens-read-"));
+    try {
+      writeFileSync(join(root, "a.css"), ".x { color: var(--y); }");
+      expect(readScannedFile(join(root, "a.css"))).toContain("--y");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when the file vanished after the glob (ENOENT)", () => {
+    expect(readScannedFile(join(tmpdir(), "design-tokens-read-gone", "no-such.css"))).toBeNull();
+  });
+
+  it("rethrows non-ENOENT errors (a directory is a real failure, not a race)", () => {
+    const root = mkdtempSync(join(tmpdir(), "design-tokens-read-dir-"));
+    try {
+      expect(() => readScannedFile(root)).toThrow();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("collectJsDefinedVars", () => {
   it("collects setProperty() calls", () => {
@@ -415,5 +450,21 @@ describe("the CLI in fixture mode", () => {
 
   it("is green against the real tree and the committed baseline", () => {
     execFileSync(process.execPath, ["scripts/check-design-tokens.mjs"], { stdio: "pipe" });
+  });
+
+  it("fails LOUD on a missing explicit fixture argument (no quiet skip)", () => {
+    // readScannedFile tolerates ENOENT only for glob-discovered files; an
+    // explicit argument is a claim, and a typo must not exit 0.
+    let status = 0;
+    try {
+      execFileSync(
+        process.execPath,
+        ["scripts/check-design-tokens.mjs", join(tmpdir(), "design-tokens-fixture-gone", "no.css")],
+        { stdio: "pipe" },
+      );
+    } catch (e) {
+      status = (e as { status?: number }).status ?? -1;
+    }
+    expect(status).not.toBe(0);
   });
 });

--- a/scripts/check-ui-phase.sh
+++ b/scripts/check-ui-phase.sh
@@ -96,7 +96,13 @@ case "$PHASE" in
     assert_cmd "lint:design-tokens green" pnpm lint:design-tokens
     # dev-docs/ is maintainer-local (gitignored — AGENTS.md); the visual-QA
     # fixtures exist only where the folder does. Same skip rule as phase 4.
-    if [[ -d dev-docs ]]; then
+    # Probe the index file, not the bare directory: gate self-tests running in
+    # the same tier (clean-dev.test.mjs) transiently create dev-docs/grills/ on
+    # trees where dev-docs is absent, and a directory probe mistook that
+    # fixture for a maintainer tree — failing this phase only under the
+    # parallel pool. The index is the one file AGENTS.md requires of a real
+    # dev-docs and no fixture creates.
+    if [[ -f dev-docs/README.md ]]; then
       assert_file dev-docs/css-reference.md "visual-QA reference doc"
       assert_file dev-docs/e2e-testing.md "e2e harness runbook"
       for theme in white paper mint sepia night solarized; do
@@ -145,7 +151,9 @@ case "$PHASE" in
     assert_file src/services/dialogs/confirmAction.ts
     # dev-docs/ is maintainer-local (gitignored — AGENTS.md): the folder does
     # not exist on a CI runner, so the doc check applies only where it can.
-    if [[ -d dev-docs ]]; then
+    # README.md probe, not a directory probe — see the phase 0 comment for the
+    # concurrent-fixture race this avoids.
+    if [[ -f dev-docs/README.md ]]; then
       assert_file dev-docs/design-system.md
     else
       ok "dev-docs/ absent (CI runner) — design-system.md check skipped per AGENTS.md"

--- a/scripts/check-ui-phase.test.mjs
+++ b/scripts/check-ui-phase.test.mjs
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, chmodSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmdirSync, rmSync, writeFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -44,8 +44,35 @@ describe("check-ui-phase.sh", () => {
     // Until WI-UI4.x landed, this test pinned the fail-closed direction (red
     // with the missing paths named). The flip to green IS part of the DoD.
     const res = run("4");
-    expect(res.status).toBe(0);
+    expect(res.status, res.stdout + res.stderr).toBe(0);
     expect(res.stdout).toContain("confirmAction.ts exists");
+  });
+
+  it("phase 4 stays green while a sibling test's transient dev-docs fixture exists", () => {
+    // clean-dev.test.mjs creates dev-docs/grills/… in the REAL repo root and
+    // removes it in afterEach; on a tree with no dev-docs (CI, fresh worktree)
+    // that window overlaps this tier's parallel pool. A markerless dev-docs is
+    // a fixture, not a maintainer tree — the probe keys on dev-docs/README.md.
+    // Directly under dev-docs/, NOT under dev-docs/grills/: clean-dev's own
+    // "no-op when grills is absent" test early-returns whenever grills
+    // exists, and a probe inside grills would make it skip silently.
+    const probe = path.join(REPO, "dev-docs/__ui-phase-race-probe__");
+    mkdirSync(probe, { recursive: true });
+    try {
+      const res = run("4");
+      expect(res.status, res.stdout + res.stderr).toBe(0);
+    } finally {
+      // Remove only what is certainly ours: the probe itself, then a
+      // NON-recursive rmdir on dev-docs — it fails on any directory that
+      // still has content (a maintainer's real dev-docs, or a sibling test's
+      // live fixture), which is exactly the safe outcome.
+      rmSync(probe, { recursive: true, force: true });
+      try {
+        rmdirSync(path.dirname(probe));
+      } catch {
+        // non-empty or already gone — leave it alone
+      }
+    }
   });
 
   it("phase 0 reports every gate wiring assertion", () => {

--- a/scripts/clean-dev.test.mjs
+++ b/scripts/clean-dev.test.mjs
@@ -16,7 +16,7 @@
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmdirSync, rmSync, existsSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -117,17 +117,12 @@ describe("spike probe artifacts", () => {
   // existed. The sweep must take the artifact dirs and NOTHING else: the spike
   // reports are the evidence §7 requires.
   //
-  // dev-docs/ is maintainer-local and gitignored, so on CI it does not exist at
-  // all. Remember the topmost path created, exactly as withBundle does above.
+  // dev-docs/ is maintainer-local and gitignored, so on CI it does not exist
+  // at all. Cleanup removes the fixture only, then prunes empty ancestors
+  // non-recursively — see the afterEach below.
   const FIXTURE = path.join(REPO, "dev-docs/grills/__clean-dev-fixture__");
-  let fixtureRoot = null;
 
   function withFixture() {
-    let candidate = FIXTURE;
-    while (!existsSync(path.dirname(candidate)) && path.dirname(candidate) !== REPO) {
-      candidate = path.dirname(candidate);
-    }
-    fixtureRoot = existsSync(FIXTURE) ? null : candidate;
     mkdirSync(path.join(FIXTURE, "probe/target/debug"), { recursive: true });
     mkdirSync(path.join(FIXTURE, "probe/node_modules/left-pad"), { recursive: true });
     mkdirSync(path.join(FIXTURE, "probe/src"), { recursive: true });
@@ -135,12 +130,22 @@ describe("spike probe artifacts", () => {
   }
 
   afterEach(() => {
-    if (fixtureRoot && existsSync(fixtureRoot)) {
-      rmSync(fixtureRoot, { recursive: true, force: true });
-    } else if (existsSync(FIXTURE)) {
-      rmSync(FIXTURE, { recursive: true, force: true });
+    // Remove only what is certainly ours (the fixture itself), then prune
+    // now-empty ancestors with a NON-recursive rmdir: it refuses any
+    // directory that still has content — a maintainer's real dev-docs, or a
+    // sibling gate test's live fixture (check-ui-phase.test.mjs probes this
+    // same tree) — which is exactly the safe outcome. The previous cleanup
+    // recursively removed the topmost dir it had created (up to dev-docs/
+    // itself on a tree where it was absent), deleting sibling fixtures
+    // mid-test under the parallel pool.
+    rmSync(FIXTURE, { recursive: true, force: true });
+    for (const dir of [path.dirname(FIXTURE), path.join(REPO, "dev-docs")]) {
+      try {
+        rmdirSync(dir);
+      } catch {
+        break; // non-empty or already gone — leave it alone
+      }
     }
-    fixtureRoot = null;
   });
 
   const actions = (args) =>

--- a/src/components/Editor/TiptapEditor.tsx
+++ b/src/components/Editor/TiptapEditor.tsx
@@ -14,7 +14,7 @@
  *   - shouldRerenderOnTransaction: false — Tiptap's default full-React-rerender per
  *     transaction is wasted work here since state flows through Zustand selectors.
  *   - content-visibility gated on .cv-idle (off during typing) and only above
- *     CV_IDLE_CHAR_THRESHOLD; stripped during edits, skipped on small docs (#823).
+ *     CV_IDLE_CHAR_THRESHOLD; viewport-preserving toggles (#823, #1340).
  *   - Native spellcheck disabled above 100K chars where rescans block the main thread.
  *   - Cursor tracking is delayed 200ms after creation to prevent spurious sync during
  *     initial render/focus.
@@ -269,8 +269,8 @@ export function TiptapEditorInner({ hidden = false, readOnly = false, preview = 
       /* v8 ignore next -- @preserve reason: hidden/preview path skips update; not exercised in WYSIWYG update tests */
       if (hiddenRef.current || previewRef.current) return;
 
-      // Suppress content-visibility during active typing; re-enable after
-      // idle on large docs only (#823) — see suppressCvIdleDuringEdit.
+      // Suppress content-visibility during active typing; re-enable after idle,
+      // preserving the viewport (#823, #1340) — see suppressCvIdleDuringEdit.
       suppressCvIdleDuringEdit(
         editorContainerRef,
         editor.state.doc.content.size,

--- a/src/components/Editor/cvIdleViewportLock.test.ts
+++ b/src/components/Editor/cvIdleViewportLock.test.ts
@@ -1,0 +1,170 @@
+// WI: #1340 — toggling `.cv-idle` (content-visibility, #823) must not move
+// what the reader sees. jsdom has no layout, so every rect is mocked: block
+// rects are keyed on the container's live class list, which is exactly how a
+// real engine behaves — the class flip changes the geometry the next
+// getBoundingClientRect reports.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setCvIdlePreservingViewport } from "./cvIdleViewportLock";
+
+interface RectSpec {
+  top: number;
+  bottom: number;
+}
+
+function mockRect(el: Element, spec: () => RectSpec): void {
+  el.getBoundingClientRect = () => {
+    const { top, bottom } = spec();
+    return {
+      top,
+      bottom,
+      left: 0,
+      right: 0,
+      width: 0,
+      height: bottom - top,
+      x: 0,
+      y: top,
+      toJSON: () => ({}),
+    } as DOMRect;
+  };
+}
+
+function buildEditorDom(blockCount: number) {
+  const scroller = document.createElement("div");
+  scroller.style.overflowY = "auto";
+  const container = document.createElement("div");
+  container.className = "tiptap-editor cv-idle";
+  const pm = document.createElement("div");
+  pm.className = "ProseMirror";
+  const blocks: HTMLElement[] = [];
+  for (let i = 0; i < blockCount; i += 1) {
+    const p = document.createElement("p");
+    pm.appendChild(p);
+    blocks.push(p);
+  }
+  container.appendChild(pm);
+  scroller.appendChild(container);
+  document.body.appendChild(scroller);
+
+  const writes: number[] = [];
+  let scrollTop = 500;
+  Object.defineProperty(scroller, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v;
+      writes.push(v);
+    },
+  });
+  mockRect(scroller, () => ({ top: 0, bottom: 800 }));
+  return { scroller, container, blocks, writes };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("setCvIdlePreservingViewport", () => {
+  it("compensates a downward shift when removing cv-idle (real heights exceed estimates)", () => {
+    const { scroller, container, blocks } = buildEditorDom(1);
+    // With cv-idle on, off-screen estimates keep the anchor at 10; removing
+    // the class realizes true heights above it and pushes it down to 50.
+    mockRect(blocks[0], () =>
+      container.classList.contains("cv-idle") ? { top: 10, bottom: 40 } : { top: 50, bottom: 80 },
+    );
+
+    setCvIdlePreservingViewport(container, false);
+
+    expect(container.classList.contains("cv-idle")).toBe(false);
+    expect(scroller.scrollTop).toBe(540);
+  });
+
+  it("compensates an upward shift with a negative delta", () => {
+    const { scroller, container, blocks } = buildEditorDom(1);
+    mockRect(blocks[0], () =>
+      container.classList.contains("cv-idle") ? { top: 50, bottom: 80 } : { top: 10, bottom: 40 },
+    );
+
+    setCvIdlePreservingViewport(container, false);
+
+    expect(container.classList.contains("cv-idle")).toBe(false);
+    expect(scroller.scrollTop).toBe(460);
+  });
+
+  it("compensates symmetrically when re-adding the class", () => {
+    const { scroller, container, blocks } = buildEditorDom(1);
+    container.classList.remove("cv-idle");
+    mockRect(blocks[0], () =>
+      container.classList.contains("cv-idle") ? { top: 10, bottom: 40 } : { top: 50, bottom: 80 },
+    );
+
+    setCvIdlePreservingViewport(container, true);
+
+    expect(container.classList.contains("cv-idle")).toBe(true);
+    expect(scroller.scrollTop).toBe(460);
+  });
+
+  it("anchors on the first block intersecting the viewport, skipping blocks fully above it", () => {
+    const { scroller, container, blocks } = buildEditorDom(3);
+    // Scroller top edge sits at 100 — anchor selection must compare against
+    // the scroller's own rect, not viewport 0.
+    mockRect(scroller, () => ({ top: 100, bottom: 900 }));
+    // Fully above the viewport (bottom <= scroller top): never the anchor,
+    // and its post-toggle shift must not leak into the compensation.
+    mockRect(blocks[0], () =>
+      container.classList.contains("cv-idle") ? { top: 20, bottom: 90 } : { top: 220, bottom: 290 },
+    );
+    // First block whose bottom clears the scroller top: the anchor.
+    mockRect(blocks[1], () =>
+      container.classList.contains("cv-idle") ? { top: 90, bottom: 150 } : { top: 115, bottom: 175 },
+    );
+    // Below the anchor: the early-exit loop must never measure it.
+    const belowRect = vi.fn(() => ({ top: 150, bottom: 300 }));
+    mockRect(blocks[2], belowRect);
+
+    setCvIdlePreservingViewport(container, false);
+
+    expect(scroller.scrollTop).toBe(525); // 500 + (115 - 90)
+    expect(belowRect).not.toHaveBeenCalled();
+  });
+
+  it("leaves scrollTop untouched when the toggle does not move the anchor", () => {
+    const { container, blocks, writes } = buildEditorDom(1);
+    mockRect(blocks[0], () => ({ top: 10, bottom: 40 }));
+
+    setCvIdlePreservingViewport(container, false);
+
+    expect(container.classList.contains("cv-idle")).toBe(false);
+    expect(writes).toEqual([]);
+  });
+
+  it("still toggles the class when the document has no blocks", () => {
+    const { container, writes } = buildEditorDom(0);
+
+    setCvIdlePreservingViewport(container, false);
+
+    expect(container.classList.contains("cv-idle")).toBe(false);
+    expect(writes).toEqual([]);
+  });
+
+  it("still toggles the class when every block sits above the viewport", () => {
+    const { container, blocks, writes } = buildEditorDom(1);
+    mockRect(blocks[0], () => ({ top: -90, bottom: -20 }));
+
+    setCvIdlePreservingViewport(container, false);
+
+    expect(container.classList.contains("cv-idle")).toBe(false);
+    expect(writes).toEqual([]);
+  });
+
+  it("still toggles the class when detached from any scroll container", () => {
+    const container = document.createElement("div");
+    container.className = "tiptap-editor cv-idle";
+    const pm = document.createElement("div");
+    pm.className = "ProseMirror";
+    pm.appendChild(document.createElement("p"));
+    container.appendChild(pm);
+
+    expect(() => setCvIdlePreservingViewport(container, false)).not.toThrow();
+    expect(container.classList.contains("cv-idle")).toBe(false);
+  });
+});

--- a/src/components/Editor/cvIdleViewportLock.ts
+++ b/src/components/Editor/cvIdleViewportLock.ts
@@ -1,0 +1,75 @@
+/**
+ * cv-idle viewport lock
+ *
+ * Purpose: toggle the `.cv-idle` class (the content-visibility optimization
+ * for large WYSIWYG documents, #823) without moving what the reader sees
+ * (#1340). Flipping the class swaps `contain-intrinsic-size` estimates for
+ * real block heights (and back); when the blocks ABOVE the viewport change
+ * height, the content under an unchanged scrollTop shifts — on a 60K+ char
+ * document, applying Bold from the toolbar threw the selection out of view.
+ *
+ * Key decisions:
+ *   - Anchor-based compensation: measure the first block intersecting the
+ *     viewport before the class flip, re-measure after, and add the delta to
+ *     the scroll container's scrollTop. Client rects already reflect any
+ *     native scroll-anchoring adjustment the engine made during the forced
+ *     layout, so the residual delta is exactly what remains to correct —
+ *     self-correcting on Chromium/WebView2, and the whole fix on WebKit,
+ *     which has no scroll anchoring at all.
+ *   - The anchor search early-exits at the first block whose bottom clears
+ *     the scroller's top edge — O(blocks above the viewport), so a full walk
+ *     happens only with the reader at the document's very end. Each visited
+ *     rect read is a cache hit once the first read has forced layout.
+ *   - No scroller or no anchor (empty doc, everything above the viewport,
+ *     detached or display:none container): just flip the class. A zero delta
+ *     writes nothing.
+ *   - The pre-toggle rect read happens while `.cv-idle` is still applied and
+ *     the DOM is dirty from the edit, forcing one content-visibility layout
+ *     pass. Deliberate: it runs only on the FIRST edit after an idle window
+ *     (the per-keystroke hot path never gets here — see
+ *     suppressCvIdleDuringEdit), typing transactions already force that same
+ *     layout before onUpdate fires (ProseMirror's scrollToSelection reads
+ *     caret coords during updateState), and the alternative — caching anchor
+ *     geometry at idle time — mis-compensates any edit that changes heights
+ *     above the viewport (find-and-replace, MCP document edits), trading
+ *     correctness for a once-per-burst saving.
+ *
+ * @coordinates-with tiptapEditorHelpers.ts — suppressCvIdleDuringEdit wraps
+ *   both of its class toggles (the edit-time strip and the idle re-add) here
+ * @module components/Editor/cvIdleViewportLock
+ */
+import { findScrollContainer } from "@/services/editor/scrollPosition";
+
+/**
+ * Set the presence of `.cv-idle` on `container`, compensating the scroll
+ * container so the block at the top of the viewport stays put.
+ */
+export function setCvIdlePreservingViewport(container: HTMLElement, enabled: boolean): void {
+  const scroller = findScrollContainer(container);
+  const anchor = scroller ? findViewportAnchor(container, scroller) : null;
+  const beforeTop = anchor ? anchor.getBoundingClientRect().top : 0;
+
+  container.classList.toggle("cv-idle", enabled);
+
+  if (!scroller || !anchor) return;
+  // Reading the rect here forces the layout the class flip invalidated, so
+  // the delta is measured against settled geometry.
+  const delta = anchor.getBoundingClientRect().top - beforeTop;
+  if (delta !== 0) scroller.scrollTop += delta;
+}
+
+/**
+ * The first `.ProseMirror > *` block, in document order, whose bottom edge
+ * clears the scroller's top edge — i.e. the first block the reader can see.
+ * Blocks fully above the viewport are skipped; blocks below it are never
+ * measured.
+ */
+function findViewportAnchor(container: HTMLElement, scroller: HTMLElement): Element | null {
+  const blocks = container.querySelector(".ProseMirror")?.children;
+  if (!blocks || blocks.length === 0) return null;
+  const viewportTop = scroller.getBoundingClientRect().top;
+  for (let i = 0; i < blocks.length; i += 1) {
+    if (blocks[i].getBoundingClientRect().bottom > viewportTop) return blocks[i];
+  }
+  return null;
+}

--- a/src/components/Editor/editor.css
+++ b/src/components/Editor/editor.css
@@ -113,7 +113,13 @@
    DOM mutations that shift positions of off-screen blocks — edits near the top of
    a long doc cost O(blocks-after-insertion), e.g. 378ms per keystroke on a 2250-block
    doc. We apply it only when the editor is idle (initial load + between edits) and
-   strip it during active typing. The debounced toggle lives in TiptapEditor.tsx. */
+   strip it during active typing. The debounced toggle is suppressCvIdleDuringEdit
+   in tiptapEditorHelpers.ts, invoked from TiptapEditor.tsx's onUpdate.
+
+   Both toggle directions are scroll-compensated (cvIdleViewportLock.ts): swapping
+   the 2.5em estimates for real heights (and back) changes the height of content
+   above the viewport, which threw the selection out of view on every edit in
+   50K+ docs (#1340). */
 .tiptap-editor.cv-idle .ProseMirror > * {
   content-visibility: auto;
   contain-intrinsic-size: auto 2.5em;

--- a/src/components/Editor/tiptapEditorHelpers.test.ts
+++ b/src/components/Editor/tiptapEditorHelpers.test.ts
@@ -1,14 +1,16 @@
 // Tests for the spellcheck-threshold helpers: the mount-time attribute must
 // flip when a document crosses SPELLCHECK_DISABLE_CHAR_THRESHOLD mid-session
 // (the original editorProps value is computed once and never re-evaluated).
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import {
   applySpellcheckForDocSize,
   buildTiptapEditorProps,
+  CV_IDLE_CHAR_THRESHOLD,
   SPELLCHECK_DISABLE_CHAR_THRESHOLD,
   spellcheckAttrForDocSize,
+  suppressCvIdleDuringEdit,
 } from "./tiptapEditorHelpers";
 
 describe("buildTiptapEditorProps", () => {
@@ -84,5 +86,166 @@ describe("applySpellcheckForDocSize", () => {
   it("survives an editor without a mounted view", () => {
     editor.destroy();
     expect(applySpellcheckForDocSize(editor, 10)).toBe(false);
+  });
+});
+
+// #1340 — suppressCvIdleDuringEdit must preserve the viewport across BOTH
+// cv-idle toggles (the synchronous strip and the 500ms idle re-add), and must
+// skip all measurement on the per-keystroke hot path where the class is
+// already off. Rects are mocked (jsdom has no layout), keyed on the live
+// class list like a real engine's geometry would be.
+describe("suppressCvIdleDuringEdit", () => {
+  function buildCvDom() {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    const container = document.createElement("div");
+    container.className = "tiptap-editor cv-idle";
+    const pm = document.createElement("div");
+    pm.className = "ProseMirror";
+    const anchor = document.createElement("p");
+    pm.appendChild(anchor);
+    container.appendChild(pm);
+    scroller.appendChild(container);
+    document.body.appendChild(scroller);
+
+    const writes: number[] = [];
+    let scrollTop = 500;
+    Object.defineProperty(scroller, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = v;
+        writes.push(v);
+      },
+    });
+    const scrollerRect = vi.fn(() => ({ top: 0, bottom: 800 }));
+    const anchorRect = vi.fn(() =>
+      container.classList.contains("cv-idle")
+        ? { top: 10, bottom: 40 }
+        : { top: 50, bottom: 80 },
+    );
+    const toDomRect = (r: { top: number; bottom: number }) =>
+      ({
+        ...r,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: r.bottom - r.top,
+        x: 0,
+        y: r.top,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    scroller.getBoundingClientRect = () => toDomRect(scrollerRect());
+    anchor.getBoundingClientRect = () => toDomRect(anchorRect());
+    return { scroller, container, writes, scrollerRect, anchorRect };
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.useRealTimers();
+  });
+
+  it("compensates the viewport when stripping cv-idle, and again on the idle re-add", () => {
+    vi.useFakeTimers();
+    const { scroller, container } = buildCvDom();
+    const containerRef = { current: container as HTMLDivElement };
+    const timeoutRef = { current: null as number | null };
+
+    suppressCvIdleDuringEdit(containerRef, CV_IDLE_CHAR_THRESHOLD, timeoutRef);
+
+    // Strip: anchor moved 10 → 50, so the scroller follows it down.
+    expect(container.classList.contains("cv-idle")).toBe(false);
+    expect(scroller.scrollTop).toBe(540);
+    expect(timeoutRef.current).not.toBeNull();
+
+    // Idle re-add: anchor moves back 50 → 10, and the viewport returns too.
+    vi.advanceTimersByTime(500);
+    expect(container.classList.contains("cv-idle")).toBe(true);
+    expect(scroller.scrollTop).toBe(500);
+    expect(timeoutRef.current).toBeNull();
+  });
+
+  it("skips all measurement on the hot path when cv-idle is already off", () => {
+    vi.useFakeTimers();
+    const { container, writes, scrollerRect, anchorRect } = buildCvDom();
+    container.classList.remove("cv-idle");
+    const containerRef = { current: container as HTMLDivElement };
+    const timeoutRef = { current: null as number | null };
+
+    suppressCvIdleDuringEdit(containerRef, CV_IDLE_CHAR_THRESHOLD, timeoutRef);
+
+    expect(scrollerRect).not.toHaveBeenCalled();
+    expect(anchorRect).not.toHaveBeenCalled();
+    expect(writes).toEqual([]);
+    // The idle re-add is still scheduled for large docs.
+    expect(timeoutRef.current).not.toBeNull();
+    vi.advanceTimersByTime(500);
+    expect(container.classList.contains("cv-idle")).toBe(true);
+  });
+
+  it("does not schedule a re-add below the threshold but still compensates the strip", () => {
+    vi.useFakeTimers();
+    const { scroller, container } = buildCvDom();
+    const containerRef = { current: container as HTMLDivElement };
+    const timeoutRef = { current: null as number | null };
+
+    suppressCvIdleDuringEdit(containerRef, CV_IDLE_CHAR_THRESHOLD - 1, timeoutRef);
+
+    expect(container.classList.contains("cv-idle")).toBe(false);
+    expect(scroller.scrollTop).toBe(540);
+    expect(timeoutRef.current).toBeNull();
+    vi.advanceTimersByTime(2000);
+    expect(container.classList.contains("cv-idle")).toBe(false);
+  });
+
+  it("clears a pending re-add and reschedules on the next edit", () => {
+    vi.useFakeTimers();
+    const { container } = buildCvDom();
+    const containerRef = { current: container as HTMLDivElement };
+    const timeoutRef = { current: null as number | null };
+
+    suppressCvIdleDuringEdit(containerRef, CV_IDLE_CHAR_THRESHOLD, timeoutRef);
+    const first = timeoutRef.current;
+    vi.advanceTimersByTime(300);
+    suppressCvIdleDuringEdit(containerRef, CV_IDLE_CHAR_THRESHOLD, timeoutRef);
+    expect(timeoutRef.current).not.toBe(first);
+
+    // 300ms after the second edit the first timer would have fired; it must not.
+    vi.advanceTimersByTime(300);
+    expect(container.classList.contains("cv-idle")).toBe(false);
+    vi.advanceTimersByTime(200);
+    expect(container.classList.contains("cv-idle")).toBe(true);
+  });
+
+  it("re-adds class-only when the idle timer fires on a hidden editor", () => {
+    // Source mode toggled within the 500ms window: display:none geometry
+    // reports zero rects, so the re-add must still restore the class (the
+    // optimization matters when the editor returns) without measuring a
+    // compensation or writing scrollTop.
+    vi.useFakeTimers();
+    const { container, writes, anchorRect } = buildCvDom();
+    const containerRef = { current: container as HTMLDivElement };
+    const timeoutRef = { current: null as number | null };
+
+    suppressCvIdleDuringEdit(containerRef, CV_IDLE_CHAR_THRESHOLD, timeoutRef);
+    const writesAfterStrip = writes.length;
+
+    // Hide the editor before the idle timer fires, zeroing all geometry the
+    // way display:none does in a real engine.
+    container.style.display = "none";
+    anchorRect.mockImplementation(() => ({ top: 0, bottom: 0 }));
+
+    vi.advanceTimersByTime(500);
+    expect(container.classList.contains("cv-idle")).toBe(true);
+    expect(writes.length).toBe(writesAfterStrip);
+  });
+
+  it("does nothing when the container ref is empty", () => {
+    const containerRef = { current: null };
+    const timeoutRef = { current: null as number | null };
+    expect(() =>
+      suppressCvIdleDuringEdit(containerRef, CV_IDLE_CHAR_THRESHOLD, timeoutRef),
+    ).not.toThrow();
+    expect(timeoutRef.current).toBeNull();
   });
 });

--- a/src/components/Editor/tiptapEditorHelpers.ts
+++ b/src/components/Editor/tiptapEditorHelpers.ts
@@ -2,8 +2,10 @@
  * TiptapEditor module helpers
  *
  * Purpose: pure, editor-instance-level helpers extracted from TiptapEditor.tsx —
- * history-free content replacement, adaptive debounce sizing, and external
- * markdown→editor sync. No React state; safe to call from effects and callbacks.
+ * history-free content replacement, adaptive debounce sizing, the spellcheck
+ * size cutoff, the viewport-preserving cv-idle toggle (#823, #1340), and
+ * external markdown→editor sync. No React state; safe to call from effects
+ * and callbacks.
  *
  * @coordinates-with TiptapEditor.tsx — sole consumer; behavior documented there
  * @module components/Editor/tiptapEditorHelpers
@@ -15,6 +17,7 @@ import type { EditorProps } from "@tiptap/pm/view";
 import { parseMarkdown } from "@/utils/markdownPipeline";
 import { getTiptapEditorView } from "@/services/editor/tiptapView";
 import { handleTableScrollToSelection } from "@/plugins/tableScroll/scrollGuard";
+import { setCvIdlePreservingViewport } from "./cvIdleViewportLock";
 import { tiptapError } from "@/utils/debug";
 
 /**
@@ -139,6 +142,11 @@ export function applySpellcheckForDocSize(
  * blocks have never been rendered. For small docs the optimization delivers
  * no measurable win and the toggle produces a "shaking" / rippling effect
  * as the total document height changes on each idle interval (#823).
+ *
+ * Large documents keep the toggle and pay the same estimate-vs-real
+ * divergence — which used to throw the viewport (and the user's selection)
+ * out of view on every edit (#1340). Both toggle directions are now
+ * scroll-compensated; see {@link suppressCvIdleDuringEdit}.
  */
 export const CV_IDLE_CHAR_THRESHOLD = 50_000;
 
@@ -151,6 +159,20 @@ export const CV_IDLE_CHAR_THRESHOLD = 50_000;
  * the toggle causes visible shaking because `contain-intrinsic-size: auto`
  * fallbacks don't match real block heights when off-screen blocks have
  * never been rendered, and small docs don't need the optimization anyway (#823).
+ *
+ * Both class toggles go through {@link setCvIdlePreservingViewport}: on a
+ * large doc the same estimate-vs-real height divergence changes the height of
+ * content ABOVE the viewport, so an unadjusted scrollTop threw the selection
+ * out of view on every edit — including toolbar mark toggles (#1340). The
+ * strip only measures when the class is actually present; within the idle
+ * window (the per-keystroke hot path) it is already off and nothing is
+ * measured or written.
+ *
+ * If the idle timer fires while the editor is hidden (Source mode toggled
+ * within the window), display:none geometry yields no anchor and the re-add
+ * is class-only — correct, since nothing is visible and returning to WYSIWYG
+ * re-derives the viewport (cursor mapping, scroll restore). Unmount never
+ * reaches the timer at all: useTiptapUnmountFlush clears it.
  */
 export function suppressCvIdleDuringEdit(
   containerRef: MutableRefObject<HTMLDivElement | null>,
@@ -159,7 +181,9 @@ export function suppressCvIdleDuringEdit(
 ): void {
   const container = containerRef.current;
   if (!container) return;
-  container.classList.remove("cv-idle");
+  if (container.classList.contains("cv-idle")) {
+    setCvIdlePreservingViewport(container, false);
+  }
   if (cvIdleTimeoutRef.current !== null) {
     window.clearTimeout(cvIdleTimeoutRef.current);
     cvIdleTimeoutRef.current = null;
@@ -167,7 +191,8 @@ export function suppressCvIdleDuringEdit(
   if (docSize >= CV_IDLE_CHAR_THRESHOLD) {
     cvIdleTimeoutRef.current = window.setTimeout(() => {
       cvIdleTimeoutRef.current = null;
-      containerRef.current?.classList.add("cv-idle");
+      const idleContainer = containerRef.current;
+      if (idleContainer) setCvIdlePreservingViewport(idleContainer, true);
     }, 500);
   }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: documents at or over `CV_IDLE_CHAR_THRESHOLD` (50K chars) carry the `content-visibility: auto; contain-intrinsic-size: auto 2.5em` optimization (#823) under `.cv-idle`. Every editor update strips that class synchronously and re-adds it after 500ms idle. Each flip swaps 2.5em estimates for real block heights (and back) for blocks the user has never scrolled past; when content **above** the viewport changes height while `scrollTop` stays put, the visible content shifts — typically downward, throwing the just-formatted selection out of view.
- **Fix**: anchor-based scroll compensation around both toggle directions (`src/components/Editor/cvIdleViewportLock.ts`). Before flipping the class, find the first `.ProseMirror > *` block intersecting the viewport (early-exit scan), measure its top, flip, re-measure, and add the delta to the scroll container's `scrollTop`. Client rects already include any native scroll-anchoring adjustment the engine made, so the residual delta is exactly what remains to correct — self-correcting on Chromium/WebView2 (the reporter's platform), and the whole fix on WebKit/macOS, which has no scroll anchoring at all.
- **Wider than the report**: the same mechanism fired on plain typing (the first keystroke after each idle window, and the re-add 500ms later), not just toolbar formatting — this fixes that too, on all platforms. The per-keystroke hot path (class already off) skips all measurement and writes.

Fixes #1340

## What Changed

**The #1340 fix**

- `src/components/Editor/cvIdleViewportLock.ts` (new) — `setCvIdlePreservingViewport`: the viewport-preserving class toggle, trade-offs documented (why measurement happens on the dirty tree rather than from an idle-time cache).
- `src/components/Editor/cvIdleViewportLock.test.ts` (new) — 8 tests: down/up shift compensation, symmetric re-add, anchor selection skipping fully-above blocks with early exit below, zero-delta writes nothing, no blocks / all-above / detached container safety.
- `src/components/Editor/tiptapEditorHelpers.ts` — `suppressCvIdleDuringEdit` routes both toggles through the lock; measures only when the class is actually present; doc comments updated (rule 22) citing #1340.
- `src/components/Editor/tiptapEditorHelpers.test.ts` — 6 tests: strip + idle re-add compensation round-trip, hot-path skips all measurement, below-threshold behavior, timer reschedule, hidden-editor idle re-add is class-only, null ref safety.
- `src/components/Editor/TiptapEditor.tsx`, `src/components/Editor/editor.css` — comment maintenance only (file stays at its 400-line baseline).

**Pre-existing gate defects hit while running the gates, fixed in the same pass** — both are instances of one class: gate self-tests treating the real repo tree as isolated when it is shared.

- `scripts/check-ui-phase.sh`, `scripts/check-ui-phase.test.mjs`, `scripts/clean-dev.test.mjs` — `clean-dev.test.mjs` transiently creates `dev-docs/` in the real repo root on trees where it is absent, and check-ui-phase's bare `[[ -d dev-docs ]]` probe mistook that markerless fixture for a maintainer tree (phases 0 and 4 failed only under the parallel pool; reproduced deterministically). The probe now keys on `dev-docs/README.md`; a regression test pins phase 4 green during the race window; cleanups on both sides are fixture-only plus non-recursive ancestor pruning so neither test can delete the other's live fixture.
- `scripts/check-design-tokens.mjs`, `scripts/check-design-tokens.test.ts`, `.claude/hooks/gha-tdd-guard.test.mjs` — the guard test transiently writes probe `*.test.ts` files under `src/lib/browser/`, and the design-tokens CLI (the one scanner that reads test-named files) crashed with ENOENT between glob and read while its self-test ran it against the real tree. `readScannedFile` carries `globFiles`' existing raced-delete contract through to the read (null on ENOENT only; everything else stays loud); explicit fixture arguments are read once at validation so a typo throws before any scan and a mid-run deletion cannot become a quiet skip; guard-test probes carry the pid and their cleanup is file-precise plus non-recursive `rmdir`. Same class `check-scripts-parity.test.mjs` already documents (~25% flake from these probes, fixed there with a single-snapshot read).

## Codex Audit

One thread, high reasoning effort, 9 review rounds, converging to NO FINDINGS three times (after the #1340 fix, after the ui-phase race fix, after the design-tokens race fix):

- Fixed from findings: stale `editor.css` comment naming the wrong toggle owner; inaccurate worst-case wording in the anchor-scan comment; `clean-dev.test.mjs` cleanup could recursively delete `dev-docs/` and a sibling's live fixture with it; the ui-phase probe originally sat under `dev-docs/grills/` where it could silently skip clean-dev's absent-grills test; ENOENT tolerance initially reachable for explicit fixture arguments (now cached at validation); fixed-name guard probes not exclusively owned across concurrent vitest runs (now pid-tagged); two stale comments.
- Pinned with tests + docs rather than restructured: idle re-add on a hidden editor is class-only (nothing visible; return path re-derives the viewport via cursor mapping / scroll restore; unmount already clears the timer).
- Rebutted with mechanism: caching anchor geometry at idle time (proposed to avoid one forced cv-on layout on the first edit after idle) mis-compensates any edit that changes heights above the viewport (find-and-replace, MCP document edits) — correctness kept over a once-per-burst cost; typing transactions already force that same layout via ProseMirror's `scrollToSelection` before `onUpdate` fires. React's `className` ownership of the initial `cv-idle` is the established pattern and deliberately unchanged.

## Validation

- [x] TDD: RED first (compensation tests failed against the old implementation; the new module's suite failed at import), then GREEN, then refactor
- [x] Gate-race fixes verified by deterministic repro before fixing (phase 4 exit 1 with a markerless `dev-docs/`; design-tokens ENOENT crash traced to the guard fixture window)
- [x] `pnpm check:predelta` — all 41 delta gates green
- [x] `pnpm check:all` — full gate green
- [x] Existing cv-idle semantics preserved (`TiptapEditor.test.tsx` class add/remove tests untouched and passing)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
