### PR TITLE
fix: keep the Linux print helper alive until a confirmed print job finishes (fixes #1343)

### DIFF
--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -41,7 +41,7 @@
     "src/export/htmlExport.ts": 331,
     "src/export/reader/vmark-reader.js": 1342,
     "src/export/resourceResolver.ts": 445,
-    "src/export/useExportOperations.ts": 446,
+    "src/export/useExportOperations.ts": 333,
     "src/hooks/useTabDragOut.ts": 356,
     "src/hooks/useUpdateChecker.ts": 404,
     "src/lib/cjkFormatter/quotePairing.ts": 378,

--- a/src-tauri/src/pdf_export/commands.rs
+++ b/src-tauri/src/pdf_export/commands.rs
@@ -170,10 +170,14 @@ fn post_process(
     outcome
 }
 
-/// Print HTML content via native macOS print dialog.
+/// Print HTML content via the system print dialog (WI-PDF4.1, all three
+/// platforms).
 ///
-/// Creates an off-screen WKWebView, loads the HTML, and shows the
-/// system print dialog. The user selects a printer and prints directly.
+/// Renders the HTML in a helper webview and shows the platform's dialog:
+/// the NSPrintOperation panel on macOS, WebView2 `ShowPrintUI` on Windows,
+/// `webkit_print_operation_run_dialog` on Linux. The helper is hidden on
+/// macOS and Linux; on Windows it must stay visible because `ShowPrintUI`
+/// draws the print UI inside it.
 #[tauri::command]
 pub async fn print_document(app: tauri::AppHandle, html: String) -> Result<(), CommandError> {
     renderer::print_document(app, html).await

--- a/src-tauri/src/pdf_export/renderer/linux.rs
+++ b/src-tauri/src/pdf_export/renderer/linux.rs
@@ -27,6 +27,7 @@
 //!
 //! @coordinates-with mod.rs — dispatches here and awaits the sink
 //! @coordinates-with page_spec.rs — supplies the geometry, in points
+//! @coordinates-with linux_print.rs — the dialog path; borrows these helpers
 //! @module pdf_export/renderer/linux
 
 use std::sync::Arc;
@@ -41,7 +42,7 @@ use crate::pdf_export::page_spec::PageSpec;
 use super::RenderSink;
 
 /// Unique per render, so two concurrent exports cannot collide on a label.
-const LABEL_PREFIX: &str = "pdf-render-";
+pub(super) const LABEL_PREFIX: &str = "pdf-render-";
 
 /// The virtual printer GTK's file backend provides. Naming it is mandatory —
 /// see ADR-PDF2.
@@ -85,13 +86,38 @@ fn start(
     window
         .with_webview(move |pw| {
             let view = pw.inner();
+
+            // A failed load still reaches `Finished` (the print path has
+            // always said so), and this path had NO failure handler: it
+            // printed WebKit's error page to the PDF and reported success.
+            // Fail loud instead, and guard Finished with a flag — `close()`
+            // only queues the teardown, so Finished still fires after the
+            // failure handler ran. Rc<Cell>, not Arc: GTK signal handlers
+            // all run on the main thread. If a SECOND navigation is ever
+            // added, reset the flag on LoadEvent::Started.
+            let load_failed = std::rc::Rc::new(std::cell::Cell::new(false));
+
+            let sink_load_fail = sink.clone();
+            let app_load_fail = app_cb.clone();
+            let label_load_fail = label_cb.clone();
+            let failed_flag = load_failed.clone();
+            view.connect_load_failed(move |_, _, _, _| {
+                failed_flag.set(true);
+                sink_load_fail.settle(Err(localized_error!(
+                    ErrorCode::Io,
+                    "errors.pdf.loadFailed"
+                )));
+                close(&app_load_fail, &label_load_fail);
+                true // handled — suppress WebKit's own error page
+            });
+
             let sink_load = sink.clone();
             let app_load = app_cb.clone();
             let label_load = label_cb.clone();
             let out_uri = out_uri.clone();
 
             view.connect_load_changed(move |view, event| {
-                if event != webkit2gtk::LoadEvent::Finished {
+                if event != webkit2gtk::LoadEvent::Finished || load_failed.get() {
                     return;
                 }
                 let op = PrintOperation::new(view);
@@ -160,13 +186,13 @@ fn start(
 }
 
 /// Tear the render window down — a timeout is not cancellation (ADR-PDF7).
-fn close(app: &AppHandle, label: &str) {
+pub(super) fn close(app: &AppHandle, label: &str) {
     if let Some(w) = app.get_webview_window(label) {
         let _ = w.close();
     }
 }
 
-fn window_error(detail: &str) -> CommandError {
+pub(super) fn window_error(detail: &str) -> CommandError {
     localized_error!(
         ErrorCode::Internal,
         "errors.pdf.renderWindowFailed",
@@ -175,7 +201,7 @@ fn window_error(detail: &str) -> CommandError {
 }
 
 /// `file://` URI, percent-encoding whatever must be encoded.
-fn path_to_file_url(path: &str) -> Result<String, CommandError> {
+pub(super) fn path_to_file_url(path: &str) -> Result<String, CommandError> {
     url::Url::from_file_path(path)
         .map(|u| u.to_string())
         .map_err(|()| {
@@ -185,90 +211,4 @@ fn path_to_file_url(path: &str) -> Result<String, CommandError> {
                 path = path
             )
         })
-}
-
-/// Show the system print dialog for the rendered document.
-///
-/// Settles once the user has DISMISSED the dialog —
-/// `webkit_print_operation_run_dialog` blocks until they respond. Like the
-/// other two platforms we do not report what they chose to do there.
-pub(super) fn print_on_main_thread(
-    app: &AppHandle,
-    html_path: &str,
-    _read_access_dir: &str,
-    sink: Arc<RenderSink>,
-) {
-    if let Err(e) = start_print(app, html_path, sink.clone()) {
-        sink.settle(Err(e));
-    }
-}
-
-fn start_print(
-    app: &AppHandle,
-    html_path: &str,
-    sink: Arc<RenderSink>,
-) -> Result<(), CommandError> {
-    let label = format!("{LABEL_PREFIX}{}", uuid::Uuid::new_v4().simple());
-    let file_url = path_to_file_url(html_path)?;
-    let blank = "about:blank".parse().expect("about:blank parses");
-    // Hidden, like the export path in `start()`. This window used to be
-    // visible on the theory that a print dialog floating over nothing is
-    // disorienting — but users read the raw-document window behind the
-    // dialog as a stray bug window (#1341), and macOS shows only the print
-    // panel. A hidden WebKitGTK webview provably still renders and prints:
-    // `start()` has always printed from a `.visible(false)` window. Do NOT
-    // unify this with Windows — there, `ShowPrintUI` draws the print UI
-    // INSIDE the webview window, so hiding it would hide the dialog itself.
-    let window = WebviewWindowBuilder::new(app, &label, WebviewUrl::External(blank))
-        .visible(false)
-        .title("VMark Print")
-        .build()
-        .map_err(|e| window_error(&e.to_string()))?;
-
-    let app_cb = app.clone();
-    let label_cb = label.clone();
-
-    window
-        .with_webview(move |pw| {
-            let view = pw.inner();
-
-            // A failed load still reaches `Finished`, so without this the
-            // dialog would come up over WebKit's error page and print it.
-            let sink_fail = sink.clone();
-            let app_fail = app_cb.clone();
-            let label_fail = label_cb.clone();
-            view.connect_load_failed(move |_, _, _, _| {
-                sink_fail.settle(Err(localized_error!(
-                    ErrorCode::Io,
-                    "errors.pdf.loadFailed"
-                )));
-                close(&app_fail, &label_fail);
-                true // handled — suppress WebKit's own error page
-            });
-
-            let sink_load = sink.clone();
-            let app_load = app_cb.clone();
-            let label_load = label_cb.clone();
-            view.connect_load_changed(move |view, event| {
-                if event != webkit2gtk::LoadEvent::Finished {
-                    return;
-                }
-                let op = PrintOperation::new(view);
-                // No parent window: the render window is hidden, and a
-                // transient parent that is never mapped gives the WM nothing
-                // to stack against — the dialog floats free, as it always has.
-                // Turbofish: `None` alone is ambiguous — the parameter is
-                // generic over `IsA<gtk::Window>` with nothing to infer from.
-                op.run_dialog(None::<&gtk::Window>);
-                // `run_dialog` returns once the user has responded, so unlike
-                // Windows' asynchronous ShowPrintUI this path CAN tear its own
-                // window down rather than stranding it.
-                sink_load.settle(Ok(()));
-                close(&app_load, &label_load);
-            });
-
-            view.load_uri(&file_url);
-        })
-        .map_err(|e| window_error(&e.to_string()))?;
-    Ok(())
 }

--- a/src-tauri/src/pdf_export/renderer/linux_print.rs
+++ b/src-tauri/src/pdf_export/renderer/linux_print.rs
@@ -1,0 +1,169 @@
+//! Linux native print dialog — `webkit_print_operation_run_dialog()`.
+//!
+//! Purpose: split from `linux.rs` so each stays under the size limit — the
+//! same split `windows.rs`/`windows_print.rs` made — and because a dialog is
+//! a different concern from writing a file: this path hands control to the
+//! user, where export renders off-screen and completes on its own.
+//!
+//! Key decisions:
+//!   - **The helper window outlives a CONFIRMED print job (#1343).**
+//!     `run_dialog` blocks until the user responds, but confirming only
+//!     STARTS the job — CUPS spooling or Print-to-File output completes
+//!     asynchronously afterwards, signalled by `finished`/`failed`. Settling
+//!     and closing when `run_dialog` returned tore the webview down while a
+//!     slow job was still rendering from it. So the response is branched:
+//!     Cancel settles and closes immediately (nothing started, so `finished`
+//!     may never fire, and waiting on it would leak the hidden helper
+//!     forever); Print defers both to the signal handlers, exactly as the
+//!     export path in `linux.rs` does.
+//!   - **The window is hidden** (#1341): users read a raw-document window
+//!     behind the dialog as a stray bug window, and a hidden WebKitGTK
+//!     webview provably still renders and prints — the export path always
+//!     has. Do NOT unify this with Windows: there `ShowPrintUI` draws the
+//!     print UI INSIDE the webview window, so hiding it would hide the
+//!     dialog itself.
+//!
+//! @coordinates-with linux.rs — shares the window, URL and error helpers
+//! @coordinates-with mod.rs — dispatches here and awaits the sink
+//! @module pdf_export/renderer/linux_print
+
+use std::sync::Arc;
+
+use tauri::{AppHandle, WebviewUrl, WebviewWindowBuilder};
+use webkit2gtk::{PrintOperation, PrintOperationExt, PrintOperationResponse, WebViewExt};
+
+use crate::command_error::{CommandError, ErrorCode};
+use crate::localized_error;
+
+use super::linux::{close, path_to_file_url, window_error, LABEL_PREFIX};
+use super::RenderSink;
+
+/// Show the system print dialog for the rendered document.
+///
+/// `webkit_print_operation_run_dialog` blocks until the user responds. On
+/// Cancel this settles right there; on Print it settles once the operation's
+/// `finished` or `failed` signal fires, because a confirmed job keeps
+/// spooling after the dialog closes (#1343). Like the other two platforms we
+/// do not report what the user chose — a cancelled dialog still settles Ok —
+/// but a confirmed job that FAILS now reports its error, as export does.
+pub(super) fn print_on_main_thread(
+    app: &AppHandle,
+    html_path: &str,
+    _read_access_dir: &str,
+    sink: Arc<RenderSink>,
+) {
+    if let Err(e) = start_print(app, html_path, sink.clone()) {
+        sink.settle(Err(e));
+    }
+}
+
+fn start_print(
+    app: &AppHandle,
+    html_path: &str,
+    sink: Arc<RenderSink>,
+) -> Result<(), CommandError> {
+    let label = format!("{LABEL_PREFIX}{}", uuid::Uuid::new_v4().simple());
+    let file_url = path_to_file_url(html_path)?;
+    let blank = "about:blank".parse().expect("about:blank parses");
+    let window = WebviewWindowBuilder::new(app, &label, WebviewUrl::External(blank))
+        .visible(false)
+        .title("VMark Print")
+        .build()
+        .map_err(|e| window_error(&e.to_string()))?;
+
+    let app_cb = app.clone();
+    let label_cb = label.clone();
+
+    window
+        .with_webview(move |pw| {
+            let view = pw.inner();
+
+            // A failed load still reaches `Finished`, and settling + closing
+            // from the failure handler is not enough on its own: `close()`
+            // only QUEUES the teardown on the event loop, so the Finished
+            // handler still ran and popped a print dialog over WebKit's error
+            // page from a window already being torn down. One flag, two
+            // handlers. Rc<Cell>, not Arc: GTK signal handlers all run on the
+            // main thread. If a SECOND navigation is ever added, reset the
+            // flag on LoadEvent::Started.
+            let load_failed = std::rc::Rc::new(std::cell::Cell::new(false));
+
+            let sink_fail = sink.clone();
+            let app_fail = app_cb.clone();
+            let label_fail = label_cb.clone();
+            let failed_flag = load_failed.clone();
+            view.connect_load_failed(move |_, _, _, _| {
+                failed_flag.set(true);
+                sink_fail.settle(Err(localized_error!(
+                    ErrorCode::Io,
+                    "errors.pdf.loadFailed"
+                )));
+                close(&app_fail, &label_fail);
+                true // handled — suppress WebKit's own error page
+            });
+
+            let sink_load = sink.clone();
+            let app_load = app_cb.clone();
+            let label_load = label_cb.clone();
+            view.connect_load_changed(move |view, event| {
+                if event != webkit2gtk::LoadEvent::Finished || load_failed.get() {
+                    return;
+                }
+                let op = PrintOperation::new(view);
+
+                // Connected BEFORE the dialog runs: WebKitGTK starts the job
+                // the moment the user confirms, and a handler connected only
+                // after `run_dialog` returns could miss a fast job's signal.
+                let sink_err = sink_load.clone();
+                let app_err = app_load.clone();
+                let label_err = label_load.clone();
+                op.connect_failed(move |_, err| {
+                    sink_err.settle(Err(localized_error!(
+                        ErrorCode::Io,
+                        "errors.pdf.comFailed",
+                        stage = "print",
+                        detail = err.to_string()
+                    )));
+                    close(&app_err, &label_err);
+                });
+
+                let sink_done = sink_load.clone();
+                let app_done = app_load.clone();
+                let label_done = label_load.clone();
+                op.connect_finished(move |_| {
+                    // `finished` fires after `failed` too, so settle() being
+                    // idempotent is what keeps a failure from reading green.
+                    sink_done.settle(Ok(()));
+                    close(&app_done, &label_done);
+                });
+
+                // No parent window: the render window is hidden, and a
+                // transient parent that is never mapped gives the WM nothing
+                // to stack against — the dialog floats free, as it always
+                // has. Turbofish: `None` alone is ambiguous — the parameter
+                // is generic over `IsA<gtk::Window>` with nothing to infer
+                // from.
+                match op.run_dialog(None::<&gtk::Window>) {
+                    // Confirmed: the job is now spooling from THIS webview
+                    // and completes asynchronously after `run_dialog`
+                    // returns (#1343). The handlers above own settle and
+                    // close. If the job outlives PDF_OPERATION_TIMEOUT the
+                    // caller reports a timeout, but the handlers still run
+                    // when the job ends: settling a settled sink is a
+                    // no-op, and the hidden window still closes itself.
+                    PrintOperationResponse::Print => {}
+                    // Cancelled: nothing was started, so `finished` may
+                    // never fire — waiting on it would leak the hidden
+                    // helper window forever. Settle and close now.
+                    _ => {
+                        sink_load.settle(Ok(()));
+                        close(&app_load, &label_load);
+                    }
+                }
+            });
+
+            view.load_uri(&file_url);
+        })
+        .map_err(|e| window_error(&e.to_string()))?;
+    Ok(())
+}

--- a/src-tauri/src/pdf_export/renderer/mod.rs
+++ b/src-tauri/src/pdf_export/renderer/mod.rs
@@ -50,6 +50,8 @@ use windows as platform;
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 mod linux;
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+mod linux_print;
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use linux as platform;
 
 /// Hard ceiling on a single PDF render. The internal print pipeline can wait
@@ -82,6 +84,48 @@ pub(super) fn emit_progress(app: &AppHandle, stage: &'static str) {
 // PDF Export
 // ============================================================================
 
+/// Write the document to the render temp file the SINK will own.
+///
+/// `tempfile` creates with O_EXCL and 0600, which a pid+clock filename plus
+/// `fs::write` does not: that name is predictable, so a symlink planted at
+/// the path would be followed, and the document — which can contain the
+/// user's entire private note — was written world-readable on a shared /tmp.
+/// The whole create-and-write runs on a blocking thread (a multi-megabyte
+/// document would otherwise hold a Tokio worker), WRITES THROUGH THE OPEN
+/// HANDLE rather than reopening the path by name, and only then
+/// `into_temp_path().keep()`s the result: `keep()` disables tempfile's RAII
+/// cleanup, and calling it before the write meant a failed or cancelled
+/// write leaked a partial private document that no one — the RenderSink that
+/// owns deletion is constructed only after this returns — would ever remove.
+async fn write_render_temp(prefix: &str, html: String) -> Result<std::path::PathBuf, CommandError> {
+    fn err(e: impl std::fmt::Display) -> CommandError {
+        localized_error!(
+            ErrorCode::Io,
+            "errors.pdf.tempWriteFailed",
+            detail = e.to_string()
+        )
+    }
+    let prefix = prefix.to_string();
+    let temp_file =
+        tokio::task::spawn_blocking(move || -> Result<tempfile::NamedTempFile, CommandError> {
+            use std::io::Write;
+            let mut temp_file = tempfile::Builder::new()
+                .prefix(&prefix)
+                .suffix(".html")
+                .tempfile()
+                .map_err(err)?;
+            temp_file.write_all(html.as_bytes()).map_err(err)?;
+            Ok(temp_file)
+        })
+        .await
+        .map_err(err)??;
+    // Kept only now, on the fully written file — if the await above is
+    // cancelled instead, the returned NamedTempFile is dropped and RAII
+    // deletes it. The webview opens the kept file by path; the sink deletes
+    // it on settle or Drop.
+    temp_file.into_temp_path().keep().map_err(err)
+}
+
 /// Render HTML to PDF via off-screen WKWebView.
 ///
 /// Writes HTML to a temp file, then dispatches to the main thread via
@@ -106,52 +150,8 @@ pub async fn render_pdf(
     // The document is written to a temp file rather than passed inline because
     // wry's `.with_html` caps at 2 MiB and a real export routinely exceeds it
     // (ADR-PDF4).
-    //
-    // `tempfile` creates with O_EXCL and 0600, which a pid+clock filename plus
-    // `fs::write` does not: that name is predictable, so a symlink planted at
-    // the path would have been followed, and the document — which can contain
-    // the user's entire private note — was written world-readable on a shared
-    // /tmp. `into_temp_path()` keeps the file after the handle closes, since
-    // the webview opens it by path; RenderSink still owns the deletion.
     let temp_dir = std::env::temp_dir();
-    let temp_file = tempfile::Builder::new()
-        .prefix("vmark-pdf-export-")
-        .suffix(".html")
-        .tempfile()
-        .map_err(|e| {
-            localized_error!(
-                ErrorCode::Io,
-                "errors.pdf.tempWriteFailed",
-                detail = e.to_string()
-            )
-        })?;
-    let temp_html = temp_file.into_temp_path().keep().map_err(|e| {
-        localized_error!(
-            ErrorCode::Io,
-            "errors.pdf.tempWriteFailed",
-            detail = e.to_string()
-        )
-    })?;
-    // Blocking I/O for a multi-megabyte document would hold a Tokio worker for
-    // the whole write; this command is async precisely so it does not.
-    let html_bytes = html.clone();
-    let temp_for_write = temp_html.clone();
-    tokio::task::spawn_blocking(move || std::fs::write(&temp_for_write, html_bytes))
-        .await
-        .map_err(|e| {
-            localized_error!(
-                ErrorCode::Io,
-                "errors.pdf.tempWriteFailed",
-                detail = e.to_string()
-            )
-        })?
-        .map_err(|e| {
-            localized_error!(
-                ErrorCode::Io,
-                "errors.pdf.tempWriteFailed",
-                detail = e.to_string()
-            )
-        })?;
+    let temp_html = write_render_temp("vmark-pdf-export-", html.clone()).await?;
 
     log::debug!(
         "[PDF] render_pdf: wrote {} bytes to {}, output: {}",
@@ -225,22 +225,11 @@ pub async fn render_pdf(
 /// silently saving to a file. The user selects a printer and prints.
 pub async fn print_document(app: AppHandle, html: String) -> Result<(), CommandError> {
     let temp_dir = std::env::temp_dir();
-    let unique_id = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let temp_html = temp_dir.join(format!(
-        "vmark-print-{}-{}.html",
-        std::process::id(),
-        unique_id
-    ));
-    std::fs::write(&temp_html, &html).map_err(|e| {
-        localized_error!(
-            ErrorCode::Io,
-            "errors.pdf.tempWriteFailed",
-            detail = e.to_string()
-        )
-    })?;
+    // Same file discipline as render_pdf — the print HTML is the same private
+    // document, and it was still being written under a predictable pid+clock
+    // name with a blocking write after render_pdf's was fixed. One helper now
+    // owns the pattern for both.
+    let temp_html = write_render_temp("vmark-print-", html).await?;
 
     let (tx, rx) = oneshot::channel::<Result<(), CommandError>>();
     let sink = RenderSink::new(tx, temp_html.clone());
@@ -252,15 +241,21 @@ pub async fn print_document(app: AppHandle, html: String) -> Result<(), CommandE
     app.run_on_main_thread(move || {
         // Same sink contract as render: macOS settles synchronously because
         // its panel is modal, Windows settles once the dialog has been SHOWN
-        // (ShowPrintUI is asynchronous), and Linux settles once the user has
-        // DISMISSED the dialog (run_dialog blocks until they respond). None
-        // of the three reports what the user chose — that has always been the
-        // documented contract here.
+        // (ShowPrintUI is asynchronous), and Linux settles on cancel when the
+        // user dismisses the dialog, or on print once the operation's
+        // finished/failed signal fires — a confirmed job keeps spooling after
+        // the dialog closes (#1343). None of the three reports what the user
+        // chose: a cancelled dialog still settles Ok.
         #[cfg(target_os = "windows")]
         windows_print::print_on_main_thread(&app_clone, &temp_html_str, &temp_dir_str, sink_clone);
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(target_os = "macos")]
         platform::print_on_main_thread(&app_clone, &temp_html_str, &temp_dir_str, sink_clone);
-        let _ = std::fs::remove_file(&temp_html_str);
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        linux_print::print_on_main_thread(&app_clone, &temp_html_str, &temp_dir_str, sink_clone);
+        // The temp file is dropped by the SINK (settle or Drop), not here —
+        // the same rule render_pdf states above: on Windows and Linux the
+        // dispatch returns while the webview is still NAVIGATING to the file,
+        // so an eager remove here raced the load (ENOENT → error page).
     })
     .map_err(|e| {
         localized_error!(

--- a/src-tauri/src/pdf_export/renderer/sink.rs
+++ b/src-tauri/src/pdf_export/renderer/sink.rs
@@ -14,7 +14,7 @@
 //! the dispatch that started it (ADR-PDF4).
 //!
 //! @coordinates-with mod.rs — constructs it
-//! @coordinates-with macos_ops.rs, windows.rs, linux.rs — settle it
+//! @coordinates-with macos_ops.rs, windows.rs, windows_print.rs, linux.rs, linux_print.rs — settle it
 //! @module pdf_export/renderer/sink
 
 use std::path::PathBuf;

--- a/src/components/BreakdownPanel/BreakdownPanel.test.tsx
+++ b/src/components/BreakdownPanel/BreakdownPanel.test.tsx
@@ -177,9 +177,10 @@ describe("BreakdownPanel — grouped list", () => {
   // RESULT_CAP + 5 = 205 rows through jsdom — by far the heaviest render in the
   // suite. It measures ~4-6s, which straddles vitest's 5s default: it passes
   // alone and intermittently times out under `--coverage` with a full worker
-  // pool. The generous timeout is for the LOAD, not for the assertions, which
-  // are synchronous and either hold immediately or not at all; a real hang here
-  // would still fail, just later.
+  // pool — 20s was exceeded once on an otherwise idle machine as the suite
+  // grew, hence the current budget. The generous timeout is for the LOAD, not
+  // for the assertions, which are synchronous and either hold immediately or
+  // not at all; a real hang here would still fail, just later.
   //
   // Shrinking the fixture is not an option — a cap test that renders fewer rows
   // than the cap tests nothing.
@@ -193,7 +194,7 @@ describe("BreakdownPanel — grouped list", () => {
     expect(
       screen.getByText(`Showing ${RESULT_CAP} of ${RESULT_CAP + 5} edges`),
     ).toBeInTheDocument();
-  }, 20000);
+  }, 45000);
 });
 
 describe("BreakdownPanel — actions", () => {

--- a/src/export/__tests__/printFailureToast.test.ts
+++ b/src/export/__tests__/printFailureToast.test.ts
@@ -1,0 +1,106 @@
+/**
+ * fix(#1343) — the print catch must tell the truth about what failed.
+ *
+ * On Linux the print helper now settles the sink from the print operation's
+ * `finished`/`failed` signals, so a CONFIRMED job that later fails rejects
+ * `print_document` — a path that used to settle Ok silently. The old catch
+ * mapped every rejection to the static "Failed to open print dialog", which
+ * is factually wrong once a failure can arrive after the dialog opened fine.
+ * The catch now uses the two-line `toast.errorDetail` (WI-UI4.4) with the
+ * neutral "Print failed" headline, handing the RAW rejection over —
+ * errorDetail owns the normalization (commandErrorMessage), so a typed
+ * CommandError renders its localized message rather than "[object Object]".
+ *
+ * @module export/__tests__/printFailureToast.test
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { mockInvoke, mockToastError, mockToastErrorDetail } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+  mockToastError: vi.fn(),
+  mockToastErrorDetail: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock("../resourceResolver", () => ({
+  resolveResources: (html: string) =>
+    Promise.resolve({ html, report: { resources: [], resolved: [], missing: [], totalSize: 0 } }),
+  getDocumentBaseDir: () => Promise.resolve(null),
+}));
+
+vi.mock("@/services/ime/imeToast", () => ({
+  imeToast: {
+    error: mockToastError,
+    errorDetail: mockToastErrorDetail,
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("../themeSnapshot", () => ({
+  captureThemeCSS: () => "",
+  isDarkTheme: () => false,
+}));
+
+vi.mock("../htmlExportStyles", () => ({
+  getEditorContentCSS: () => "",
+}));
+
+vi.mock("../pdfHtmlTemplate", () => ({
+  getKatexCSS: () => "",
+  getForceLightThemeCSS: () => "",
+  getSharedContentCSS: () => "",
+}));
+
+vi.mock("@/i18n", () => ({
+  default: { t: (key: string) => key },
+}));
+
+import { exportToPdf } from "../useExportOperations";
+
+/** Install a fake live `.ProseMirror` element so the WYSIWYG branch is taken. */
+function installLiveEditor(innerHTML: string): void {
+  const el = document.createElement("div");
+  el.className = "ProseMirror";
+  el.innerHTML = innerHTML;
+  document.body.appendChild(el);
+}
+
+describe("exportToPdf — print failure surfaces the real error (issue #1343)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+    mockInvoke.mockResolvedValue(undefined);
+  });
+
+  it("hands a print_document rejection to errorDetail RAW, under the printFailed headline", async () => {
+    installLiveEditor("<p>hi</p>");
+    // A CommandError rejection as Tauri delivers it: a plain object. The
+    // catch must not stringify it (that renders "[object Object]") and must
+    // not claim the dialog failed to open — the job can fail after it did.
+    const rejection = {
+      code: "io",
+      message: "PDF export failed at print: lp: printer unreachable",
+      i18nKey: "errors.pdf.comFailed",
+    };
+    mockInvoke.mockRejectedValueOnce(rejection);
+
+    await exportToPdf({ markdown: "hi" });
+
+    expect(mockToastErrorDetail).toHaveBeenCalledTimes(1);
+    expect(mockToastErrorDetail).toHaveBeenCalledWith("dialog:toast.printFailed", rejection);
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("shows no error toast when printing succeeds", async () => {
+    installLiveEditor("<p>hi</p>");
+
+    await exportToPdf({ markdown: "hi" });
+
+    expect(mockToastErrorDetail).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+});

--- a/src/export/renderMarkdownToHtml.ts
+++ b/src/export/renderMarkdownToHtml.ts
@@ -1,0 +1,124 @@
+/**
+ * Off-screen markdown → HTML rendering via ExportSurface.
+ *
+ * Purpose: split from useExportOperations.ts (file-size gate) — the one
+ * DOM-heavy primitive every export operation shares: mount an ExportSurface
+ * in a hidden container, wait for assets (fonts, images, math, diagrams) to
+ * stabilise, extract the HTML, and tear the container down again.
+ *
+ * @coordinates-with useExportOperations.ts — the only consumer
+ * @module export/renderMarkdownToHtml
+ */
+
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+import { ExportSurface, type ExportSurfaceRef } from "./ExportSurface";
+import { waitForAssets } from "./waitForAssets";
+import i18n from "@/i18n";
+import { toError } from "@/utils/errorMessage";
+
+/** Timeout for waiting on assets (fonts, images, math, diagrams) */
+const ASSET_WAIT_TIMEOUT = 10000;
+
+/** Maximum time to wait for render before giving up */
+const RENDER_TIMEOUT = 15000;
+
+/**
+ * Render markdown to HTML using ExportSurface.
+ * Creates a temporary DOM element, renders ExportSurface, waits for stability,
+ * then extracts the HTML.
+ */
+export async function renderMarkdownToHtml(
+  markdown: string,
+  lightTheme: boolean = true
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // Guard against multiple resolution (timeout vs callback race)
+    let settled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    // Create temporary container
+    const container = document.createElement("div");
+    container.style.cssText = "position: absolute; left: -9999px; top: -9999px;";
+    document.body.appendChild(container);
+
+    const surfaceRef = React.createRef<ExportSurfaceRef>();
+    let root: ReturnType<typeof createRoot> | null = null;
+
+    const cleanup = () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      root?.unmount();
+      if (container.parentNode) {
+        document.body.removeChild(container);
+      }
+    };
+
+    const complete = (html: string) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(html);
+    };
+
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const handleReady = async () => {
+      if (settled) return;
+      try {
+        // Wait for assets
+        const surfaceContainer = surfaceRef.current?.getContainer();
+        if (surfaceContainer) {
+          await waitForAssets(surfaceContainer, { timeout: ASSET_WAIT_TIMEOUT });
+        }
+
+        // Extract HTML
+        const html = surfaceRef.current?.getHTML() ?? "";
+        complete(html);
+      } catch (error) {
+        fail(toError(error));
+      }
+    };
+
+    const handleError = (error: Error) => {
+      fail(error);
+    };
+
+    // Render ExportSurface
+    try {
+      root = createRoot(container);
+      root.render(
+        React.createElement(ExportSurface, {
+          ref: surfaceRef,
+          markdown,
+          lightTheme,
+          onReady: () => void handleReady(),
+          onError: handleError,
+        })
+      );
+    } catch (error) {
+      cleanup();
+      reject(toError(error));
+      return;
+    }
+
+    // Timeout fallback
+    timeoutId = setTimeout(() => {
+      if (settled) return;
+      const html = surfaceRef.current?.getHTML();
+      if (html) {
+        complete(html);
+      } else {
+        fail(new Error(i18n.t("dialog:toast.exportRenderTimedOut")));
+      }
+    }, RENDER_TIMEOUT);
+  });
+}

--- a/src/export/useExportOperations.ts
+++ b/src/export/useExportOperations.ts
@@ -1,133 +1,24 @@
 /**
  * Export Operations
  *
- * Print: Injects @media print styles and calls window.print() on the main webview.
- * HTML Export: Uses ExportSurface for visual-parity rendering.
+ * Print: sends self-contained HTML to the Rust `print_document` command
+ * (helper webview + system print dialog). HTML Export: ExportSurface.
  */
 
 import { save } from "@tauri-apps/plugin-dialog";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { imeToast as toast } from "@/services/ime/imeToast";
-import { createRoot } from "react-dom/client";
-import React from "react";
 
-import { ExportSurface, type ExportSurfaceRef } from "./ExportSurface";
 import { exportWarn, exportError, pdfError, printError } from "@/utils/debug";
 import i18n from "@/i18n";
 import { exportHtml } from "./htmlExport";
-import { waitForAssets } from "./waitForAssets";
+import { renderMarkdownToHtml } from "./renderMarkdownToHtml";
 import { captureThemeCSS } from "./themeSnapshot";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { joinPath } from "@/utils/pathUtils";
 import { showError, FileErrors } from "@/services/dialogs/errorDialog";
 import { commandErrorMessage } from "@/services/commands/commandError";
-import { toError } from "@/utils/errorMessage";
 import { warnMissingResources } from "./exportResourceWarnings";
-
-/** Timeout for waiting on assets (fonts, images, math, diagrams) */
-const ASSET_WAIT_TIMEOUT = 10000;
-
-/** Maximum time to wait for render before giving up */
-const RENDER_TIMEOUT = 15000;
-
-/**
- * Render markdown to HTML using ExportSurface.
- * Creates a temporary DOM element, renders ExportSurface, waits for stability,
- * then extracts the HTML.
- */
-async function renderMarkdownToHtml(
-  markdown: string,
-  lightTheme: boolean = true
-): Promise<string> {
-  return new Promise((resolve, reject) => {
-    // Guard against multiple resolution (timeout vs callback race)
-    let settled = false;
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    // Create temporary container
-    const container = document.createElement("div");
-    container.style.cssText = "position: absolute; left: -9999px; top: -9999px;";
-    document.body.appendChild(container);
-
-    const surfaceRef = React.createRef<ExportSurfaceRef>();
-    let root: ReturnType<typeof createRoot> | null = null;
-
-    const cleanup = () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
-      root?.unmount();
-      if (container.parentNode) {
-        document.body.removeChild(container);
-      }
-    };
-
-    const complete = (html: string) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve(html);
-    };
-
-    const fail = (error: Error) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      reject(error);
-    };
-
-    const handleReady = async () => {
-      if (settled) return;
-      try {
-        // Wait for assets
-        const surfaceContainer = surfaceRef.current?.getContainer();
-        if (surfaceContainer) {
-          await waitForAssets(surfaceContainer, { timeout: ASSET_WAIT_TIMEOUT });
-        }
-
-        // Extract HTML
-        const html = surfaceRef.current?.getHTML() ?? "";
-        complete(html);
-      } catch (error) {
-        fail(toError(error));
-      }
-    };
-
-    const handleError = (error: Error) => {
-      fail(error);
-    };
-
-    // Render ExportSurface
-    try {
-      root = createRoot(container);
-      root.render(
-        React.createElement(ExportSurface, {
-          ref: surfaceRef,
-          markdown,
-          lightTheme,
-          onReady: () => void handleReady(),
-          onError: handleError,
-        })
-      );
-    } catch (error) {
-      cleanup();
-      reject(toError(error));
-      return;
-    }
-
-    // Timeout fallback
-    timeoutId = setTimeout(() => {
-      if (settled) return;
-      const html = surfaceRef.current?.getHTML();
-      if (html) {
-        complete(html);
-      } else {
-        fail(new Error(i18n.t("dialog:toast.exportRenderTimedOut")));
-      }
-    }, RENDER_TIMEOUT);
-  });
-}
 
 /** Options for the exportToHtml operation. */
 export interface ExportToHtmlOptions {
@@ -236,8 +127,9 @@ export interface ExportToPdfOptions {
 }
 
 /**
- * Print via native macOS print dialog (Rust-side WKWebView).
- * On non-macOS platforms, print is not supported (menu item hidden).
+ * Print via the system print dialog on all three platforms (WI-PDF4.1):
+ * macOS NSPrintOperation, Windows ShowPrintUI, Linux
+ * webkit_print_operation_run_dialog — see src-tauri/src/pdf_export/renderer.
  */
 export async function exportToPdf(options: ExportToPdfOptions): Promise<void> {
   const { markdown, sourceFilePath } = options;
@@ -291,24 +183,6 @@ export async function exportToPdfNative(options: ExportToPdfOptions): Promise<vo
 }
 
 /**
- * Print via native macOS print dialog (Rust-side WKWebView).
- *
- * The app's WKWebView can't paginate properly with window.print() because
- * printOperationWithPrintInfo uses the webview's frame size. Instead, we
- * invoke a Rust command that creates a separate off-screen WKWebView,
- * loads the rendered HTML, and shows the native print dialog — same
- * approach as PDF export but with the print panel visible.
- *
- * Note: In WYSIWYG mode this reads HTML directly from the live editor DOM
- * (`.ProseMirror`) for speed rather than re-rendering via ExportSurface
- * (which Export PDF uses). The trade-off is slightly different output
- * between Print and Export PDF (live DOM may include editor UI artifacts).
- *
- * In Source mode there is no `.ProseMirror` element, so we fall back to
- * rendering the markdown via ExportSurface — slower but correct, instead of
- * showing a misleading "no content to print" error.
- */
-/**
  * Decide where to source the HTML for printing.
  * Exposed for tests; production callers use `exportToPdfBrowser`.
  *
@@ -328,8 +202,17 @@ export function pickPrintHtmlSource(
   return { kind: "empty" };
 }
 
-// fix(#999) — inline local images as data-URIs before print/PDF so the
-// off-screen WKWebView (no Tauri asset:// handler) can render them.
+/**
+ * Print via the Rust-side helper webview and the system print dialog.
+ *
+ * The app's own webview can't paginate properly with window.print() because
+ * printOperationWithPrintInfo uses the webview's frame size. Instead, the
+ * `print_document` command builds a separate hidden webview, loads the
+ * rendered HTML, and shows the platform's print dialog — same approach as
+ * PDF export but with the print panel visible (all three platforms since
+ * WI-PDF4.1). Local images are inlined as data-URIs first (#999): the helper
+ * webview has no Tauri asset:// handler.
+ */
 async function exportToPdfBrowser(
   markdown: string,
   sourceFilePath: string | null = null,
@@ -403,7 +286,11 @@ ${html}
     await invoke("print_document", { html: fullHtml });
   } catch (error) {
     printError("Failed to print:", error);
-    toast.error(i18n.t("dialog:toast.failedToOpenPrintDialog"));
+    // "Print failed", not "failed to open print dialog": on Linux a CONFIRMED
+    // job that fails afterwards rejects too (#1343), so the dialog may well
+    // have opened fine. Raw error — errorDetail owns the normalization
+    // (commandErrorMessage), so the typed CommandError renders its message.
+    toast.errorDetail(i18n.t("dialog:toast.printFailed"), error);
   }
 }
 

--- a/src/locales/de/dialog.json
+++ b/src/locales/de/dialog.json
@@ -88,7 +88,7 @@
   "toast.exportImageWarning_other": "{{count}} Bilder konnten nicht eingebettet werden und fehlen in der Ausgabe",
   "toast.failedToPreparePdf": "PDF-Export konnte nicht vorbereitet werden",
   "toast.noEditorContentToPrint": "Kein Editor-Inhalt zum Drucken",
-  "toast.failedToOpenPrintDialog": "Druckdialog konnte nicht geöffnet werden",
+  "toast.printFailed": "Drucken fehlgeschlagen",
   "toast.htmlCopied": "HTML in Zwischenablage kopiert",
   "toast.pdfExportSuccess": "PDF erfolgreich exportiert",
   "toast.pdfExportPartial": "PDF exportiert, aber {{what}} konnte nicht hinzugefügt werden.",

--- a/src/locales/en/dialog.json
+++ b/src/locales/en/dialog.json
@@ -110,7 +110,7 @@
   "toast.exportImageWarning_other": "{{count}} images could not be embedded and are missing from the output",
   "toast.failedToPreparePdf": "Failed to prepare PDF export",
   "toast.noEditorContentToPrint": "No editor content to print",
-  "toast.failedToOpenPrintDialog": "Failed to open print dialog",
+  "toast.printFailed": "Print failed",
   "toast.htmlCopied": "HTML copied to clipboard",
   "toast.pdfExportSuccess": "PDF exported successfully",
   "toast.pdfExportPartial": "PDF exported, but {{what}} could not be added.",

--- a/src/locales/es/dialog.json
+++ b/src/locales/es/dialog.json
@@ -88,7 +88,7 @@
   "toast.exportImageWarning_other": "No se pudieron incrustar {{count}} imágenes y faltan en el resultado",
   "toast.failedToPreparePdf": "Error al preparar la exportación a PDF",
   "toast.noEditorContentToPrint": "No hay contenido del editor para imprimir",
-  "toast.failedToOpenPrintDialog": "Error al abrir el cuadro de diálogo de impresión",
+  "toast.printFailed": "Error al imprimir",
   "toast.htmlCopied": "HTML copiado al portapapeles",
   "toast.pdfExportSuccess": "PDF exportado correctamente",
   "toast.pdfExportPartial": "PDF exportado, pero no se pudo añadir {{what}}.",

--- a/src/locales/fr/dialog.json
+++ b/src/locales/fr/dialog.json
@@ -88,7 +88,7 @@
   "toast.exportImageWarning_other": "{{count}} images n'ont pas pu être intégrées et sont absentes du résultat",
   "toast.failedToPreparePdf": "Impossible de préparer l'exportation PDF",
   "toast.noEditorContentToPrint": "Aucun contenu d'éditeur à imprimer",
-  "toast.failedToOpenPrintDialog": "Impossible d'ouvrir la boîte de dialogue d'impression",
+  "toast.printFailed": "Échec de l'impression",
   "toast.htmlCopied": "HTML copié dans le presse-papiers",
   "toast.pdfExportSuccess": "PDF exporté avec succès",
   "toast.pdfExportPartial": "PDF exporté, mais {{what}} n'a pas pu être ajouté.",

--- a/src/locales/it/dialog.json
+++ b/src/locales/it/dialog.json
@@ -88,7 +88,7 @@
   "toast.exportImageWarning_other": "Impossibile incorporare {{count}} immagini, che risultano assenti dall'output",
   "toast.failedToPreparePdf": "Preparazione esportazione PDF fallita",
   "toast.noEditorContentToPrint": "Nessun contenuto dell'editor da stampare",
-  "toast.failedToOpenPrintDialog": "Apertura della finestra di dialogo di stampa fallita",
+  "toast.printFailed": "Stampa non riuscita",
   "toast.htmlCopied": "HTML copiato negli appunti",
   "toast.pdfExportSuccess": "PDF esportato con successo",
   "toast.pdfExportPartial": "PDF esportato, ma non è stato possibile aggiungere {{what}}.",

--- a/src/locales/ja/dialog.json
+++ b/src/locales/ja/dialog.json
@@ -88,7 +88,7 @@
   "toast.exportImageWarning_other": "{{count}}個の画像を埋め込めなかったため、出力から欠落しています",
   "toast.failedToPreparePdf": "PDFエクスポートの準備に失敗しました",
   "toast.noEditorContentToPrint": "印刷するエディターコンテンツがありません",
-  "toast.failedToOpenPrintDialog": "印刷ダイアログを開けませんでした",
+  "toast.printFailed": "印刷に失敗しました",
   "toast.htmlCopied": "HTMLをクリップボードにコピーしました",
   "toast.pdfExportSuccess": "PDFのエクスポートに成功しました",
   "toast.pdfExportPartial": "PDF を書き出しましたが、{{what}}を追加できませんでした。",

--- a/src/locales/ko/dialog.json
+++ b/src/locales/ko/dialog.json
@@ -88,7 +88,7 @@
   "toast.exportImageWarning_other": "이미지 {{count}}개를 포함하지 못해 출력에서 누락되었습니다",
   "toast.failedToPreparePdf": "PDF 내보내기 준비에 실패했습니다",
   "toast.noEditorContentToPrint": "인쇄할 편집기 콘텐츠가 없습니다",
-  "toast.failedToOpenPrintDialog": "인쇄 대화 상자를 열지 못했습니다",
+  "toast.printFailed": "인쇄에 실패했습니다",
   "toast.htmlCopied": "HTML이 클립보드에 복사되었습니다",
   "toast.pdfExportSuccess": "PDF 내보내기가 완료되었습니다",
   "toast.pdfExportPartial": "PDF를 내보냈지만 {{what}}을(를) 추가하지 못했습니다.",

--- a/src/locales/pt-BR/dialog.json
+++ b/src/locales/pt-BR/dialog.json
@@ -88,7 +88,7 @@
   "toast.exportImageWarning_other": "{{count}} imagens não puderam ser incorporadas e estão ausentes da saída",
   "toast.failedToPreparePdf": "Falha ao preparar a exportação de PDF",
   "toast.noEditorContentToPrint": "Nenhum conteúdo do editor para imprimir",
-  "toast.failedToOpenPrintDialog": "Falha ao abrir a caixa de diálogo de impressão",
+  "toast.printFailed": "Falha ao imprimir",
   "toast.htmlCopied": "HTML copiado para a área de transferência",
   "toast.pdfExportSuccess": "PDF exportado com sucesso",
   "toast.pdfExportPartial": "PDF exportado, mas não foi possível adicionar {{what}}.",

--- a/src/locales/zh-CN/dialog.json
+++ b/src/locales/zh-CN/dialog.json
@@ -88,7 +88,7 @@
   "toast.exportImageWarning_other": "{{count}} 张图片无法嵌入，输出中将缺失",
   "toast.failedToPreparePdf": "无法准备 PDF 导出",
   "toast.noEditorContentToPrint": "没有要打印的编辑器内容",
-  "toast.failedToOpenPrintDialog": "无法打开打印对话框",
+  "toast.printFailed": "打印失败",
   "toast.htmlCopied": "HTML 已复制到剪贴板",
   "toast.pdfExportSuccess": "PDF 导出成功",
   "toast.pdfExportPartial": "已导出 PDF，但无法添加{{what}}。",

--- a/src/locales/zh-TW/dialog.json
+++ b/src/locales/zh-TW/dialog.json
@@ -88,7 +88,7 @@
   "toast.exportImageWarning_other": "{{count}} 張圖片無法嵌入，輸出中將缺失",
   "toast.failedToPreparePdf": "無法準備 PDF 匯出",
   "toast.noEditorContentToPrint": "沒有可列印的編輯器內容",
-  "toast.failedToOpenPrintDialog": "無法開啟列印對話框",
+  "toast.printFailed": "列印失敗",
   "toast.htmlCopied": "HTML 已複製至剪貼簿",
   "toast.pdfExportSuccess": "PDF 匯出成功",
   "toast.pdfExportPartial": "已匯出 PDF，但無法加入{{what}}。",


### PR DESCRIPTION
## Summary

- On Linux, `start_print()` settled the sink and closed the hidden print helper webview the moment `webkit_print_operation_run_dialog` returned. Confirming the dialog only STARTS the job — CUPS spooling / Print-to-File output completes asynchronously afterwards, signalled by the operation's `finished`/`failed` signals — so a slow job could still be rendering from a webview being torn down (#1343, surfaced by the Codex audit of #1341's fix and deferred there with this exact fix shape).
- The fix branches on `run_dialog`'s `PrintOperationResponse`: **Cancel** settles and closes immediately (nothing started; `finished` may never fire, so waiting on it would leak the hidden helper forever); **Print** defers settle-and-close to `finished`/`failed` handlers connected before the dialog runs — exactly what the export path `start()` has always done. A confirmed job that fails now reports its error instead of silently reading as success.

Fixes #1343

## What changed

- `src-tauri/src/pdf_export/renderer/linux_print.rs` (new) — the print-dialog path, moved out of `linux.rs` mirroring the existing `windows.rs`/`windows_print.rs` split (the fix pushed `linux.rs` past the 300-line gate). Carries the `PrintOperationResponse` branch and the timeout note (`PDF_OPERATION_TIMEOUT`: a job that outlives it still settles idempotently and the hidden window still closes itself).
- `src-tauri/src/pdf_export/renderer/linux.rs` — export path only; shared helpers now `pub(super)`. Both Linux `Finished` handlers gained a `load_failed` flag: a failed load still reaches `Finished`, and `close()` only queues the teardown, so the print path popped a dialog over WebKit's error page and the export path printed the error page into a PDF reported as **success**. Export now fails loudly (`errors.pdf.loadFailed`), matching Windows' `IsSuccess` check.
- `src-tauri/src/pdf_export/renderer/mod.rs` — dispatches print to `linux_print` per platform. Two temp-file defects fixed in the same pass (both audit-confirmed):
  - `print_document` unlinked the temp HTML right after dispatch, while navigation was still reading it — deleted; the sink owns deletion (settle + Drop, both pinned by `mod.test.rs`), the rule `render_pdf` already documents.
  - `print_document` still wrote its temp file under a predictable pid+clock name with a blocking write — the class `render_pdf` had already fixed. Both paths now share `write_render_temp`: O_EXCL + 0600 via `tempfile`, written **through the open handle** on a blocking thread, `keep()`ed only after the write succeeds (`keep()` before the write — the previous shape — leaked a partial private document on a failed write, with no owner left to remove it).
- `src/export/useExportOperations.ts` + all ten `src/locales/*/dialog.json` — the catch on `print_document` mapped every rejection to "Failed to open print dialog"; a confirmed-then-failed Linux job now rejects *after* the dialog opened fine, so the message was wrong exactly when it matters. Now `toast.errorDetail` under a neutral "Print failed" headline with the raw typed error (key renamed `failedToOpenPrintDialog` → `printFailed`, translated in all ten locales). `printFailureToast.test.ts` pins both, written RED first.
- `src/export/renderMarkdownToHtml.ts` (new) — verbatim extraction from `useExportOperations.ts`, which sits under a frozen file-size baseline the new catch comment crossed; the gate's remedy is a split, not a squeeze. Baseline lowered 446 → 333.
- Stale docs corrected in the same pass (rule 22): `commands.rs` and two `useExportOperations.ts` blocks still called print "native macOS print dialog" / `window.print()` (false since WI-PDF4.1); `sink.rs`'s coordinates line omitted both `*_print.rs` settlers; `commands.rs` now also records that the helper is hidden on macOS/Linux but must stay visible on Windows (`ShowPrintUI` draws inside it).

## Audits

- **Workflow adversarial review** (3 lenses × 3-vote refutation): zero sustained findings; the toast-wording concern was confirmed in verification and fixed here.
- **Codex round 1**: five objections — temp-file unlink race (fixed), zombie dialog after failed load (fixed), mislabeled toast (fixed), stale macOS-only docs (fixed), missing Rust regression test (**overruled with evidence**: the modules compile only on CI's Linux leg, `tauri::test::MockRuntime` creates no real webview, and the behavior needs a display plus dialog interaction — the boundary PR #1342 records; the sibling export path has no unit tests for the same reason).
- **Codex round 2** (verification): confirmed the `Rc<Cell>` captures against the pinned tauri/webkit2gtk closure bounds (Send only on the outer `with_webview` closure; the Rc never crosses it), confirmed no caller depends on the old garbage-PDF-as-success export behavior, found the `keep()`-before-write leak in my first `write_render_temp` (fixed as above), and confirmed all ten locale files parse with full key parity.

## Validation

- `cargo fmt --check` — pass (rustfmt parses the cfg'd-out Linux modules, so their syntax and formatting are verified locally).
- `cargo clippy --all-targets -- -D warnings` — pass (macOS view; this compiles `write_render_temp` and the `mod.rs` dispatch for real).
- `cargo test --lib pdf_export` — 103 passed (includes the sink settle-once/Drop invariants both fixes lean on).
- `bash scripts/check-cross-target.sh` — Windows view compiles clean.
- `pnpm vitest run src/export/__tests__` — 308 passed, including the new RED-first `printFailureToast.test.ts`.
- `pnpm check:predelta` — all 41 delta gates pass; `pnpm check:all` — pass.
- Every webkit2gtk API use was verified against the pinned `webkit2gtk-2.0.2` crate source in the local registry (`run_dialog` signature/return, `PrintOperationResponse` variants + `#[non_exhaustive]`, signal closure bounds). Compile verification of the Linux modules happens on CI's Linux `rust-test` leg — no local cargo invocation can see them on macOS.
- The Linux `pdf-smoke` CI job runs `render_pdf` through the real WebKitGTK backend under Xvfb, so `write_render_temp` and the export-path `load_failed` guard get real runtime coverage there.

## Runtime verification still open (needs a Linux desktop)

The issue's verification steps require an interactive Linux box: a deliberately slow print target (paused CUPS queue, or Print-to-File with a large document), confirm via Ctrl+P, verify the job completes intact and the helper closes afterwards; on Cancel, verify the helper still closes promptly (`wmctrl -l` — it is invisible since #1341). A `pdf_smoke` extension could automate this (preselect Print-to-File, drive the GTK dialog from a GLib callback, assert a `pdf-render-*` helper survives a delayed job and is gone after) — noted as follow-up; it is a new harness capability, not something verifiable from this macOS machine.

## Type of change

- Bug fix
