### PR TITLE
feat(terminal): per-workspace-instance terminal session sets (WI-TS)

### DIFF
--- a/.cc-suite/audits/audit-fix-20260831-190500-findings.md
+++ b/.cc-suite/audits/audit-fix-20260831-190500-findings.md
@@ -1,0 +1,54 @@
+# Audit Findings
+
+**Run**: audit-fix 20260831-190500 | **Scope**: uncommitted changes (terminal-scoping plan + pill/tab UI, 36 files) | **Audit type**: mini
+**Model**: gpt-5.6-sol | **Effort**: high | **Audit threads**: 01a05769-9cdb-7f81-9e20-26bc21eebd8d (b1); b2a/b2b/b3a per job logs; b3b+b4 stalled → Claude fallback
+**Status values**: open | fixed | not-fixed | partial | regressed | skipped (severity filter) | skipped (user stop)
+
+| # | File | Line | Severity | Dimension | Finding | Suggested fix | Status | Round |
+|---|------|------|----------|-----------|---------|---------------|--------|-------|
+| 1 | src/stores/uiStore.ts | 203 | Low | Logic | Comment says 50% cap; TERMINAL_MAX_RATIO is 0.8 | Fix comment | fixed | 1 |
+| 2 | src/stores/uiStore/terminalSlice.ts | 71 | High | Duplication | creationUnion reimplements the scope-visibility predicate (also in terminalScopeSelectors + terminalScopeActions) | One shared pure predicate | fixed | 1 |
+| 3 | src/stores/uiStore/terminalSlice.ts | 210 | Medium | Shortcuts | Title sanitization strips only C0+DEL; C1 and bidi controls pass through | Strip C1 + bidi controls too | fixed | 1 |
+| 4 | src/stores/uiStore/terminalScopeActions.ts | 31 | High | Duplication | visibleIn/renumber duplicate the visibility rule | Reuse shared predicate | fixed | 1 |
+| 5 | src/stores/uiStore/terminalScopeSelectors.ts | 37 | Low | Dead Code | selectVisibleSessionCount has no production caller | Use it at production count gates (canOpenTerminalHere) | not-fixed (deferred — see report) | 1 |
+| 6 | src/stores/workspaceInstancesStore.ts | 94 | High | Logic | ID-accepting placeholder/loose paths don't reject IDs owned by another instance (pre-existing) | Needs a design decision (reject vs reconcile) | not-fixed (deferred — see report) | 1 |
+| 7 | src/stores/workspaceInstancesStore.ts | 118 | High | Debt | ensureLooseInstance 109-line action (pre-existing) | Extract pure reducer | not-fixed (deferred — see report) | 1 |
+| 8 | src/stores/workspaceInstancesStore.ts | 180 | High | Duplication | Placeholder filtering duplicates applyAddWorkspaceInstance/removePlaceholdersFromWindow (pre-existing) | One placeholder-removal helper | not-fixed (deferred — see report) | 1 |
+| 9 | src/stores/workspaceInstancesStore.ts | 218 | High | Logic | Rekey fan-out omits tabStoreClosedScopes — closed history orphaned under old id; publishes before dependent rekeys | Add closed-scopes rekey follower | fixed | 1 |
+| 10 | src/stores/workspaceInstancesStore/helpers.ts | 106 | High | Logic | Same-ID placeholder→real corrupts state: id filtered from membership then record deleted (pre-existing, moved verbatim) | Exclude incoming id from placeholder eviction; regression test | fixed | 1 |
+| 11 | src/stores/workspaceInstancesStore/helpers.ts | 77 | Medium | Debt | applyAddWorkspaceInstance >30 lines (pre-existing) | Split into pure helpers | not-fixed (deferred — see report) | 1 |
+| 12 | src/stores/tabStoreClosedScopes.ts | 80 | High | Logic | isValidClosedEntry validates a subset of Tab; malformed persisted entries reach tabStore (pre-existing) | Validate full discriminated schema | not-fixed (deferred — see report) | 1 |
+| 13 | src/stores/tabStoreClosedScopes.ts | 195 | Medium | Logic | Hydration slices before sorting; reordered payload keeps wrong entries (pre-existing) | Sort by closedSeq desc before cap | fixed | 1 |
+| 14 | src/stores/tabStoreClosedScopes.ts | 207 | Medium | Logic | closedSeq near MAX_SAFE_INTEGER breaks monotonic nextSeq (pre-existing) | Reject entries without safe headroom | fixed | 1 |
+| 15 | src/stores/tabStoreClosedScopes.ts | 222 | Medium | Dead Code | removeWindowClosedScopes has no production caller (pre-existing; known in plan) | Wire into window teardown or remove | not-fixed (deferred — see report) | 1 |
+| 16 | src/services/terminal/terminalCdFollow.ts | 29 | High | Logic | Rail-off early return treats an unknown/removed session as followable | Lookup first; absent → false | fixed | 1 |
+| 17 | src/services/terminal/maybeAutoCreateTerminalSession.ts | 54 | High | Duplication | Owner-aware creation repeated across 4 creators | One shared creation service | fixed | 1 |
+| 18 | src/services/terminal/revealTerminalSession.ts | 44 | High | Logic | activeSessionId reused without visible-membership check; fallback not activated | Verify membership; setActive on fallback | fixed | 1 |
+| 19 | src/services/terminal/revealTerminalSession.ts | 53 | High | Logic | Non-null assertion on creation result | Explicit null handling (fail loud) | fixed | 1 |
+| 20 | src/services/terminal/openTerminalHere.ts | 46 | High | Logic | canOpenTerminalHere counts visible; creation uses owner union — can diverge | One authoritative can-create predicate | fixed | 1 |
+| 21 | src/services/terminal/openTerminalHere.ts | 36 | Medium | Debt | OpenTerminalHereResult not a discriminated union | Discriminate on ok | fixed | 1 |
+| 22 | src/services/workspaces/switchWorkspaceInstance.ts | 113 | High | Duplication | restoreIncomingInstance duplicates hydrate's restoration block | Shared context-restoration helper | fixed | 1 |
+| 23 | src/services/workspaces/switchWorkspaceInstance.ts | 173 | High | Logic | Missing-record outgoing satisfies kind!=="placeholder" → adopt stamps dead owner; incoming record unchecked | Require present records | fixed | 1 |
+| 24 | src/services/workspaces/closeWorkspaceInstance.ts | 108 | High | Logic | Owned tabs snapshotted before await; tabs opened during prompt orphaned on removal (pre-existing) | Re-collect and re-close until empty/cancelled | fixed | 1 |
+| 25 | src/services/workspaces/closeWorkspaceInstance.ts | 126 | High | Logic | Active-close successor gets ONLY terminal hydration; panes/sidebar/config stale | Run full hydrateWorkspaceInstanceContext | fixed | 1 |
+| 26 | src/services/workspaces/closeWorkspaceInstance.ts | 123 | High | Duplication | Post-removal lifecycle duplicates move's and has drifted | Shared removal finalizer | fixed | 1 |
+| 27 | src/services/workspaces/workspaceWindowActions.ts | 38 | High | Duplication | Move cleans fewer per-instance stores than close (ui/pane) | Plan G2 explicitly defers cross-window ui/pane orphan cleanup | not-fixed (deferred — see report) | 1 |
+| 28 | src/services/workspaces/workspaceWindowActions.ts | 31 | High | Logic | Move/duplicate have no in-flight lock (close has `closing` set) | Mirror the closing-set guard | fixed | 1 |
+| 29 | src/services/workspaces/workspaceWindowActions.ts | 103 | High | Logic | Transfer application has no rollback (pre-existing machinery) | Needs transactional design + Rust changes | not-fixed (deferred — see report) | 1 |
+| 30 | src/services/workspaces/workspaceWindowActions.ts | 163 | High | Logic | Ack retry vs backend route removal (pre-existing, Rust interplay) | Needs backend contract change | not-fixed (deferred — see report) | 1 |
+| 31 | src/services/workspaces/workspaceWindowActions.ts | 239 | High | Logic | Timeout cancel cannot stop a claimed in-progress target (pre-existing) | Needs transfer state machine | not-fixed (deferred — see report) | 1 |
+| 32 | src/components/Terminal/TerminalPanel.tsx | 191 | High | Duplication | handleClose duplicates closeSessionOnCleanExit; predicates drifted; stale hidden active removable | One shared close helper, membership-verified | fixed | 1 |
+| 33 | src/components/Terminal/TerminalPanel.tsx | 62 | Medium | Debt | Panel mixes many concerns (~290 lines, pre-existing shape) | Extract hooks (defer) | not-fixed (deferred — see report) | 1 |
+| 34 | src/components/Terminal/TerminalTabBar.tsx | 130 | Medium | Logic | renamingId survives scope switches; rename mode resurrects | Clear when session not visible | fixed | 1 |
+| 35 | src/components/Terminal/TerminalTabBar.tsx | 94 | Medium | Debt | Component combines many roles (pre-existing shape) | Extract subcomponents (defer) | not-fixed (deferred — see report) | 1 |
+| 36 | src/components/Terminal/terminalKeyHandler.ts | 58 | High | Duplication | DEFAULT_TERMINAL_FONT_SIZE=13 duplicates settings defaults | Import canonical default | fixed | 1 |
+| 37 | src/components/Terminal/terminalKeyHandler.ts | 90 | High | Debt | 182-line order-sensitive handler (pre-existing) | Split handlers (defer) | not-fixed (deferred — see report) | 1 |
+| 38 | src/components/Terminal/useTerminalSessions.ts | 153 | High | Logic | createTerminalInstance throw leaves store session alive → permanent blank tab (pre-existing) | Remove store session on failure + test | fixed | 1 |
+| 39 | src/components/Terminal/useTerminalSessions.ts | 65 | Medium | Debt | Hook + 70-line createSession (pre-existing) | Factory extraction (defer) | not-fixed (deferred — see report) | 1 |
+| 40 | src/components/Terminal/useTerminalSessions.ts | 239 | Low | Dead Code | sessionsRef exposed in return with no consumer | Remove from return | fixed | 1 |
+| 41 | src/components/Terminal/useTerminalSessionsInit.ts | 40 | Medium | Debt | 57-line effect (this plan; concerns are documented) | Extract helpers (defer) | not-fixed (deferred — see report) | 1 |
+| 42 | src/components/Terminal/useTerminalShellLifecycle.ts | 102 | Medium | Debt | startShell ~120 lines (pre-existing, Claude-fallback finding) | Extract spawn phases (defer) | not-fixed (deferred — see report) | 1 |
+| 43 | src/components/Terminal/spawnPty.ts | 52 | Low | Dead Code | resolveTerminalCwd has no production caller post-WI-TS4.1 (tests only; documented contract) | Keep-or-remove decision | not-fixed (deferred — see report) | 1 |
+| 44 | src/components/Terminal/terminalSessionStoreSync.ts | 152 | Medium | Debt | syncRoot long/nested (pre-existing, Claude-fallback finding) | Extract loop body (defer) | not-fixed (deferred — see report) | 1 |
+| 45 | e2e/lib/rail.mjs | 36 | Medium | Duplication | Settings StorageEvent writer duplicates browser.mjs's (Claude-fallback finding) | Shared patchPersistedSettings helper | fixed | 1 |
+| 46 | scripts/check-tscope-phase.sh | 40 | Low | Duplication | Helper fns copied from check-gha-phase.sh — governance §3 prescribes copy-as-template | Justified; skip | skipped (justified: governance §3 copy-as-template) | 1 |

--- a/.cc-suite/audits/audit-fix-20260831-211200-r2-findings.md
+++ b/.cc-suite/audits/audit-fix-20260831-211200-r2-findings.md
@@ -1,0 +1,37 @@
+# Audit Findings — Round 2 (of 3)
+
+**Run**: audit-fix 20260831-211200 | **Scope**: the ~22 files touched by round 1 (`.cc-suite/audits/audit-fix-20260831-190500-findings.md`) | **Audit type**: mini (5-dim), 4 batches
+**Model**: gpt-5.6-sol | **Effort**: medium | **Sandbox**: read-only (audit), Claude fixer
+**Verify thread**: 01a057f5-5075-70f3-9896-5a2f0f3d2055 — all 15 fixes verdicted FIXED, REGRESSIONS: none
+**Status values**: open | fixed | not-fixed | partial | regressed | skipped (deferred, justified)
+
+Round-1 deferred items were listed in the audit preamble as known; only NEW findings appear here.
+
+| # | File | Line | Severity | Dimension | Finding | Fix applied | Status | Round |
+|---|------|------|----------|-----------|---------|-------------|--------|-------|
+| R2-1 | src/services/terminal/createTerminalSession.ts | 25 | High | test-coverage | `canCreateTerminalSessionHere` / `createTerminalSessionInScope` parity has no direct tests | NEW `createTerminalSession.test.ts`: owner-stamping carve-outs + predicate⇔action parity across plain/hidden-scope/window-scoped/unscoped states | fixed | 2 |
+| R2-2 | src/services/terminal/closeTerminalSession.ts | 36 | High | test-coverage | `onlyIfVisible` refusal, last-visible hide, no-resurrect untested directly | NEW `closeTerminalSession.test.ts` (6 tests incl. hidden-scope fallback pick) | fixed | 2 |
+| R2-3 | src/services/terminal/terminalCdFollow.ts | 33 | High | test-coverage | unknown-session branch untested in either rail mode | NEW `terminalCdFollow.test.ts` (unknown-id both modes, stamps inert rail-off, check-time owner resolution) | fixed | 2 |
+| R2-4 | src/services/terminal/revealTerminalSession.ts | 46 | High | test-coverage | stale-hidden-active fallback (#18) untested | NEW `revealTerminalSession.test.ts` (5 tests incl. fallback activation + cap null) | fixed | 2 |
+| R2-5 | src/stores/uiStore/terminalScopeActions.ts | 58 | Medium | duplication | smallest-unused-ordinal loop duplicated with `nextTerminalOrdinal` | shared `smallestUnusedOrdinal()` exported from terminalSlice, both callers use it | fixed | 2 |
+| R2-6 | src/stores/uiStore/terminalScopeActions.ts | 75 | Medium | duplication | `withActivation` re-implements `terminalSetActiveSession`'s activity-clear transition | shared `withActiveSession()` in terminalSlice; slice action + all scope actions use it | fixed | 2 |
+| R2-7 | src/stores/uiStore/terminalScopeActions.ts | 87 | Low | size-debt | scope-actions factory growing | — deferred: adjacent to round-1 deferred size class; file is under the gate | skipped (deferred, justified) | 2 |
+| R2-8 | src/stores/tabStoreClosedScopes.ts | 134 | High | correctness | unowned-tab fallback records history under a PLACEHOLDER-active id; placeholder eviction orphans it | fallback skips placeholder actives → `WINDOW_ALL_SCOPE`; regression test | fixed | 2 |
+| R2-9 | src/stores/tabStoreClosedScopes.ts | 209 | High | correctness | hydration adds ids to `seenIds` BEFORE the cap, so an id capped out of scope A is suppressed from every later scope (exposed by round 1's sort fix) | dedup moved to acceptance time (only surviving entries enter `seenIds`); 3 regression tests | fixed | 2 |
+| R2-10 | src/services/workspaces/finalizeInstanceRemoval.ts | 40 | High | test-coverage | the shared removal lifecycle has no focused tests | NEW `finalizeInstanceRemoval.test.ts`: table-driven close/move dispatch, placeholder/empty-window invariants, active-only hydration | fixed | 2 |
+| R2-11 | src/services/workspaces/switchWorkspaceInstance.ts | 48 | Low | dead-code | `sanitizeSplitForInstance` re-export has no production importer | re-export removed; test imports `./restoreInstanceContext` directly | fixed | 2 |
+| R2-12 | src/services/workspaces/closeWorkspaceInstance.ts | 113 | Medium | clarity/UX | convergence bound is a bare `5`; `busy` result discarded silently by the rail caller | `MAX_CLOSE_CONVERGENCE_PASSES` named + documented; exhaustion test; rail toasts `busy` (`toast.workspaceCloseBusy` added to all 10 locales) | fixed | 2 |
+| R2-13 | src/services/workspaces/closeWorkspaceInstance.ts | 90 | Low | size-debt | extract the convergence loop | — deferred: function is cohesive and under repo norms; extraction is churn without a defect | skipped (deferred, justified) | 2 |
+| R2-14 | src/services/workspaces/workspaceWindowActions.ts | 29 | High | correctness | `closing` and `transferring` are SEPARATE sets — a close can start during a move's ack wait (and vice versa) on the same instance | NEW `instanceOperationLock.ts` (one per-instance lock across close/move/duplicate); cross-operation exclusion tests | fixed | 2 |
+| R2-15 | src/components/Terminal/TerminalPanel.tsx | 96 | High | correctness | rail-MODE toggle is not an auto-create dependency and nothing realigns the active session — a hidden active over an empty tab bar blocks auto-create | `terminalRealignActive` store action + `realignTerminalActiveToVisible` service; effect deps now `[visible, activeInstanceId, railEnabled]`, realign before auto-create; action + component tests | fixed | 2 |
+| R2-16 | e2e/lib/rail.mjs | 46 | Medium | correctness | restore writes `before ?? false` — an ABSENT key comes back as explicit `false`, shadowing future default changes | presence-faithful restore: `patchPersistedSettings` gains `deleteKeys`; `clearRailMode()` deletes when the key was absent | fixed | 2 |
+| R2-17 | e2e/lib/rail.mjs | 46 | High | correctness | restore errors swallowed (`.catch(() => {})`) — a failed restore leaves the profile flipped silently (hit live in round 1) | restore failure rethrows when the body succeeded; logged (not masking) when the body already failed | fixed | 2 |
+
+Incidental (consequence of R2-12's fix): `WorkspaceRail.tsx` crossed the 300-line
+gate → close/move/duplicate handlers extracted to
+`src/components/WorkspaceRail/workspaceRailHandlers.ts` (behavior unchanged;
+rail tests green).
+
+Verification battery already run: 9 direct test files (104 tests), dependent
+files (209 tests), `pnpm test:changed` (65 files / 1,237 tests), i18n gate,
+`pnpm check:predelta` 41/41 green.

--- a/.cc-suite/audits/audit-fix-20260831-213000-r3-findings.md
+++ b/.cc-suite/audits/audit-fix-20260831-213000-r3-findings.md
@@ -1,0 +1,38 @@
+# Audit Findings — Round 3 (of 3)
+
+**Run**: audit-fix 20260831-213000 | **Scope**: the files touched by round 2 (`.cc-suite/audits/audit-fix-20260831-211200-r2-findings.md`) | **Audit type**: mini (5-dim), 3 batches
+**Model**: gpt-5.6-sol | **Effort**: medium | **Sandbox**: read-only (audit), Claude fixer
+**Verification**: the Codex verify call STALLED (thread 01a05815-285b-7c20-8604-958c13916f91, no output; per the skill, a stalled call is not retried). Fallback: Claude evidence-based verification — every production edit spot-checked present in the tree, every fix's pinned test run green, plus `check:predelta` 41/41 and a full `pnpm check:all` green (36,825 passed | 1 expected fail | 82 skipped).
+**Status values**: open | fixed | not-fixed | partial | regressed | skipped (deferred, justified)
+
+Round-1/round-2 deferred items were listed in the audit preamble as known.
+Batch 2 nevertheless re-surfaced the deferred **transfer state machine** class
+(5 High findings at workspaceWindowActions.ts:41/115/178/190/250 — mid-move
+mutation freeze, atomic claim/commit protocol, Rust ack-route retention,
+target-side rollback, cancellation race). All five need the Rust-side transfer
+protocol redesign that round 1 recorded as deferred; same disposition here,
+not new work items. Every other batch-2 file was CLEAN.
+
+| # | File | Line | Severity | Dimension | Finding | Fix applied | Status | Round |
+|---|------|------|----------|-----------|---------|-------------|--------|-------|
+| R3-1 | src/stores/uiStore/terminalSlice.ts | 195 | Medium | correctness | `terminalRemoveSession` assigned its fallback `activeSessionId` directly, bypassing `withActiveSession` — an activated fallback kept a stale activity dot | removal now applies the fallback through `withActiveSession` (D-T11); regression tests in `terminalSlice.scope.test.ts` | fixed | 3 |
+| R3-2 | src/stores/tabStoreClosedScopes.ts | 88 | High | correctness | `isValidClosedEntry` accepted incomplete tabs (no title/isPinned/formatId/automationMode/persistPolicy) that reopen restores VERBATIM into tabStore | full per-kind required-shape + enum validation; moved to NEW `tabStoreClosedScopesValidation.ts` (file-size split, `ClosedTabEntry` re-exported); per-field rejection tests | fixed | 3 |
+| R3-3 | src/stores/tabStoreClosedScopes.ts | 112 | Medium | correctness | the canonical URL was computed for validation then DISCARDED — noncanonical persisted spellings bypassed the live creation invariant | `normalizeAcceptedEntry` rewrites the URL to canonical at acceptance; pinned by test | fixed | 3 |
+| R3-4 | src/stores/tabStoreClosedScopes.ts | 206 | Medium | correctness | hydration accepted scope keys for nonexistent/cross-window instances — unreachable history retained and re-persisted forever | scope-key whitelist (window-all, browser, THIS window's instance ids — same restore ordering R2-F16 relies on); test + fixtures seeded | fixed | 3 |
+| R3-5 | src/stores/tabStoreClosedScopes.ts | 267 | Low | dead-code | `removeWindowClosedScopes` had tests but zero production callers | wired into `windowCloseFlow.ts` teardown beside tabStore/paneStore `removeWindow` | fixed | 3 |
+| R3-6 | src/stores/tabStoreClosedScopes.test.ts | 180 | Medium | test-coverage | hydration fixtures were themselves malformed Tabs, institutionalizing the incomplete validation | `doc()`/`browserTab()`/`docEntry()`/`webEntry()` now build complete typed shapes; rejection cases added per missing field | fixed | 3 |
+| R3-7 | src/stores/tabStoreClosedScopes.test.ts | 200 | Medium | test-coverage | hydration tests used `wsi-a`/`wsi-b` without creating instances, so orphan-scope acceptance was undetectable | affected describes seed real instances; explicit ghost-scope rejection test | fixed | 3 |
+| R3-8 | src/components/WorkspaceRail/WorkspaceRail.tsx | 145 | High | correctness | claim: a genuine outside-viewport drag ends with `dropEffect === "none"`, so the cancel guard may suppress the move-to-new-window gesture | — deferred: the guard predates this plan train (0.8.10-era audit fix for Esc-cancel-treated-as-move); whether a real outside drag reports "none" in Tauri WebKit is only decidable by a LIVE drag test, and removing the guard risks regressing the documented cancel bug. Needs manual/e2e verification before any change | skipped (deferred, justified) | 3 |
+| R3-9 | e2e/lib/rail.mjs | 68 | High | correctness | deleting the persisted key cannot reset the LIVE store — the storage-event reconciler deep-merges, so the journey's forced value survived (confirmed against `reconcile.ts`) | absent-key restore now pushes the shipped default (`false`) through the event FIRST, then deletes the key | fixed | 3 |
+| R3-10 | src/components/WorkspaceRail/workspaceRailHandlers.ts | 39 | Medium | correctness | service rejections escaped the void-fired handlers — unhandled rejection, no failure toast | all three handlers catch, log via `workspaceError`, and toast (`toast.workspaceCloseFailed` added to all 10 locales); rejection tests | fixed | 3 |
+| R3-11 | src/components/WorkspaceRail/WorkspaceRail.tsx | 56 | Low | correctness | disabling the rail kept `menu` state — re-enabling resurrected a stale context menu | render-time guarded `setMenu(null)` before the early return; toggle-while-open test | fixed | 3 |
+| R3-12 | src/components/WorkspaceRail/workspaceRailHandlers.ts | 42 | Low | test-coverage | the close busy/cancelled/missing toast policy had no assertions | NEW `workspaceRailHandlers.test.ts`: table-driven policy + rejection paths for all three handlers | fixed | 3 |
+
+Incidental (consequence of R3-2): `tabStoreClosedScopes.ts` crossed the
+300-line gate → validation extracted to `tabStoreClosedScopesValidation.ts`;
+a type-only back-import tripped dependency-cruiser's `no-circular`, so
+`ClosedTabEntry` is defined in the validation module and re-exported.
+
+Batch-3 CLEAN files: visibleTerminalSessions.ts, the four new terminal test
+files, TerminalPanel.tsx, settingsPatch.mjs (aside from R3-9's pairing).
+Batch-1 CLEAN files: terminalScopeActions.ts, types.ts, terminalScopeActions.test.ts.

--- a/.claude/rules/21-website-docs.md
+++ b/.claude/rules/21-website-docs.md
@@ -28,6 +28,7 @@ Update website docs when:
 | Change broken-link checking | `website/guide/link-check.md` |
 | Change PTY / terminal pause | `website/guide/terminal.md` |
 | Change workspace content search | `website/guide/workspace-management.md` |
+| Change workspace rail behavior (rail UI, context switch, per-workspace terminal scoping) | `website/guide/workspace-rail.md` |
 | Add/modify AI suggestion UI | `website/guide/ai-genies.md` |
 | Add/modify format adapter (registry / dispatch / new file type) | `website/guide/formats.md` |
 | Change SplitPaneEditor behavior (source pane, validation gutter, split UX) | `website/guide/formats.md` |
@@ -56,6 +57,7 @@ Update website docs when:
 | `src/lib/lintEngine/`, `src/plugins/lint/` | `website/guide/lint.md` |
 | `src/lib/markdownLinkCheck/` | `website/guide/link-check.md` |
 | `src-tauri/src/content_search.rs` | `website/guide/workspace-management.md` (Workspace Content Search) |
+| `src/components/WorkspaceRail/`, `src/services/workspaces/` (instances, switch, close/move) | `website/guide/workspace-rail.md` |
 | `src/plugins/aiSuggestion/`, `src/stores/aiStore/suggestion.ts` | `website/guide/ai-genies.md` (AI Suggestions section) |
 | `src/lib/formats/` (registry + adapters) | `website/guide/formats.md` |
 | `src/components/Editor/SplitPaneEditor/` | `website/guide/formats.md` |

--- a/.claude/rules/31-design-tokens.md
+++ b/.claude/rules/31-design-tokens.md
@@ -192,7 +192,7 @@ no interactive element takes a smaller hit box; paint-small controls centre a
 | `--radius-sm` | `4px` | Small buttons, toggles |
 | `--radius-md` | `6px` | Inputs, medium containers |
 | `--radius-lg` | `8px` | Popups, dialogs, menus |
-| `--radius-pill` | `100px` | Pill shapes, tags |
+| `--radius-pill` | `100px` | Pill shapes, tags, `.vm-btn--pill` capsule buttons |
 
 **Acceptable hardcoded values** (do not tokenize):
 - `0.5px` for retina sub-pixel borders

--- a/.claude/rules/32-component-patterns.md
+++ b/.claude/rules/32-component-patterns.md
@@ -6,7 +6,7 @@ Standard patterns for UI components. Follow these for consistency.
 
 | Need | Use | Defined in |
 |---|---|---|
-| Text button (start, stop, confirm, cancel) | `.vm-btn` (+ `--primary`, `--cta`, `--plain`, `--danger`, `--compact`) | `src/styles/button-shared.css` |
+| Text button (start, stop, confirm, cancel) | `.vm-btn` (+ `--primary`, `--cta`, `--plain`, `--danger`, `--compact`, `--pill`) | `src/styles/button-shared.css` |
 | Dropdown / `<select>` | `.vm-select` inside a `.vm-select-field` wrapper | `src/styles/select-shared.css` |
 | Icon-only square button inside a popup | `.popup-icon-btn` (+ `--primary`, `--danger`) — an alias of `.vm-icon-btn` base (md) | `src/styles/icon-button-shared.css` |
 | Icon-only square button anywhere else | `.vm-icon-btn` (+ `--sm` 24 / `--lg` 28 / `--bordered` / `--primary` / `--danger`) | `src/styles/icon-button-shared.css` |
@@ -25,7 +25,12 @@ Standard patterns for UI components. Follow these for consistency.
 current tab reads as a card raised to the page surface; that is deliberate and
 carries `ui-ok(state): current-tab` where the C9 gate would otherwise ask for
 `--accent-bg`. Selected LIST rows are the accent vocabulary (R6); the current
-tab is not a selected row.
+tab is not a selected row. Since 2026-08-31 the STATUS-BAR pills are
+borderless (`--shadow-sm` is the active boundary; WI-UI3.6's ring is
+superseded there) and their hover is the NEGATIVE treatment — ink and page
+swap tokens (`--text-color` bg, `--bg-color` text), AA by construction. The
+embedded browser's `.browser-page-tab` keeps the control-border idiom. Pinned
+by `tabPillSurface.test.ts`.
 
 A bare `<select>` keeps `appearance: auto`, so WebKit draws its own control —
 native bezel, native chevron, 5px pill radius — and author styling only partly

--- a/.claude/tdd-guardian/20260831-terminal-per-instance-sessions.md
+++ b/.claude/tdd-guardian/20260831-terminal-per-instance-sessions.md
@@ -1,0 +1,426 @@
+# Plan: Per-workspace-instance terminal session sets (WI-TS)
+
+**Status:** Phase 0 not started · v3 after refuter-panel round 1 + Codex
+cross-model review round 2 (see Review rounds; §6 requirement satisfied)
+**Home:** `.claude/tdd-guardian/` (tracked — committed on maintainer direction, 2026-08-31; DoD script lives in `scripts/`)
+**WI namespace:** `WI-TS<phase>.<n>` (§1 — bare `WI-N.M` collides across plans)
+**Release note:** Phases 1–4 are ONE release train — intermediate mains are
+gate-green but a rail user on a mid-train build sees transitional oddities
+(unfiltered tab bar until Phase 3). Do not tag a release between Phase 1 and
+the end of Phase 4.
+
+## Problem
+
+Terminal sessions are one window-global set (`terminalSlice.ts:35-36`); a rail
+switch "follows" only by typing `cd` into every live shell
+(`terminalSessionStoreSync.ts:172-193`). Live repro on 2026-08-31 (dev app,
+Tauri MCP harness) established:
+
+- Idle shell + rail switch → cd follows within ~1s (works).
+- **Busy shell** (`sleep 300`, i.e. any claude/vim/dev-server) + rail switch →
+  UI switches, shell stays in the old workspace for the entire life of the
+  foreground command, silently (`pendingRoot` deferral,
+  `terminalSessionStoreSync.ts:179-182`). This is the reported
+  "terminal isn't following" — for AI-tool users the shell is busy ~always.
+- Non-integrated shells (fish, all Windows — `shell_integration.rs:98-105`
+  returns `None`) have `isShellBusy()` ≡ false, so the switch types
+  `Ctrl+U cd '…'\n` INTO the foreground program.
+- Even when cd works it mutates the user's shell (clears partial input,
+  pollutes history) and shares one session set — scrollback, running
+  processes, `VMARK_WORKSPACE` — across every workspace.
+
+**Maintainer decision (2026-08-31): the right fix, not the cheap one** — scope
+terminal sessions to their owning `workspaceInstanceId`, the pattern the rail
+plan used for pane layouts (D3) and closed-tab scopes (D4). This revises
+rail-plan D2's "terminal is window-global" for the session set only; panel
+visibility/geometry stay window-global.
+
+## Decision record (settled — do not relitigate during implementation)
+
+| # | Decision | Rationale anchor |
+|---|---|---|
+| D-T1 | **Ownership is a per-session field, stamped at creation** from `getActiveWorkspaceScope(windowLabel).workspaceInstanceId` — with THREE carve-outs, resolved by ONE shared helper `resolveTerminalOwnerInstanceId(windowLabel)` in `src/services/terminal/`: never stamp a **placeholder** instance's id (placeholders are deleted silently by `addWorkspaceInstance`/`ensureLooseInstance` with no lifecycle follower — `workspaceInstancesStore.ts:51-65`, `:216-227`); never stamp while **`isWindowContextRestoring(windowLabel)`** (a mid-restore auto-create would bind to the pre-reconcile active id — `restoreHelpers.ts:165` fires before reconcile can re-activate); never stamp while the **rail is off**. Field absent ⇒ *window-scoped*. On every rail switch (and on hydrate), window-scoped sessions are **adopted by the outgoing (resp. active) instance**, skipping placeholder targets. | Creation always happens under the active scope (`useTerminalShellLifecycle.ts:122-137`). The carve-outs close the round-1 blocker (placeholder-stranded PTY) and the restore race (stamped-too-early → hidden session + double-create). |
+| D-T2 | **Store shape: flat list + owner field + per-scope active memory.** `TerminalSession.workspaceInstanceId?: string` (optional-key pattern of `requestedCwd`, `terminalSlice.ts:113`); new `lastActiveByScope: Record<string, string \| null>`. `activeSessionId` KEEPS its meaning — *the session currently shown* — so all ~10 consumers (fit, search, getActiveTerminal, bell isActive, restart, reveal, Cmd+N) stay semantically correct unmodified. | Verified round 1: every listed consumer is null-safe. |
+| D-T3 | **Sessions NEVER leave the store on a switch; scoping lives in selectors + visibility.** The reconcile subscription treats "id left the array" as *dispose xterm + kill PTY* (pre-split `useTerminalSessions.ts:258-273` → the module WI-TS0.2 extracts; → `terminalSessionReconcile.ts:42-45` → `removeSessionEntry`), with no guard on the removed side. Hiding = `switchVisibility`'s existing `display:none` driven by the `activeSessionId` change; hidden entries keep PTY + buffer (`terminalSessionRegistry.ts:54-65`). | Both review rounds confirmed: no other code path removes sessions on workspace changes; `switchVisibility(null)` hides all while preserving PTYs; the panel never unmounts once activated. |
+| D-T4 | **cd-follow applies ONLY to effectively-window-scoped sessions, at all THREE sites:** the syncRoot loop (`terminalSessionStoreSync.ts:172`, guard before `:179`), the post-spawn catch-up (`useTerminalShellLifecycle.ts:205-209`), and **`flushPendingRoot` (`terminalSessionStoreSync.ts:65-79`)** — the OSC-133 idle callback is an independent cd path and a `pendingRoot` recorded pre-adoption survives adoption. Owner resolved live from the store by session id. Guards are rail-aware (D-T15). | "Both sites" was refuted by BOTH review rounds independently — the flush is a third site; one guard inside `flushPendingRoot` covers every caller. |
+| D-T5 | **Cap and ordinals are per *visible population*; the cap is a CREATION-TIME GATE, not a population invariant.** Creation counts target scope ∪ window-scoped when rail on, all sessions when off; ordinal = smallest unused across the same union (no two visible "Terminal 1"). `terminalAdoptUnscopedSessions` renumbers on in-scope collision (labels untouched) and **never kills** — so a scope can transiently exceed 5 (reachable: sessions created under an active placeholder count no hidden scope, then get adopted later); the `+` stays disabled until the visible count drops below 5. **No window-level ceiling**: creation is one user click at a time behind the gate; a hidden idle session costs one PTY + a few MB of xterm buffer. If field feedback shows runaway populations, add a window ceiling then — measured, not guessed. | Round-1/round-2 convergent refutation of the v1 rule (per-scope smallest-unused breaks visible uniqueness and its own adoption AC). The Codex over-cap sequence is real via the placeholder path and is pinned by test rather than "prevented" by a kill nobody wants. |
+| D-T6 | **Instance lifecycle:** close → remove that instance's sessions (the reconcile's dispose-on-remove path is *correct* here), strictly after the re-validate point (`closeWorkspaceInstance.ts:117-122` — never before the dirty-check await); move-to-window → same kill on the source after ack (`workspaceWindowActions.ts:32-46`; the ack-timeout/cancel path kills nothing); duplicate → copies nothing; loose-instance **rekey merges**: re-stamp every oldId session to newId, renumber ordinals on in-scope collision, `lastActiveByScope` target-wins (mirror `workspaceInstanceUiStore.ts:204`), cap unaffected (creation gate). **Close/move of the ACTIVE instance must also realign:** `removeWorkspaceInstance` promotes `ids[0]` (`workspaceInstancesStore/helpers.ts:28-41`) with no switch event, so after removal the caller calls `terminalHydrateScope(successorId)` — otherwise `activeSessionId` stays null over the successor's hidden sessions and auto-create refuses (non-empty scope): a blank panel with live hidden PTYs. | PTY/xterm state cannot cross webviews (payload carries instance identity + tabs only, `workspace_transfer.rs:46-63`). Realign + merge semantics are round-1/round-2 convergent findings. |
+| D-T7 | **"Last session" panel-hide is computed on the VISIBLE population** at both sites (`TerminalPanel.tsx:183-189`, `useTerminalShellLifecycle.ts:69-79`). | Panel-hide is about what the user sees; hidden sessions keep running. |
+| D-T8 | **Auto-create is scope-aware, gate-checked against the INCOMING SCOPE, and BOTH creators go through ONE shared helper.** `canAutoCreateInScope(scope, activeTabHasSavedFile)` = `scope.isWorkspaceMode \|\| activeTabHasSavedFile`, evaluated on `getActiveWorkspaceScope(...)` (synchronous, instance-backed). `canOpenTerminal()` (`terminalGate.ts:10-22`) reads the LEGACY `useWorkspaceStore`, updated only by the *async* `syncLegacyWorkspaceContext` refresh and **never after a close** — gating on it races the scope it gates. The shared helper `maybeAutoCreateTerminalSession(windowLabel)` is used by the panel effect (re-fires on `[visible, activeInstanceId]`) AND the mount-time creator (pre-split `useTerminalSessions.ts:237-243`) — today the latter creates unconditionally, so a hot-exit-restored-visible panel over a refusing scope would spawn into `$HOME`. Gate refuses → i18n'd empty-state hint. Toggle-time gate (`requestToggleTerminal`) unchanged. | Round-1 showed the legacy gate makes the WI's own tests unimplementable; round-2 caught the second, ungated creator. |
+| D-T9 | **A session's spawn env/cwd derive from a pure, named contract:** `resolveTerminalSpawnContext(windowLabel, session)` → `{ cwd, workspaceRoot }` = `requestedCwd` ?? same-scope sibling OSC-7 cwd ?? (owner instance's `rootPath` when stamped and the instance still exists; else active-scope resolution as today). Resolved ONCE pre-await; `spawnPty` takes `workspaceRoot` as a parameter and stops re-resolving post-await (`spawnPty.ts:189`). Missing owner (deleted mid-spawn) falls back to active scope — spawn only ever starts for a visible session, so this is the degenerate case, not the norm. | Kills the mid-spawn race (cwd pre-await vs `VMARK_WORKSPACE` post-await). Round-2 asked for the contract to be named rather than implied; here it is. |
+| D-T10 | **Run-in-Terminal / reveal pick from the visible population** (`revealTerminalSession.ts:35-44`). Deferred delivery stays pinned to the session id (`runInTerminal.ts:171-223`) — a command requested in workspace A lands in A's shell even if the user switches away mid-delivery. | Id-pinning is already deliberate; now stated. |
+| D-T11 | **Bell/attention stay window-level.** `hasActivity` still sets; OS notification + window attention fire regardless of scope (`terminalAttention.ts:117-134`). **Every action that activates a session — `terminalSetActiveSession`, `terminalSwitchScope`, `terminalHydrateScope` — applies the same `hasActivity` clear** (`terminalSlice.ts:139-155`), so a restored remembered session doesn't carry a stale dot. Rail-item activity badge = named follow-up. | Round-2 caught the switchScope/activity-clear bypass. |
+| D-T12 | **No session persistence.** Hot exit keeps capturing exactly `terminal_visible`/`terminal_height` (`_hotExitCapture.ts:48-49`); PTYs die at relaunch (`restartWithHotExit.ts:111`). Restore safety: **the restore guard is released BEFORE hydrate runs** (`_hotExitRestore.ts:83` `finally` precedes the `hydrateWorkspaceInstanceContext` await at `:97` — v2's "runs while declined" claim was FALSE, caught by round 2). The actual safety argument: any user switch landing in the gap performs adoption itself (WI-TS2.2), and hydrate's adopt+`terminalHydrateScope(activeId)` is convergent — it re-aligns to whatever instance is active, so it cannot clobber a user's explicit switch. Pin that idempotence. | Persisting an association whose referent cannot survive is dead weight. |
+| D-T13 | **E2E: journey 18 gets an explicit rail-OFF precondition; a new rail journey asserts the scoped contract.** New `e2e/lib/rail.mjs` (settings patch via the `patchBrowserSettings` StorageEvent pattern, `browser.mjs:45-64` — verified to rehydrate `general.*` live; rail clicks via new stable `data-*` attributes — aria-labels are localized). CI list in `tier0-e2e.yml:180-189` is hardcoded and must name the new journey. | Journeys 17/18 silently depend on the runner's rail-off default profile. |
+| D-T14 | **`workspaceRailMode` default stays `false`.** | Non-goal; keeps tier-0 CI meaning stable. |
+| D-T15 | **Rail OFF makes stamps INERT, never erased.** With `isWorkspaceRailEnabled()` false: the visible selector returns **all** sessions; cap/ordinal count all sessions; cd-follow guards treat **every** session as followable. Stamps stay on the records and reactivate on re-enable. The toggle is involutive; no cleanup, no new lifecycle site. | Both rounds independently flagged the ON→OFF transition as stranding stamped sessions invisibly with live PTYs. Inert-at-query-time is the only repair that preserves invariant 3. |
+
+## Architecture invariants
+
+1. **A store-removal is a PTY kill; a switch is never a store-removal.** Only
+   close-session, close-instance, move-out, and window teardown remove ids
+   from `terminal.sessions`.
+2. **Exactly one session is displayed per window** (`activeSessionId`), always
+   a member of the current visible population (or null), and a non-empty
+   visible population with a visible panel never renders blank (D-T6 realign
+   + D-T8 auto-create together guarantee it).
+3. **Owner changes are monotone**: absent → non-placeholder instanceId
+   (stamp/adopt) or instanceId → instanceId (rekey). Never instanceId →
+   absent; never a placeholder id. **Every stamped owner exists in the
+   instances map** — a set-level invariant test over arbitrary lifecycle
+   sequences (create/switch/close/move/rekey/placeholder churn).
+4. **Rail-off — never-enabled or toggled off mid-session — behaves exactly as
+   today for every session** (D-T15 inert stamps). Pinning tests include the
+   toggle transition with stamped sessions present, and on→off→on.
+5. **Theme/settings sync stays global** — hidden scopes' sessions keep
+   receiving font/theme/scrollback updates (`terminalSessionStoreSync.ts:115-129`;
+   pinned by `.live`/`.theme` tests), or they come back stale on reveal.
+6. **No async in the terminal switch step.** All transition writes are
+   synchronous store ops; the generation guard problem
+   (`switchWorkspaceInstance.ts:185-194`) cannot arise.
+7. **Selector vocabulary has ONE count meaning**: the visible population
+   (`selectVisibleTerminalSessions` / `selectVisibleSessionCount`) drives
+   visibility, cap, ordinals, last-session, and auto-create alike. Owner-exact
+   enumeration exists only inside remove/rekey/adopt actions and is not
+   exported as a count.
+
+## Phases and work items
+
+TDD mandatory (RED→GREEN→REFACTOR); store tests via `getState()` +
+`beforeEach` reset; file gate < 300 lines. **Two files need pre-splits**
+(WI-TS0.2/0.3): `useTerminalSessions.ts` (295/300) and
+`workspaceInstancesStore.ts` (**299/300**, unbaselined — a 2-line addition
+fails `lint:file-size`). `useTerminalShellLifecycle.ts` (262),
+`TerminalPanel.tsx` (261), `terminalSlice.ts` (200) have headroom but split
+proactively if a WI pushes them near 300.
+Prefer NEW test files over the four frozen-size terminal test files
+(`file-size-baseline.json:104-107`). New store `vi.mock`s in tests are
+mock-boundaries findings — use real stores (probe style: mock only
+`@tauri-apps/api/core` and window-label). knip is at zero, but test files are
+knip entry points (verified), so Phase-1 selectors consumed only by their unit
+tests are fine.
+
+**Sequencing rationale (round-2 finding):** the cd-follow guards land BEFORE
+the coordinator wiring, and the full lifecycle wiring lands in the SAME phase
+— otherwise the intermediate states either reproduce the injected-`cd` bug on
+hidden sessions or strand sessions on close/move.
+
+**Inner loop:** `pnpm check:fast` / `pnpm vitest related <file>`. **Pre-push:**
+`pnpm check:predelta`, then one `pnpm check:all`.
+
+---
+
+### Phase 0 — Infrastructure & headroom
+
+**Gate:** `pnpm check:all`; `bash scripts/check-tscope-phase.sh 0`.
+
+#### WI-TS0.1: Plan infrastructure
+Copy `scripts/check-gha-phase.sh` → `scripts/check-tscope-phase.sh`; per-phase
+assertions. **WI linkage must be invoked as
+`bash scripts/check-wi-linkage.sh <plan> --phase=TS<N>`** — the filter regex
+builds `^WI-<arg>…` and fails closed on zero matches, so a bare numeric phase
+exits 1 against `WI-TS*` ids (verified by execution).
+- Tests: missing artifacts → non-zero; unknown phase → exit 64; smoke check
+  that the linkage invocation finds ≥ 1 WI for phase TS0.
+
+#### WI-TS0.2: Split `useTerminalSessions.ts` (mechanical)
+Extract the bell wiring (`:165-172`) and the mount/init + store-subscription
+block (`:230-281`) into sibling modules. No behavior change. **Update this
+plan's own line anchors in the same change** (D-T3/D-T8 cite ranges this WI
+relocates).
+- AC: all existing terminal suites green unmodified; file < 250 lines.
+
+#### WI-TS0.3: Split `workspaceInstancesStore.ts` (mechanical)
+299/300, unbaselined; Phase 2's follower needs headroom. Move pure logic into
+`workspaceInstancesStore/helpers.ts` (or a second helper module).
+- AC: existing store suites green unmodified; file ≤ 280 lines.
+
+---
+
+### Phase 1 — Store model (no wiring yet)
+
+**Gate:** `pnpm check:all`; `bash scripts/check-tscope-phase.sh 1`.
+
+#### WI-TS1.1: Owner field + stamping helper + union cap/ordinals
+`TerminalSession.workspaceInstanceId?: string`; `terminalCreateSession` takes
+`ownerInstanceId?` (the slice never imports workspace stores — callers resolve
+via the ONE shared helper `resolveTerminalOwnerInstanceId(windowLabel)`
+implementing D-T1's three carve-outs). Cap + ordinal allocation per D-T5
+(visible-union when rail on; all when off).
+- Tests (new `terminalSlice.scope.test.ts` +
+  `resolveTerminalOwnerInstanceId.test.ts`): stamp per carve-out (placeholder
+  / restoring / rail-off → absent); cap counts the union and is a creation
+  gate only (the Codex over-cap population — 5 scoped + N unscoped via the
+  placeholder path — blocks creation but is representable); ordinal never
+  duplicates within the visible union; rail-off allocation identical to
+  today.
+
+#### WI-TS1.2: Scope-transition actions (the kernel)
+`terminalAdoptUnscopedSessions(instanceId)` — absent→instanceId, renumbers on
+in-scope ordinal collision, never targets a placeholder (caller guarantees),
+idempotent; `terminalSwitchScope(outgoingId, incomingId)` — records
+`activeSessionId` into `lastActiveByScope[outgoingId]`, activates
+remembered-live ?? first-visible ?? null, **clears `hasActivity` on the
+session it activates** (same rule as `terminalSetActiveSession`, D-T11);
+`terminalHydrateScope(activeId)` — same activation WITHOUT writing any
+outgoing memory (hydrate/close/move have no outgoing context — round-2
+ambiguity resolved: it is a distinct action, not `switchScope(null, …)`);
+`terminalRemoveScopeSessions(instanceId)`; `terminalRekeyScope(oldId, newId)`
+— merge per D-T6. `terminalRemoveSession` fallback-active picks from the
+visible population.
+- Tests (L1/L4): remember/restore per scope; empty incoming → null;
+  remembered-but-closed falls back; activity cleared on restore (B→A→B with a
+  bell on A's remembered session); adopt renumbers + idempotent; rekey merge
+  with BOTH scopes populated (sessions merged, ordinals renumbered,
+  lastActive target-wins); remove-fallback stays visible; hydrateScope writes
+  no outgoing memory.
+
+#### WI-TS1.3: Scoped selectors
+`selectVisibleTerminalSessions(state, activeInstanceId, railEnabled)` =
+railEnabled ? (window-scoped ∪ active-instance-scoped) : ALL;
+`selectVisibleSessionCount` (invariant 7 — the only exported count).
+- Tests: rail-on filtering; rail-off returns everything including stamped
+  sessions (invariant 4: stamp → rail off → all visible → rail on → scoped
+  again).
+
+---
+
+### Phase 2 — Guards + transition wiring (coordinator, lifecycle)
+
+**Gate:** `pnpm check:all`; `bash scripts/check-tscope-phase.sh 2`.
+
+#### WI-TS2.1: Gate cd-follow at all three sites (BEFORE any wiring)
+Owner-guard (rail-aware, D-T15) in: syncRoot loop body
+(`terminalSessionStoreSync.ts:172`, before `:179`), null-root invalidation
+loop (`:160`), post-spawn catch-up (`useTerminalShellLifecycle.ts:205-209`),
+and **inside `flushPendingRoot`** (`:65-79`) — covers the idle callback and
+any future caller. Owner resolved from the store at check time.
+- Tests (extend root.test with a scoped population): scoped session never
+  written on root change (idle OR busy — no pendingRoot recorded); adopted
+  session with a pre-adoption pendingRoot does NOT cd on next idle;
+  window-scoped behavior unchanged verbatim; rail-off follows all sessions
+  including stamped (D-T15).
+
+#### WI-TS2.2: Coordinator + hydrate
+`switchWorkspaceInstance`: beside `stashOutgoingInstance` (`:177`)
+`terminalAdoptUnscopedSessions(outgoingId)` (skip placeholder outgoing);
+after `restoreIncomingInstance` (`:182`) `terminalSwitchScope(outgoingId,
+incomingId)`. `hydrateWorkspaceInstanceContext` (`:44-56`): adopt into the
+final active instance + `terminalHydrateScope(activeId)`. Note (D-T12): the
+restore guard is already released when hydrate runs; a user switch in the gap
+adopts on its own, and hydrate's realign is convergent — pin that
+idempotence.
+- Tests (real stores; extend `switchWorkspaceInstance.test.ts` +
+  `workspaceSwitchInterplay.test.ts`): switch A→B hides A's set; membership
+  UNCHANGED (invariant 1); set-level owner-exists invariant over arbitrary
+  sequences **including placeholder churn** (activate placeholder → create →
+  open real workspace → placeholder deleted → session window-scoped, visible,
+  adoptable — not stranded); hydrate homes the restore-race session with no
+  double-create; user-switch-then-hydrate converges (no clobber).
+
+#### WI-TS2.3: Instance lifecycle wiring (close / move / rekey / realign)
+Close (`closeWorkspaceInstance.ts:125-126` block, strictly after re-validate
+`:117-122`): `terminalRemoveScopeSessions(id)` + drop `lastActiveByScope`
+slot + **if the closed instance was active, `terminalHydrateScope(successor)`**
+(successor = the store's post-removal active, promoted `ids[0]`,
+`workspaceInstancesStore/helpers.ts:28-41`). Move source cleanup
+(`workspaceWindowActions.ts:32-46`, post-ack only): same kill + realign;
+ack-timeout/cancel kills nothing. Rekey follower beside
+`rekeyInstanceUiState`/`rekeyPaneLayout` (post-WI-TS0.3; importing uiStore
+there creates NO cycle — verified round 1).
+- Tests: close A kills exactly A's; close ACTIVE A with B holding sessions →
+  B's remembered session becomes active (the blank-panel case, pinned);
+  cancel path kills nothing; move kills after ack, not before; duplicate
+  copies/kills nothing; rekey merge per WI-TS1.2.
+- **Adjacent defect, fix in the same block (flagged for review):** closed-tab
+  scopes are never cleaned per-instance (`tabStoreClosedScopes.ts` has no
+  per-instance removal; `removeWindowClosedScopes` has zero production
+  callers — verified twice). Add `removeClosedScope(windowLabel, scopeKey)`
+  + call it here, with its own test. One line plus an action at the exact
+  line this WI edits; skipping would re-record the leak knowingly.
+
+#### WI-TS2.4: End-to-end store-chain integration test
+Re-land the 2026-08-31 probe as a permanent test
+(`terminalSessionStoreSync.railswitch.test.ts`, real stores, minimal mocks):
+rail switch swaps the visible set, does NOT cd instance-scoped sessions, DOES
+cd window-scoped ones; the root.test population (window-scoped) behaves
+exactly as before. Runs green in THIS phase because WI-TS2.1's guards landed
+first (round-2 sequencing finding). This is the regression test for the
+investigated bug class; the rail→terminal chain had zero non-mocked coverage.
+
+---
+
+### Phase 3 — UI
+
+**Gate:** `pnpm check:all`; `bash scripts/check-tscope-phase.sh 3`.
+
+#### WI-TS3.1: UI filtering
+`TerminalTabBar` renders `selectVisibleTerminalSessions`; `isMaxed` per the
+union rule; `terminalKeyHandler` Cmd+1..5 indexes the visible list;
+TerminalSearchBar key and `getActiveTerminal` consumers unchanged (D-T2).
+Keep every `data-terminal-action` value verbatim (E2E contract).
+- Tests: TabBar renders only the visible population (new
+  `TerminalTabBar.scope.test.tsx`); a11y suite green; keyHandler positional
+  switch over the filtered list; rail-off renders all (invariant 4).
+
+#### WI-TS3.2: Shared auto-create helper + empty state
+`maybeAutoCreateTerminalSession(windowLabel)` (D-T8) used by BOTH creators —
+the panel effect (re-fires on `[visible, activeInstanceId]`) and the
+mount-time creator. Gate = `canAutoCreateInScope` on the synchronous
+instance-backed scope, never `canOpenTerminal`. Refusal → empty-state hint:
+new flat key `terminal.noWorkspaceSession` in `src/locales/en/statusbar.json`
++ all 9 locales — flat keys only (`localeShape.test.ts:80`), no trailing
+period (i18n-copy), genuinely translated (`terminalI18nCoverage.test.ts`
+covers statusbar `terminal.*` — verified; untranslated baseline stays EMPTY).
+- Tests: switch into empty workspace scope, panel visible → one stamped
+  session; switch into refusing scope **with the legacy refresh unresolved** →
+  no create, empty state (the RED test the legacy gate cannot pass);
+  mount-time path with restored-visible panel over a refusing scope → no
+  `$HOME` spawn (round-2 case); no re-create when scope non-empty.
+
+#### WI-TS3.3: Visible-scope "last session" semantics
+`TerminalPanel.handleClose` and `closeSessionOnCleanExit` compute last-ness
+on the visible population (D-T7).
+- Tests: clean exit of the visible population's only session hides the panel
+  while a hidden scope holds sessions; closing a non-last visible session
+  does not.
+
+---
+
+### Phase 4 — Spawn & pickers
+
+**Gate:** `pnpm check:all`; `bash scripts/check-tscope-phase.sh 4`.
+
+#### WI-TS4.1: Spawn context contract
+Implement `resolveTerminalSpawnContext(windowLabel, session)` per D-T9 (pure;
+full matrix: requestedCwd / same-scope sibling / stamped owner present /
+owner deleted / unscoped / loose-with-file). Lifecycle resolves once
+pre-await; `spawnPty` takes `workspaceRoot` as a parameter (stops re-resolving
+at `:189`); `VMARK_WORKSPACE` matches the owner even mid-switch. NOTE:
+`resolveTerminalWorkspaceRoot`'s missing `isWorkspaceMode` check
+(`spawnPty.ts:96` vs sync's `:149`) is EXISTING behavior for the unscoped
+fallback — preserve, don't silently fix.
+- Tests: the contract matrix (L1, table-driven); sibling inheritance ignores
+  other-scope sessions; spawn env root == owner root under a simulated
+  mid-spawn switch (L5 on the spawn seam).
+
+#### WI-TS4.2: Out-of-tree pickers
+`reuseOrCreateTerminalSession` picks from the visible population (D-T10);
+`openTerminalHere`/`canOpenTerminalHere` cap per union; created sessions
+stamped via `resolveTerminalOwnerInstanceId`. `runInTerminal` unchanged — add
+a test PINNING id-pinned delivery across a rail switch.
+- Tests: reveal creates in the active scope; Open-Terminal-Here at cap
+  refuses with the existing reason; runInTerminal delivers to the originally
+  targeted session after a switch.
+
+---
+
+### Phase 5 — E2E, docs, i18n
+
+**Gate:** `pnpm check:all`; new journey green locally against a debug app;
+`cd website && pnpm build`; `bash scripts/check-tscope-phase.sh 5`.
+
+#### WI-TS5.1: Rail e2e plumbing
+Stable selectors: `data-rail-action="activate|duplicate"` +
+`data-instance-id` on rail buttons. New `e2e/lib/rail.mjs`:
+`withRailMode(client, enabled, fn)` (StorageEvent settings patch — verified
+live rehydration), `clickRailInstance(client, instanceId)`,
+`getRailInstances(client)`.
+- Tests: WorkspaceRail.test.tsx pins the new attributes.
+
+#### WI-TS5.2: Journeys
+(a) Journey 18 wrapped in `withRailMode(client, false, …)`; headers of 17/18
+updated — I15 is explicitly the *legacy/window-scoped* cd-follow.
+(b) New `35-terminal-rail-scoping.mjs`: rail ON; workspaces A+B; session in A
+(record pid); rail-click to B → A's pid **alive, cwd unchanged**
+(`getAppShellCwds` pid identity), tab set swapped (DOM), new session in B
+spawns in B; switch back → same pid revealed, same cwd. House skip rules;
+teardown restores rail setting + panel visibility, removes temp dirs.
+(c) Append to `tier0-e2e.yml`'s hardcoded list (`:180-189`).
+(d) Update `dev-docs/e2e-tier0-matrix.md`.
+
+#### WI-TS5.3: Website docs
+`website/guide/terminal.md` + `website/guide/workspace-rail.md` (terminal
+section). Add the missing `workspace-rail.md` mapping row to
+`.claude/rules/21-website-docs.md` (page exists, unmapped — 1 line, same
+change). Verify `cd website && pnpm build`.
+
+#### WI-TS5.4: Locale sweep
+All new keys translated in de/es/fr/it/ja/ko/pt-BR/zh-CN/zh-TW. Use the
+`translate-docs` flow if the string count warrants it.
+
+---
+
+## Risks & assumptions
+
+- **Biggest structural risk: per-instance cleanup is a hand-maintained
+  checklist** (close/move/rekey/placeholder-deletion — exactly how the
+  closed-scopes leak and the placeholder hole happened). Mitigation is
+  structural: the **set-level owner-exists invariant test** (WI-TS2.2) runs
+  arbitrary lifecycle sequences including placeholder churn, so a forgotten
+  follower fails a test regardless of which lifecycle forgot it; D-T1 keeps
+  placeholders out of the owner vocabulary entirely; and ALL lifecycle wiring
+  lands in one phase (round-2 sequencing).
+- **Unbounded total sessions across scopes** (D-T5): accepted with mechanism
+  (one gated click per creation; cheap hidden sessions). Named follow-up: if
+  field feedback shows runaway populations, measure (PTY count/RSS via
+  `getAppShellCwds`-style probe) and add a window ceiling then.
+- **`workspaceInstanceUiStore`'s documented lifecycle is partly fiction**
+  (`copyInstanceUiState`/`copyPaneLayout`: zero production callers). Don't
+  model terminal-copy on it. Fixing that header is out of scope.
+- **Move/duplicate already orphan per-instance UI state cross-window**
+  (rail-plan gap G2, outstanding). Terminal gets an explicit policy (kill +
+  realign); G2 stays G2.
+- **Assumption:** `activeSessionId = null` with a visible panel renders
+  acceptably during the one-frame gap before auto-create; if a flash shows,
+  batch switchScope + create into one store update.
+- **Deferred (named):** rail-item activity badge; fish/Windows shell
+  integration (scoping removes their worst failure mode here anyway); rail
+  default flip (D-T14); window-level session ceiling (measured-if-needed).
+
+## Review rounds
+
+**Round 1 — adversarial refuter panel (3 lenses, 2026-08-31).** 12 findings,
+11 accepted, 1 self-refuted (knip fear — test files are knip entries).
+Accepted: placeholder stranding (blocker → D-T1), rail ON→OFF stranding
+(→ D-T15), close/move-of-active blank panel (→ D-T6), ordinal union/adoption
+collision (→ D-T5), restore race defeats adoption (→ D-T1), gate races legacy
+store (→ D-T8), `flushPendingRoot` third cd site (→ D-T4),
+`workspaceInstancesStore.ts` 299/300 (→ WI-TS0.3), `--phase=TS<N>` spelling
+(→ WI-TS0.1), stale anchors after split (→ WI-TS0.2), knip hedge deletion.
+Verified in the plan's favor: D-T2 null-safety, D-T3 (no other disposal
+path), D-T9 race description, no uiStore↔workspaceInstancesStore cycle,
+`withRailMode` live rehydration, `terminalI18nCoverage` statusbar coverage.
+
+**Round 2 — Codex cross-model review (thread `01a056ad-7912-7533-9001-699fda8706ed`,
+gpt high-effort, read-only; reviewed v1).** Verdict on v1: MAJOR GAPS — its 3
+criticals were the same as round 1's (convergent: rail-off, flushPendingRoot,
+close/move successor; already fixed in v2). Newly accepted from round 2:
+Phase-2-test-needs-Phase-3-guards sequencing (→ guards moved to WI-TS2.1,
+lifecycle consolidated into Phase 2), switchScope activity-clear bypass
+(→ D-T11/WI-TS1.2), ungated mount-time creator (→ D-T8/WI-TS3.2),
+`resolveTerminalSpawnContext` contract (→ D-T9/WI-TS4.1),
+`terminalHydrateScope` argument semantics (→ WI-TS1.2), rekey merge
+semantics with both scopes populated (→ D-T6/WI-TS1.2), adoption over-cap
+via the placeholder path (→ D-T5 cap-as-creation-gate), selector count
+vocabulary (→ invariant 7), FALSE restore-guard citation (verified by
+reading `_hotExitRestore.ts:75-97`: `endWindowContextRestore` is in the
+`finally`, hydrate awaited after → D-T12 rewritten with the convergence
+argument). **Overruled, with mechanism:** a hard window-level session ceiling
+(D-T5: creation is a gated single user click; cost per hidden session is one
+idle PTY + MBs; ceiling deferred to a measured follow-up rather than guessed
+now) and a CI soak test for 20×5 PTYs (same — measured-if-needed, recorded
+under Risks).
+
+## Verification map
+
+| Phase | Commands |
+|---|---|
+| 0 | `pnpm check:all` && `bash scripts/check-tscope-phase.sh 0` |
+| 1 | `pnpm check:all` && `bash scripts/check-tscope-phase.sh 1` |
+| 2 | `pnpm check:all` && `bash scripts/check-tscope-phase.sh 2` |
+| 3 | `pnpm check:all` && `bash scripts/check-tscope-phase.sh 3` |
+| 4 | `pnpm check:all` && `bash scripts/check-tscope-phase.sh 4` |
+| 5 | `pnpm check:all` && journey 35 green (local debug app) && `cd website && pnpm build` && `bash scripts/check-tscope-phase.sh 5` |
+
+Before every push: `pnpm check:predelta`, then one `pnpm check:all`.

--- a/.claude/tdd-guardian/20260831-terminal-per-instance-sessions.md
+++ b/.claude/tdd-guardian/20260831-terminal-per-instance-sessions.md
@@ -1,7 +1,10 @@
 # Plan: Per-workspace-instance terminal session sets (WI-TS)
 
-**Status:** Phase 0 not started · v3 after refuter-panel round 1 + Codex
-cross-model review round 2 (see Review rounds; §6 requirement satisfied)
+**Status:** Phases 0–5 IMPLEMENTED, 2026-08-31 (all 19 WIs stamped DONE below;
+`check-tscope-phase.sh` 0–5 all green; WI linkage 19/19; `check:predelta`
+41/41; one confirming `pnpm check:all` exit 0; journeys 17/18/35 green against
+a live debug app) · v3 after refuter-panel round 1 + Codex cross-model review
+round 2 (see Review rounds; §6 requirement satisfied)
 **Home:** `.claude/tdd-guardian/` (tracked — committed on maintainer direction, 2026-08-31; DoD script lives in `scripts/`)
 **WI namespace:** `WI-TS<phase>.<n>` (§1 — bare `WI-N.M` collides across plans)
 **Release note:** Phases 1–4 are ONE release train — intermediate mains are
@@ -41,12 +44,12 @@ visibility/geometry stay window-global.
 |---|---|---|
 | D-T1 | **Ownership is a per-session field, stamped at creation** from `getActiveWorkspaceScope(windowLabel).workspaceInstanceId` — with THREE carve-outs, resolved by ONE shared helper `resolveTerminalOwnerInstanceId(windowLabel)` in `src/services/terminal/`: never stamp a **placeholder** instance's id (placeholders are deleted silently by `addWorkspaceInstance`/`ensureLooseInstance` with no lifecycle follower — `workspaceInstancesStore.ts:51-65`, `:216-227`); never stamp while **`isWindowContextRestoring(windowLabel)`** (a mid-restore auto-create would bind to the pre-reconcile active id — `restoreHelpers.ts:165` fires before reconcile can re-activate); never stamp while the **rail is off**. Field absent ⇒ *window-scoped*. On every rail switch (and on hydrate), window-scoped sessions are **adopted by the outgoing (resp. active) instance**, skipping placeholder targets. | Creation always happens under the active scope (`useTerminalShellLifecycle.ts:122-137`). The carve-outs close the round-1 blocker (placeholder-stranded PTY) and the restore race (stamped-too-early → hidden session + double-create). |
 | D-T2 | **Store shape: flat list + owner field + per-scope active memory.** `TerminalSession.workspaceInstanceId?: string` (optional-key pattern of `requestedCwd`, `terminalSlice.ts:113`); new `lastActiveByScope: Record<string, string \| null>`. `activeSessionId` KEEPS its meaning — *the session currently shown* — so all ~10 consumers (fit, search, getActiveTerminal, bell isActive, restart, reveal, Cmd+N) stay semantically correct unmodified. | Verified round 1: every listed consumer is null-safe. |
-| D-T3 | **Sessions NEVER leave the store on a switch; scoping lives in selectors + visibility.** The reconcile subscription treats "id left the array" as *dispose xterm + kill PTY* (pre-split `useTerminalSessions.ts:258-273` → the module WI-TS0.2 extracts; → `terminalSessionReconcile.ts:42-45` → `removeSessionEntry`), with no guard on the removed side. Hiding = `switchVisibility`'s existing `display:none` driven by the `activeSessionId` change; hidden entries keep PTY + buffer (`terminalSessionRegistry.ts:54-65`). | Both review rounds confirmed: no other code path removes sessions on workspace changes; `switchVisibility(null)` hides all while preserving PTYs; the panel never unmounts once activated. |
+| D-T3 | **Sessions NEVER leave the store on a switch; scoping lives in selectors + visibility.** The reconcile subscription treats "id left the array" as *dispose xterm + kill PTY* (`useTerminalSessionsInit.ts`, the WI-TS0.2 extraction → `terminalSessionReconcile.ts:42-45` → `removeSessionEntry`), with no guard on the removed side. Hiding = `switchVisibility`'s existing `display:none` driven by the `activeSessionId` change; hidden entries keep PTY + buffer (`terminalSessionRegistry.ts:54-65`). | Both review rounds confirmed: no other code path removes sessions on workspace changes; `switchVisibility(null)` hides all while preserving PTYs; the panel never unmounts once activated. |
 | D-T4 | **cd-follow applies ONLY to effectively-window-scoped sessions, at all THREE sites:** the syncRoot loop (`terminalSessionStoreSync.ts:172`, guard before `:179`), the post-spawn catch-up (`useTerminalShellLifecycle.ts:205-209`), and **`flushPendingRoot` (`terminalSessionStoreSync.ts:65-79`)** — the OSC-133 idle callback is an independent cd path and a `pendingRoot` recorded pre-adoption survives adoption. Owner resolved live from the store by session id. Guards are rail-aware (D-T15). | "Both sites" was refuted by BOTH review rounds independently — the flush is a third site; one guard inside `flushPendingRoot` covers every caller. |
 | D-T5 | **Cap and ordinals are per *visible population*; the cap is a CREATION-TIME GATE, not a population invariant.** Creation counts target scope ∪ window-scoped when rail on, all sessions when off; ordinal = smallest unused across the same union (no two visible "Terminal 1"). `terminalAdoptUnscopedSessions` renumbers on in-scope collision (labels untouched) and **never kills** — so a scope can transiently exceed 5 (reachable: sessions created under an active placeholder count no hidden scope, then get adopted later); the `+` stays disabled until the visible count drops below 5. **No window-level ceiling**: creation is one user click at a time behind the gate; a hidden idle session costs one PTY + a few MB of xterm buffer. If field feedback shows runaway populations, add a window ceiling then — measured, not guessed. | Round-1/round-2 convergent refutation of the v1 rule (per-scope smallest-unused breaks visible uniqueness and its own adoption AC). The Codex over-cap sequence is real via the placeholder path and is pinned by test rather than "prevented" by a kill nobody wants. |
 | D-T6 | **Instance lifecycle:** close → remove that instance's sessions (the reconcile's dispose-on-remove path is *correct* here), strictly after the re-validate point (`closeWorkspaceInstance.ts:117-122` — never before the dirty-check await); move-to-window → same kill on the source after ack (`workspaceWindowActions.ts:32-46`; the ack-timeout/cancel path kills nothing); duplicate → copies nothing; loose-instance **rekey merges**: re-stamp every oldId session to newId, renumber ordinals on in-scope collision, `lastActiveByScope` target-wins (mirror `workspaceInstanceUiStore.ts:204`), cap unaffected (creation gate). **Close/move of the ACTIVE instance must also realign:** `removeWorkspaceInstance` promotes `ids[0]` (`workspaceInstancesStore/helpers.ts:28-41`) with no switch event, so after removal the caller calls `terminalHydrateScope(successorId)` — otherwise `activeSessionId` stays null over the successor's hidden sessions and auto-create refuses (non-empty scope): a blank panel with live hidden PTYs. | PTY/xterm state cannot cross webviews (payload carries instance identity + tabs only, `workspace_transfer.rs:46-63`). Realign + merge semantics are round-1/round-2 convergent findings. |
 | D-T7 | **"Last session" panel-hide is computed on the VISIBLE population** at both sites (`TerminalPanel.tsx:183-189`, `useTerminalShellLifecycle.ts:69-79`). | Panel-hide is about what the user sees; hidden sessions keep running. |
-| D-T8 | **Auto-create is scope-aware, gate-checked against the INCOMING SCOPE, and BOTH creators go through ONE shared helper.** `canAutoCreateInScope(scope, activeTabHasSavedFile)` = `scope.isWorkspaceMode \|\| activeTabHasSavedFile`, evaluated on `getActiveWorkspaceScope(...)` (synchronous, instance-backed). `canOpenTerminal()` (`terminalGate.ts:10-22`) reads the LEGACY `useWorkspaceStore`, updated only by the *async* `syncLegacyWorkspaceContext` refresh and **never after a close** — gating on it races the scope it gates. The shared helper `maybeAutoCreateTerminalSession(windowLabel)` is used by the panel effect (re-fires on `[visible, activeInstanceId]`) AND the mount-time creator (pre-split `useTerminalSessions.ts:237-243`) — today the latter creates unconditionally, so a hot-exit-restored-visible panel over a refusing scope would spawn into `$HOME`. Gate refuses → i18n'd empty-state hint. Toggle-time gate (`requestToggleTerminal`) unchanged. | Round-1 showed the legacy gate makes the WI's own tests unimplementable; round-2 caught the second, ungated creator. |
+| D-T8 | **Auto-create is scope-aware, gate-checked against the INCOMING SCOPE, and BOTH creators go through ONE shared helper.** `canAutoCreateInScope(scope, activeTabHasSavedFile)` = `scope.isWorkspaceMode \|\| activeTabHasSavedFile`, evaluated on `getActiveWorkspaceScope(...)` (synchronous, instance-backed). `canOpenTerminal()` (`terminalGate.ts:10-22`) reads the LEGACY `useWorkspaceStore`, updated only by the *async* `syncLegacyWorkspaceContext` refresh and **never after a close** — gating on it races the scope it gates. The shared helper `maybeAutoCreateTerminalSession(windowLabel)` is used by the panel effect (re-fires on `[visible, activeInstanceId]`) AND the mount-time creator (`useTerminalSessionsInit.ts`, the WI-TS0.2 extraction) — today the latter creates unconditionally, so a hot-exit-restored-visible panel over a refusing scope would spawn into `$HOME`. Gate refuses → i18n'd empty-state hint. Toggle-time gate (`requestToggleTerminal`) unchanged. | Round-1 showed the legacy gate makes the WI's own tests unimplementable; round-2 caught the second, ungated creator. |
 | D-T9 | **A session's spawn env/cwd derive from a pure, named contract:** `resolveTerminalSpawnContext(windowLabel, session)` → `{ cwd, workspaceRoot }` = `requestedCwd` ?? same-scope sibling OSC-7 cwd ?? (owner instance's `rootPath` when stamped and the instance still exists; else active-scope resolution as today). Resolved ONCE pre-await; `spawnPty` takes `workspaceRoot` as a parameter and stops re-resolving post-await (`spawnPty.ts:189`). Missing owner (deleted mid-spawn) falls back to active scope — spawn only ever starts for a visible session, so this is the degenerate case, not the norm. | Kills the mid-spawn race (cwd pre-await vs `VMARK_WORKSPACE` post-await). Round-2 asked for the contract to be named rather than implied; here it is. |
 | D-T10 | **Run-in-Terminal / reveal pick from the visible population** (`revealTerminalSession.ts:35-44`). Deferred delivery stays pinned to the session id (`runInTerminal.ts:171-223`) — a command requested in workspace A lands in A's shell even if the user switches away mid-delivery. | Id-pinning is already deliberate; now stated. |
 | D-T11 | **Bell/attention stay window-level.** `hasActivity` still sets; OS notification + window attention fire regardless of scope (`terminalAttention.ts:117-134`). **Every action that activates a session — `terminalSetActiveSession`, `terminalSwitchScope`, `terminalHydrateScope` — applies the same `hasActivity` clear** (`terminalSlice.ts:139-155`), so a restored remembered session doesn't carry a stale dot. Rail-item activity badge = named follow-up. | Round-2 caught the switchScope/activity-clear bypass. |
@@ -115,6 +118,10 @@ hidden sessions or strand sessions on close/move.
 **Gate:** `pnpm check:all`; `bash scripts/check-tscope-phase.sh 0`.
 
 #### WI-TS0.1: Plan infrastructure
+
+**Status:** DONE — 2026-08-31
+**Changed:** scripts/check-tscope-phase.sh, scripts/check-tscope-phase.test.mjs
+**Verified:** pnpm vitest run --config vitest.gates.config.ts scripts/check-tscope-phase.test.mjs (5 passed)
 Copy `scripts/check-gha-phase.sh` → `scripts/check-tscope-phase.sh`; per-phase
 assertions. **WI linkage must be invoked as
 `bash scripts/check-wi-linkage.sh <plan> --phase=TS<N>`** — the filter regex
@@ -124,6 +131,10 @@ exits 1 against `WI-TS*` ids (verified by execution).
   that the linkage invocation finds ≥ 1 WI for phase TS0.
 
 #### WI-TS0.2: Split `useTerminalSessions.ts` (mechanical)
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/components/Terminal/useTerminalSessions.ts (295→241), src/components/Terminal/terminalSessionBell.ts (new), src/components/Terminal/useTerminalSessionsInit.ts (new), plan anchors D-T3/D-T8
+**Verified:** pnpm vitest related --run (214 files, 3237 passed)
 Extract the bell wiring (`:165-172`) and the mount/init + store-subscription
 block (`:230-281`) into sibling modules. No behavior change. **Update this
 plan's own line anchors in the same change** (D-T3/D-T8 cite ranges this WI
@@ -131,6 +142,10 @@ relocates).
 - AC: all existing terminal suites green unmodified; file < 250 lines.
 
 #### WI-TS0.3: Split `workspaceInstancesStore.ts` (mechanical)
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/stores/workspaceInstancesStore.ts (299→261), src/stores/workspaceInstancesStore/helpers.ts (applyAddWorkspaceInstance moved in verbatim)
+**Verified:** pnpm vitest related --run (214 files, 3237 passed — same run as WI-TS0.2)
 299/300, unbaselined; Phase 2's follower needs headroom. Move pure logic into
 `workspaceInstancesStore/helpers.ts` (or a second helper module).
 - AC: existing store suites green unmodified; file ≤ 280 lines.
@@ -142,6 +157,10 @@ relocates).
 **Gate:** `pnpm check:all`; `bash scripts/check-tscope-phase.sh 1`.
 
 #### WI-TS1.1: Owner field + stamping helper + union cap/ordinals
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/stores/uiStore/types.ts, src/stores/uiStore/terminalSlice.ts, src/services/terminal/resolveTerminalOwnerInstanceId.ts (new), src/stores/uiStore/terminalSlice.scope.test.ts (new), src/services/terminal/resolveTerminalOwnerInstanceId.test.ts (new)
+**Verified:** pnpm vitest run (4 files, 40 passed — Phase 1 batch)
 `TerminalSession.workspaceInstanceId?: string`; `terminalCreateSession` takes
 `ownerInstanceId?` (the slice never imports workspace stores — callers resolve
 via the ONE shared helper `resolveTerminalOwnerInstanceId(windowLabel)`
@@ -156,6 +175,10 @@ implementing D-T1's three carve-outs). Cap + ordinal allocation per D-T5
   today.
 
 #### WI-TS1.2: Scope-transition actions (the kernel)
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/stores/uiStore/terminalScopeActions.ts (new), src/stores/uiStore/types.ts (TerminalScopeActions), src/stores/uiStore.ts (merge), src/stores/uiStore/terminalSlice.ts (terminalRemoveSession visibleIds), src/stores/uiStore/terminalScopeActions.test.ts (new)
+**Verified:** pnpm vitest run (4 files, 40 passed — Phase 1 batch)
 `terminalAdoptUnscopedSessions(instanceId)` — absent→instanceId, renumbers on
 in-scope ordinal collision, never targets a placeholder (caller guarantees),
 idempotent; `terminalSwitchScope(outgoingId, incomingId)` — records
@@ -176,6 +199,10 @@ visible population.
   no outgoing memory.
 
 #### WI-TS1.3: Scoped selectors
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/stores/uiStore/terminalScopeSelectors.ts (new), src/stores/uiStore/terminalScopeSelectors.test.ts (new)
+**Verified:** pnpm vitest run (4 files, 40 passed — Phase 1 batch)
 `selectVisibleTerminalSessions(state, activeInstanceId, railEnabled)` =
 railEnabled ? (window-scoped ∪ active-instance-scoped) : ALL;
 `selectVisibleSessionCount` (invariant 7 — the only exported count).
@@ -190,6 +217,10 @@ railEnabled ? (window-scoped ∪ active-instance-scoped) : ALL;
 **Gate:** `pnpm check:all`; `bash scripts/check-tscope-phase.sh 2`.
 
 #### WI-TS2.1: Gate cd-follow at all three sites (BEFORE any wiring)
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/services/terminal/terminalCdFollow.ts (new), src/components/Terminal/terminalSessionStoreSync.ts (syncRoot guard + flushPendingRoot(sessionId, entry) + id-wired idle flush), src/components/Terminal/useTerminalShellLifecycle.ts (post-spawn guard), src/components/Terminal/terminalSessionStoreSync.scope.test.ts (new), src/components/Terminal/useTerminalShellLifecycle.scope.test.ts (new), terminalSessionStoreSync.root.test.ts (flush signature)
+**Verified:** pnpm vitest run (4 files, 35 passed). Note: the null-root invalidation loop deliberately clears pendingRoot for ALL sessions rather than skipping stamped ones — skipping would let a stale pending survive a later rail-off toggle and resurrect audit-#14 through the D-T15 branch; the D-T4 property (scoped sessions never cd) is held by the sync + flush guards.
 Owner-guard (rail-aware, D-T15) in: syncRoot loop body
 (`terminalSessionStoreSync.ts:172`, before `:179`), null-root invalidation
 loop (`:160`), post-spawn catch-up (`useTerminalShellLifecycle.ts:205-209`),
@@ -202,6 +233,10 @@ any future caller. Owner resolved from the store at check time.
   including stamped (D-T15).
 
 #### WI-TS2.2: Coordinator + hydrate
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/services/workspaces/switchWorkspaceInstance.ts (adopt outgoing + switchScope), src/services/workspaces/hydrateWorkspaceInstanceContext.ts (adopt + hydrateScope), switchWorkspaceInstance.test.ts (+4 tests), workspaceSwitchInterplay.test.ts (owner-exists invariant incl. placeholder churn)
+**Verified:** pnpm vitest related --run (217 files, 3262 passed)
 `switchWorkspaceInstance`: beside `stashOutgoingInstance` (`:177`)
 `terminalAdoptUnscopedSessions(outgoingId)` (skip placeholder outgoing);
 after `restoreIncomingInstance` (`:182`) `terminalSwitchScope(outgoingId,
@@ -219,6 +254,10 @@ idempotence.
   double-create; user-switch-then-hydrate converges (no clobber).
 
 #### WI-TS2.3: Instance lifecycle wiring (close / move / rekey / realign)
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/services/workspaces/closeWorkspaceInstance.ts (kill + memory-slot drop + removeClosedScope + realign-if-active), src/services/workspaces/workspaceWindowActions.ts (move: post-ack kill + removeClosedScope + realign; cancel path kills nothing; duplicate untouched), src/stores/workspaceInstancesStore.ts (terminalRekeyScope follower), src/stores/tabStoreClosedScopes.ts (removeClosedScope action — the adjacent closed-scopes leak, applied at BOTH lifecycle exits: close and move-out), tabStoreClosedScopes.test.ts (+2), workspaceSwitchInterplay.test.ts (close-of-active realign)
+**Verified:** pnpm vitest related --run (217 files, 3262 passed — same run as WI-TS2.2)
 Close (`closeWorkspaceInstance.ts:125-126` block, strictly after re-validate
 `:117-122`): `terminalRemoveScopeSessions(id)` + drop `lastActiveByScope`
 slot + **if the closed instance was active, `terminalHydrateScope(successor)`**
@@ -240,6 +279,10 @@ there creates NO cycle — verified round 1).
   line this WI edits; skipping would re-record the leak knowingly.
 
 #### WI-TS2.4: End-to-end store-chain integration test
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/components/Terminal/terminalSessionStoreSync.railswitch.test.ts (new — real stores + real coordinator + real scope resolver; mocks: Tauri invoke, window label)
+**Verified:** pnpm vitest run (3 passed) + bash scripts/check-tscope-phase.sh 2 (14 passed, 0 failed)
 Re-land the 2026-08-31 probe as a permanent test
 (`terminalSessionStoreSync.railswitch.test.ts`, real stores, minimal mocks):
 rail switch swaps the visible set, does NOT cd instance-scoped sessions, DOES
@@ -255,6 +298,10 @@ investigated bug class; the rail→terminal chain had zero non-mocked coverage.
 **Gate:** `pnpm check:all`; `bash scripts/check-tscope-phase.sh 3`.
 
 #### WI-TS3.1: UI filtering
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/components/Terminal/useVisibleTerminalSessions.ts (new React face), src/services/terminal/visibleTerminalSessions.ts (new imperative face), TerminalTabBar.tsx (visible population + stamped create + union isMaxed), terminalKeyHandler.ts (Cmd+1..5 over visible), TerminalTabBar.scope.test.tsx (new), terminalKeyHandler.scope.test.ts (new). data-terminal-action values untouched.
+**Verified:** pnpm vitest run (10 files, 153 passed incl. existing TabBar + a11y + keyHandler suites)
 `TerminalTabBar` renders `selectVisibleTerminalSessions`; `isMaxed` per the
 union rule; `terminalKeyHandler` Cmd+1..5 indexes the visible list;
 TerminalSearchBar key and `getActiveTerminal` consumers unchanged (D-T2).
@@ -264,6 +311,10 @@ Keep every `data-terminal-action` value verbatim (E2E contract).
   switch over the filtered list; rail-off renders all (invariant 4).
 
 #### WI-TS3.2: Shared auto-create helper + empty state
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/services/terminal/maybeAutoCreateTerminalSession.ts (new — canAutoCreateInScope on the instance-backed scope, never canOpenTerminal), TerminalPanel.tsx (visibility effect re-fires on [visible, activeInstanceId] + empty-state hint), useTerminalSessionsInit.ts (mount-time creator gated), terminal-panel.css (.terminal-empty-state), src/locales/*/statusbar.json (terminal.noWorkspaceSession ×10, genuinely translated), maybeAutoCreateTerminalSession.test.ts (new — incl. the legacy-gate-unresolvable RED case), useTerminalSessionsInit.scope.test.ts (new — no-$HOME-spawn case)
+**Verified:** pnpm vitest run (10 files, 153 passed) + pnpm lint:i18n (all checks passed, untranslated baseline EMPTY) + pnpm vitest run src/locales (12 passed)
 `maybeAutoCreateTerminalSession(windowLabel)` (D-T8) used by BOTH creators —
 the panel effect (re-fires on `[visible, activeInstanceId]`) and the
 mount-time creator. Gate = `canAutoCreateInScope` on the synchronous
@@ -279,6 +330,10 @@ covers statusbar `terminal.*` — verified; untranslated baseline stays EMPTY).
   `$HOME` spawn (round-2 case); no re-create when scope non-empty.
 
 #### WI-TS3.3: Visible-scope "last session" semantics
+
+**Status:** DONE — 2026-08-31
+**Changed:** TerminalPanel.tsx (handleClose last-ness + visibleIds fallback), useTerminalShellLifecycle.ts (closeSessionOnCleanExit last-ness + visibleIds fallback), useTerminalShellLifecycle.scope.test.ts (+2 clean-exit tests)
+**Verified:** pnpm vitest run (10 files, 153 passed — same batch)
 `TerminalPanel.handleClose` and `closeSessionOnCleanExit` compute last-ness
 on the visible population (D-T7).
 - Tests: clean exit of the visible population's only session hides the panel
@@ -292,6 +347,10 @@ on the visible population (D-T7).
 **Gate:** `pnpm check:all`; `bash scripts/check-tscope-phase.sh 4`.
 
 #### WI-TS4.1: Spawn context contract
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/components/Terminal/resolveTerminalSpawnContext.ts (new — the D-T9 contract), spawnPty.ts (workspaceRoot parameter; resolveActiveFileCwd extracted verbatim; stops re-resolving post-await; resolveTerminalWorkspaceRoot's missing isWorkspaceMode check preserved), useTerminalShellLifecycle.ts (resolves once pre-await), resolveTerminalSpawnContext.test.ts (new — full matrix), useTerminalShellLifecycle.scope.test.ts (L5 seam: env root == owner root under mid-spawn switch), spawnPty.test.ts (two tests pass workspaceRoot as the parameter)
+**Verified:** pnpm vitest run (9 files, 174 passed)
 Implement `resolveTerminalSpawnContext(windowLabel, session)` per D-T9 (pure;
 full matrix: requestedCwd / same-scope sibling / stamped owner present /
 owner deleted / unscoped / loose-with-file). Lifecycle resolves once
@@ -305,6 +364,10 @@ fallback — preserve, don't silently fix.
   mid-spawn switch (L5 on the spawn seam).
 
 #### WI-TS4.2: Out-of-tree pickers
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/services/terminal/revealTerminalSession.ts (reuse picks from the visible population; both creators stamp via resolveTerminalOwnerInstanceId), src/services/terminal/openTerminalHere.ts (canOpenTerminalHere caps per visible union), runInTerminal.ts unchanged, runInTerminal.test.ts (+ id-pinned delivery across a rail switch)
+**Verified:** pnpm vitest run (9 files, 174 passed — same batch)
 `reuseOrCreateTerminalSession` picks from the visible population (D-T10);
 `openTerminalHere`/`canOpenTerminalHere` cap per union; created sessions
 stamped via `resolveTerminalOwnerInstanceId`. `runInTerminal` unchanged — add
@@ -321,6 +384,10 @@ a test PINNING id-pinned delivery across a rail switch.
 `cd website && pnpm build`; `bash scripts/check-tscope-phase.sh 5`.
 
 #### WI-TS5.1: Rail e2e plumbing
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/components/WorkspaceRail/WorkspaceRail.tsx (data-rail-action="activate|duplicate" + data-instance-id), e2e/lib/rail.mjs (new — withRailMode via the verified StorageEvent pattern, clickRailInstance, getRailInstances, readRailMode/setRailMode), WorkspaceRail.test.tsx (attribute contract pinned)
+**Verified:** pnpm vitest run WorkspaceRail.test.tsx (32 passed); helpers exercised live by journey 35 (PASS)
 Stable selectors: `data-rail-action="activate|duplicate"` +
 `data-instance-id` on rail buttons. New `e2e/lib/rail.mjs`:
 `withRailMode(client, enabled, fn)` (StorageEvent settings patch — verified
@@ -329,6 +396,10 @@ live rehydration), `clickRailInstance(client, instanceId)`,
 - Tests: WorkspaceRail.test.tsx pins the new attributes.
 
 #### WI-TS5.2: Journeys
+
+**Status:** DONE — 2026-08-31
+**Changed:** e2e/journeys/35-terminal-rail-scoping.mjs (new), e2e/journeys/18-terminal-workspace-cd-sync.mjs (withRailMode(false) wrap + I15-is-legacy header), e2e/journeys/17-terminal-workspace-cwd.mjs (rail note), .github/workflows/tier0-e2e.yml (journey list + terminal-rail-scoping), dev-docs/e2e-tier0-matrix.md (I16 row). Diagnosed en route: the lazy-spawn rAF is SUSPENDED by WebKit while the app window is backgrounded (foreground dependency shared with 17/18 — documented in the journey header), and journey 35's first teardown exposed TerminalPanel.handleClose's blind toggle resurrecting a hidden panel (fixed + pinned, see WI-TS3.3 addendum in TerminalPanel.tsx/TerminalPanel.test.tsx).
+**Verified:** live debug app (pnpm tauri:dev, window foregrounded): terminal-rail-scoping PASS (2.8s), terminal-workspace-cwd PASS, terminal-workspace-cd-sync PASS — in sequence in one app instance, so 35's teardown provably leaves no residue
 (a) Journey 18 wrapped in `withRailMode(client, false, …)`; headers of 17/18
 updated — I15 is explicitly the *legacy/window-scoped* cd-follow.
 (b) New `35-terminal-rail-scoping.mjs`: rail ON; workspaces A+B; session in A
@@ -340,12 +411,20 @@ teardown restores rail setting + panel visibility, removes temp dirs.
 (d) Update `dev-docs/e2e-tier0-matrix.md`.
 
 #### WI-TS5.3: Website docs
+
+**Status:** DONE — 2026-08-31
+**Changed:** website/guide/terminal.md (new "Terminal sessions and the workspace rail" section), website/guide/workspace-rail.md (new "Terminal sessions" section), .claude/rules/21-website-docs.md (trigger + file-mapping rows for workspace-rail.md)
+**Verified:** cd website && pnpm build (build complete in 9.76s)
 `website/guide/terminal.md` + `website/guide/workspace-rail.md` (terminal
 section). Add the missing `workspace-rail.md` mapping row to
 `.claude/rules/21-website-docs.md` (page exists, unmapped — 1 line, same
 change). Verify `cd website && pnpm build`.
 
 #### WI-TS5.4: Locale sweep
+
+**Status:** DONE — 2026-08-31
+**Changed:** src/locales/{en,de,es,fr,it,ja,ko,pt-BR,zh-CN,zh-TW}/statusbar.json (terminal.noWorkspaceSession, vocabulary aligned with the existing toast.terminalNeedsWorkspace translations), src/locales/__tests__/terminalI18nCoverage.test.ts (WI citation — the identical-to-English gate guards the sweep)
+**Verified:** pnpm lint:i18n (all checks passed, untranslated baseline EMPTY) + terminalI18nCoverage.test.ts (6 passed)
 All new keys translated in de/es/fr/it/ja/ko/pt-BR/zh-CN/zh-TW. Use the
 `translate-docs` flow if the string count warrants it.
 

--- a/.github/workflows/tier0-e2e.yml
+++ b/.github/workflows/tier0-e2e.yml
@@ -185,7 +185,8 @@ jobs:
             failed-save-preserves-document \
             external-change-reloads-clean-doc \
             terminal-workspace-cwd \
-            terminal-workspace-cd-sync
+            terminal-workspace-cd-sync \
+            terminal-rail-scoping
           do
             echo "::group::$journey"
             if ! node e2e/run-journeys.mjs --only "$journey"; then

--- a/e2e/journeys/17-terminal-workspace-cwd.mjs
+++ b/e2e/journeys/17-terminal-workspace-cwd.mjs
@@ -26,6 +26,11 @@
  * React ref), so the assertion reads the OS process table instead — see
  * e2e/lib/terminal.mjs. `VMARK_WORKSPACE` stays manual-only (macOS SIP).
  *
+ * RAIL NOTE (WI-TS5.2): this journey runs on the runner's rail-off default
+ * profile, and its assertion holds under the rail too — a scoped session's
+ * spawn cwd is its owner workspace's root, the same directory. Journey 35
+ * (terminal-rail-scoping) covers the rail-ON contract.
+ *
  * Safety:
  *   - Creates and closes only its OWN session; pre-existing sessions are never
  *     touched, and the panel is returned to its prior visibility.

--- a/e2e/journeys/18-terminal-workspace-cd-sync.mjs
+++ b/e2e/journeys/18-terminal-workspace-cd-sync.mjs
@@ -9,6 +9,12 @@
  * tree while the UI claims the new one — the most dangerous possible
  * disagreement between what is displayed and where commands land.
  *
+ * I15 is explicitly the LEGACY / WINDOW-SCOPED cd-follow (WI-TS5.2): with the
+ * workspace rail ON, sessions are scoped per workspace and a switch HIDES
+ * them instead of cd'ing (journey 35, terminal-rail-scoping). The rail is
+ * therefore forced OFF via withRailMode rather than silently inherited from
+ * the runner's default profile.
+ *
  * This is the COMPLEMENT of journey 17, and the two are deliberately disjoint:
  * 17 asserts a NEW pid (proving `spawnPty`'s create-time CWD, excluding this
  * `cd` path), while this journey asserts the SAME pid MOVED (proving the sync
@@ -34,6 +40,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { getPersistedWorkspaceRoot, poll } from "../lib/vmark.mjs";
 import { openWorkspaceViaMcp, closeWorkspace } from "../lib/workspace.mjs";
+import { withRailMode } from "../lib/rail.mjs";
 import {
   isTerminalOpen,
   openTerminal,
@@ -69,6 +76,8 @@ export default {
       };
     }
 
+    // Rail OFF, explicitly (WI-TS5.2): I15 is the window-scoped cd-follow.
+    return withRailMode(client, false, async () => {
     const terminalWasOpen = await isTerminalOpen(client);
     let dirA = null;
     let dirB = null;
@@ -120,5 +129,6 @@ export default {
         if (d) await rm(d, { recursive: true, force: true }).catch(() => {});
       }
     }
+    });
   },
 };

--- a/e2e/journeys/35-terminal-rail-scoping.mjs
+++ b/e2e/journeys/35-terminal-rail-scoping.mjs
@@ -1,0 +1,184 @@
+/**
+ * Journey: terminal-rail-scoping  (Tier-0 · workspace-rail/terminal integration)
+ *
+ * Invariant I16 (WI-TS5.2) — with the workspace rail ON, terminal sessions are
+ * scoped to their owning workspace instance: a rail switch SWAPS the visible
+ * session set and leaves every hidden shell exactly where it was — alive, same
+ * pid, same cwd, nothing typed into it. This is the regression journey for the
+ * 2026-08-31 bug class: the old window-global set "followed" a switch by
+ * typing `cd` into every live shell, which deferred forever under a busy
+ * foreground command (any AI tool, vim, a dev server) and, on non-integrated
+ * shells, typed INTO the running program.
+ *
+ * COMPLEMENT of journeys 17/18: those pin the rail-OFF (window-scoped)
+ * behaviors — spawn cwd and cd-follow. This journey pins the rail-ON
+ * contract: pid identity + cwd stability across switches, per-scope tab
+ * sets, and per-scope auto-create.
+ *
+ * Safety:
+ *   - SKIPS when a workspace is already open (driving rail switches would
+ *     disturb it) and when any terminal session exists (window-scoped
+ *     leftovers stay visible in every scope and would blur the swap
+ *     assertions).
+ *   - Rail mode is restored by withRailMode's `finally`; panel visibility is
+ *     restored; its own sessions are closed; both temp dirs removed.
+ *
+ * FOREGROUND DEPENDENCY (shared with journeys 17/18): the lazy shell spawn
+ * runs in a requestAnimationFrame, and WebKit SUSPENDS rAF while the window
+ * is backgrounded — a spawn wait against a hidden window times out with the
+ * session tab visible and no PTY. CI keeps the app window frontmost; run
+ * locally with the debug app's window in the foreground. (Verified live
+ * 2026-08-31: the parked spawn fired the instant the window was focused.)
+ */
+
+import { rm, mkdtemp, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getPersistedWorkspaceRoot, poll } from "../lib/vmark.mjs";
+import { evalJs } from "../lib/bridge.mjs";
+import { openWorkspaceViaMcp, closeWorkspace } from "../lib/workspace.mjs";
+import { withRailMode, getRailInstances, clickRailInstance } from "../lib/rail.mjs";
+import {
+  isTerminalOpen,
+  openTerminal,
+  closeTerminal,
+  getAppShellCwds,
+  getTerminalSessions,
+  closeActiveTerminalSession,
+} from "../lib/terminal.mjs";
+
+async function makeWorkspace() {
+  const dir = await mkdtemp(join(homedir(), ".vmark-e2e-rail-"));
+  await writeFile(join(dir, "readme.md"), "# e2e rail workspace\n", "utf8");
+  return dir;
+}
+
+/** Visible terminal tabs in the DOM — the scoped tab bar's rendering. */
+const visibleTabCount = (client) =>
+  evalJs(client, `document.querySelectorAll(".terminal-tab").length`);
+
+export default {
+  name: "terminal-rail-scoping",
+
+  async run(client, ctx) {
+    const existingRoot = await getPersistedWorkspaceRoot(client, ctx.windowLabel);
+    if (existingRoot) {
+      return {
+        skip: `workspace already open (${existingRoot}) — this journey drives rail switches itself`,
+      };
+    }
+    const preSessions = await getTerminalSessions(client);
+    if (preSessions.total > 0) {
+      return {
+        skip: `${preSessions.total} terminal session(s) already open — window-scoped leftovers stay visible in every scope`,
+      };
+    }
+
+    return withRailMode(client, true, async () => {
+      const terminalWasOpen = await isTerminalOpen(client);
+      let dirA = null;
+      let dirB = null;
+      let idA = null;
+      let idB = null;
+      try {
+        // Workspace A joins the rail; its empty scope auto-creates a session.
+        dirA = await makeWorkspace();
+        await openWorkspaceViaMcp(client, dirA, { windowLabel: ctx.windowLabel });
+        const railAfterA = await poll(
+          () => getRailInstances(client),
+          (list) => list.length >= 1,
+          "workspace A to appear on the rail",
+          { timeoutMs: 10000, intervalMs: 250 },
+        );
+        idA = railAfterA[railAfterA.length - 1].instanceId;
+
+        const pidsBefore = new Set((await getAppShellCwds()).map((s) => s.pid));
+        await openTerminal(client, ctx.windowLabel);
+        const spawnedA = await poll(
+          () => getAppShellCwds(),
+          (list) => list.some((s) => !pidsBefore.has(s.pid) && s.cwd === dirA),
+          `A's session to spawn in workspace A (${dirA})`,
+          { timeoutMs: 15000, intervalMs: 500 },
+        );
+        const shellA = spawnedA.find((s) => !pidsBefore.has(s.pid) && s.cwd === dirA);
+        ctx.log(`A's shell ${shellA.comm} (pid ${shellA.pid}) in ${dirA}`);
+
+        // Workspace B joins the rail; switch to it.
+        dirB = await makeWorkspace();
+        await openWorkspaceViaMcp(client, dirB, { windowLabel: ctx.windowLabel });
+        const railAfterB = await poll(
+          () => getRailInstances(client),
+          (list) => list.length >= 2,
+          "workspace B to appear on the rail",
+          { timeoutMs: 10000, intervalMs: 250 },
+        );
+        idB = railAfterB.map((i) => i.instanceId).find((id) => id !== idA);
+        await clickRailInstance(client, idB);
+
+        // B's empty scope auto-creates its own session, IN B.
+        const spawnedB = await poll(
+          () => getAppShellCwds(),
+          (list) => list.some((s) => s.cwd === dirB),
+          `B's session to spawn in workspace B (${dirB})`,
+          { timeoutMs: 15000, intervalMs: 500 },
+        );
+        const shellB = spawnedB.find((s) => s.cwd === dirB);
+        ctx.log(`B's shell ${shellB.comm} (pid ${shellB.pid}) in ${dirB}`);
+
+        // THE invariant: A's shell is ALIVE, in the SAME cwd — never cd'd.
+        const listInB = await getAppShellCwds();
+        const shellAInB = listInB.find((s) => s.pid === shellA.pid);
+        if (!shellAInB) {
+          throw new Error(`A's shell (pid ${shellA.pid}) died on the rail switch`);
+        }
+        if (shellAInB.cwd !== dirA) {
+          throw new Error(
+            `A's shell was cd'd by the switch: ${shellAInB.cwd} (expected ${dirA})`,
+          );
+        }
+        // …and the DOM tab set swapped to B's single session.
+        await poll(
+          () => visibleTabCount(client),
+          (n) => n === 1,
+          "the tab bar to show only B's session",
+          { timeoutMs: 10000, intervalMs: 250 },
+        );
+        ctx.log(`tab set swapped; A's pid ${shellA.pid} untouched in ${dirA}`);
+
+        // Switch back: the SAME pid revealed, same cwd — no respawn, no cd.
+        await clickRailInstance(client, idA);
+        await poll(
+          () => visibleTabCount(client),
+          (n) => n === 1,
+          "the tab bar to show only A's session again",
+          { timeoutMs: 10000, intervalMs: 250 },
+        );
+        const listBack = await getAppShellCwds();
+        const shellABack = listBack.find((s) => s.pid === shellA.pid);
+        if (!shellABack || shellABack.cwd !== dirA) {
+          throw new Error(
+            `switch-back did not reveal the SAME shell in the SAME cwd: ${JSON.stringify(shellABack ?? null)}`,
+          );
+        }
+        ctx.log(`switch-back revealed pid ${shellA.pid} unchanged — scoped sessions intact`);
+      } finally {
+        // Close our OWN sessions in whichever scopes still exist.
+        await closeActiveTerminalSession(client).catch(() => {});
+        for (const id of [idB, idA]) {
+          if (!id) continue;
+          await clickRailInstance(client, id).catch(() => {});
+          await closeActiveTerminalSession(client).catch(() => {});
+        }
+        if (!terminalWasOpen) await closeTerminal(client, ctx.windowLabel).catch(() => {});
+        if (dirA || dirB) {
+          // Each close promotes the next railed workspace; two closes empty the rail.
+          await closeWorkspace(client, { windowLabel: ctx.windowLabel }).catch(() => {});
+          await closeWorkspace(client, { windowLabel: ctx.windowLabel }).catch(() => {});
+        }
+        for (const d of [dirA, dirB]) {
+          if (d) await rm(d, { recursive: true, force: true }).catch(() => {});
+        }
+      }
+    });
+  },
+};

--- a/e2e/lib/browser.mjs
+++ b/e2e/lib/browser.mjs
@@ -20,20 +20,14 @@
 
 import { evalJs } from "./bridge.mjs";
 import { poll } from "./vmark.mjs";
-
-const SETTINGS_KEY = "vmark-settings";
+import {
+  patchPersistedSettings,
+  readPersistedSettingsSection,
+} from "./settingsPatch.mjs";
 
 /** Read the persisted `browser` settings section. */
 export async function readBrowserSettings(client) {
-  const raw = await evalJs(
-    client,
-    `(() => { try { return JSON.stringify(JSON.parse(localStorage.getItem(${JSON.stringify(SETTINGS_KEY)}) || "{}")?.state?.browser ?? null); } catch { return "null"; } })()`
-  );
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  return readPersistedSettingsSection(client, "browser");
 }
 
 /**
@@ -43,24 +37,8 @@ export async function readBrowserSettings(client) {
  * would produce, so `useSettingsSync` applies it to the live Zustand store.
  */
 export async function patchBrowserSettings(client, patch) {
-  const ok = await evalJs(
-    client,
-    `(() => {
-       try {
-         const key = ${JSON.stringify(SETTINGS_KEY)};
-         const oldValue = localStorage.getItem(key);
-         const parsed = JSON.parse(oldValue || "{}");
-         parsed.state = parsed.state || {};
-         parsed.state.browser = { ...(parsed.state.browser || {}), ...${JSON.stringify(patch)} };
-         const newValue = JSON.stringify(parsed);
-         localStorage.setItem(key, newValue);
-         // The app's own cross-window sync path (useSettingsSync.ts).
-         window.dispatchEvent(new StorageEvent("storage", { key, oldValue, newValue, storageArea: localStorage }));
-         return true;
-       } catch (e) { return "ERR " + (e && e.message); }
-     })()`
-  );
-  if (ok !== true) throw new Error(`failed to patch browser settings: ${ok}`);
+  // Shared writer (audit 20260831 #45) — see settingsPatch.mjs.
+  await patchPersistedSettings(client, "browser", patch);
 }
 
 /**

--- a/e2e/lib/rail.mjs
+++ b/e2e/lib/rail.mjs
@@ -1,0 +1,113 @@
+/**
+ * Workspace-rail E2E helpers (WI-TS5.1).
+ *
+ * HOW THE SETTING IS CHANGED: by writing `vmark-settings` and dispatching a
+ * `storage` event — the app's OWN cross-window settings mechanism
+ * (`useSettingsSync.ts`), the same pattern browser.mjs uses. Verified to
+ * rehydrate `general.*` into the live store without a reload.
+ *
+ * Rail clicks go through stable `data-rail-action` / `data-instance-id`
+ * attributes — aria-labels are localized, so selecting by them breaks under
+ * any non-English locale. The attribute values are an automation CONTRACT
+ * pinned by WorkspaceRail.test.tsx.
+ *
+ * @coordinates-with src/hooks/useSettingsSync.ts — the storage-event listener
+ * @coordinates-with src/components/WorkspaceRail/WorkspaceRail.tsx — the hooks
+ */
+
+import { evalJs } from "./bridge.mjs";
+import {
+  patchPersistedSettings,
+  readPersistedSettingsSection,
+} from "./settingsPatch.mjs";
+
+/** The persisted `general.workspaceRailMode`, or null when unset. */
+export async function readRailMode(client) {
+  const general = await readPersistedSettingsSection(client, "general");
+  return general?.workspaceRailMode ?? null;
+}
+
+/** Set `general.workspaceRailMode` and notify the running app. */
+export async function setRailMode(client, enabled) {
+  await patchPersistedSettings(client, "general", { workspaceRailMode: enabled });
+}
+
+/** Remove the persisted `general.workspaceRailMode` key entirely (R2-16). */
+export async function clearRailMode(client) {
+  await patchPersistedSettings(client, "general", {}, { deleteKeys: ["workspaceRailMode"] });
+}
+
+/**
+ * Run `fn` with the rail forced on/off, restoring the prior state in a
+ * `finally` — a journey that leaves the rail flipped has silently changed
+ * the user's configuration.
+ *
+ * Restore is PRESENCE-faithful (R2-16): a key that was absent before is
+ * deleted after, never written back as an explicit `false` that would shadow
+ * a future default change. And a restore failure is LOUD (R2-17): when the
+ * journey body succeeded, the error propagates and fails the journey — a
+ * swallowed one leaves the dev profile flipped, which round 1's journey
+ * re-verification hit live. When the body itself failed, the body's error
+ * stays primary and the restore failure is logged.
+ */
+export async function withRailMode(client, enabled, fn) {
+  const general = await readPersistedSettingsSection(client, "general");
+  const hadKey = Boolean(
+    general && Object.prototype.hasOwnProperty.call(general, "workspaceRailMode"),
+  );
+  const prior = general?.workspaceRailMode;
+  await setRailMode(client, enabled);
+  let bodyFailed = false;
+  try {
+    return await fn();
+  } catch (error) {
+    bodyFailed = true;
+    throw error;
+  } finally {
+    try {
+      if (hadKey) {
+        await setRailMode(client, prior);
+      } else {
+        // The storage-event reconciler DEEP-MERGES, so deleting the persisted
+        // key alone never resets the LIVE store (R3-9) — first push the
+        // shipped default through the event (the same `false` the pre-R2-16
+        // restore encoded), then delete the key so persistence stays
+        // presence-faithful.
+        await setRailMode(client, false);
+        await clearRailMode(client);
+      }
+    } catch (restoreError) {
+      if (!bodyFailed) throw restoreError;
+      console.error("withRailMode: failed to restore rail mode after body error:", restoreError);
+    }
+  }
+}
+
+/** The rail's instances as `[{ instanceId, active }]`, in rail order. */
+export async function getRailInstances(client) {
+  const raw = await evalJs(
+    client,
+    `(() => {
+       const items = [...document.querySelectorAll('[data-rail-action="activate"]')];
+       return JSON.stringify(items.map((el) => ({
+         instanceId: el.getAttribute("data-instance-id"),
+         active: el.getAttribute("aria-pressed") === "true",
+       })));
+     })()`,
+  );
+  return JSON.parse(raw);
+}
+
+/** Click a rail workspace by instance id (the full context switch). */
+export async function clickRailInstance(client, instanceId) {
+  const ok = await evalJs(
+    client,
+    `(() => {
+       const el = document.querySelector('[data-rail-action="activate"][data-instance-id=' + JSON.stringify(${JSON.stringify(instanceId)}) + ']');
+       if (!el) return "MISSING";
+       el.click();
+       return true;
+     })()`,
+  );
+  if (ok !== true) throw new Error(`rail instance ${instanceId} not clickable: ${ok}`);
+}

--- a/e2e/lib/settingsPatch.mjs
+++ b/e2e/lib/settingsPatch.mjs
@@ -1,0 +1,60 @@
+/**
+ * Shared persisted-settings reader/patcher (audit 20260831 #45): rail.mjs and
+ * browser.mjs had grown byte-similar copies of the same localStorage +
+ * StorageEvent writer. This is the app's OWN cross-window settings mechanism
+ * (`useSettingsSync.ts` listens for exactly this event), so the running store
+ * rehydrates through a supported path rather than needing a reload.
+ *
+ * @coordinates-with src/hooks/useSettingsSync.ts — the storage-event listener
+ * @coordinates-with rail.mjs, browser.mjs — the section-specific wrappers
+ */
+
+import { evalJs } from "./bridge.mjs";
+
+const SETTINGS_KEY = "vmark-settings";
+
+/** Read one persisted settings section (e.g. "general", "browser"), or null. */
+export async function readPersistedSettingsSection(client, section) {
+  const raw = await evalJs(
+    client,
+    `(() => { try { return JSON.stringify(JSON.parse(localStorage.getItem(${JSON.stringify(SETTINGS_KEY)}) || "{}")?.state?.[${JSON.stringify(section)}] ?? null); } catch { return "null"; } })()`,
+  );
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Patch one settings section and notify the running app via StorageEvent.
+ *
+ * `options.deleteKeys` removes keys from the section entirely (R2-16) — a
+ * restore path needs "the key was absent before" to mean absent AFTER, not
+ * an explicit default value that shadows future default changes.
+ */
+export async function patchPersistedSettings(client, section, patch, options = {}) {
+  const deleteKeys = options.deleteKeys ?? [];
+  const ok = await evalJs(
+    client,
+    `(() => {
+       try {
+         const key = ${JSON.stringify(SETTINGS_KEY)};
+         const section = ${JSON.stringify(section)};
+         const oldValue = localStorage.getItem(key);
+         const parsed = JSON.parse(oldValue || "{}");
+         parsed.state = parsed.state || {};
+         parsed.state[section] = { ...(parsed.state[section] || {}), ...${JSON.stringify(patch)} };
+         for (const k of ${JSON.stringify(deleteKeys)}) delete parsed.state[section][k];
+         const newValue = JSON.stringify(parsed);
+         localStorage.setItem(key, newValue);
+         // The app's own cross-window sync path (useSettingsSync.ts).
+         window.dispatchEvent(new StorageEvent("storage", { key, oldValue, newValue, storageArea: localStorage }));
+         return true;
+       } catch (e) { return "ERR " + (e && e.message); }
+     })()`,
+  );
+  if (ok !== true) {
+    throw new Error(`failed to patch settings section ${section}: ${ok}`);
+  }
+}

--- a/scripts/check-tscope-phase.sh
+++ b/scripts/check-tscope-phase.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# DoD checker for the per-workspace-instance terminal sessions plan (WI-TS).
+# Plan: .claude/tdd-guardian/20260831-terminal-per-instance-sessions.md
+#
+# Usage: bash scripts/check-tscope-phase.sh <phase-number 0-5>
+#
+# Each phase block runs assertions for that phase's Definition of Done.
+# Exit code is 0 if all assertions pass, 1 if any fail, 64 on bad invocation.
+# Run before ticking the plan's Status header to the next phase.
+#
+# WI linkage is invoked as `--phase=TS<N>` — the linkage filter builds
+# `^WI-<arg>…`, so a bare numeric phase matches zero `WI-TS*` ids and the
+# fail-closed branch exits 1 (verified by execution; see WI-TS0.1).
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+PLAN_FILE=".claude/tdd-guardian/20260831-terminal-per-instance-sessions.md"
+
+PHASE="${1:-}"
+if [[ -z "$PHASE" ]]; then
+  echo "Usage: $0 <phase-number>"
+  echo "  0  Infrastructure & headroom (gate script, pre-splits)"
+  echo "  1  Store model (owner field, scope actions, selectors)"
+  echo "  2  Guards + transition wiring (cd-follow, coordinator, lifecycle)"
+  echo "  3  UI (tab bar filtering, auto-create, last-session)"
+  echo "  4  Spawn & pickers (spawn context contract, out-of-tree pickers)"
+  echo "  5  E2E, docs, i18n"
+  exit 64
+fi
+
+PASS=0
+FAIL=0
+FAIL_DETAIL=()
+
+ok()   { echo "  ✓ $1"; PASS=$((PASS+1)); }
+fail() { echo "  ✗ $1"; FAIL=$((FAIL+1)); FAIL_DETAIL+=("$1"); }
+
+assert_file() {
+  local path="$1"; local label="${2:-$1}"
+  if [[ -f "$path" ]]; then ok "$label exists"; else fail "$label missing: $path"; fi
+}
+
+assert_grep() {
+  local pattern="$1"; local file="$2"; local label="$3"
+  if grep -q -- "$pattern" "$file" 2>/dev/null; then ok "$label"; else fail "$label (pattern '$pattern' not in $file)"; fi
+}
+
+assert_wc_max() {
+  local path="$1"; local max="$2"; local label="$3"
+  local n
+  if [[ -f "$path" ]]; then
+    n=$(wc -l <"$path" | tr -d ' ')
+    if (( n <= max )); then ok "$label ($n lines ≤ $max)"; else fail "$label ($n lines, need ≤ $max)"; fi
+  else
+    fail "$label (file missing: $path)"
+  fi
+}
+
+# WI linkage for one phase. MUST use the TS-prefixed spelling: the linkage
+# filter regex is `^WI-<arg>…`, so `--phase=0` matches nothing in a WI-TS plan
+# and fails closed.
+assert_linkage() {
+  local phase="$1"
+  if bash scripts/check-wi-linkage.sh "$PLAN_FILE" --phase="TS${phase}" >/dev/null 2>&1; then
+    ok "WI linkage green for phase TS${phase}"
+  else
+    fail "WI linkage red for phase TS${phase} (run: bash scripts/check-wi-linkage.sh $PLAN_FILE --phase=TS${phase})"
+  fi
+}
+
+# ─── Phase 0 — Infrastructure & headroom ─────────────────────────────────
+phase_0() {
+  echo "Phase 0 — Infrastructure & headroom"
+
+  # WI-TS0.1 — this gate + its self-test
+  assert_file "scripts/check-tscope-phase.test.mjs" "WI-TS0.1 gate self-test"
+  assert_file "$PLAN_FILE" "WI-TS0.1 plan file"
+
+  # WI-TS0.2 — useTerminalSessions pre-split
+  assert_file "src/components/Terminal/terminalSessionBell.ts"     "WI-TS0.2 bell wiring module"
+  assert_file "src/components/Terminal/useTerminalSessionsInit.ts" "WI-TS0.2 mount/init module"
+  assert_wc_max "src/components/Terminal/useTerminalSessions.ts" 249 "WI-TS0.2 useTerminalSessions.ts under 250"
+
+  # WI-TS0.3 — workspaceInstancesStore pre-split
+  assert_wc_max "src/stores/workspaceInstancesStore.ts" 280 "WI-TS0.3 workspaceInstancesStore.ts ≤ 280"
+
+  assert_linkage 0
+}
+
+# ─── Phase 1 — Store model ───────────────────────────────────────────────
+phase_1() {
+  echo "Phase 1 — Store model (no wiring yet)"
+
+  # WI-TS1.1 — owner field + stamping helper + union cap/ordinals
+  assert_grep "workspaceInstanceId" "src/stores/uiStore/types.ts" "WI-TS1.1 owner field on TerminalSession"
+  assert_file "src/services/terminal/resolveTerminalOwnerInstanceId.ts" "WI-TS1.1 stamping helper"
+  assert_file "src/services/terminal/resolveTerminalOwnerInstanceId.test.ts" "WI-TS1.1 stamping helper tests"
+  assert_file "src/stores/uiStore/terminalSlice.scope.test.ts" "WI-TS1.1 slice scope tests"
+
+  # WI-TS1.2 — scope-transition actions
+  assert_file "src/stores/uiStore/terminalScopeActions.ts" "WI-TS1.2 scope actions module"
+  for action in terminalAdoptUnscopedSessions terminalSwitchScope terminalHydrateScope \
+                terminalRemoveScopeSessions terminalRekeyScope; do
+    assert_grep "$action" "src/stores/uiStore/terminalScopeActions.ts" "WI-TS1.2 action $action"
+  done
+  assert_grep "lastActiveByScope" "src/stores/uiStore/types.ts" "WI-TS1.2 per-scope active memory"
+
+  # WI-TS1.3 — scoped selectors
+  assert_file "src/stores/uiStore/terminalScopeSelectors.ts" "WI-TS1.3 selectors module"
+  assert_grep "selectVisibleTerminalSessions" "src/stores/uiStore/terminalScopeSelectors.ts" "WI-TS1.3 visible selector"
+  assert_grep "selectVisibleSessionCount" "src/stores/uiStore/terminalScopeSelectors.ts" "WI-TS1.3 count selector"
+
+  assert_linkage 1
+}
+
+# ─── Phase 2 — Guards + transition wiring ────────────────────────────────
+phase_2() {
+  echo "Phase 2 — Guards + transition wiring"
+
+  # WI-TS2.1 — cd-follow gated at all three sites
+  assert_file "src/services/terminal/terminalCdFollow.ts" "WI-TS2.1 cd-follow predicate module"
+  assert_grep "shouldFollowWorkspaceCd" "src/components/Terminal/terminalSessionStoreSync.ts" "WI-TS2.1 syncRoot + flushPendingRoot guard"
+  assert_grep "shouldFollowWorkspaceCd" "src/components/Terminal/useTerminalShellLifecycle.ts" "WI-TS2.1 post-spawn catch-up guard"
+
+  # WI-TS2.2 — coordinator + hydrate
+  assert_grep "terminalAdoptUnscopedSessions" "src/services/workspaces/switchWorkspaceInstance.ts" "WI-TS2.2 adoption on switch"
+  assert_grep "terminalSwitchScope" "src/services/workspaces/switchWorkspaceInstance.ts" "WI-TS2.2 scope switch on switch"
+  assert_grep "terminalHydrateScope" "src/services/workspaces/hydrateWorkspaceInstanceContext.ts" "WI-TS2.2 hydrate realign"
+
+  # WI-TS2.3 — instance lifecycle wiring
+  assert_grep "terminalRemoveScopeSessions" "src/services/workspaces/closeWorkspaceInstance.ts" "WI-TS2.3 close kills scope sessions"
+  assert_grep "terminalHydrateScope" "src/services/workspaces/closeWorkspaceInstance.ts" "WI-TS2.3 close realigns active"
+  assert_grep "terminalRemoveScopeSessions" "src/services/workspaces/workspaceWindowActions.ts" "WI-TS2.3 move kills source scope"
+  assert_grep "terminalRekeyScope" "src/stores/workspaceInstancesStore.ts" "WI-TS2.3 rekey follower"
+  assert_grep "removeClosedScope" "src/stores/tabStoreClosedScopes.ts" "WI-TS2.3 closed-scope cleanup action"
+  assert_grep "removeClosedScope" "src/services/workspaces/closeWorkspaceInstance.ts" "WI-TS2.3 closed-scope cleanup wired"
+
+  # WI-TS2.4 — store-chain integration test
+  assert_file "src/components/Terminal/terminalSessionStoreSync.railswitch.test.ts" "WI-TS2.4 rail-switch chain test"
+
+  assert_linkage 2
+}
+
+# ─── Phase 3 — UI ────────────────────────────────────────────────────────
+phase_3() {
+  echo "Phase 3 — UI"
+
+  # WI-TS3.1 — UI filtering
+  assert_grep "useVisibleTerminalSessions" "src/components/Terminal/TerminalTabBar.tsx" "WI-TS3.1 tab bar renders visible population"
+  assert_file "src/components/Terminal/TerminalTabBar.scope.test.tsx" "WI-TS3.1 tab bar scope tests"
+  assert_grep "visible" "src/components/Terminal/terminalKeyHandler.ts" "WI-TS3.1 keyHandler indexes visible list"
+
+  # WI-TS3.2 — shared auto-create helper + empty state
+  assert_file "src/services/terminal/maybeAutoCreateTerminalSession.ts" "WI-TS3.2 shared auto-create helper"
+  assert_grep "canAutoCreateInScope" "src/services/terminal/maybeAutoCreateTerminalSession.ts" "WI-TS3.2 scope-aware gate"
+  for locale in en de es fr it ja ko pt-BR zh-CN zh-TW; do
+    assert_grep "terminal.noWorkspaceSession" "src/locales/${locale}/statusbar.json" "WI-TS3.2 empty-state key (${locale})"
+  done
+
+  # WI-TS3.3 — visible-scope last-session semantics
+  assert_grep "visible" "src/components/Terminal/TerminalPanel.tsx" "WI-TS3.3 panel last-ness on visible population"
+
+  assert_linkage 3
+}
+
+# ─── Phase 4 — Spawn & pickers ───────────────────────────────────────────
+phase_4() {
+  echo "Phase 4 — Spawn & pickers"
+
+  # WI-TS4.1 — spawn context contract
+  assert_file "src/components/Terminal/resolveTerminalSpawnContext.ts" "WI-TS4.1 spawn context contract"
+  assert_file "src/components/Terminal/resolveTerminalSpawnContext.test.ts" "WI-TS4.1 contract matrix tests"
+  assert_grep "workspaceRoot" "src/components/Terminal/spawnPty.ts" "WI-TS4.1 spawnPty takes workspaceRoot"
+
+  # WI-TS4.2 — out-of-tree pickers
+  assert_grep "resolveTerminalOwnerInstanceId" "src/services/terminal/revealTerminalSession.ts" "WI-TS4.2 pickers stamp owners"
+  assert_grep "WI-TS4.2" "src/services/terminal/runInTerminal.test.ts" "WI-TS4.2 id-pinned delivery test"
+
+  assert_linkage 4
+}
+
+# ─── Phase 5 — E2E, docs, i18n ───────────────────────────────────────────
+phase_5() {
+  echo "Phase 5 — E2E, docs, i18n"
+
+  # WI-TS5.1 — rail e2e plumbing
+  assert_file "e2e/lib/rail.mjs" "WI-TS5.1 rail e2e helpers"
+  assert_grep "data-rail-action" "src/components/WorkspaceRail/WorkspaceRail.tsx" "WI-TS5.1 stable rail selectors"
+
+  # WI-TS5.2 — journeys
+  assert_file "e2e/journeys/35-terminal-rail-scoping.mjs" "WI-TS5.2 rail-scoping journey"
+  assert_grep "withRailMode" "e2e/journeys/18-terminal-workspace-cd-sync.mjs" "WI-TS5.2 journey 18 rail-OFF precondition"
+  # CI's run loop passes journey NAMES (--only substrings), not file names.
+  assert_grep "terminal-rail-scoping" ".github/workflows/tier0-e2e.yml" "WI-TS5.2 CI journey list includes 35"
+  if [[ -d dev-docs ]]; then
+    assert_grep "terminal-rail-scoping" "dev-docs/e2e-tier0-matrix.md" "WI-TS5.2 tier-0 matrix updated"
+  else
+    echo "  ⓘ dev-docs/ absent on this machine — matrix check skipped (maintainer-local)"
+  fi
+
+  # WI-TS5.3 — website docs
+  assert_grep "workspace" "website/guide/terminal.md" "WI-TS5.3 terminal guide covers scoping"
+  assert_grep "erminal" "website/guide/workspace-rail.md" "WI-TS5.3 rail guide terminal section"
+  assert_grep "workspace-rail.md" ".claude/rules/21-website-docs.md" "WI-TS5.3 rule 21 mapping row"
+
+  assert_linkage 5
+}
+
+# ─── Dispatch ────────────────────────────────────────────────────────────
+case "$PHASE" in
+  0) phase_0 ;;
+  1) phase_1 ;;
+  2) phase_2 ;;
+  3) phase_3 ;;
+  4) phase_4 ;;
+  5) phase_5 ;;
+  *) echo "unknown phase: $PHASE"; exit 64 ;;
+esac
+
+echo
+echo "─────────────────────────────────────────────"
+echo "Phase $PHASE: $PASS passed, $FAIL failed"
+if (( FAIL > 0 )); then
+  echo
+  echo "Failed assertions:"
+  for d in "${FAIL_DETAIL[@]}"; do echo "  • $d"; done
+  exit 1
+fi
+exit 0

--- a/scripts/check-tscope-phase.test.mjs
+++ b/scripts/check-tscope-phase.test.mjs
@@ -1,0 +1,85 @@
+// WI-TS0.1 — DoD gate self-test for scripts/check-tscope-phase.sh.
+// WI-TS0.2 / WI-TS0.3 — linked here deliberately: the phase-0 leg of the gate
+//   asserts exactly those WIs' deliverables (the extracted modules plus the
+//   file-size ceilings on useTerminalSessions.ts and workspaceInstancesStore.ts),
+//   and this file pins that the gate actually fails when they are absent.
+// WI-TS5.2 / WI-TS5.3 — same rationale one phase later: journeys and website
+//   docs live outside every unit-test tier, so their DoD artifacts (journey
+//   file, rail-OFF wrap, CI list entry, guide sections, rule-21 mapping) are
+//   asserted by the gate's phase-5 leg, which this file exercises.
+//
+// Conventions follow check-wi-linkage.test.mjs: the REAL script runs as a
+// subprocess. For the missing-artifact case it is SYMLINKED into a scratch
+// tree — the script does `cd "$(dirname "$0")/.."`, so the symlink's parent
+// decides which tree is checked while the bytes executed stay the real
+// script's. The linkage smoke test runs against the real repo and asserts
+// only the PARSE result ("WIs found: N"), never the linkage verdict — the
+// verdict depends on commit history this test must not assume.
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = path.join(REPO, "scripts", "check-tscope-phase.sh");
+const PLAN = ".claude/tdd-guardian/20260831-terminal-per-instance-sessions.md";
+
+function run(args, cwd = REPO) {
+  return spawnSync("bash", [SCRIPT, ...args], { cwd, encoding: "utf8" });
+}
+
+describe("check-tscope-phase.sh", () => {
+  it("exits 64 with a usage message on no argument", () => {
+    const r = run([]);
+    expect(r.status).toBe(64);
+    expect(r.stdout).toContain("Usage:");
+  });
+
+  it("exits 64 on an unknown phase", () => {
+    const r = run(["9"]);
+    expect(r.status).toBe(64);
+    expect(r.stdout).toContain("unknown phase");
+  });
+
+  it("fails (non-zero) when a phase's artifacts are missing", () => {
+    // Scratch tree with NO artifacts at all. The symlinked script cd's to the
+    // scratch root, so every assert_file/assert_grep must fail — a gate that
+    // passed here would be asserting nothing.
+    const root = mkdtempSync(path.join(tmpdir(), "tscope-phase-"));
+    mkdirSync(path.join(root, "scripts"), { recursive: true });
+    symlinkSync(SCRIPT, path.join(root, "scripts", "check-tscope-phase.sh"));
+    const r = spawnSync(
+      "bash",
+      [path.join(root, "scripts", "check-tscope-phase.sh"), "0"],
+      { cwd: root, encoding: "utf8" },
+    );
+    expect(r.status).not.toBe(0);
+    expect(r.stdout).toContain("missing");
+  });
+
+  it("smoke: the WI-linkage invocation parses ≥ 1 WI for phase TS0", () => {
+    // The gate invokes check-wi-linkage.sh with `--phase=TS<N>`. A bare
+    // numeric phase would match zero WI-TS ids and trip the fail-closed
+    // zero-match branch — this pins that the TS spelling actually parses the
+    // plan's declarations (3 WIs in phase TS0).
+    const r = spawnSync(
+      "bash",
+      ["scripts/check-wi-linkage.sh", PLAN, "--phase=TS0"],
+      { cwd: REPO, encoding: "utf8" },
+    );
+    expect(r.stdout).not.toContain("no WI-IDs matching");
+    expect(r.stdout).toMatch(/WIs found: 3/);
+  });
+
+  it("the bare-numeric spelling fails closed (the trap WI-TS0.1 documents)", () => {
+    const r = spawnSync(
+      "bash",
+      ["scripts/check-wi-linkage.sh", PLAN, "--phase=0"],
+      { cwd: REPO, encoding: "utf8" },
+    );
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain("no WI-IDs matching");
+  });
+});

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -103,7 +103,7 @@
     "src/components/Tabs/useTabContextMenuActions.test.ts": 840,
     "src/components/Terminal/TerminalContextMenu.test.tsx": 889,
     "src/components/Terminal/createTerminalInstance.test.ts": 1116,
-    "src/components/Terminal/spawnPty.test.ts": 815,
+    "src/components/Terminal/spawnPty.test.ts": 811,
     "src/components/Terminal/terminalKeyHandler.test.ts": 862,
     "src/contexts/WindowContext.test.tsx": 1557,
     "src/export/resourceResolver.test.ts": 1084,

--- a/scripts/test-types-baseline.json
+++ b/scripts/test-types-baseline.json
@@ -54,7 +54,6 @@
   "src/components/Terminal/createTerminalInstance.test.ts": 25,
   "src/components/Terminal/createTerminalInstance.webgl.test.ts": 1,
   "src/components/Terminal/terminalSessionStoreSync.root.test.ts": 1,
-  "src/components/Terminal/useTerminalShellLifecycle.test.ts": 1,
   "src/contexts/startupFileOpen.test.ts": 20,
   "src/contexts/tabTransferHandlers.test.ts": 2,
   "src/export/__tests__/PdfSettingsSidebar.test.tsx": 1,

--- a/src/components/Sidebar/FileExplorer/contextMenuActions.test.ts
+++ b/src/components/Sidebar/FileExplorer/contextMenuActions.test.ts
@@ -29,7 +29,7 @@ function makeDeps(overrides: Partial<ContextMenuActionDeps> = {}): ContextMenuAc
     revealInFinder: vi.fn(() => Promise.resolve()),
     newFile: vi.fn(() => Promise.resolve()),
     newFolder: vi.fn(() => Promise.resolve()),
-    openTerminalHere: vi.fn(() => ({ ok: true, sessionId: "term-1" })),
+    openTerminalHere: vi.fn(() => ({ ok: true as const, sessionId: "term-1" })),
     notifyError: vi.fn(),
     ...overrides,
   };
@@ -165,7 +165,7 @@ describe("runContextMenuAction", () => {
       const deps = makeDeps({
         targetPath: "/w/src",
         targetIsFolder: true,
-        openTerminalHere: vi.fn(() => ({ ok: false, reason: "max-sessions" as const })),
+        openTerminalHere: vi.fn(() => ({ ok: false as const, reason: "max-sessions" as const })),
       });
       await runContextMenuAction("openTerminalHere", deps);
       expect(deps.notifyError).toHaveBeenCalledWith("statusbar:terminal.maxSessions");

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -259,8 +259,11 @@
 }
 
 .tab-pill:hover {
-  background-color: var(--hover-bg);
-  color: var(--text-color);
+  /* ui-ok(state): negative hover (maintainer direction 2026-08-31) — the pill
+     inverts to ink-on-page: background and text swap tokens, so the contrast
+     is the body pair's own ratio, AA by construction in every theme. */
+  background-color: var(--text-color);
+  color: var(--bg-color);
 }
 
 .tab-pill:focus-visible {
@@ -270,12 +273,14 @@
 .tab-pill.active {
   /* ui-ok(state): the active tab SHARES THE PAGE SURFACE it fronts — the
      browser-tab idiom; an accent wash here would disconnect tab from page. */
-  /* WI-UI3.6: a real surface — on night the page-vs-bar contrast alone was
-     ~1.05:1, so the active pill was findable only by its text weight. The
-     --control-border boundary is authored ≥ 3:1 on every theme (D8). */
+  /* Borderless by maintainer direction (2026-08-31), superseding WI-UI3.6's
+     --control-border ring. The trade is known: on night the page-vs-bar
+     contrast alone is ~1.05:1, so findability now rests on the raised
+     --shadow-sm surface (whose dark value is pinned deep enough to exist on a
+     dark page — tabPillSurface.test.ts) plus the negative hover affordance. */
   background-color: var(--bg-color);
   color: var(--text-color);
-  box-shadow: inset 0 0 0 var(--border-thin) var(--control-border), var(--shadow-sm);
+  box-shadow: var(--shadow-sm);
 }
 
 .browser-workspace-tab {
@@ -295,8 +300,10 @@
 }
 
 .browser-workspace-tab:hover {
-  color: var(--text-color);
-  background: var(--hover-bg);
+  /* ui-ok(state): negative hover — matches .tab-pill:hover; the two share
+     one strip and must speak one hover language (maintainer 2026-08-31). */
+  color: var(--bg-color);
+  background: var(--text-color);
 }
 
 .browser-workspace-tab.active {

--- a/src/components/StatusBar/tabPillSurface.test.ts
+++ b/src/components/StatusBar/tabPillSurface.test.ts
@@ -1,22 +1,58 @@
-// WI-UI3.6 — the active tab pill has a REAL surface: on night the page-vs-bar
-// contrast alone is ~1.05:1, so the boundary must come from --control-border.
+// The tab-strip pill surface contract.
+//
+// WI-UI3.6 originally drew the active pill's boundary with a --control-border
+// ring. The maintainer superseded that on 2026-08-31: the strip's pills are
+// BORDERLESS — the active pill is a raised --shadow-sm card sharing the page
+// surface, and hover is a photographic NEGATIVE (ink and page swap tokens, so
+// the pair's contrast is the body ratio, AA by construction in every theme).
+// The dark --shadow-sm depth is therefore MORE load-bearing than before: it is
+// now the active pill's only boundary on a dark page.
+//
+// The embedded browser's own page tabs (.browser-page-tab) deliberately KEEP
+// the WI-UI3.6 control-border idiom — real-browser chrome, separate system.
 // @vitest-environment node
 import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
 
-describe("active tab pill surface (WI-UI3.6)", () => {
-  it(".tab-pill.active draws its boundary with --control-border", () => {
-    const css = readFileSync("src/components/StatusBar/StatusBar.css", "utf8");
-    const i = css.indexOf(".tab-pill.active {");
-    expect(i).toBeGreaterThan(-1);
-    const body = css.slice(i, css.indexOf("}", i));
-    expect(body).toContain("var(--control-border)");
+const statusBarCss = () => readFileSync("src/components/StatusBar/StatusBar.css", "utf8");
+
+function ruleBody(css: string, selector: string): string {
+  const i = css.indexOf(selector);
+  expect(i, selector).toBeGreaterThan(-1);
+  return css.slice(i, css.indexOf("}", i));
+}
+
+describe("tab-strip pill surface (borderless + negative hover, 2026-08-31)", () => {
+  it(".tab-pill.active is a borderless raised card — no control-border ring", () => {
+    const body = ruleBody(statusBarCss(), ".tab-pill.active {");
+    expect(body).not.toContain("var(--control-border)");
+    expect(body).toContain("var(--shadow-sm)");
+    expect(body).toContain("var(--bg-color)");
   });
 
-  it(".browser-page-tab.active uses the same idiom", () => {
+  it(".tab-pill:hover inverts — ink background, page-colour text", () => {
+    const body = ruleBody(statusBarCss(), ".tab-pill:hover {");
+    expect(body).toContain("background-color: var(--text-color)");
+    expect(body).toContain("color: var(--bg-color)");
+  });
+
+  it(".browser-workspace-tab:hover speaks the same negative hover language", () => {
+    const body = ruleBody(statusBarCss(), ".browser-workspace-tab:hover {");
+    expect(body).toContain("var(--text-color)");
+    expect(body).toContain("var(--bg-color)");
+  });
+
+  it("the active rule still OUTRANKS the hover inversion (declared later, equal specificity)", () => {
+    const css = statusBarCss();
+    // .tab-pill:hover and .tab-pill.active tie at (0,2,0); source order is
+    // what keeps the active card stable under the pointer. A refactor that
+    // reorders them would make hovering the active tab invert it.
+    expect(css.indexOf(".tab-pill:hover {")).toBeLessThan(css.indexOf(".tab-pill.active {"));
+  });
+
+  it(".browser-page-tab.active KEEPS the control-border idiom (browser chrome is a separate system)", () => {
     const css = readFileSync("src/components/Browser/browser-chrome.css", "utf8");
-    const i = css.indexOf(".browser-page-tab.active {");
-    const body = css.slice(i, css.indexOf("}", i));
+    const body = ruleBody(css, ".browser-page-tab.active {");
     expect(body).toContain("var(--control-border)");
   });
 

--- a/src/components/Terminal/TerminalPanel.test.tsx
+++ b/src/components/Terminal/TerminalPanel.test.tsx
@@ -5,8 +5,8 @@
  * (cc-suite:audit-fix) flagged this wiring as untested critical:
  * a regression here would silently remove the #856 fix in real usage.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, fireEvent, screen } from "@testing-library/react";
 import type { Terminal } from "@xterm/xterm";
 import type { IPty } from "@/lib/pty";
 
@@ -36,7 +36,10 @@ vi.mock("./useTerminalResize", () => ({
 }));
 
 vi.mock("./TerminalTabBar", () => ({
-  TerminalTabBar: () => <div data-testid="tab-bar" />,
+  // Expose onClose so the close path (WI-TS3.3) is reachable from tests.
+  TerminalTabBar: (props: { onClose: () => void }) => (
+    <button data-testid="tab-bar" onClick={props.onClose} />
+  ),
 }));
 
 vi.mock("./TerminalSearchBar", () => ({
@@ -49,7 +52,13 @@ vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
 }));
 
 import { TerminalPanel } from "./TerminalPanel";
-import { useUIStore } from "@/stores/uiStore";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
 
 function makeFakeTerm(): Terminal {
   return {
@@ -118,5 +127,128 @@ describe("TerminalPanel — resetDisplay wiring (#856)", () => {
 
     // Menu should not render at all when there's no active terminal
     expect(screen.queryByText("Reset Display")).not.toBeInTheDocument();
+  });
+});
+
+describe("TerminalPanel — closing the last VISIBLE session (WI-TS3.3)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTerminalSessionStore();
+    mockUseTerminalSessions.mockReturnValue({
+      fit: mockFit,
+      getActiveTerminal: mockGetActiveTerminal,
+      getActiveSearchAddon: vi.fn(() => null),
+      restartActiveSession: vi.fn(),
+    });
+    mockGetActiveTerminal.mockReturnValue(null);
+  });
+
+  it("hides the panel when the last visible session closes", () => {
+    useUIStore.setState({ terminalVisible: true });
+    useUIStore.getState().terminalCreateSession();
+    render(<TerminalPanel />);
+
+    fireEvent.click(screen.getByTestId("tab-bar"));
+
+    expect(useUIStore.getState().terminal.sessions).toHaveLength(0);
+    expect(useUIStore.getState().terminalVisible).toBe(false);
+  });
+
+  it("never TOGGLES an already-hidden panel back to visible (the journey-35 resurrect)", () => {
+    useUIStore.setState({ terminalVisible: true });
+    useUIStore.getState().terminalCreateSession();
+    render(<TerminalPanel />);
+    // Automation teardown: the panel goes hidden, the session outlives it.
+    act(() => {
+      useUIStore.setState({ terminalVisible: false });
+    });
+
+    fireEvent.click(screen.getByTestId("tab-bar"));
+
+    expect(useUIStore.getState().terminal.sessions).toHaveLength(0);
+    // The old blind toggle flipped this back to true — and the panel's
+    // auto-create then spawned a shell nobody asked for.
+    expect(useUIStore.getState().terminalVisible).toBe(false);
+  });
+});
+
+describe("TerminalPanel — rail-mode toggle realigns and auto-creates (R2-15)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTerminalSessionStore();
+    useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+    setRail(false);
+    mockUseTerminalSessions.mockReturnValue({
+      fit: mockFit,
+      getActiveTerminal: mockGetActiveTerminal,
+      getActiveSearchAddon: vi.fn(() => null),
+      restartActiveSession: vi.fn(),
+    });
+    mockGetActiveTerminal.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    setRail(false);
+    useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  });
+
+  function addWorkspace(id: string, rootPath: string): void {
+    const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+    if (!root.ok) throw new Error("bad test root");
+    useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+      createWorkspaceInstance({
+        workspaceInstanceId: id,
+        root: root.root,
+        ownerWindowLabel: "main",
+        createdFrom: "open",
+      }),
+    );
+  }
+
+  function setRail(enabled: boolean): void {
+    useSettingsStore.setState({
+      general: {
+        ...useSettingsStore.getState().general,
+        workspaceRailMode: enabled,
+      },
+    });
+  }
+
+  it("toggling the rail ON realigns a newly-hidden active onto a visible session", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    addWorkspace("wsi-b", "/repo-b");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance("main", "wsi-a");
+    const sA = useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" })!;
+    const sB = useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-b" })!;
+    useUIStore.getState().terminalSetActiveSession(sB.id);
+    useUIStore.setState({ terminalVisible: true });
+    render(<TerminalPanel />);
+    // Rail off: sB is visible (stamps inert) and legitimately active.
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(sB.id);
+
+    act(() => setRail(true)); // sB hides — wsi-a is the active scope
+
+    // Before R2-15 nothing re-ran: the hidden sB stayed "active" over a tab
+    // bar that no longer shows it.
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(sA.id);
+    // No phantom session: the visible population was non-empty.
+    expect(useUIStore.getState().terminal.sessions).toHaveLength(2);
+  });
+
+  it("toggling the rail ON over an EMPTY visible scope auto-creates its first session", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    addWorkspace("wsi-b", "/repo-b");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance("main", "wsi-a");
+    const sB = useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-b" })!;
+    useUIStore.setState({ terminalVisible: true });
+    render(<TerminalPanel />);
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(sB.id);
+
+    act(() => setRail(true)); // wsi-a's visible population is empty
+
+    const terminal = useUIStore.getState().terminal;
+    const created = terminal.sessions.find((s) => s.workspaceInstanceId === "wsi-a");
+    expect(created).toBeDefined();
+    expect(terminal.activeSessionId).toBe(created?.id);
   });
 });

--- a/src/components/Terminal/TerminalPanel.tsx
+++ b/src/components/Terminal/TerminalPanel.tsx
@@ -41,6 +41,13 @@
 import { useRef, useEffect, useState, useCallback, type RefObject, type MutableRefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useUIStore } from "@/stores/uiStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
+import { maybeAutoCreateTerminalSession } from "@/services/terminal/maybeAutoCreateTerminalSession";
+import { realignTerminalActiveToVisible } from "@/services/terminal/visibleTerminalSessions";
+import { removeTerminalSessionWithPanelPolicy } from "@/services/terminal/closeTerminalSession";
+import { useVisibleTerminalSessions } from "./useVisibleTerminalSessions";
 import { useTerminalSessions } from "./useTerminalSessions";
 import { useTerminalResize } from "./useTerminalResize";
 import { useTerminalAutoFit } from "./useTerminalAutoFit";
@@ -80,15 +87,31 @@ export function TerminalPanel() {
   const { fit, getActiveTerminal, getActiveSearchAddon, restartActiveSession } =
     useTerminalSessions(activated ? containerRef : NULL_REF, { onSearch });
 
-  // Create a session when terminal becomes visible with none existing
-  // (e.g., user closed all tabs then re-opened the panel)
+  // Auto-create when the panel is visible over an EMPTY visible scope
+  // (WI-TS3.2/D-T8): gated on the synchronous instance-backed scope through
+  // the ONE shared helper, and re-fired on rail switches so entering an
+  // empty workspace scope creates its first session there. A refusal renders
+  // the empty-state hint below instead of spawning into $HOME.
+  //
+  // The rail MODE is a dependency too (R2-15): toggling it changes the
+  // visible population with no scope switch, so the active session is first
+  // realigned to what is actually visible — otherwise a newly-hidden active
+  // session would sit over an empty tab bar and block auto-create.
+  const activeInstanceId = useWorkspaceInstancesStore(
+    (s) => s.windows[getCurrentWindowLabel()]?.activeWorkspaceInstanceId ?? null,
+  );
+  const railEnabled = useSettingsStore(
+    (s) => s.general?.workspaceRailMode ?? false,
+  );
   useEffect(() => {
     if (!visible) return;
-    const store = useUIStore.getState();
-    if (store.terminal.sessions.length === 0) {
-      store.terminalCreateSession();
-    }
-  }, [visible]);
+    realignTerminalActiveToVisible(getCurrentWindowLabel());
+    maybeAutoCreateTerminalSession(getCurrentWindowLabel());
+  }, [visible, activeInstanceId, railEnabled]);
+
+  // The visible population (WI-TS3.3/D-T7): drives the empty-state hint and
+  // close/last-ness decisions — hidden scopes' sessions keep running.
+  const visibleSessions = useVisibleTerminalSessions();
 
   // Refit when shown, resized, or position changes
   useEffect(() => {
@@ -175,18 +198,12 @@ export function TerminalPanel() {
     setContextMenu(null);
   }, []);
 
-  // Tab bar actions
+  // Tab bar actions — the ONE remove+hide policy (audit 20260831 #32):
+  // membership-verified, visible fallback, no hidden-panel resurrect.
   const handleClose = useCallback(() => {
-    const store = useUIStore.getState();
-    if (!store.terminal.activeSessionId) return;
-
-    const isLast = store.terminal.sessions.length <= 1;
-    store.terminalRemoveSession(store.terminal.activeSessionId);
-
-    // Last session — also hide the panel
-    if (isLast) {
-      useUIStore.getState().toggleTerminal();
-    }
+    const activeId = useUIStore.getState().terminal.activeSessionId;
+    if (!activeId) return;
+    removeTerminalSessionWithPanelPolicy(activeId, { onlyIfVisible: true });
   }, []);
 
   const handleRestart = useCallback(() => {
@@ -230,6 +247,11 @@ export function TerminalPanel() {
             className="terminal-container"
             onContextMenu={handleContextMenu}
           />
+          {visibleSessions.length === 0 && (
+            <div className="terminal-empty-state" role="note">
+              {t("terminal.noWorkspaceSession")}
+            </div>
+          )}
           {searchVisible && (
             <TerminalSearchBar
               // Reset search state when switching terminal sessions so stale highlights are cleared.

--- a/src/components/Terminal/TerminalTabBar.scope.test.tsx
+++ b/src/components/Terminal/TerminalTabBar.scope.test.tsx
@@ -1,0 +1,125 @@
+// WI-TS3.1 — the tab bar renders the VISIBLE population (plan invariant 7):
+// active scope ∪ window-scoped with the rail on, everything with it off
+// (invariant 4), the + gate counts the visible union (D-T5), and a created
+// session is stamped through the ONE shared resolver (D-T1).
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, fireEvent } from "@testing-library/react";
+import { TerminalTabBar } from "./TerminalTabBar";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+
+vi.mock("@/services/persistence/workspaceStorage", () => ({
+  getCurrentWindowLabel: () => "main",
+}));
+
+const W = "main";
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function addWorkspace(id: string, rootPath: string): void {
+  const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+  if (!root.ok) throw new Error("bad test root");
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: id,
+      root: root.root,
+      ownerWindowLabel: W,
+      createdFrom: "open",
+    }),
+  );
+}
+
+function renderBar() {
+  return render(
+    <TerminalTabBar onClose={vi.fn()} onRestart={vi.fn()} position="bottom" />,
+  );
+}
+
+const tabCount = (container: HTMLElement) =>
+  container.querySelectorAll(".terminal-tab").length;
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  setRail(true);
+  addWorkspace("wsi-a", "/repo-a");
+  addWorkspace("wsi-b", "/repo-b");
+  useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+});
+
+afterEach(() => {
+  setRail(false);
+});
+
+describe("TerminalTabBar — scoped rendering (WI-TS3.1)", () => {
+  it("renders only the visible population: active scope ∪ window-scoped", () => {
+    useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" });
+    useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" });
+    useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-b" });
+    useUIStore.getState().terminalCreateSession(); // window-scoped
+
+    const { container } = renderBar();
+
+    expect(tabCount(container)).toBe(3); // 2×A + 1 window-scoped; B hidden
+  });
+
+  it("rail OFF renders ALL sessions, stamped included (invariant 4)", () => {
+    useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" });
+    useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-b" });
+    useUIStore.getState().terminalCreateSession();
+    setRail(false);
+
+    const { container } = renderBar();
+
+    expect(tabCount(container)).toBe(3);
+  });
+
+  it("re-renders the swap on a rail switch (store-driven)", () => {
+    useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" });
+    useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" });
+    useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-b" });
+    const { container } = renderBar();
+    expect(tabCount(container)).toBe(2); // A's pair
+
+    act(() => {
+      useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-b");
+    });
+
+    expect(tabCount(container)).toBe(1); // B's single tab
+  });
+
+  it("isMaxed gates on the VISIBLE union: a full hidden scope frees nothing, an empty scope frees the +", () => {
+    for (let i = 0; i < 5; i++) {
+      useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" });
+    }
+    const { container } = renderBar();
+    const plus = () =>
+      container.querySelector<HTMLButtonElement>('[data-terminal-action="new"]');
+    expect(plus()?.disabled).toBe(true);
+
+    act(() => {
+      useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-b");
+    });
+    expect(plus()?.disabled).toBe(false);
+  });
+
+  it("+ stamps the created session with the active scope (D-T1)", () => {
+    const { container } = renderBar();
+    const plus = container.querySelector<HTMLButtonElement>(
+      '[data-terminal-action="new"]',
+    );
+    fireEvent.click(plus!);
+
+    const created = useUIStore.getState().terminal.sessions[0];
+    expect(created?.workspaceInstanceId).toBe("wsi-a");
+  });
+});

--- a/src/components/Terminal/TerminalTabBar.tsx
+++ b/src/components/Terminal/TerminalTabBar.tsx
@@ -40,6 +40,9 @@ import { useTranslation } from "react-i18next";
 import { useUIStore, MAX_TERMINAL_SESSIONS, type EffectiveTerminalPosition } from "@/stores/uiStore";
 import type { TerminalSession } from "@/stores/uiStore/types";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
+import { createTerminalSessionInScope } from "@/services/terminal/createTerminalSession";
+import { useVisibleTerminalSessions } from "./useVisibleTerminalSessions";
 import { oppositeTerminalPosition, isHorizontalTerminalAxis } from "./useTerminalPosition";
 import { TerminalTabRename } from "./TerminalTabRename";
 import "./TerminalTabBar.css";
@@ -90,11 +93,16 @@ function getTabDisplay(session: TerminalSession, displayName: string): string {
 /** Renders numbered buttons for switching between terminal sessions plus create/close/restart controls. */
 export function TerminalTabBar({ onClose, onRestart, orientation = "vertical", position }: TerminalTabBarProps) {
   const { t } = useTranslation("statusbar");
-  const sessions = useUIStore((s) => s.terminal.sessions);
+  // WI-TS3.1: the tab bar renders the VISIBLE population — the active
+  // workspace scope's sessions ∪ window-scoped (everything with rail off).
+  const sessions = useVisibleTerminalSessions();
   const activeId = useUIStore((s) => s.terminal.activeSessionId);
 
   const handleCreate = useCallback(() => {
-    useUIStore.getState().terminalCreateSession();
+    // The ONE owner-aware creation service (D-T1; audit 20260831 #17) — it
+    // resolves the scope and applies the placeholder/restore/rail-off
+    // carve-outs, identically to every other creator.
+    createTerminalSessionInScope(getCurrentWindowLabel());
   }, []);
 
   // Swap flips the panel to the opposite end of its current axis. In auto
@@ -118,10 +126,20 @@ export function TerminalTabBar({ onClose, onRestart, orientation = "vertical", p
 
   // Which tab is being renamed, if any (WI-4.1).
   const [renamingId, setRenamingId] = useState<string | null>(null);
+  // A rename box must not survive its session leaving the VISIBLE set
+  // (audit 20260831 #34): a rail switch mid-rename would otherwise resurrect
+  // edit mode when the user returns to the scope. Adjusted during render (the
+  // guarded one-way pattern TerminalPanel's `activated` latch uses) — an
+  // effect calling setState synchronously trips the cascading-render lint.
+  if (renamingId && !sessions.some((s) => s.id === renamingId)) {
+    setRenamingId(null);
+  }
   const handleRename = useCallback((id: string, name: string) => {
     useUIStore.getState().terminalRenameSession(id, name);
   }, []);
 
+  // The cap gates on what the user can SEE (D-T5's visible union) — a hidden
+  // scope's sessions do not consume this scope's headroom.
   const isMaxed = sessions.length >= MAX_TERMINAL_SESSIONS;
 
   return (

--- a/src/components/Terminal/resolveTerminalSpawnContext.test.ts
+++ b/src/components/Terminal/resolveTerminalSpawnContext.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+// WI-TS4.1 — the spawn env/cwd contract (D-T9), table-driven over the full
+// matrix: requestedCwd / same-scope sibling / stamped owner present / owner
+// deleted / unscoped / loose-with-file. Real stores; the sibling-cwd accessor
+// is the injected seam (it stands for the live xterm entries).
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useTabStore } from "@/stores/tabStore";
+import { useDocumentStore } from "@/stores/documentStore";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+import { resolveTerminalSpawnContext } from "./resolveTerminalSpawnContext";
+
+const W = "main";
+const noSiblings = () => undefined;
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function addWorkspace(id: string, rootPath: string): void {
+  const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+  if (!root.ok) throw new Error("bad test root");
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: id,
+      root: root.root,
+      ownerWindowLabel: W,
+      createdFrom: "open",
+    }),
+  );
+}
+
+const create = (options?: Parameters<
+  ReturnType<typeof useUIStore.getState>["terminalCreateSession"]
+>[0]) => useUIStore.getState().terminalCreateSession(options)!;
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  useWorkspaceStore.getState().closeWorkspace();
+  useTabStore.setState({ tabs: {}, activeTabId: {}, untitledCounter: 0 });
+  useDocumentStore.setState({ documents: {} });
+  setRail(true);
+  addWorkspace("wsi-a", "/repo-a");
+  addWorkspace("wsi-b", "/repo-b");
+  useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+});
+
+afterEach(() => {
+  setRail(false);
+});
+
+describe("resolveTerminalSpawnContext (WI-TS4.1, D-T9)", () => {
+  it("requestedCwd outranks everything, while workspaceRoot stays the owner's", () => {
+    const s = create({ ownerInstanceId: "wsi-a", requestedCwd: "/asked/for" });
+    const ctx = resolveTerminalSpawnContext(W, s, () => "/sibling/cwd");
+    expect(ctx).toEqual({ cwd: "/asked/for", workspaceRoot: "/repo-a" });
+  });
+
+  it("inherits a SAME-scope sibling's live cwd", () => {
+    const sib = create({ ownerInstanceId: "wsi-a" });
+    const s = create({ ownerInstanceId: "wsi-a" });
+    const ctx = resolveTerminalSpawnContext(W, s, (id) =>
+      id === sib.id ? "/repo-a/sub" : undefined,
+    );
+    expect(ctx).toEqual({ cwd: "/repo-a/sub", workspaceRoot: "/repo-a" });
+  });
+
+  it("ignores an OTHER-scope sibling's cwd (D-T9: scope-narrowed inheritance)", () => {
+    const other = create({ ownerInstanceId: "wsi-b" });
+    const s = create({ ownerInstanceId: "wsi-a" });
+    const ctx = resolveTerminalSpawnContext(W, s, (id) =>
+      id === other.id ? "/repo-b/somewhere" : undefined,
+    );
+    expect(ctx).toEqual({ cwd: "/repo-a", workspaceRoot: "/repo-a" });
+  });
+
+  it("stamped owner present: owner's root wins EVEN when another scope is active (mid-switch)", () => {
+    const s = create({ ownerInstanceId: "wsi-a" });
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-b");
+    const ctx = resolveTerminalSpawnContext(W, s, noSiblings);
+    expect(ctx).toEqual({ cwd: "/repo-a", workspaceRoot: "/repo-a" });
+  });
+
+  it("owner deleted mid-spawn: falls back to the active scope (degenerate case)", () => {
+    const s = create({ ownerInstanceId: "wsi-ghost" });
+    const ctx = resolveTerminalSpawnContext(W, s, noSiblings);
+    expect(ctx).toEqual({ cwd: "/repo-a", workspaceRoot: "/repo-a" });
+  });
+
+  it("unscoped session: active-scope resolution as today", () => {
+    const s = create();
+    const ctx = resolveTerminalSpawnContext(W, s, noSiblings);
+    expect(ctx).toEqual({ cwd: "/repo-a", workspaceRoot: "/repo-a" });
+  });
+
+  it("loose-with-file: no root, so the active saved file's parent anchors the cwd", () => {
+    const loose = useWorkspaceInstancesStore.getState().ensureLooseInstance(W);
+    const tabId = useTabStore.getState().createTab(W, "/notes/dir/saved.md");
+    useDocumentStore
+      .getState()
+      .initDocument(tabId, "x", "/notes/dir/saved.md", { savedContent: "x" });
+    useTabStore.getState().setActiveTab(W, tabId);
+    const s = create({ ownerInstanceId: loose.workspaceInstanceId });
+
+    const ctx = resolveTerminalSpawnContext(W, s, noSiblings);
+
+    expect(ctx).toEqual({ cwd: "/notes/dir" });
+    expect(ctx.workspaceRoot).toBeUndefined();
+  });
+
+  it("undefined session (mid-teardown): unscoped default, no request, no sibling walk", () => {
+    const ctx = resolveTerminalSpawnContext(W, undefined, () => "/never");
+    expect(ctx).toEqual({ cwd: "/repo-a", workspaceRoot: "/repo-a" });
+  });
+});

--- a/src/components/Terminal/resolveTerminalSpawnContext.ts
+++ b/src/components/Terminal/resolveTerminalSpawnContext.ts
@@ -1,0 +1,89 @@
+/**
+ * resolveTerminalSpawnContext — the spawn env/cwd contract (WI-TS4.1, D-T9).
+ *
+ * Purpose: ONE named rule for what directory a session's shell starts in and
+ * what VMARK_WORKSPACE it carries:
+ *
+ *   cwd:  requestedCwd ("Open Terminal Here")
+ *         ?? a SAME-SCOPE sibling's live OSC-7 cwd
+ *         ?? (stamped & owner alive: owner's rootPath ?? active file's parent)
+ *         ?? (unscoped / owner deleted: active-scope root ?? active file's parent)
+ *   workspaceRoot (→ VMARK_WORKSPACE):
+ *         stamped & owner alive: owner's rootPath
+ *         else: active-scope resolution as today — deliberately WITHOUT an
+ *         isWorkspaceMode check (resolveTerminalWorkspaceRoot's existing
+ *         behavior for the unscoped fallback; preserved, not silently fixed).
+ *
+ * The caller resolves this ONCE, before the spawn await, and spawnPty stops
+ * re-resolving — so a rail switch mid-spawn can no longer hand the shell a
+ * different scope's cwd/VMARK_WORKSPACE (the D-T9 race). A missing owner
+ * (deleted mid-spawn) falls back to the active scope: spawn only ever starts
+ * for a visible session, so that is the degenerate case, not the norm.
+ *
+ * @coordinates-with useTerminalShellLifecycle.ts — sole production caller
+ * @coordinates-with spawnPty.ts — consumes { cwd, workspaceRoot }
+ * @module components/Terminal/resolveTerminalSpawnContext
+ */
+import { useUIStore } from "@/stores/uiStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import type { TerminalSession } from "@/stores/uiStore/types";
+import {
+  resolveActiveFileCwd,
+  resolveTerminalWorkspaceRoot,
+} from "./spawnPty";
+
+export interface TerminalSpawnContext {
+  cwd?: string;
+  workspaceRoot?: string;
+}
+
+/**
+ * Resolve the spawn context for `session`. `liveSiblingCwd` returns a
+ * sibling's OSC-7 cwd only while that sibling's shell is alive (the caller
+ * owns the xterm entries; this module never touches them). An undefined
+ * `session` (store entry already gone mid-teardown) resolves as unscoped
+ * with no request — the pre-scoping default.
+ */
+export function resolveTerminalSpawnContext(
+  windowLabel: string,
+  session: TerminalSession | undefined,
+  liveSiblingCwd: (sessionId: string) => string | undefined,
+): TerminalSpawnContext {
+  const scopeKey = session?.workspaceInstanceId ?? null;
+  const owner = scopeKey
+    ? useWorkspaceInstancesStore.getState().instances[scopeKey]
+    : undefined;
+
+  const workspaceRoot = owner
+    ? owner.rootPath ?? undefined
+    : resolveTerminalWorkspaceRoot(windowLabel);
+
+  // WI-4.2: an explicit request outranks everything.
+  let cwd: string | undefined = session?.requestedCwd;
+
+  // WI-2.2, scope-narrowed (D-T9): inherit a live sibling's cwd, but only
+  // from the SAME scope — another workspace's shell is somewhere the user
+  // never put THIS scope.
+  if (!cwd && session) {
+    for (const sibling of useUIStore.getState().terminal.sessions) {
+      if (sibling.id === session.id) continue;
+      if ((sibling.workspaceInstanceId ?? null) !== scopeKey) continue;
+      const live = liveSiblingCwd(sibling.id);
+      if (live) {
+        cwd = live;
+        break;
+      }
+    }
+  }
+
+  if (!cwd) {
+    cwd = owner
+      ? owner.rootPath ?? resolveActiveFileCwd(windowLabel)
+      : resolveTerminalWorkspaceRoot(windowLabel) ?? resolveActiveFileCwd(windowLabel);
+  }
+
+  return {
+    ...(cwd !== undefined ? { cwd } : {}),
+    ...(workspaceRoot !== undefined ? { workspaceRoot } : {}),
+  };
+}

--- a/src/components/Terminal/spawnPty.test.ts
+++ b/src/components/Terminal/spawnPty.test.ts
@@ -407,15 +407,14 @@ describe("spawnPty shell selection", () => {
     expect(spawnCalls).toEqual(["/usr/bin/nonexistent", "/bin/zsh"]);
   });
 
-  it("sets VMARK_WORKSPACE env when workspace root is available", async () => {
+  it("sets VMARK_WORKSPACE env from the caller-resolved workspaceRoot (WI-TS4.1)", async () => {
     vi.mocked(useSettingsStore.getState).mockReturnValue({
       terminal: { shell: "" },
     } as ReturnType<typeof useSettingsStore.getState>);
-    vi.mocked(useWorkspaceStore.getState).mockReturnValue({
-      rootPath: "/my/workspace",
-    } as ReturnType<typeof useWorkspaceStore.getState>);
 
-    await spawnPty({ term: mockTerm, onExit: vi.fn(), disposed: () => false });
+    // The root arrives as a PARAMETER (resolveTerminalSpawnContext, resolved
+    // once pre-await) — spawnPty no longer re-resolves it itself (WI-TS4.1).
+    await spawnPty({ term: mockTerm, workspaceRoot: "/my/workspace", onExit: vi.fn(), disposed: () => false });
 
     const spawnCallEnv = vi.mocked(spawn).mock.calls[0][2] as { env: Record<string, string> };
     expect(spawnCallEnv.env.VMARK_WORKSPACE).toBe("/my/workspace");
@@ -429,16 +428,13 @@ describe("spawnPty shell selection", () => {
     vi.mocked(useSettingsStore.getState).mockReturnValue({
       terminal: { shell: "" },
     } as ReturnType<typeof useSettingsStore.getState>);
-    vi.mocked(useWorkspaceStore.getState).mockReturnValue({
-      rootPath: "/my/workspace",
-    } as ReturnType<typeof useWorkspaceStore.getState>);
     vi.mocked(invoke).mockImplementation((cmd: string) => {
       if (cmd === "get_default_shell") return Promise.resolve("/bin/zsh");
       if (cmd === "get_login_shell_path") return Promise.resolve("/usr/local/bin:/bin");
       return Promise.resolve(null);
     });
 
-    await spawnPty({ term: mockTerm, onExit: vi.fn(), disposed: () => false });
+    await spawnPty({ term: mockTerm, workspaceRoot: "/my/workspace", onExit: vi.fn(), disposed: () => false });
 
     const spawnCallEnv = vi.mocked(spawn).mock.calls[0][2] as { env: Record<string, string> };
     expect(spawnCallEnv.env).toEqual({

--- a/src/components/Terminal/spawnPty.ts
+++ b/src/components/Terminal/spawnPty.ts
@@ -51,41 +51,44 @@ import {
  */
 export function resolveTerminalCwd(): string | undefined {
   const windowLabel = getCurrentWindowLabel();
-  const workspaceRoot = resolveTerminalWorkspaceRoot(windowLabel);
-  if (workspaceRoot) return workspaceRoot;
+  return (
+    resolveTerminalWorkspaceRoot(windowLabel) ?? resolveActiveFileCwd(windowLabel)
+  );
+}
 
+/** The active saved file's parent directory (CWD priority #2), or undefined.
+ *  Split out of resolveTerminalCwd so the spawn-context contract (WI-TS4.1)
+ *  can reach the file fallback without the active-scope root. */
+export function resolveActiveFileCwd(windowLabel: string): string | undefined {
   const activeTabId = useTabStore.getState().activeTabId[windowLabel];
-  if (activeTabId) {
-    const doc = useDocumentStore.getState().getDocument(activeTabId);
-    if (doc?.filePath) {
-      // Use the cross-platform path helper instead of a raw forward-slash
-      // search. On Windows, `doc.filePath` is typically backslash-separated
-      // (`C:\Users\foo\bar.md`); `lastIndexOf("/")` returned -1 and the
-      // terminal opened in $HOME, breaking the documented CWD priority.
-      // `getParentDir` normalizes both separators and returns "" for
-      // filesystem roots.
-      const parent = getParentDir(doc.filePath);
-      // getParentDir returns "" for both POSIX root files (`/file.md`) and
-      // Windows drive-root files (`C:\file.md`) — but those need DIFFERENT
-      // roots, not $HOME. Resolve each explicitly so the terminal starts in
-      // the file's actual directory.
-      if (parent) {
-        // Windows drive-root edge: `C:\sub\file.md` → getParentDir yields
-        // "c:" (a drive-relative reference, NOT an absolute path), which
-        // would start the shell in the wrong directory. Append a slash so it
-        // anchors to the drive root.
-        if (/^[a-z]:$/i.test(parent)) return `${parent}/`;
-        return parent;
-      }
-      // File is directly at a filesystem root.
-      if (doc.filePath.startsWith("/")) return "/";
-      // Windows drive-root file (e.g. `C:\file.md` or `C:/file.md`) — return
-      // the drive root so the shell starts at `C:/` rather than $HOME.
-      const driveMatch = /^([a-zA-Z]):[/\\]/.exec(doc.filePath);
-      if (driveMatch) return `${driveMatch[1].toLowerCase()}:/`;
-    }
+  if (!activeTabId) return undefined;
+  const doc = useDocumentStore.getState().getDocument(activeTabId);
+  if (!doc?.filePath) return undefined;
+  // Use the cross-platform path helper instead of a raw forward-slash
+  // search. On Windows, `doc.filePath` is typically backslash-separated
+  // (`C:\Users\foo\bar.md`); `lastIndexOf("/")` returned -1 and the
+  // terminal opened in $HOME, breaking the documented CWD priority.
+  // `getParentDir` normalizes both separators and returns "" for
+  // filesystem roots.
+  const parent = getParentDir(doc.filePath);
+  // getParentDir returns "" for both POSIX root files (`/file.md`) and
+  // Windows drive-root files (`C:\file.md`) — but those need DIFFERENT
+  // roots, not $HOME. Resolve each explicitly so the terminal starts in
+  // the file's actual directory.
+  if (parent) {
+    // Windows drive-root edge: `C:\sub\file.md` → getParentDir yields
+    // "c:" (a drive-relative reference, NOT an absolute path), which
+    // would start the shell in the wrong directory. Append a slash so it
+    // anchors to the drive root.
+    if (/^[a-z]:$/i.test(parent)) return `${parent}/`;
+    return parent;
   }
-
+  // File is directly at a filesystem root.
+  if (doc.filePath.startsWith("/")) return "/";
+  // Windows drive-root file (e.g. `C:\file.md` or `C:/file.md`) — return
+  // the drive root so the shell starts at `C:/` rather than $HOME.
+  const driveMatch = /^([a-zA-Z]):[/\\]/.exec(doc.filePath);
+  if (driveMatch) return `${driveMatch[1].toLowerCase()}:/`;
   return undefined;
 }
 
@@ -100,6 +103,11 @@ export function resolveTerminalWorkspaceRoot(
 export interface SpawnOptions {
   term: Terminal;
   cwd?: string;
+  /** VMARK_WORKSPACE root, resolved ONCE by the caller before the spawn
+   *  awaits (WI-TS4.1/D-T9 — resolveTerminalSpawnContext). spawnPty no
+   *  longer re-resolves it post-await, so a workspace switch during the
+   *  spawn cannot retarget the shell's env. Absent ⇒ no VMARK_WORKSPACE. */
+  workspaceRoot?: string;
   onExit: (exitCode: number) => void;
   disposed: () => boolean;
 }
@@ -170,7 +178,7 @@ export function wirePtyFlowControl(
  * Reads shell from Tauri backend, accepts optional cwd, wires data streams.
  */
 export async function spawnPty(options: SpawnOptions): Promise<IPty> {
-  const { term, cwd, onExit, disposed } = options;
+  const { term, cwd, workspaceRoot, onExit, disposed } = options;
 
   // Fetch login shell PATH so CLI tools (node, claude, etc.) are discoverable.
   // macOS GUI apps have minimal PATH; this aligns with system terminal behavior.
@@ -186,7 +194,6 @@ export async function spawnPty(options: SpawnOptions): Promise<IPty> {
   const shellIsAbsolute = defaultShell.startsWith("/") || /^[a-zA-Z]:[/\\]/.test(defaultShell);
   const shell = shellIsAbsolute ? defaultShell : "/bin/sh";
   if (disposed()) throw new Error("disposed before spawn");
-  const workspaceRoot = resolveTerminalWorkspaceRoot();
 
   const env = buildBaseTerminalEnv(loginPath, workspaceRoot);
   // Observability (T1): make "why doesn't `git commit` open VMark?" answerable

--- a/src/components/Terminal/terminal-panel.css
+++ b/src/components/Terminal/terminal-panel.css
@@ -148,3 +148,20 @@
 .vmark-cmd-fail {
   background: var(--error-color);
 }
+
+/* WI-TS3.2 — empty-state hint shown when the visible scope has no session
+   and the auto-create gate refused (no workspace, no saved file). Chrome
+   text: the UI face, never the reading font (R3). */
+.terminal-empty-state {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-2);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-base);
+  pointer-events: none;
+  text-align: center;
+}

--- a/src/components/Terminal/terminalKeyHandler.scope.test.ts
+++ b/src/components/Terminal/terminalKeyHandler.scope.test.ts
@@ -1,0 +1,111 @@
+// WI-TS3.1 — Cmd+1..5 positional switching indexes the VISIBLE population
+// (plan invariant 7): a hidden scope's session is not addressable; rail off
+// addresses everything (invariant 4).
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Terminal } from "@xterm/xterm";
+import { createTerminalKeyHandler } from "./terminalKeyHandler";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+
+vi.mock("@/services/persistence/workspaceStorage", () => ({
+  getCurrentWindowLabel: () => "main",
+}));
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: vi.fn().mockResolvedValue(""),
+  writeText: vi.fn().mockResolvedValue(undefined),
+}));
+
+const W = "main";
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function addWorkspace(id: string, rootPath: string): void {
+  const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+  if (!root.ok) throw new Error("bad test root");
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: id,
+      root: root.root,
+      ownerWindowLabel: W,
+      createdFrom: "open",
+    }),
+  );
+}
+
+function makeHandler() {
+  const term = {
+    hasSelection: () => false,
+    getSelection: () => "",
+    clearSelection: vi.fn(),
+    clear: vi.fn(),
+    paste: vi.fn(),
+    selectAll: vi.fn(),
+  } as unknown as Terminal;
+  return createTerminalKeyHandler(term, { current: null }, {
+    onSearch: vi.fn(),
+    isComposing: () => false,
+  });
+}
+
+function pressCmd(handler: (e: KeyboardEvent) => boolean, key: string): void {
+  handler(
+    new KeyboardEvent("keydown", { key, metaKey: true, cancelable: true }),
+  );
+}
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  setRail(true);
+  addWorkspace("wsi-a", "/repo-a");
+  addWorkspace("wsi-b", "/repo-b");
+  useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+});
+
+afterEach(() => {
+  setRail(false);
+});
+
+describe("terminalKeyHandler — Cmd+N over the visible population (WI-TS3.1)", () => {
+  it("Cmd+2 activates the SECOND VISIBLE session, skipping a hidden scope's", () => {
+    const a1 = useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" })!;
+    const b1 = useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-b" })!;
+    const a2 = useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" })!;
+    useUIStore.getState().terminalSetActiveSession(a1.id);
+
+    pressCmd(makeHandler(), "2");
+
+    // Visible order is [a1, a2]; b1 (store position 2) is not addressable.
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(a2.id);
+    expect(useUIStore.getState().terminal.activeSessionId).not.toBe(b1.id);
+  });
+
+  it("an index past the visible population is a no-op even when the store has more", () => {
+    const a1 = useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" })!;
+    useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-b" });
+    useUIStore.getState().terminalSetActiveSession(a1.id);
+
+    pressCmd(makeHandler(), "2"); // visible has 1 entry; store has 2
+
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(a1.id);
+  });
+
+  it("rail OFF addresses every session by store order (invariant 4)", () => {
+    useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" });
+    const b1 = useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-b" })!;
+    setRail(false);
+
+    pressCmd(makeHandler(), "2");
+
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(b1.id);
+  });
+});

--- a/src/components/Terminal/terminalKeyHandler.ts
+++ b/src/components/Terminal/terminalKeyHandler.ts
@@ -43,17 +43,22 @@ import { readText, writeText } from "@tauri-apps/plugin-clipboard-manager";
 import type { Terminal } from "@xterm/xterm";
 import { useUIStore } from "@/stores/uiStore";
 import { useSettingsStore, useShortcutsStore } from "@/stores/settingsStore";
+import { initialState as settingsDefaults } from "@/stores/settingsStore/defaults";
 import { isImeKeyEvent } from "@/utils/imeGuard";
 import { isMacPlatform, matchesShortcutEvent } from "@/utils/shortcutMatch";
 import { clipboardWarn } from "@/utils/debug";
 import { errorMessage } from "@/utils/errorMessage";
 import { requestToggleTerminal } from "@/services/terminal/terminalGate";
+import { getVisibleTerminalSessions } from "@/services/terminal/visibleTerminalSessions";
+import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
 import { handleReadlineNavKey } from "./terminalReadlineKeys";
 
-/** Terminal font-zoom step and reset value. `terminal.fontSize` default is 13
- *  (settingsStore/defaults.ts); the store clamps to the terminal range [8,32]. */
+/** Terminal font-zoom step and reset value. The reset target is the store's
+ *  OWN default (audit 20260831 #36 — a restated literal would silently keep
+ *  Cmd/Ctrl+0 resetting to an old value if the default ever moved); the
+ *  store clamps to the terminal range [8,32]. */
 const TERMINAL_FONT_SIZE_STEP = 2;
-const DEFAULT_TERMINAL_FONT_SIZE = 13;
+const DEFAULT_TERMINAL_FONT_SIZE = settingsDefaults.terminal.fontSize;
 
 /** Nudge the terminal font size; the store clamps to the valid range. */
 function adjustTerminalFontSize(delta: number): void {
@@ -255,10 +260,11 @@ export function createTerminalKeyHandler(
       case "1": case "2": case "3": case "4": case "5": {
         event.preventDefault();
         const idx = parseInt(event.key, 10) - 1;
-        const { sessions } = useUIStore.getState().terminal;
-        const setActiveSession = useUIStore.getState().terminalSetActiveSession;
-        if (idx < sessions.length) {
-          setActiveSession(sessions[idx].id);
+        // WI-TS3.1: positional switch indexes the VISIBLE population — a
+        // hidden scope's sessions are not addressable from the keyboard.
+        const visible = getVisibleTerminalSessions(getCurrentWindowLabel());
+        if (idx < visible.length) {
+          useUIStore.getState().terminalSetActiveSession(visible[idx].id);
         }
         return false;
       }

--- a/src/components/Terminal/terminalSessionBell.ts
+++ b/src/components/Terminal/terminalSessionBell.ts
@@ -1,0 +1,31 @@
+/**
+ * terminalSessionBell
+ *
+ * Purpose: builds the per-session onBell handler for createTerminalInstance.
+ * Extracted verbatim from useTerminalSessions.ts (WI-TS0.2 pre-split) — the
+ * handler reads live store state on every ring (bell mode, active session) so
+ * it needs no React closure and no memoization.
+ *
+ * @coordinates-with useTerminalSessions.ts — sole caller
+ * @coordinates-with terminalBell.ts — the bell policy it parameterizes
+ * @module components/Terminal/terminalSessionBell
+ */
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useUIStore } from "@/stores/uiStore";
+import { applyTerminalBell } from "./terminalBell";
+import {
+  maybeNotifyTerminalBell,
+  flagWindowAttentionOnBell,
+} from "@/services/terminalAttention";
+
+/** onBell handler for one session. Live store reads per ring — never cached. */
+export function sessionBellHandler(sessionId: string): () => void {
+  return () =>
+    applyTerminalBell(sessionId, {
+      bellMode: useSettingsStore.getState().terminal?.bellMode ?? "visual",
+      isActive: useUIStore.getState().terminal.activeSessionId === sessionId,
+      markActivity: (id) => useUIStore.getState().terminalMarkActivity(id),
+      notify: maybeNotifyTerminalBell,
+      flagAttention: flagWindowAttentionOnBell,
+    });
+}

--- a/src/components/Terminal/terminalSessionStoreSync.railswitch.test.ts
+++ b/src/components/Terminal/terminalSessionStoreSync.railswitch.test.ts
@@ -1,0 +1,217 @@
+/**
+ * WI-TS2.4 — end-to-end store-chain regression test for the investigated bug
+ * class (plan 20260831): a rail switch must swap the VISIBLE terminal set and
+ * must NOT type `cd` into instance-scoped sessions — busy or idle — while the
+ * legacy window-scoped population keeps today's cd-follow behavior verbatim.
+ *
+ * Real stores end to end: settingsStore (rail), workspaceInstancesStore,
+ * workspaceStore, uiStore, the REAL switchWorkspaceInstance coordinator and
+ * the REAL getActiveWorkspaceScope. Mocked: Tauri invoke and the window
+ * label. This chain had zero non-mocked coverage before this file — the
+ * root.test mocks the scope resolver, and the coordinator tests never touch
+ * xterm entries.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+
+const { mockInvoke } = vi.hoisted(() => ({
+  mockInvoke: vi.fn<(cmd: string, args?: unknown) => Promise<unknown>>(() =>
+    Promise.resolve(null),
+  ),
+}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mockInvoke }));
+vi.mock("@/services/persistence/workspaceStorage", () => ({
+  getCurrentWindowLabel: () => "main",
+}));
+vi.mock("@/theme", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/theme")>()),
+  buildXtermThemeForId: () => ({}),
+}));
+vi.mock("@/utils/fontStacks", () => ({ resolveMonoFontStack: () => "mono" }));
+
+import {
+  useUIStoreSync,
+  type SyncableSessionEntry,
+} from "./terminalSessionStoreSync";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import { selectVisibleTerminalSessions } from "@/stores/uiStore/terminalScopeSelectors";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+import { resetContextGenerations } from "@/services/workspaces/workspaceContextGeneration";
+import { switchWorkspaceInstance } from "@/services/workspaces/switchWorkspaceInstance";
+
+const W = "main";
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function addWorkspace(id: string, rootPath: string): void {
+  const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+  if (!root.ok) throw new Error("bad test root");
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: id,
+      root: root.root,
+      ownerWindowLabel: W,
+      createdFrom: "open",
+    }),
+  );
+}
+
+interface FakeInstance {
+  busy: boolean;
+  cwd: string | null;
+  idleCb: (() => void) | null;
+  term: { options: Record<string, unknown> };
+  fitAddon: { fit: () => void };
+  isShellBusy: () => boolean;
+  getCwd: () => string | null;
+  setOnShellIdle: (cb: (() => void) | null) => void;
+}
+
+function makeEntry(opts?: Partial<{ busy: boolean; cwd: string }>): {
+  entry: SyncableSessionEntry;
+  writes: string[];
+  instance: FakeInstance;
+} {
+  const writes: string[] = [];
+  const instance: FakeInstance = {
+    busy: opts?.busy ?? false,
+    cwd: opts?.cwd ?? "/repo-a",
+    idleCb: null,
+    term: { options: {} },
+    fitAddon: { fit: vi.fn() },
+    isShellBusy() {
+      return this.busy;
+    },
+    getCwd() {
+      return this.cwd;
+    },
+    setOnShellIdle(cb) {
+      this.idleCb = cb;
+    },
+  };
+  const entry: SyncableSessionEntry = {
+    instance: instance as unknown as SyncableSessionEntry["instance"],
+    pty: { write: (s: string) => writes.push(s) } as unknown as SyncableSessionEntry["pty"],
+    shellExited: false,
+    spawnedCwd: opts?.cwd ?? "/repo-a",
+  };
+  return { entry, writes, instance };
+}
+
+const visibleIds = () => {
+  const activeId =
+    useWorkspaceInstancesStore.getState().windows[W]?.activeWorkspaceInstanceId ?? null;
+  return selectVisibleTerminalSessions(
+    useUIStore.getState().terminal,
+    activeId,
+    useSettingsStore.getState().general?.workspaceRailMode ?? false,
+  ).map((s) => s.id);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInvoke.mockResolvedValue(null);
+  resetContextGenerations();
+  resetTerminalSessionStore();
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  useWorkspaceStore.getState().closeWorkspace();
+  setRail(true);
+  addWorkspace("wsi-a", "/repo-a");
+  addWorkspace("wsi-b", "/repo-b");
+  useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+});
+
+afterEach(() => {
+  setRail(false);
+});
+
+describe("rail switch × live terminal chain (WI-TS2.4)", () => {
+  it("swaps the visible set and types NOTHING into scoped sessions (idle)", () => {
+    const sa = useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-a" })!;
+    const sb = useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-b" })!;
+    useUIStore.getState().terminalSetActiveSession(sa.id);
+    const a = makeEntry({ cwd: "/repo-a" });
+    const b = makeEntry({ cwd: "/repo-b" });
+    const sessionsRef: RefObject<Map<string, SyncableSessionEntry>> = {
+      current: new Map([
+        [sa.id, a.entry],
+        [sb.id, b.entry],
+      ]),
+    };
+    renderHook(() => useUIStoreSync(sessionsRef));
+    expect(visibleIds()).toEqual([sa.id]);
+
+    switchWorkspaceInstance(W, "wsi-b");
+
+    // Visible set swapped; membership untouched (invariant 1).
+    expect(visibleIds()).toEqual([sb.id]);
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(sb.id);
+    expect(useUIStore.getState().terminal.sessions).toHaveLength(2);
+    // NO cd typed into either shell; cwds untouched.
+    expect(a.writes).toHaveLength(0);
+    expect(b.writes).toHaveLength(0);
+    expect(a.entry.spawnedCwd).toBe("/repo-a");
+  });
+
+  it("the reported bug class: a BUSY shell gets neither a cd nor a pendingRoot from a rail switch", () => {
+    // The live repro: `sleep 300` in A's shell, then a rail click. The old
+    // code queued a pendingRoot and cd'd the shell (or typed into the
+    // foreground program) when it went idle. Now the session is adopted by A
+    // and left alone.
+    const su = useUIStore.getState().terminalCreateSession()!; // unscoped
+    const busy = makeEntry({ busy: true, cwd: "/repo-a" });
+    const sessionsRef: RefObject<Map<string, SyncableSessionEntry>> = {
+      current: new Map([[su.id, busy.entry]]),
+    };
+    renderHook(() => useUIStoreSync(sessionsRef));
+
+    switchWorkspaceInstance(W, "wsi-b");
+
+    // Adopted by the outgoing instance, hidden, untouched.
+    const adopted = useUIStore
+      .getState()
+      .terminal.sessions.find((s) => s.id === su.id);
+    expect(adopted?.workspaceInstanceId).toBe("wsi-a");
+    expect(visibleIds()).toEqual([]);
+    expect(busy.entry.pendingRoot).toBeFalsy();
+
+    // The foreground command finishing must not deliver a deferred cd either.
+    busy.instance.busy = false;
+    busy.instance.idleCb?.();
+    expect(busy.writes).toHaveLength(0);
+
+    // Switching back reveals the same session, same cwd, no writes ever.
+    switchWorkspaceInstance(W, "wsi-a");
+    expect(visibleIds()).toEqual([su.id]);
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(su.id);
+    expect(busy.writes).toHaveLength(0);
+    expect(busy.entry.spawnedCwd).toBe("/repo-a");
+  });
+
+  it("rail OFF: the legacy window-scoped population still cd-follows root changes verbatim", () => {
+    setRail(false);
+    const su = useUIStore.getState().terminalCreateSession()!;
+    const u = makeEntry({ cwd: "/repo-a" });
+    const sessionsRef: RefObject<Map<string, SyncableSessionEntry>> = {
+      current: new Map([[su.id, u.entry]]),
+    };
+    useWorkspaceStore.setState({ rootPath: "/repo-a", isWorkspaceMode: true });
+    renderHook(() => useUIStoreSync(sessionsRef));
+
+    useWorkspaceStore.setState({ rootPath: "/repo-b", isWorkspaceMode: true });
+
+    expect(u.writes).toEqual(["\x15cd '/repo-b'\n"]);
+    expect(u.entry.spawnedCwd).toBe("/repo-b");
+  });
+});

--- a/src/components/Terminal/terminalSessionStoreSync.root.test.ts
+++ b/src/components/Terminal/terminalSessionStoreSync.root.test.ts
@@ -40,6 +40,25 @@ import {
   type SyncableSessionEntry,
 } from "./terminalSessionStoreSync";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+
+// The cd-follow predicate resolves each session in the STORE before writing
+// (a session missing from the store is mid-teardown and never followed —
+// audit 20260831 #16), so the harness seeds store records for the ids its
+// sessionsRef maps use. Rail mode stays off here: the legacy behavior.
+beforeEach(() => {
+  resetTerminalSessionStore();
+  useUIStore.setState({
+    terminal: {
+      sessions: [
+        { id: "s1", label: "s1", ordinal: 1, isAlive: true },
+        { id: "s2", label: "s2", ordinal: 2, isAlive: true },
+      ],
+      activeSessionId: "s1",
+      lastActiveByScope: {},
+    },
+  });
+});
 
 interface FakeInstance {
   busy: boolean;
@@ -206,21 +225,21 @@ describe("terminalSessionStoreSync — workspace root sync", () => {
 describe("flushPendingRoot", () => {
   it("returns false with no pending root", () => {
     const { entry } = makeEntry({ cwd: "/root/a" });
-    expect(flushPendingRoot(entry)).toBe(false);
+    expect(flushPendingRoot("s1", entry)).toBe(false);
   });
 
   it("returns false and clears pending when the PTY is gone", () => {
     const { entry } = makeEntry({ cwd: "/root/a" });
     entry.pendingRoot = "/root/b";
     entry.pty = null;
-    expect(flushPendingRoot(entry)).toBe(false);
+    expect(flushPendingRoot("s1", entry)).toBe(false);
     expect(entry.pendingRoot).toBeNull();
   });
 
   it("does not flush while the shell is busy", () => {
     const { entry, writes } = makeEntry({ busy: true, cwd: "/root/a" });
     entry.pendingRoot = "/root/b";
-    expect(flushPendingRoot(entry)).toBe(false);
+    expect(flushPendingRoot("s1", entry)).toBe(false);
     expect(writes).toHaveLength(0);
     // Still pending — will retry on a later idle.
     expect(entry.pendingRoot).toBe("/root/b");
@@ -229,7 +248,7 @@ describe("flushPendingRoot", () => {
   it("does not cd when the pending root equals current cwd", () => {
     const { entry, writes } = makeEntry({ cwd: "/root/b" });
     entry.pendingRoot = "/root/b";
-    expect(flushPendingRoot(entry)).toBe(false);
+    expect(flushPendingRoot("s1", entry)).toBe(false);
     expect(writes).toHaveLength(0);
     expect(entry.pendingRoot).toBeNull();
   });

--- a/src/components/Terminal/terminalSessionStoreSync.scope.test.ts
+++ b/src/components/Terminal/terminalSessionStoreSync.scope.test.ts
@@ -1,0 +1,219 @@
+/**
+ * WI-TS2.1 — cd-follow is gated on session ownership at every site
+ * (plan 20260831, D-T4/D-T15): the syncRoot loop, the pendingRoot queue, and
+ * flushPendingRoot (the OSC-133 idle path). Real uiStore + settingsStore;
+ * only the active-scope resolver and window label are mocked, exactly like
+ * the sibling root.test.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+
+const { mockScope } = vi.hoisted(() => ({
+  mockScope: vi.fn(() => ({ isWorkspaceMode: true, rootPath: "/root/a" })),
+}));
+
+vi.mock("@/services/workspaces/activeWorkspaceScope", () => ({
+  getActiveWorkspaceScope: () => mockScope(),
+}));
+vi.mock("@/services/persistence/workspaceStorage", () => ({
+  getCurrentWindowLabel: () => "main",
+}));
+vi.mock("@/theme", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/theme")>()),
+  buildXtermThemeForId: () => ({}),
+}));
+vi.mock("@/utils/fontStacks", () => ({ resolveMonoFontStack: () => "mono" }));
+
+import {
+  useUIStoreSync,
+  flushPendingRoot,
+  type SyncableSessionEntry,
+} from "./terminalSessionStoreSync";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+
+interface FakeInstance {
+  busy: boolean;
+  cwd: string | null;
+  idleCb: (() => void) | null;
+  term: { options: Record<string, unknown> };
+  fitAddon: { fit: () => void };
+  isShellBusy: () => boolean;
+  getCwd: () => string | null;
+  setOnShellIdle: (cb: (() => void) | null) => void;
+}
+
+function makeEntry(opts?: Partial<{ busy: boolean; cwd: string | null }>): {
+  entry: SyncableSessionEntry;
+  writes: string[];
+  instance: FakeInstance;
+} {
+  const writes: string[] = [];
+  const instance: FakeInstance = {
+    busy: opts?.busy ?? false,
+    cwd: opts?.cwd ?? "/root/a",
+    idleCb: null,
+    term: { options: {} },
+    fitAddon: { fit: vi.fn() },
+    isShellBusy() {
+      return this.busy;
+    },
+    getCwd() {
+      return this.cwd;
+    },
+    setOnShellIdle(cb) {
+      this.idleCb = cb;
+    },
+  };
+  const entry: SyncableSessionEntry = {
+    instance: instance as unknown as SyncableSessionEntry["instance"],
+    pty: { write: (s: string) => writes.push(s) } as unknown as SyncableSessionEntry["pty"],
+    shellExited: false,
+    spawnedCwd: "/root/a",
+  };
+  return { entry, writes, instance };
+}
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function setRoot(root: string) {
+  mockScope.mockReturnValue({ isWorkspaceMode: true, rootPath: root });
+  useWorkspaceStore.setState((s) => ({ ...s }));
+}
+
+/** Create a store session (stamped or not) and return its id. */
+function createStoreSession(ownerInstanceId?: string): string {
+  return useUIStore
+    .getState()
+    .terminalCreateSession(ownerInstanceId ? { ownerInstanceId } : undefined)!.id;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetTerminalSessionStore();
+  mockScope.mockReturnValue({ isWorkspaceMode: true, rootPath: "/root/a" });
+  setRail(true);
+});
+
+afterEach(() => {
+  setRail(false);
+});
+
+describe("WI-TS2.1 — scoped sessions never follow the workspace root", () => {
+  it("idle scoped session: no cd written on a root change", () => {
+    const id = createStoreSession("wsi-b");
+    const { entry, writes } = makeEntry({ cwd: "/root/a" });
+    const sessionsRef: RefObject<Map<string, SyncableSessionEntry>> = {
+      current: new Map([[id, entry]]),
+    };
+    renderHook(() => useUIStoreSync(sessionsRef));
+
+    setRoot("/root/b");
+
+    expect(writes).toHaveLength(0);
+    expect(entry.spawnedCwd).toBe("/root/a");
+  });
+
+  it("busy scoped session: no pendingRoot is even recorded", () => {
+    const id = createStoreSession("wsi-b");
+    const { entry, writes, instance } = makeEntry({ busy: true, cwd: "/root/a" });
+    const sessionsRef: RefObject<Map<string, SyncableSessionEntry>> = {
+      current: new Map([[id, entry]]),
+    };
+    renderHook(() => useUIStoreSync(sessionsRef));
+
+    setRoot("/root/b");
+    expect(entry.pendingRoot).toBeFalsy();
+
+    // Even if the shell later goes idle, nothing flushes.
+    instance.busy = false;
+    instance.idleCb?.();
+    expect(writes).toHaveLength(0);
+  });
+
+  it("a pre-adoption pendingRoot does NOT cd after the session is adopted (D-T4)", () => {
+    const id = createStoreSession(); // window-scoped at record time
+    const { entry, writes, instance } = makeEntry({ busy: true, cwd: "/root/a" });
+    const sessionsRef: RefObject<Map<string, SyncableSessionEntry>> = {
+      current: new Map([[id, entry]]),
+    };
+    renderHook(() => useUIStoreSync(sessionsRef));
+
+    setRoot("/root/b");
+    expect(entry.pendingRoot).toBe("/root/b"); // recorded while unscoped
+
+    // The rail switch adopts the session into the outgoing instance.
+    useUIStore.getState().terminalAdoptUnscopedSessions("wsi-a");
+
+    instance.busy = false;
+    instance.idleCb?.();
+
+    expect(writes).toHaveLength(0);
+    expect(entry.pendingRoot).toBeNull(); // dropped, not retried forever
+  });
+
+  it("window-scoped behavior is unchanged with the rail on", () => {
+    const id = createStoreSession();
+    const { entry, writes } = makeEntry({ cwd: "/root/a" });
+    const sessionsRef: RefObject<Map<string, SyncableSessionEntry>> = {
+      current: new Map([[id, entry]]),
+    };
+    renderHook(() => useUIStoreSync(sessionsRef));
+
+    setRoot("/root/b");
+
+    expect(writes).toEqual(["\x15cd '/root/b'\n"]);
+    expect(entry.spawnedCwd).toBe("/root/b");
+  });
+
+  it("rail OFF follows ALL sessions, stamped included (D-T15 inert stamps)", () => {
+    const id = createStoreSession("wsi-b");
+    setRail(false);
+    const { entry, writes } = makeEntry({ cwd: "/root/a" });
+    const sessionsRef: RefObject<Map<string, SyncableSessionEntry>> = {
+      current: new Map([[id, entry]]),
+    };
+    renderHook(() => useUIStoreSync(sessionsRef));
+
+    setRoot("/root/b");
+
+    expect(writes).toEqual(["\x15cd '/root/b'\n"]);
+  });
+});
+
+describe("WI-TS2.1 — flushPendingRoot owner guard (covers every caller)", () => {
+  it("refuses and clears a scoped session's pending root", () => {
+    const id = createStoreSession("wsi-b");
+    const { entry, writes } = makeEntry({ cwd: "/root/a" });
+    entry.pendingRoot = "/root/b";
+
+    expect(flushPendingRoot(id, entry)).toBe(false);
+    expect(entry.pendingRoot).toBeNull();
+    expect(writes).toHaveLength(0);
+  });
+
+  it("still flushes a window-scoped session's pending root", () => {
+    const id = createStoreSession();
+    const { entry, writes } = makeEntry({ cwd: "/root/a" });
+    entry.pendingRoot = "/root/b";
+
+    expect(flushPendingRoot(id, entry)).toBe(true);
+    expect(writes).toEqual(["\x15cd '/root/b'\n"]);
+  });
+
+  it("rail OFF flushes a stamped session's pending root (D-T15)", () => {
+    const id = createStoreSession("wsi-b");
+    setRail(false);
+    const { entry, writes } = makeEntry({ cwd: "/root/a" });
+    entry.pendingRoot = "/root/b";
+
+    expect(flushPendingRoot(id, entry)).toBe(true);
+    expect(writes).toEqual(["\x15cd '/root/b'\n"]);
+  });
+});

--- a/src/components/Terminal/terminalSessionStoreSync.ts
+++ b/src/components/Terminal/terminalSessionStoreSync.ts
@@ -39,6 +39,7 @@ import { buildXtermThemeForId, drawBoldTextInBrightColorsForId } from "@/theme";
 import { useTabStore } from "@/stores/tabStore";
 import { getRuntimePlatform } from "@/utils/platform";
 import { verifiedMonoStack } from "@/services/fonts/verifiedMonoStack";
+import { shouldFollowWorkspaceCd } from "@/services/terminal/terminalCdFollow";
 import { fitAndResizePty } from "./fitAndResizePty";
 // Re-exported so existing importers (and tests) keep one obvious home for it.
 export type { SyncableSessionEntry } from "./terminalSessionTypes";
@@ -62,9 +63,17 @@ export function buildCdCommand(path: string): string {
  * the shell is still running a foreground command. Returns true if a `cd` was
  * written.
  */
-export function flushPendingRoot(entry: SyncableSessionEntry): boolean {
+export function flushPendingRoot(sessionId: string, entry: SyncableSessionEntry): boolean {
   const pending = entry.pendingRoot;
   if (!pending) return false;
+  // WI-TS2.1 (D-T4): the owner is resolved AT FLUSH TIME, so a pendingRoot
+  // recorded before this session was adopted into a workspace scope is
+  // dropped rather than cd'ing a now-scoped shell. This one guard covers the
+  // OSC-133 idle callback and any future caller of the flush.
+  if (!shouldFollowWorkspaceCd(sessionId)) {
+    entry.pendingRoot = null;
+    return false;
+  }
   if (!entry.pty || entry.shellExited) {
     entry.pendingRoot = null;
     return false;
@@ -156,6 +165,11 @@ export function useUIStoreSync(
         // early return skipped the loop below, so a root queued while a shell
         // was busy outlived the workspace, and the next idle event cd'd into a
         // directory the user had just closed (audit 20260815-163607 #14).
+        // WI-TS2.1 note: this clear deliberately applies to EVERY session,
+        // stamped or not — clearing a scoped session's (pre-adoption) pending
+        // is exactly what keeps it from ever being cd'd, and skipping stamped
+        // sessions here would let a stale pending survive a later rail-off
+        // toggle and resurrect the audit-#14 bug through the D-T15 branch.
         prevRoot = newRoot;
         for (const [, entry] of sessionsRef.current ?? []) entry.pendingRoot = null;
         return;
@@ -169,7 +183,16 @@ export function useUIStoreSync(
       const cdCommand = buildCdCommand(newRoot);
       const sessions = sessionsRef.current;
       if (!sessions) return;
-      for (const [, entry] of sessions) {
+      for (const [id, entry] of sessions) {
+        // WI-TS2.1 (D-T4): only effectively-window-scoped sessions follow the
+        // workspace root — a stamped session's workspace never changes under
+        // it; a rail switch HIDES it instead (D-T3). Checked live per session
+        // and rail-aware (D-T15: rail off ⇒ everything follows, as today).
+        // A scoped session must not even QUEUE a root while busy.
+        if (!shouldFollowWorkspaceCd(id)) {
+          entry.pendingRoot = null;
+          continue;
+        }
         // Never inject `cd` into a shell that's running a foreground command
         // (e.g. vim, less) — the Ctrl+U + cd would corrupt it. Record the
         // root as pending so the idle flush (OSC 133 done) cd's once the
@@ -211,10 +234,10 @@ export function useUIStoreSync(
         entry.instance.setOnShellIdle(null);
         wired.delete(entry);
       }
-      for (const entry of live) {
+      for (const [id, entry] of sessions) {
         if (wired.has(entry)) continue;
         wired.add(entry);
-        entry.instance.setOnShellIdle(() => flushPendingRoot(entry));
+        entry.instance.setOnShellIdle(() => flushPendingRoot(id, entry));
       }
     };
     wireIdleFlush();

--- a/src/components/Terminal/useTerminalSessions.createFail.test.tsx
+++ b/src/components/Terminal/useTerminalSessions.createFail.test.tsx
@@ -1,0 +1,38 @@
+// Audit 20260831 #38 — a createTerminalInstance throw (WebGL exhaustion,
+// disposed parent) must not leave the store session alive: nothing ever
+// registers an entry for it, so the tab rendered forever-blank and neither
+// fit nor restart could reach it. The failed session is removed instead.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("./createTerminalInstance", () => ({
+  createTerminalInstance: vi.fn(() => {
+    throw new Error("boom: WebGL context exhausted");
+  }),
+}));
+vi.mock("@/services/persistence/workspaceStorage", () => ({
+  getCurrentWindowLabel: () => "main",
+}));
+
+import { useTerminalSessions } from "./useTerminalSessions";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+
+describe("useTerminalSessions — instance construction failure (audit #38)", () => {
+  beforeEach(() => {
+    resetTerminalSessionStore();
+  });
+
+  it("removes the store session when the xterm factory throws", () => {
+    const containerRef = { current: document.createElement("div") };
+    renderHook(() => useTerminalSessions(containerRef));
+
+    act(() => {
+      useUIStore.getState().terminalCreateSession();
+    });
+
+    // The old behavior: session survives with no instance — a permanently
+    // blank, unrecoverable tab.
+    expect(useUIStore.getState().terminal.sessions).toHaveLength(0);
+    expect(useUIStore.getState().terminal.activeSessionId).toBeNull();
+  });
+});

--- a/src/components/Terminal/useTerminalSessions.ts
+++ b/src/components/Terminal/useTerminalSessions.ts
@@ -42,14 +42,13 @@ import type { IPty } from "@/lib/pty";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { initialState } from "@/stores/settingsStore/defaults";
 import { currentTerminalThemeId } from "./terminalThemeId";
-import { diffSessionIds } from "./terminalSessionReconcile";
 import { useUIStore } from "@/stores/uiStore";
 import { createTerminalInstance } from "./createTerminalInstance";
-import { applyTerminalBell } from "./terminalBell";
-import { maybeNotifyTerminalBell, flagWindowAttentionOnBell } from "@/services/terminalAttention";
+import { sessionBellHandler } from "./terminalSessionBell";
 import { useUIStoreSync } from "./terminalSessionStoreSync";
 import { useTerminalShellLifecycle } from "./useTerminalShellLifecycle";
-import { removeSessionEntry, switchVisibility, disposeAllSessions } from "./terminalSessionRegistry";
+import { useTerminalSessionsInit } from "./useTerminalSessionsInit";
+import { removeSessionEntry, switchVisibility } from "./terminalSessionRegistry";
 import { registerTerminalResolver } from "@/services/terminal/activeTerminal";
 import { wireSessionInput } from "./terminalSessionInputWiring";
 import type { SearchAddon } from "@xterm/addon-search";
@@ -68,7 +67,6 @@ export function useTerminalSessions(
   callbacks?: UseTerminalSessionsCallbacks,
 ) {
   const sessionsRef = useRef<Map<string, SessionEntry>>(new Map());
-  const initializedRef = useRef(false);
 
   // Store callbacks in a ref to avoid recreating createSession on every render.
   // The callbacks object is a new literal each render, but the individual
@@ -162,17 +160,15 @@ export function useTerminalSessions(
         settings: { fontSize, lineHeight, cursorStyle, cursorBlink, useWebGL, macOptionIsMeta, screenReaderMode, minimumContrastRatio, scrollback, osc52Clipboard, themeId },
         ptyRef: ptyRefForKeys,
         onSearch: () => callbacksRef.current?.onSearch?.(),
-        onBell: () =>
-          applyTerminalBell(sessionId, {
-            bellMode: useSettingsStore.getState().terminal?.bellMode ?? "visual",
-            isActive: useUIStore.getState().terminal.activeSessionId === sessionId,
-            markActivity: (id) => useUIStore.getState().terminalMarkActivity(id),
-            notify: maybeNotifyTerminalBell,
-            flagAttention: flagWindowAttentionOnBell,
-          }),
+        onBell: sessionBellHandler(sessionId),
         });
       } catch (error) {
         terminalError(`Failed to create terminal instance for ${sessionId}:`, error);
+        // Audit 20260831 #38: leaving the store session alive rendered a
+        // permanently blank tab that neither fit nor restart could recover
+        // (no entry ever registered). Remove it — the reconcile's removal
+        // pass is a no-op for an id with no live instance.
+        useUIStore.getState().terminalRemoveSession(sessionId);
         return;
       }
 
@@ -227,59 +223,14 @@ export function useTerminalSessions(
     [startShell],
   );
 
-  // Initialize on mount — subscribe to store changes
-  useEffect(() => {
-    if (!containerRef.current || initializedRef.current) return;
-    initializedRef.current = true;
-
-    const state = useUIStore.getState();
-
-    if (state.terminal.sessions.length === 0) {
-      // First launch — create initial session
-      const session = state.terminalCreateSession();
-      if (session) {
-        createSession(session.id);
-        switchToVisible(session.id);
-      }
-    } else {
-      // Sessions already exist (e.g., hot-exit restore) — create instances
-      for (const s of state.terminal.sessions) {
-        createSession(s.id);
-      }
-      switchToVisible(state.terminal.activeSessionId);
-    }
-
-    // Subscribe to store changes
-    let prevSessionIds = new Set(
-      useUIStore.getState().terminal.sessions.map((s) => s.id),
-    );
-    let prevActiveId = useUIStore.getState().terminal.activeSessionId;
-
-    const unsubscribe = useUIStore.subscribe((storeState) => {
-      const currentIds = new Set(storeState.terminal.sessions.map((s) => s.id));
-
-      const { added, removed } = diffSessionIds(prevSessionIds, currentIds, (id) =>
-        sessionsRef.current.has(id));
-      for (const id of added) createSession(id);
-      for (const id of removed) removeSession(id);
-
-      // Detect active session change
-      if (storeState.terminal.activeSessionId !== prevActiveId) {
-        switchToVisible(storeState.terminal.activeSessionId);
-      }
-
-      prevSessionIds = currentIds;
-      prevActiveId = storeState.terminal.activeSessionId;
-    });
-
-    const sessions = sessionsRef.current;
-    return () => {
-      unsubscribe();
-      // Per-entry PTY resize timers are cleared by disposeAllSessions.
-      disposeAllSessions(sessions);
-      initializedRef.current = false;
-    };
-  }, [containerRef, createSession, removeSession, switchToVisible]);
+  // Initialize on mount and subscribe to store changes. Extracted to
+  // useTerminalSessionsInit.ts (WI-TS0.2) — the D-T3 reconcile (store removal
+  // → dispose) and the D-T8 mount-time creator both live there.
+  useTerminalSessionsInit(containerRef, sessionsRef, {
+    createSession,
+    removeSession,
+    switchToVisible,
+  });
 
   // Theme + workspace-root + terminal-settings sync, all in one call.
   // See terminalSessionStoreSync.ts for the per-effect design notes.
@@ -290,6 +241,5 @@ export function useTerminalSessions(
     getActiveTerminal,
     getActiveSearchAddon,
     restartActiveSession,
-    sessionsRef,
   };
 }

--- a/src/components/Terminal/useTerminalSessionsInit.scope.test.ts
+++ b/src/components/Terminal/useTerminalSessionsInit.scope.test.ts
@@ -1,0 +1,107 @@
+// WI-TS3.2 — the MOUNT-TIME creator goes through the ONE shared auto-create
+// gate (D-T8): a hot-exit-restored-visible panel over a refusing scope must
+// NOT create (and therefore never spawns a shell into $HOME) — the round-2
+// finding. Real stores; only the window label is mocked.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useTerminalSessionsInit } from "./useTerminalSessionsInit";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+import type { SessionEntry } from "./terminalSessionTypes";
+
+vi.mock("@/services/persistence/workspaceStorage", () => ({
+  getCurrentWindowLabel: () => "main",
+}));
+
+const W = "main";
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function addWorkspace(id: string, rootPath: string): void {
+  const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+  if (!root.ok) throw new Error("bad test root");
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: id,
+      root: root.root,
+      ownerWindowLabel: W,
+      createdFrom: "open",
+    }),
+  );
+}
+
+function mount() {
+  const containerRef = { current: document.createElement("div") };
+  const sessionsRef = { current: new Map<string, SessionEntry>() };
+  const callbacks = {
+    createSession: vi.fn<(id: string) => void>(),
+    removeSession: vi.fn<(id: string) => void>(),
+    switchToVisible: vi.fn<(id: string | null) => void>(),
+  };
+  renderHook(() => useTerminalSessionsInit(containerRef, sessionsRef, callbacks));
+  return callbacks;
+}
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  useWorkspaceStore.getState().closeWorkspace();
+  setRail(true);
+});
+
+afterEach(() => {
+  setRail(false);
+});
+
+describe("useTerminalSessionsInit — gated mount-time creator (WI-TS3.2)", () => {
+  it("refusing scope: creates NOTHING — no session, no xterm instance ($HOME spawn case)", () => {
+    // Loose instance + stale legacy workspace-mode: the legacy gate would
+    // say yes; the instance-backed gate refuses.
+    useWorkspaceInstancesStore.getState().ensureLooseInstance(W);
+    useWorkspaceStore.setState({ isWorkspaceMode: true, rootPath: "/stale" });
+
+    const callbacks = mount();
+
+    expect(useUIStore.getState().terminal.sessions).toHaveLength(0);
+    expect(callbacks.createSession).not.toHaveBeenCalled();
+    expect(callbacks.switchToVisible).not.toHaveBeenCalled();
+  });
+
+  it("allowing scope: creates ONE stamped session and shows it", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+
+    const callbacks = mount();
+
+    const sessions = useUIStore.getState().terminal.sessions;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.workspaceInstanceId).toBe("wsi-a");
+    expect(callbacks.createSession).toHaveBeenCalledWith(sessions[0]?.id);
+    expect(callbacks.switchToVisible).toHaveBeenCalledWith(sessions[0]?.id);
+  });
+
+  it("existing sessions (hot-exit shape): instances built for each, no extra create", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    const s1 = useUIStore.getState().terminalCreateSession()!;
+    const s2 = useUIStore.getState().terminalCreateSession()!;
+
+    const callbacks = mount();
+
+    expect(useUIStore.getState().terminal.sessions).toHaveLength(2);
+    expect(callbacks.createSession).toHaveBeenCalledTimes(2);
+    expect(callbacks.createSession).toHaveBeenCalledWith(s1.id);
+    expect(callbacks.createSession).toHaveBeenCalledWith(s2.id);
+    expect(callbacks.switchToVisible).toHaveBeenCalledWith(s2.id);
+  });
+});

--- a/src/components/Terminal/useTerminalSessionsInit.ts
+++ b/src/components/Terminal/useTerminalSessionsInit.ts
@@ -1,0 +1,97 @@
+/**
+ * useTerminalSessionsInit
+ *
+ * Purpose: mount-time initialization + store subscription for the terminal
+ * session registry. Extracted verbatim from useTerminalSessions.ts (WI-TS0.2
+ * pre-split). Owns two responsibilities the plan's decision record cites:
+ *   - D-T3's reconcile: an id that LEFT the store array means dispose xterm +
+ *     kill PTY (via removeSession → removeSessionEntry). A workspace switch
+ *     must therefore never remove ids from the store.
+ *   - D-T8's mount-time creator: the first-launch auto-create for a window
+ *     with no sessions.
+ *
+ * @coordinates-with useTerminalSessions.ts — sole caller
+ * @coordinates-with terminalSessionReconcile.ts — pure id diff
+ * @coordinates-with terminalSessionRegistry.ts — dispose helpers
+ * @module components/Terminal/useTerminalSessionsInit
+ */
+import { useEffect, useRef } from "react";
+import { useUIStore } from "@/stores/uiStore";
+import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
+import { maybeAutoCreateTerminalSession } from "@/services/terminal/maybeAutoCreateTerminalSession";
+import { diffSessionIds } from "./terminalSessionReconcile";
+import { disposeAllSessions } from "./terminalSessionRegistry";
+import type { SessionsRef } from "./terminalSessionTypes";
+
+export interface TerminalSessionsInitCallbacks {
+  createSession: (sessionId: string) => void;
+  removeSession: (sessionId: string) => void;
+  switchToVisible: (activeId: string | null) => void;
+}
+
+/** Initialize on mount and subscribe to store changes (create/remove/switch). */
+export function useTerminalSessionsInit(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  sessionsRef: SessionsRef,
+  { createSession, removeSession, switchToVisible }: TerminalSessionsInitCallbacks,
+): void {
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    if (!containerRef.current || initializedRef.current) return;
+    initializedRef.current = true;
+
+    const state = useUIStore.getState();
+
+    if (state.terminal.sessions.length === 0) {
+      // First launch — auto-create through the ONE shared gate (WI-TS3.2 /
+      // D-T8). This creator used to be unconditional, so a hot-exit-restored
+      // visible panel over a refusing scope spawned a shell into $HOME; a
+      // refusal now leaves the panel's empty-state hint instead.
+      if (maybeAutoCreateTerminalSession(getCurrentWindowLabel())) {
+        const createdId = useUIStore.getState().terminal.activeSessionId;
+        if (createdId) {
+          createSession(createdId);
+          switchToVisible(createdId);
+        }
+      }
+    } else {
+      // Sessions already exist (e.g., hot-exit restore) — create instances
+      for (const s of state.terminal.sessions) {
+        createSession(s.id);
+      }
+      switchToVisible(state.terminal.activeSessionId);
+    }
+
+    // Subscribe to store changes
+    let prevSessionIds = new Set(
+      useUIStore.getState().terminal.sessions.map((s) => s.id),
+    );
+    let prevActiveId = useUIStore.getState().terminal.activeSessionId;
+
+    const unsubscribe = useUIStore.subscribe((storeState) => {
+      const currentIds = new Set(storeState.terminal.sessions.map((s) => s.id));
+
+      const { added, removed } = diffSessionIds(prevSessionIds, currentIds, (id) =>
+        sessionsRef.current.has(id));
+      for (const id of added) createSession(id);
+      for (const id of removed) removeSession(id);
+
+      // Detect active session change
+      if (storeState.terminal.activeSessionId !== prevActiveId) {
+        switchToVisible(storeState.terminal.activeSessionId);
+      }
+
+      prevSessionIds = currentIds;
+      prevActiveId = storeState.terminal.activeSessionId;
+    });
+
+    const sessions = sessionsRef.current;
+    return () => {
+      unsubscribe();
+      // Per-entry PTY resize timers are cleared by disposeAllSessions.
+      disposeAllSessions(sessions);
+      initializedRef.current = false;
+    };
+  }, [containerRef, sessionsRef, createSession, removeSession, switchToVisible]);
+}

--- a/src/components/Terminal/useTerminalShellLifecycle.scope.test.ts
+++ b/src/components/Terminal/useTerminalShellLifecycle.scope.test.ts
@@ -1,0 +1,265 @@
+/**
+ * WI-TS2.1 — the post-spawn catch-up cd is owner-guarded (plan 20260831,
+ * D-T4 third… fourth cd site: a workspace switch that lands while a scoped
+ * session's shell is still spawning must not cd it to the new scope's root).
+ * WI-TS3.3 — clean exit computes "last session" on the VISIBLE population
+ * (D-T7): a hidden scope's live sessions neither hold the panel open nor get
+ * activated by the close fallback.
+ * WI-TS4.1 — the spawn env root reaches spawnPty as a parameter, resolved
+ * once pre-await from the OWNER scope (D-T9's mid-spawn race, L5 seam).
+ * Harness mirrors useTerminalShellLifecycle.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTerminalShellLifecycle } from "./useTerminalShellLifecycle";
+import { useUIStore, resetTerminalSessionStore } from "@/stores/uiStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { spawnPty, resolveTerminalWorkspaceRoot } from "./spawnPty";
+import type { SessionEntry } from "./terminalSessionTypes";
+import type { TerminalInstance } from "./createTerminalInstance";
+import type { IPty } from "@/lib/pty";
+
+vi.mock("./spawnPty", () => ({
+  spawnPty: vi.fn(),
+  resolveTerminalCwd: vi.fn(() => "/tmp"),
+  resolveActiveFileCwd: vi.fn(() => undefined),
+  resolveTerminalWorkspaceRoot: vi.fn(() => null),
+}));
+
+function makeEntry(): SessionEntry {
+  const instance = {
+    term: { write: vi.fn(), clear: vi.fn() },
+    resetDisplay: () => {},
+    getCwd: () => null,
+    getCommands: () => [],
+    isShellBusy: () => false,
+    dispose: () => {},
+  } as unknown as TerminalInstance;
+  return {
+    instance,
+    pty: null,
+    ptyRefForKeys: { current: null },
+    spawnedCwd: undefined,
+    shellStarted: false,
+    shellExited: false,
+    shellSpawning: false,
+    disposed: false,
+    spawnGen: 0,
+    pendingRafId: null,
+  };
+}
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+/** Spawn with the workspace root CHANGING mid-spawn: a → b. The flip happens
+ *  INSIDE the mocked spawn, exactly where a real rail switch would land —
+ *  every pre-await read sees /root/a, every post-await read sees /root/b. */
+async function spawnAcrossRootChange(sessionId: string): Promise<IPty> {
+  const pty = { write: vi.fn(), resize: vi.fn(), kill: vi.fn() } as unknown as IPty;
+  vi.mocked(resolveTerminalWorkspaceRoot).mockReturnValue("/root/a");
+  vi.mocked(spawnPty).mockImplementation(async () => {
+    vi.mocked(resolveTerminalWorkspaceRoot).mockReturnValue("/root/b");
+    return pty;
+  });
+
+  const entry = makeEntry();
+  const sessionsRef = { current: new Map([[sessionId, entry]]) };
+  const { result } = renderHook(() => useTerminalShellLifecycle(sessionsRef));
+  await act(async () => {
+    await result.current.startShell(sessionId);
+  });
+  return pty;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetTerminalSessionStore();
+  setRail(true);
+});
+
+afterEach(() => {
+  setRail(false);
+});
+
+describe("WI-TS2.1 — post-spawn catch-up cd is owner-guarded", () => {
+  it("does NOT cd a scoped session when the workspace changed mid-spawn", async () => {
+    const id = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-a" })!.id;
+
+    const pty = await spawnAcrossRootChange(id);
+
+    expect(pty.write).not.toHaveBeenCalled();
+  });
+
+  it("still cd's a window-scoped session (behavior unchanged)", async () => {
+    const id = useUIStore.getState().terminalCreateSession()!.id;
+
+    const pty = await spawnAcrossRootChange(id);
+
+    expect(pty.write).toHaveBeenCalledWith("\x15cd '/root/b'\n");
+  });
+
+  it("rail OFF: a stamped session is followable again (D-T15 inert stamps)", async () => {
+    const id = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-a" })!.id;
+    setRail(false);
+
+    const pty = await spawnAcrossRootChange(id);
+
+    expect(pty.write).toHaveBeenCalledWith("\x15cd '/root/b'\n");
+  });
+});
+
+describe("WI-TS3.3 — clean exit computes last-ness on the VISIBLE population", () => {
+  async function startAndExitCleanly(sessionId: string): Promise<void> {
+    let onExit: ((code: number) => void) | undefined;
+    vi.mocked(spawnPty).mockImplementation(async (opts) => {
+      onExit = opts.onExit;
+      return { write: vi.fn(), resize: vi.fn(), kill: vi.fn() } as unknown as IPty;
+    });
+    vi.mocked(resolveTerminalWorkspaceRoot).mockReturnValue(undefined);
+    const entry = makeEntry();
+    const sessionsRef = { current: new Map([[sessionId, entry]]) };
+    const { result } = renderHook(() => useTerminalShellLifecycle(sessionsRef));
+    await act(async () => {
+      await result.current.startShell(sessionId);
+    });
+    if (!onExit) throw new Error("spawnPty was not called");
+    act(() => onExit?.(0));
+  }
+
+  it("last VISIBLE session exits cleanly → panel hides while a hidden scope keeps its sessions", async () => {
+    const sa = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-a" })!;
+    const sb = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-b" })!;
+    useUIStore.setState({ terminalVisible: true });
+    useUIStore.getState().terminalSetActiveSession(sa.id);
+    // Active scope is wsi-a (no instances store in this harness — the
+    // resolver sees no active instance, so visible = window-scoped ∪ null).
+    // Force determinism: activate wsi-a's scope via the instances store.
+    const { useWorkspaceInstancesStore } = await import(
+      "@/stores/workspaceInstancesStore"
+    );
+    const { createWorkspaceInstance, createWorkspaceRootIdentity } = await import(
+      "@/utils/workspaceIdentity"
+    );
+    const root = createWorkspaceRootIdentity("/repo-a", { platform: "macos" });
+    if (!root.ok) throw new Error("bad test root");
+    useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+      createWorkspaceInstance({
+        workspaceInstanceId: "wsi-a",
+        root: root.root,
+        ownerWindowLabel: "main",
+        createdFrom: "open",
+      }),
+    );
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance("main", "wsi-a");
+
+    await startAndExitCleanly(sa.id);
+
+    // sa closed; panel hidden (it was the last VISIBLE session)…
+    expect(useUIStore.getState().terminalVisible).toBe(false);
+    // …while the hidden scope's session survives untouched.
+    expect(useUIStore.getState().terminal.sessions.map((s) => s.id)).toEqual([
+      sb.id,
+    ]);
+    expect(useUIStore.getState().terminal.activeSessionId).toBeNull();
+  });
+
+  it("non-last visible session exits → panel stays; fallback stays visible", async () => {
+    const { useWorkspaceInstancesStore } = await import(
+      "@/stores/workspaceInstancesStore"
+    );
+    const { createWorkspaceInstance, createWorkspaceRootIdentity } = await import(
+      "@/utils/workspaceIdentity"
+    );
+    const root = createWorkspaceRootIdentity("/repo-a", { platform: "macos" });
+    if (!root.ok) throw new Error("bad test root");
+    useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+      createWorkspaceInstance({
+        workspaceInstanceId: "wsi-a",
+        root: root.root,
+        ownerWindowLabel: "main",
+        createdFrom: "open",
+      }),
+    );
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance("main", "wsi-a");
+    const sa1 = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-a" })!;
+    const sa2 = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-a" })!;
+    useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-b" });
+    useUIStore.setState({ terminalVisible: true });
+    useUIStore.getState().terminalSetActiveSession(sa1.id);
+
+    await startAndExitCleanly(sa1.id);
+
+    expect(useUIStore.getState().terminalVisible).toBe(true);
+    // Fallback active is the remaining VISIBLE session, not wsi-b's.
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(sa2.id);
+  });
+});
+
+describe("WI-TS4.1 — spawn env root is resolved ONCE, from the owner, pre-await", () => {
+  it("hands spawnPty the OWNER's workspaceRoot even when the active scope switches mid-spawn", async () => {
+    const { useWorkspaceInstancesStore } = await import(
+      "@/stores/workspaceInstancesStore"
+    );
+    const { createWorkspaceInstance, createWorkspaceRootIdentity } = await import(
+      "@/utils/workspaceIdentity"
+    );
+    const add = (id: string, rootPath: string) => {
+      const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+      if (!root.ok) throw new Error("bad test root");
+      useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+        createWorkspaceInstance({
+          workspaceInstanceId: id,
+          root: root.root,
+          ownerWindowLabel: "main",
+          createdFrom: "open",
+        }),
+      );
+    };
+    add("wsi-a", "/repo-a");
+    add("wsi-b", "/repo-b");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance("main", "wsi-a");
+    const s = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-a" })!;
+
+    let receivedRoot: string | undefined = "unset";
+    vi.mocked(spawnPty).mockImplementation(async (opts) => {
+      receivedRoot = (opts as { workspaceRoot?: string }).workspaceRoot;
+      // Simulate the rail switch landing WHILE the spawn is in flight.
+      useWorkspaceInstancesStore
+        .getState()
+        .activateWorkspaceInstance("main", "wsi-b");
+      return { write: vi.fn(), resize: vi.fn(), kill: vi.fn() } as unknown as IPty;
+    });
+    vi.mocked(resolveTerminalWorkspaceRoot).mockReturnValue(undefined);
+
+    const entry = makeEntry();
+    const sessionsRef = { current: new Map([[s.id, entry]]) };
+    const { result } = renderHook(() => useTerminalShellLifecycle(sessionsRef));
+    await act(async () => {
+      await result.current.startShell(s.id);
+    });
+
+    // The env root is the OWNER's, captured before the await — not the scope
+    // that happens to be active when the spawn completes.
+    expect(receivedRoot).toBe("/repo-a");
+  });
+});

--- a/src/components/Terminal/useTerminalShellLifecycle.test.ts
+++ b/src/components/Terminal/useTerminalShellLifecycle.test.ts
@@ -18,6 +18,7 @@ import type { IPty } from "@/lib/pty";
 vi.mock("./spawnPty", () => ({
   spawnPty: vi.fn(),
   resolveTerminalCwd: vi.fn(() => "/tmp"),
+  resolveActiveFileCwd: vi.fn(() => undefined),
   resolveTerminalWorkspaceRoot: vi.fn(() => null),
 }));
 
@@ -81,8 +82,9 @@ function seedStore(sessionIds: string[], terminalVisible: boolean): void {
   useUIStore.setState({
     terminalVisible,
     terminal: {
-      sessions: sessionIds.map((id) => ({ id, label: id, isAlive: true })),
+      sessions: sessionIds.map((id, i) => ({ id, label: id, ordinal: i + 1, isAlive: true })),
       activeSessionId: sessionIds[sessionIds.length - 1] ?? null,
+      lastActiveByScope: {},
     },
   });
 }
@@ -261,7 +263,7 @@ describe("restart during an in-flight spawn (audit fix)", () => {
     const sessions = new Map([["term-1", entry]]);
     const sessionsRef = { current: sessions };
     useUIStore.setState({
-      terminal: { sessions: [{ id: "term-1", label: "Terminal 1", ordinal: 1, isAlive: true }], activeSessionId: "term-1" },
+      terminal: { sessions: [{ id: "term-1", label: "Terminal 1", ordinal: 1, isAlive: true }], activeSessionId: "term-1", lastActiveByScope: {} },
     });
 
     const first = deferredSpawn();
@@ -293,7 +295,7 @@ describe("restart during an in-flight spawn (audit fix)", () => {
     const { entry } = makeEntry();
     const sessionsRef = { current: new Map([["term-1", entry]]) };
     useUIStore.setState({
-      terminal: { sessions: [{ id: "term-1", label: "Terminal 1", ordinal: 1, isAlive: true }], activeSessionId: "term-1" },
+      terminal: { sessions: [{ id: "term-1", label: "Terminal 1", ordinal: 1, isAlive: true }], activeSessionId: "term-1", lastActiveByScope: {} },
     });
 
     const first = deferredSpawn();

--- a/src/components/Terminal/useTerminalShellLifecycle.ts
+++ b/src/components/Terminal/useTerminalShellLifecycle.ts
@@ -36,12 +36,12 @@ import { useCallback } from "react";
 import { useUIStore } from "@/stores/uiStore";
 import { errorMessage } from "@/utils/errorMessage";
 import { terminalWarn } from "@/utils/debug";
-import {
-  spawnPty,
-  resolveTerminalCwd,
-  resolveTerminalWorkspaceRoot,
-} from "./spawnPty";
+import { spawnPty, resolveTerminalWorkspaceRoot } from "./spawnPty";
+import { resolveTerminalSpawnContext } from "./resolveTerminalSpawnContext";
 import { buildCdCommand } from "./terminalSessionStoreSync";
+import { shouldFollowWorkspaceCd } from "@/services/terminal/terminalCdFollow";
+import { removeTerminalSessionWithPanelPolicy } from "@/services/terminal/closeTerminalSession";
+import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
 import {
   processExitedLine,
   pressAnyKeyToRestartLine,
@@ -59,23 +59,15 @@ function detachExitedPty(entry: SessionEntry): void {
 }
 
 /**
- * Clean exit (Ctrl+D / `exit`, code 0): close the tab (#1103), and hide the
- * panel when this was the last session. Instance/registry teardown follows
- * from the store removal via useTerminalSessions' subscription
- * (removeSessionEntry). A hidden panel stays hidden; reopening auto-creates
- * a fresh session (TerminalPanel visibility effect).
+ * Clean exit (Ctrl+D / `exit`, code 0): close the tab (#1103) via the ONE
+ * remove+hide policy (audit 20260831 #32 — TerminalPanel's close button and
+ * this path had drifted). The panel hides only when this was the last
+ * VISIBLE session (WI-TS3.3/D-T7); a hidden scope's exiting shell still
+ * closes its tab. Instance/registry teardown follows from the store removal
+ * via useTerminalSessions' subscription (removeSessionEntry).
  */
 function closeSessionOnCleanExit(sessionId: string): void {
-  const ui = useUIStore.getState();
-  const wasLast =
-    ui.terminal.sessions.length === 1 &&
-    ui.terminal.sessions[0].id === sessionId;
-  ui.terminalRemoveSession(sessionId);
-  if (!wasLast) return;
-  // Re-read state: removal ran subscribers synchronously — only hide a
-  // panel that is still visible.
-  const now = useUIStore.getState();
-  if (now.terminalVisible) now.toggleTerminal();
+  removeTerminalSessionWithPanelPolicy(sessionId);
 }
 
 /** Non-zero exit: keep the buffer readable and offer respawn on any key. */
@@ -114,27 +106,27 @@ export function useTerminalShellLifecycle(
       // session dead — the guard below ignores exits from a superseded gen.
       const gen = ++entry.spawnGen;
       // WI-4.2: an EXPLICIT request ("Open Terminal Here") outranks
-      // everything below. Without this the sibling-cwd inheritance would win
-      // and the new terminal would silently open in some other directory —
-      // exactly the one thing the user did not ask for. PEEKED, not consumed:
-      // it is cleared only once the spawn succeeds, so a failed first spawn
-      // can still be retried in the directory the user actually asked for.
+      // everything else. PEEKED, not consumed: it is cleared only once the
+      // spawn succeeds, so a failed first spawn can still be retried in the
+      // directory the user actually asked for.
       const requestedCwd = useUIStore.getState().terminalPeekRequestedCwd(sessionId);
-      // WI-2.2: otherwise a new terminal inherits a live sibling's cwd (OSC 7)
-      // so it starts where the user is; first terminal / no sibling →
-      // workspace-or-file resolution.
-      let inheritedCwd: string | undefined;
-      if (!requestedCwd) {
-        for (const [id, sib] of sessionsRef.current) {
-          if (id === sessionId || sib.disposed || !sib.pty || sib.shellExited) continue;
-          const live = sib.instance.getCwd();
-          if (live) {
-            inheritedCwd = live;
-            break;
-          }
-        }
-      }
-      const cwd = requestedCwd ?? inheritedCwd ?? resolveTerminalCwd();
+      // D-T9 (WI-TS4.1): cwd AND the env's workspace root come from the ONE
+      // spawn-context contract — request > same-scope sibling OSC-7 cwd >
+      // owner scope > active-scope/file fallback — resolved ONCE before the
+      // await, so a rail switch mid-spawn cannot retarget either.
+      const storeSession = useUIStore
+        .getState()
+        .terminal.sessions.find((s) => s.id === sessionId);
+      const context = resolveTerminalSpawnContext(
+        getCurrentWindowLabel(),
+        storeSession,
+        (siblingId) => {
+          const sib = sessionsRef.current.get(siblingId);
+          if (!sib || sib.disposed || !sib.pty || sib.shellExited) return undefined;
+          return sib.instance.getCwd() ?? undefined;
+        },
+      );
+      const cwd = context.cwd;
       // Captured BEFORE the await so the post-spawn check can tell "the
       // workspace changed while we were spawning" from "this session simply
       // starts somewhere other than the workspace root". Comparing the root
@@ -147,6 +139,9 @@ export function useTerminalShellLifecycle(
           term: entry.instance.term,
           // Omitted when nothing resolved a directory — see spawnPty's cwd note.
           ...(cwd !== undefined ? { cwd } : {}),
+          ...(context.workspaceRoot !== undefined
+            ? { workspaceRoot: context.workspaceRoot }
+            : {}),
           onExit: (exitCode) => {
             const e = sessionsRef.current.get(sessionId);
             // Ignore a stale exit from a PTY superseded by a restart.
@@ -198,12 +193,19 @@ export function useTerminalShellLifecycle(
         if (requestedCwd) useUIStore.getState().terminalClearRequestedCwd(sessionId);
 
         // If the workspace changed WHILE spawning, cd to the new root — but
-        // NOT when the user explicitly asked for a directory (WI-4.2). That
+        // NOT when the user explicitly asked for a directory (WI-4.2), and
+        // NOT for a scope-stamped session (WI-TS2.1/D-T4 — its workspace
+        // never changes under it; a rail switch hides it instead). That
         // catch-up `cd` would otherwise walk the shell straight back out of
         // the folder they right-clicked, which looks like the feature is
         // broken rather than like a workspace sync.
         const currentRoot = resolveTerminalWorkspaceRoot();
-        if (!requestedCwd && currentRoot && currentRoot !== rootBeforeSpawn) {
+        if (
+          !requestedCwd &&
+          currentRoot &&
+          currentRoot !== rootBeforeSpawn &&
+          shouldFollowWorkspaceCd(sessionId)
+        ) {
           pty.write(buildCdCommand(currentRoot));
           currentEntry.spawnedCwd = currentRoot;
         }

--- a/src/components/Terminal/useVisibleTerminalSessions.ts
+++ b/src/components/Terminal/useVisibleTerminalSessions.ts
@@ -1,0 +1,34 @@
+/**
+ * useVisibleTerminalSessions — React face of the ONE visibility rule
+ * (WI-TS3.1, plan invariant 7).
+ *
+ * Purpose: subscribes to the three inputs of the visible population —
+ * sessions, rail flag, active workspace instance — and derives the filtered
+ * list through the same pure selector the imperative service uses.
+ *
+ * @coordinates-with services/terminal/visibleTerminalSessions.ts — imperative face
+ * @coordinates-with TerminalTabBar.tsx, TerminalPanel.tsx — consumers
+ * @module components/Terminal/useVisibleTerminalSessions
+ */
+import { useMemo } from "react";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useUIStore } from "@/stores/uiStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
+import { selectVisibleTerminalSessions } from "@/stores/uiStore/terminalScopeSelectors";
+import type { TerminalSession } from "@/stores/uiStore/types";
+
+/** The window's currently-visible terminal sessions, as reactive state. */
+export function useVisibleTerminalSessions(): TerminalSession[] {
+  const sessions = useUIStore((s) => s.terminal.sessions);
+  const railEnabled = useSettingsStore(
+    (s) => s.general?.workspaceRailMode ?? false,
+  );
+  const activeInstanceId = useWorkspaceInstancesStore(
+    (s) => s.windows[getCurrentWindowLabel()]?.activeWorkspaceInstanceId ?? null,
+  );
+  return useMemo(
+    () => selectVisibleTerminalSessions({ sessions }, activeInstanceId, railEnabled),
+    [sessions, activeInstanceId, railEnabled],
+  );
+}

--- a/src/components/Welcome/WelcomeScreen.test.tsx
+++ b/src/components/Welcome/WelcomeScreen.test.tsx
@@ -223,11 +223,15 @@ describe("front door copy and buttons (WI-UI4.7)", () => {
     expect(screen.getByRole("region", { name: "Welcome" })).toBeInTheDocument();
   });
 
-  it("all three actions are canonical .vm-btn", () => {
+  it("all three actions are canonical .vm-btn pills", () => {
     render(<WelcomeScreen />);
     for (const name of ["New File", "Open File", "Open Workspace…"]) {
       const btn = screen.getByRole("button", { name });
       expect(btn.className, name).toContain("vm-btn");
+      // Pill shape via the promoted variant (maintainer direction 2026-08-31)
+      // — never a per-wrapper radius override, which the shape-drift gate
+      // would rightly flag.
+      expect(btn.className, name).toContain("vm-btn--pill");
     }
   });
 });

--- a/src/components/Welcome/WelcomeScreen.tsx
+++ b/src/components/Welcome/WelcomeScreen.tsx
@@ -114,17 +114,17 @@ export function WelcomeScreen() {
         <div className="welcome-screen__actions">
           <button
             type="button"
-            className="vm-btn welcome-action"
+            className="vm-btn vm-btn--pill welcome-action"
             onClick={() => handleNew(windowLabel)}
           >
             <FilePlus className="welcome-action__icon" aria-hidden="true" />
             <span>{t("emptyState.newFile")}</span>
           </button>
-          <button type="button" className="vm-btn welcome-action" onClick={onOpenFile}>
+          <button type="button" className="vm-btn vm-btn--pill welcome-action" onClick={onOpenFile}>
             <FileUp className="welcome-action__icon" aria-hidden="true" />
             <span>{t("emptyState.openFile")}</span>
           </button>
-          <button type="button" className="vm-btn welcome-action" onClick={onOpenFolder}>
+          <button type="button" className="vm-btn vm-btn--pill welcome-action" onClick={onOpenFolder}>
             <FolderOpen className="welcome-action__icon" aria-hidden="true" />
             <span>{t("emptyState.openFolder")}</span>
           </button>

--- a/src/components/Welcome/welcome.css
+++ b/src/components/Welcome/welcome.css
@@ -42,8 +42,10 @@
   justify-content: center;
 }
 
-/* The actions are the canonical `.vm-btn` (WI-UI4.7); the residual keeps the
-   front door's larger size and its FINDABLE boundary (--control-border, D8). */
+/* The actions are the canonical `.vm-btn` + `--pill` (WI-UI4.7; pill shape by
+   maintainer direction 2026-08-31); the residual keeps the front door's larger
+   size and its FINDABLE boundary (--control-border, D8). A capsule's round
+   ends visually eat horizontal padding, hence the wider inset. */
 .welcome-action {
   gap: var(--space-2);
   padding: var(--space-2) var(--space-4);

--- a/src/components/WorkspaceRail/WorkspaceRail.test.tsx
+++ b/src/components/WorkspaceRail/WorkspaceRail.test.tsx
@@ -1,4 +1,5 @@
 // WI-3R — rail click performs the full context switch (tests)
+// WI-TS5.1 — stable data-rail-action/data-instance-id automation attributes
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -489,6 +490,22 @@ describe("WorkspaceRail", () => {
       return screen.getByRole("menu");
     }
 
+    it("does not resurrect a stale menu across a rail-mode toggle (R3-11)", async () => {
+      setRailMode(true);
+      addInstance("main", "wsi-a", "/Users/xiaolai/alpha");
+      render(<WorkspaceRail windowLabel="main" />);
+      await openMenu("alpha");
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+
+      // Disable the rail with the menu open, then re-enable: the menu's
+      // instance may be long gone by the time the rail returns.
+      act(() => setRailMode(false));
+      expect(screen.queryByRole("menu")).toBeNull();
+      act(() => setRailMode(true));
+
+      expect(screen.queryByRole("menu")).toBeNull();
+    });
+
     it("opens on right-click with the three workspace actions", async () => {
       setRailMode(true);
       addInstance("main", "wsi-a", "/Users/xiaolai/alpha");
@@ -591,5 +608,25 @@ describe("WorkspaceRail", () => {
         useWorkspaceInstancesStore.getState().windows["main"]?.activeWorkspaceInstanceId,
       ).toBe("wsi-b");
     });
+  });
+});
+describe("stable rail automation hooks (WI-TS5.1)", () => {
+  it("every rail item carries data-rail-action + data-instance-id (E2E contract)", () => {
+    setRailMode(true);
+    addInstance("main", "wsi-a", "/Users/xiaolai/a");
+    addInstance("main", "wsi-b", "/Users/xiaolai/b");
+
+    const { container } = render(<WorkspaceRail windowLabel="main" />);
+
+    const activate = [...container.querySelectorAll('[data-rail-action="activate"]')];
+    expect(activate.map((el) => el.getAttribute("data-instance-id"))).toEqual([
+      "wsi-a",
+      "wsi-b",
+    ]);
+    const duplicate = [...container.querySelectorAll('[data-rail-action="duplicate"]')];
+    expect(duplicate.map((el) => el.getAttribute("data-instance-id"))).toEqual([
+      "wsi-a",
+      "wsi-b",
+    ]);
   });
 });

--- a/src/components/WorkspaceRail/WorkspaceRail.tsx
+++ b/src/components/WorkspaceRail/WorkspaceRail.tsx
@@ -3,18 +3,14 @@ import { useRef, useState, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
-import {
-  duplicateWorkspaceInstanceToNewWindow,
-  moveWorkspaceInstanceToNewWindow,
-} from "@/services/workspaces/workspaceWindowActions";
-import type { WorkspaceWindowActionResult } from "@/types/workspaceTransfer";
-import { imeToast as toast } from "@/services/ime/imeToast";
 import { switchWorkspaceInstance } from "@/services/workspaces/switchWorkspaceInstance";
-import { cleanupTabState } from "@/services/windowClose/tabCleanup";
-import { closeTabsWithDirtyCheck } from "@/services/tabs/tabOperations";
 import { disambiguateWorkspaceDisplayNames } from "@/utils/workspaceIdentity";
 import { workspaceRailGlyphs } from "@/utils/workspaceRailGlyphs";
-import { closeWorkspaceInstance } from "@/services/workspaces/closeWorkspaceInstance";
+import {
+  handleCloseWorkspace,
+  handleDuplicateWorkspace,
+  handleMoveWorkspace,
+} from "./workspaceRailHandlers";
 import {
   WorkspaceRailContextMenu,
   type WorkspaceRailMenuPosition,
@@ -57,7 +53,14 @@ export function WorkspaceRail({ windowLabel }: { windowLabel: string }) {
     { instanceId: string; name: string; position: WorkspaceRailMenuPosition } | null
   >(null);
 
-  if (!enabled) return null;
+  // Clear a lingering context menu when the rail is disabled (R3-11) —
+  // re-enabling must not resurrect a stale menu over an instance that may be
+  // gone. Render-time guarded one-way adjustment, the TerminalPanel latch
+  // pattern (an effect cannot run once we return null every render).
+  if (!enabled) {
+    if (menu) setMenu(null);
+    return null;
+  }
 
   const instances = workspaceInstanceIds
     .map((id) => instancesById[id])
@@ -98,6 +101,11 @@ export function WorkspaceRail({ windowLabel }: { windowLabel: string }) {
               <button
                 type="button"
                 className="workspace-rail__item"
+                // Stable automation hooks (WI-TS5.1): aria-labels are
+                // localized, so E2E selects by these instead. A CONTRACT —
+                // renaming them breaks e2e/lib/rail.mjs, not just a unit test.
+                data-rail-action="activate"
+                data-instance-id={instanceId}
                 aria-label={t("workspaceRail.activate", { name: displayLabel })}
                 aria-pressed={active}
                 title={displayLabel}
@@ -175,6 +183,8 @@ export function WorkspaceRail({ windowLabel }: { windowLabel: string }) {
               <button
                 type="button"
                 className="workspace-rail__duplicate"
+                data-rail-action="duplicate"
+                data-instance-id={instanceId}
                 aria-label={t("workspaceRail.duplicate", { name: displayLabel })}
                 title={t("workspaceRail.duplicate", { name: displayLabel })}
                 onClick={() => {
@@ -193,9 +203,7 @@ export function WorkspaceRail({ windowLabel }: { windowLabel: string }) {
           workspaceName={menu.name}
           onClose={() => setMenu(null)}
           onCloseWorkspace={() => {
-            void closeWorkspaceInstance(windowLabel, menu.instanceId, {
-              closeTabs: closeTabsWithDirtyCheck,
-            });
+            void handleCloseWorkspace(windowLabel, menu.instanceId, t);
           }}
           onDuplicate={() => {
             void handleDuplicateWorkspace(windowLabel, menu.instanceId, t);
@@ -229,45 +237,6 @@ function workspaceRailColorForSeed(seed: string): string {
     hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
   }
   return WORKSPACE_RAIL_COLORS[hash % WORKSPACE_RAIL_COLORS.length];
-}
-
-async function handleMoveWorkspace(
-  windowLabel: string,
-  instanceId: string,
-  t: ReturnType<typeof useTranslation>["t"],
-): Promise<void> {
-  const result = await moveWorkspaceInstanceToNewWindow(windowLabel, instanceId, {
-    cleanupTab: cleanupTabState,
-  });
-  if (result && !result.ok) {
-    toast.error(t("dialog:toast.workspaceMoveFailed"));
-  }
-}
-
-async function handleDuplicateWorkspace(
-  windowLabel: string,
-  instanceId: string,
-  t: ReturnType<typeof useTranslation>["t"],
-): Promise<void> {
-  const result = await duplicateWorkspaceInstanceToNewWindow(windowLabel, instanceId);
-  if (!result) return;
-  if (!result.ok) {
-    toast.error(t("dialog:toast.workspaceDuplicateFailed"));
-    return;
-  }
-  const skipped = countSkippedTabs(result);
-  if (skipped > 0) {
-    toast.message(t("dialog:toast.workspaceDuplicateSkipped", { count: skipped }));
-  }
-}
-
-function countSkippedTabs(result: WorkspaceWindowActionResult): number {
-  if (!result.ok) return 0;
-  return (
-    (result.skippedDirtyCount ?? 0)
-    + (result.skippedUntitledCount ?? 0)
-    + (result.skippedMissingCount ?? 0)
-  );
 }
 
 function isOutsideViewport(clientX: number, clientY: number): boolean {

--- a/src/components/WorkspaceRail/workspaceRailHandlers.test.ts
+++ b/src/components/WorkspaceRail/workspaceRailHandlers.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+// Audit round 3, R3-10/R3-12 — the rail handlers' toast POLICY, and the
+// rejection paths every call site fires with `void`: a thrown service error
+// must surface as a failure toast, never an unhandled rejection.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const closeWorkspaceInstance = vi.fn();
+const moveWorkspaceInstanceToNewWindow = vi.fn();
+const duplicateWorkspaceInstanceToNewWindow = vi.fn();
+const toastError = vi.fn();
+const toastMessage = vi.fn();
+
+vi.mock("@/services/workspaces/closeWorkspaceInstance", () => ({
+  closeWorkspaceInstance: (...args: unknown[]) => closeWorkspaceInstance(...args),
+}));
+vi.mock("@/services/workspaces/workspaceWindowActions", () => ({
+  moveWorkspaceInstanceToNewWindow: (...args: unknown[]) =>
+    moveWorkspaceInstanceToNewWindow(...args),
+  duplicateWorkspaceInstanceToNewWindow: (...args: unknown[]) =>
+    duplicateWorkspaceInstanceToNewWindow(...args),
+}));
+vi.mock("@/services/ime/imeToast", () => ({
+  imeToast: {
+    error: (...args: unknown[]) => toastError(...args),
+    message: (...args: unknown[]) => toastMessage(...args),
+  },
+}));
+vi.mock("@/services/tabs/tabOperations", () => ({
+  closeTabsWithDirtyCheck: vi.fn(),
+}));
+vi.mock("@/services/windowClose/tabCleanup", () => ({
+  cleanupTabState: vi.fn(),
+}));
+
+import {
+  handleCloseWorkspace,
+  handleDuplicateWorkspace,
+  handleMoveWorkspace,
+} from "./workspaceRailHandlers";
+
+const t = ((key: string) => key) as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("handleCloseWorkspace toast policy (R3-12)", () => {
+  it.each([
+    { result: { ok: true }, toasts: 0, label: "success is silent" },
+    { result: { ok: false, reason: "cancelled" }, toasts: 0, label: "cancelled is the user's own choice" },
+    { result: { ok: false, reason: "missing" }, toasts: 0, label: "missing means already gone" },
+    { result: { ok: false, reason: "busy" }, toasts: 1, label: "busy is the one refusal worth a toast" },
+  ])("$label", async ({ result, toasts }) => {
+    closeWorkspaceInstance.mockResolvedValue(result);
+    await handleCloseWorkspace("main", "wsi-a", t);
+    expect(toastError).toHaveBeenCalledTimes(toasts);
+    if (toasts > 0) {
+      expect(toastError).toHaveBeenCalledWith("dialog:toast.workspaceCloseBusy");
+    }
+  });
+
+  it("a thrown close surfaces as the close-failed toast, not an unhandled rejection", async () => {
+    closeWorkspaceInstance.mockRejectedValue(new Error("dialog plumbing died"));
+    await expect(handleCloseWorkspace("main", "wsi-a", t)).resolves.toBeUndefined();
+    expect(toastError).toHaveBeenCalledWith("dialog:toast.workspaceCloseFailed");
+  });
+});
+
+describe("handleMoveWorkspace rejection path (R3-10)", () => {
+  it("a thrown move surfaces as the move-failed toast", async () => {
+    moveWorkspaceInstanceToNewWindow.mockRejectedValue(new Error("ipc died"));
+    await expect(handleMoveWorkspace("main", "wsi-a", t)).resolves.toBeUndefined();
+    expect(toastError).toHaveBeenCalledWith("dialog:toast.workspaceMoveFailed");
+  });
+
+  it("a refused move still toasts (result-shaped failure)", async () => {
+    moveWorkspaceInstanceToNewWindow.mockResolvedValue({ ok: false, reason: "timeout" });
+    await handleMoveWorkspace("main", "wsi-a", t);
+    expect(toastError).toHaveBeenCalledWith("dialog:toast.workspaceMoveFailed");
+  });
+});
+
+describe("handleDuplicateWorkspace rejection path (R3-10)", () => {
+  it("a thrown duplicate surfaces as the duplicate-failed toast", async () => {
+    duplicateWorkspaceInstanceToNewWindow.mockRejectedValue(new Error("ipc died"));
+    await expect(handleDuplicateWorkspace("main", "wsi-a", t)).resolves.toBeUndefined();
+    expect(toastError).toHaveBeenCalledWith("dialog:toast.workspaceDuplicateFailed");
+  });
+
+  it("a successful duplicate with skipped tabs reports the count", async () => {
+    duplicateWorkspaceInstanceToNewWindow.mockResolvedValue({
+      ok: true,
+      targetWindowLabel: "doc-2",
+      skippedDirtyCount: 2,
+      skippedUntitledCount: 1,
+      skippedMissingCount: 0,
+    });
+    await handleDuplicateWorkspace("main", "wsi-a", t);
+    expect(toastMessage).toHaveBeenCalledWith("dialog:toast.workspaceDuplicateSkipped");
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/WorkspaceRail/workspaceRailHandlers.ts
+++ b/src/components/WorkspaceRail/workspaceRailHandlers.ts
@@ -1,0 +1,105 @@
+/**
+ * WorkspaceRail — close/move/duplicate handlers with their toast policy.
+ *
+ * Purpose: the async action handlers the rail's buttons and context menu
+ * dispatch. Split from WorkspaceRail.tsx to keep the component under the
+ * file-size gate; the toast POLICY (which refusals the user hears about)
+ * lives here with the calls it governs.
+ *
+ * Key decisions:
+ *   - Close toasts on `busy` only (R2-12): `cancelled` is the user's own
+ *     choice at the dirty prompt, and `missing` means the instance is
+ *     already gone — both are silently correct outcomes from the rail.
+ *   - `result &&` guards match across handlers — test doubles may resolve
+ *     void where the real services always return a result.
+ *
+ * @coordinates-with WorkspaceRail.tsx — the dispatching component
+ * @coordinates-with services/workspaces/closeWorkspaceInstance.ts — close leg
+ * @coordinates-with services/workspaces/workspaceWindowActions.ts — move/duplicate
+ * @module components/WorkspaceRail/workspaceRailHandlers
+ */
+import type { useTranslation } from "react-i18next";
+import { imeToast as toast } from "@/services/ime/imeToast";
+import { cleanupTabState } from "@/services/windowClose/tabCleanup";
+import { closeTabsWithDirtyCheck } from "@/services/tabs/tabOperations";
+import { closeWorkspaceInstance } from "@/services/workspaces/closeWorkspaceInstance";
+import {
+  duplicateWorkspaceInstanceToNewWindow,
+  moveWorkspaceInstanceToNewWindow,
+} from "@/services/workspaces/workspaceWindowActions";
+import type { WorkspaceWindowActionResult } from "@/types/workspaceTransfer";
+import { workspaceError } from "@/utils/debug";
+
+type Translate = ReturnType<typeof useTranslation>["t"];
+
+// Every call site fires these with `void` (R3-10), so a service REJECTION —
+// e.g. the dirty-save dialog plumbing throwing mid-close — would otherwise be
+// an unhandled rejection with no user-visible failure. Each handler catches,
+// logs, and shows its failure toast.
+
+export async function handleCloseWorkspace(
+  windowLabel: string,
+  instanceId: string,
+  t: Translate,
+): Promise<void> {
+  try {
+    const result = await closeWorkspaceInstance(windowLabel, instanceId, {
+      closeTabs: closeTabsWithDirtyCheck,
+    });
+    if (result && !result.ok && result.reason === "busy") {
+      toast.error(t("dialog:toast.workspaceCloseBusy"));
+    }
+  } catch (error) {
+    workspaceError("Workspace close threw:", error);
+    toast.error(t("dialog:toast.workspaceCloseFailed"));
+  }
+}
+
+export async function handleMoveWorkspace(
+  windowLabel: string,
+  instanceId: string,
+  t: Translate,
+): Promise<void> {
+  try {
+    const result = await moveWorkspaceInstanceToNewWindow(windowLabel, instanceId, {
+      cleanupTab: cleanupTabState,
+    });
+    if (result && !result.ok) {
+      toast.error(t("dialog:toast.workspaceMoveFailed"));
+    }
+  } catch (error) {
+    workspaceError("Workspace move threw:", error);
+    toast.error(t("dialog:toast.workspaceMoveFailed"));
+  }
+}
+
+export async function handleDuplicateWorkspace(
+  windowLabel: string,
+  instanceId: string,
+  t: Translate,
+): Promise<void> {
+  try {
+    const result = await duplicateWorkspaceInstanceToNewWindow(windowLabel, instanceId);
+    if (!result) return;
+    if (!result.ok) {
+      toast.error(t("dialog:toast.workspaceDuplicateFailed"));
+      return;
+    }
+    const skipped = countSkippedTabs(result);
+    if (skipped > 0) {
+      toast.message(t("dialog:toast.workspaceDuplicateSkipped", { count: skipped }));
+    }
+  } catch (error) {
+    workspaceError("Workspace duplicate threw:", error);
+    toast.error(t("dialog:toast.workspaceDuplicateFailed"));
+  }
+}
+
+function countSkippedTabs(result: WorkspaceWindowActionResult): number {
+  if (!result.ok) return 0;
+  return (
+    (result.skippedDirtyCount ?? 0)
+    + (result.skippedUntitledCount ?? 0)
+    + (result.skippedMissingCount ?? 0)
+  );
+}

--- a/src/locales/__tests__/terminalI18nCoverage.test.ts
+++ b/src/locales/__tests__/terminalI18nCoverage.test.ts
@@ -1,5 +1,8 @@
 // @vitest-environment node
 // WI-2.3 — Gate against untranslated terminal settings strings (T10).
+// WI-TS5.4 — the terminal-scoping locale sweep (terminal.noWorkspaceSession
+//   in every statusbar bundle) is guarded here: a locale shipping the English
+//   value verbatim fails this file's identical-to-English check.
 //
 // Six terminal settings strings shipped as verbatim English in all nine
 // non-English locales, plus the two WCAG contrast options and one statusbar

--- a/src/locales/de/dialog.json
+++ b/src/locales/de/dialog.json
@@ -67,6 +67,8 @@
   "toast.quarantineClearedDesc": "macOS markiert Dateien, die von bestimmten Apps heruntergeladen wurden, mit einem Attribut, das den Finder-Doppelklick stillschweigend blockiert, während VMark läuft. VMark hat es entfernt, damit diese Dateien geöffnet werden können. Unter Einstellungen → Erweitert deaktivierbar.",
   "toast.failedToOpenFilesInNewWindow": "Dateien konnten nicht in neuem Fenster geöffnet werden",
   "toast.workspaceMoveFailed": "Arbeitsbereich konnte nicht in ein neues Fenster verschoben werden",
+  "toast.workspaceCloseBusy": "Arbeitsbereich ist mit einem anderen Vorgang beschäftigt — versuche das Schließen erneut",
+  "toast.workspaceCloseFailed": "Arbeitsbereich konnte nicht geschlossen werden",
   "toast.workspaceDuplicateFailed": "Arbeitsbereich konnte nicht dupliziert werden",
   "toast.workspaceDuplicateSkipped_one": "Arbeitsbereich dupliziert; 1 ungespeicherter, unbenannter oder fehlender Tab wurde übersprungen.",
   "toast.workspaceDuplicateSkipped_other": "Arbeitsbereich dupliziert; {{count}} ungespeicherte, unbenannte oder fehlende Tabs wurden übersprungen.",

--- a/src/locales/de/statusbar.json
+++ b/src/locales/de/statusbar.json
@@ -98,5 +98,6 @@
   "scrollTabsLeft": "Tabs nach links scrollen",
   "scrollTabsRight": "Tabs nach rechts scrollen",
   "terminal.sessionExited": "{{name}} (beendet)",
-  "terminal.backgroundActivity": "Hintergrundaktivität"
+  "terminal.backgroundActivity": "Hintergrundaktivität",
+  "terminal.noWorkspaceSession": "Öffnen Sie einen Ordner oder speichern Sie Ihre Datei, um das Terminal zu verwenden"
 }

--- a/src/locales/en/dialog.json
+++ b/src/locales/en/dialog.json
@@ -89,6 +89,8 @@
   "toast.quarantineClearedDesc": "macOS marks files downloaded by some apps with a flag that silently blocks Finder double-click while VMark is running. VMark cleared it so those files open. Disable in Settings → Advanced.",
   "toast.failedToOpenFilesInNewWindow": "Failed to open files in new window",
   "toast.workspaceMoveFailed": "Failed to move workspace to a new window",
+  "toast.workspaceCloseBusy": "Workspace is busy with another operation — try closing it again",
+  "toast.workspaceCloseFailed": "Failed to close workspace",
   "toast.workspaceDuplicateFailed": "Failed to duplicate workspace",
   "toast.workspaceDuplicateSkipped_one": "Duplicated workspace and skipped 1 dirty, untitled, or missing tab.",
   "toast.workspaceDuplicateSkipped_other": "Duplicated workspace and skipped {{count}} dirty, untitled, or missing tabs.",

--- a/src/locales/en/statusbar.json
+++ b/src/locales/en/statusbar.json
@@ -98,5 +98,6 @@
   "scrollTabsLeft": "Scroll tabs left",
   "scrollTabsRight": "Scroll tabs right",
   "terminal.sessionExited": "{{name}} (exited)",
-  "terminal.backgroundActivity": "Background activity"
+  "terminal.backgroundActivity": "Background activity",
+  "terminal.noWorkspaceSession": "Open a folder or save your file to use the terminal"
 }

--- a/src/locales/es/dialog.json
+++ b/src/locales/es/dialog.json
@@ -67,6 +67,8 @@
   "toast.quarantineClearedDesc": "macOS marca los archivos descargados por algunas aplicaciones con un atributo que bloquea silenciosamente el doble clic del Finder mientras VMark se está ejecutando. VMark lo eliminó para que esos archivos se abran. Desactivar en Ajustes → Avanzado.",
   "toast.failedToOpenFilesInNewWindow": "Error al abrir archivos en una nueva ventana",
   "toast.workspaceMoveFailed": "No se pudo mover el espacio de trabajo a una ventana nueva",
+  "toast.workspaceCloseBusy": "El espacio de trabajo está ocupado con otra operación — intenta cerrarlo de nuevo",
+  "toast.workspaceCloseFailed": "No se pudo cerrar el espacio de trabajo",
   "toast.workspaceDuplicateFailed": "No se pudo duplicar el espacio de trabajo",
   "toast.workspaceDuplicateSkipped_one": "Espacio de trabajo duplicado; se omitió 1 pestaña sin guardar, sin título o faltante.",
   "toast.workspaceDuplicateSkipped_other": "Espacio de trabajo duplicado; se omitieron {{count}} pestañas sin guardar, sin título o faltantes.",

--- a/src/locales/es/statusbar.json
+++ b/src/locales/es/statusbar.json
@@ -98,5 +98,6 @@
   "scrollTabsLeft": "Desplazar pestañas a la izquierda",
   "scrollTabsRight": "Desplazar pestañas a la derecha",
   "terminal.sessionExited": "{{name}} (finalizado)",
-  "terminal.backgroundActivity": "Actividad en segundo plano"
+  "terminal.backgroundActivity": "Actividad en segundo plano",
+  "terminal.noWorkspaceSession": "Abre una carpeta o guarda tu archivo para usar la terminal"
 }

--- a/src/locales/fr/dialog.json
+++ b/src/locales/fr/dialog.json
@@ -67,6 +67,8 @@
   "toast.quarantineClearedDesc": "macOS marque les fichiers téléchargés par certaines applications avec un attribut qui bloque silencieusement le double-clic dans le Finder lorsque VMark est en cours d'exécution. VMark l'a retiré pour que ces fichiers s'ouvrent. Désactiver dans Paramètres → Avancé.",
   "toast.failedToOpenFilesInNewWindow": "Impossible d'ouvrir les fichiers dans une nouvelle fenêtre",
   "toast.workspaceMoveFailed": "Échec du déplacement de l'espace de travail vers une nouvelle fenêtre",
+  "toast.workspaceCloseBusy": "L’espace de travail est occupé par une autre opération — réessayez de le fermer",
+  "toast.workspaceCloseFailed": "Échec de la fermeture de l’espace de travail",
   "toast.workspaceDuplicateFailed": "Échec de la duplication de l'espace de travail",
   "toast.workspaceDuplicateSkipped_one": "Espace de travail dupliqué ; 1 onglet non enregistré, sans titre ou manquant a été ignoré.",
   "toast.workspaceDuplicateSkipped_other": "Espace de travail dupliqué ; {{count}} onglets non enregistrés, sans titre ou manquants ont été ignorés.",

--- a/src/locales/fr/statusbar.json
+++ b/src/locales/fr/statusbar.json
@@ -98,5 +98,6 @@
   "scrollTabsLeft": "Faire défiler les onglets vers la gauche",
   "scrollTabsRight": "Faire défiler les onglets vers la droite",
   "terminal.sessionExited": "{{name}} (terminé)",
-  "terminal.backgroundActivity": "Activité en arrière-plan"
+  "terminal.backgroundActivity": "Activité en arrière-plan",
+  "terminal.noWorkspaceSession": "Ouvrez un dossier ou enregistrez votre fichier pour utiliser le terminal"
 }

--- a/src/locales/it/dialog.json
+++ b/src/locales/it/dialog.json
@@ -67,6 +67,8 @@
   "toast.quarantineClearedDesc": "macOS contrassegna i file scaricati da alcune app con un attributo che blocca silenziosamente il doppio clic dal Finder mentre VMark è in esecuzione. VMark lo ha rimosso per consentire l'apertura di quei file. Disattivabile in Impostazioni → Avanzate.",
   "toast.failedToOpenFilesInNewWindow": "Apertura dei file in una nuova finestra fallita",
   "toast.workspaceMoveFailed": "Impossibile spostare l'area di lavoro in una nuova finestra",
+  "toast.workspaceCloseBusy": "L’area di lavoro è occupata da un’altra operazione — riprova a chiuderla",
+  "toast.workspaceCloseFailed": "Impossibile chiudere l’area di lavoro",
   "toast.workspaceDuplicateFailed": "Impossibile duplicare l'area di lavoro",
   "toast.workspaceDuplicateSkipped_one": "Area di lavoro duplicata; è stata saltata 1 scheda non salvata, senza titolo o mancante.",
   "toast.workspaceDuplicateSkipped_other": "Area di lavoro duplicata; sono state saltate {{count}} schede non salvate, senza titolo o mancanti.",

--- a/src/locales/it/statusbar.json
+++ b/src/locales/it/statusbar.json
@@ -98,5 +98,6 @@
   "scrollTabsLeft": "Scorri le schede a sinistra",
   "scrollTabsRight": "Scorri le schede a destra",
   "terminal.sessionExited": "{{name}} (terminato)",
-  "terminal.backgroundActivity": "Attività in background"
+  "terminal.backgroundActivity": "Attività in background",
+  "terminal.noWorkspaceSession": "Apri una cartella o salva il file per usare il terminale"
 }

--- a/src/locales/ja/dialog.json
+++ b/src/locales/ja/dialog.json
@@ -67,6 +67,8 @@
   "toast.quarantineClearedDesc": "macOS では、一部のアプリでダウンロードしたファイルにフラグが付けられ、VMark の実行中に Finder のダブルクリックが密かにブロックされます。VMark がそのフラグを削除したため、これらのファイルが開けるようになりました。設定 → 詳細で無効にできます。",
   "toast.failedToOpenFilesInNewWindow": "新しいウィンドウでファイルを開けませんでした",
   "toast.workspaceMoveFailed": "ワークスペースを新しいウィンドウに移動できませんでした",
+  "toast.workspaceCloseBusy": "ワークスペースは別の操作を実行中です — もう一度閉じてみてください",
+  "toast.workspaceCloseFailed": "ワークスペースを閉じられませんでした",
   "toast.workspaceDuplicateFailed": "ワークスペースを複製できませんでした",
   "toast.workspaceDuplicateSkipped_one": "ワークスペースを複製し、未保存・無題・欠落しているタブを 1 個スキップしました。",
   "toast.workspaceDuplicateSkipped_other": "ワークスペースを複製し、未保存・無題・欠落しているタブを {{count}} 個スキップしました。",

--- a/src/locales/ja/statusbar.json
+++ b/src/locales/ja/statusbar.json
@@ -98,5 +98,6 @@
   "scrollTabsLeft": "タブを左にスクロール",
   "scrollTabsRight": "タブを右にスクロール",
   "terminal.sessionExited": "{{name}}（終了済み）",
-  "terminal.backgroundActivity": "バックグラウンドの動作"
+  "terminal.backgroundActivity": "バックグラウンドの動作",
+  "terminal.noWorkspaceSession": "ターミナルを使用するには、フォルダを開くかファイルを保存してください"
 }

--- a/src/locales/ko/dialog.json
+++ b/src/locales/ko/dialog.json
@@ -67,6 +67,8 @@
   "toast.quarantineClearedDesc": "macOS는 일부 앱에서 다운로드한 파일에 플래그를 표시하여 VMark 실행 중에 Finder의 더블클릭을 조용히 차단합니다. VMark가 이 플래그를 제거하여 해당 파일이 열릴 수 있게 했습니다. 설정 → 고급에서 비활성화할 수 있습니다.",
   "toast.failedToOpenFilesInNewWindow": "새 창에서 파일을 열지 못했습니다",
   "toast.workspaceMoveFailed": "워크스페이스를 새 창으로 이동하지 못했습니다",
+  "toast.workspaceCloseBusy": "워크스페이스가 다른 작업을 수행 중입니다 — 다시 닫아 보세요",
+  "toast.workspaceCloseFailed": "워크스페이스를 닫지 못했습니다",
   "toast.workspaceDuplicateFailed": "워크스페이스를 복제하지 못했습니다",
   "toast.workspaceDuplicateSkipped_one": "워크스페이스를 복제하고 저장되지 않았거나 제목이 없거나 누락된 탭 1개를 건너뛰었습니다.",
   "toast.workspaceDuplicateSkipped_other": "워크스페이스를 복제하고 저장되지 않았거나 제목이 없거나 누락된 탭 {{count}}개를 건너뛰었습니다.",

--- a/src/locales/ko/statusbar.json
+++ b/src/locales/ko/statusbar.json
@@ -98,5 +98,6 @@
   "scrollTabsLeft": "탭을 왼쪽으로 스크롤",
   "scrollTabsRight": "탭을 오른쪽으로 스크롤",
   "terminal.sessionExited": "{{name}} (종료됨)",
-  "terminal.backgroundActivity": "백그라운드 활동"
+  "terminal.backgroundActivity": "백그라운드 활동",
+  "terminal.noWorkspaceSession": "터미널을 사용하려면 폴더를 열거나 파일을 저장하세요"
 }

--- a/src/locales/pt-BR/dialog.json
+++ b/src/locales/pt-BR/dialog.json
@@ -67,6 +67,8 @@
   "toast.quarantineClearedDesc": "O macOS marca arquivos baixados por alguns aplicativos com um atributo que bloqueia silenciosamente o duplo clique do Finder enquanto o VMark está em execução. O VMark removeu o atributo para que esses arquivos possam ser abertos. Desative em Configurações → Avançado.",
   "toast.failedToOpenFilesInNewWindow": "Falha ao abrir arquivos em uma nova janela",
   "toast.workspaceMoveFailed": "Falha ao mover o espaço de trabalho para uma nova janela",
+  "toast.workspaceCloseBusy": "O espaço de trabalho está ocupado com outra operação — tente fechá-lo novamente",
+  "toast.workspaceCloseFailed": "Falha ao fechar o espaço de trabalho",
   "toast.workspaceDuplicateFailed": "Falha ao duplicar o espaço de trabalho",
   "toast.workspaceDuplicateSkipped_one": "Espaço de trabalho duplicado; 1 aba não salva, sem título ou ausente foi ignorada.",
   "toast.workspaceDuplicateSkipped_other": "Espaço de trabalho duplicado; {{count}} abas não salvas, sem título ou ausentes foram ignoradas.",

--- a/src/locales/pt-BR/statusbar.json
+++ b/src/locales/pt-BR/statusbar.json
@@ -98,5 +98,6 @@
   "scrollTabsLeft": "Rolar abas para a esquerda",
   "scrollTabsRight": "Rolar abas para a direita",
   "terminal.sessionExited": "{{name}} (encerrado)",
-  "terminal.backgroundActivity": "Atividade em segundo plano"
+  "terminal.backgroundActivity": "Atividade em segundo plano",
+  "terminal.noWorkspaceSession": "Abra uma pasta ou salve seu arquivo para usar o terminal"
 }

--- a/src/locales/zh-CN/dialog.json
+++ b/src/locales/zh-CN/dialog.json
@@ -67,6 +67,8 @@
   "toast.quarantineClearedDesc": "macOS 会给某些应用下载的文件加上一个标记，导致 VMark 运行时在 Finder 双击打开会被静默拦截。VMark 已为你清除该标记，使这些文件可以正常打开。可在设置 → 高级中关闭。",
   "toast.failedToOpenFilesInNewWindow": "无法在新窗口中打开文件",
   "toast.workspaceMoveFailed": "将工作区移动到新窗口失败",
+  "toast.workspaceCloseBusy": "工作区正忙于其他操作 — 请再次尝试关闭",
+  "toast.workspaceCloseFailed": "无法关闭工作区",
   "toast.workspaceDuplicateFailed": "复制工作区失败",
   "toast.workspaceDuplicateSkipped_one": "已复制工作区,并跳过 1 个未保存、未命名或丢失的标签页。",
   "toast.workspaceDuplicateSkipped_other": "已复制工作区,并跳过 {{count}} 个未保存、未命名或丢失的标签页。",

--- a/src/locales/zh-CN/statusbar.json
+++ b/src/locales/zh-CN/statusbar.json
@@ -98,5 +98,6 @@
   "scrollTabsLeft": "向左滚动标签页",
   "scrollTabsRight": "向右滚动标签页",
   "terminal.sessionExited": "{{name}}（已退出）",
-  "terminal.backgroundActivity": "后台活动"
+  "terminal.backgroundActivity": "后台活动",
+  "terminal.noWorkspaceSession": "打开文件夹或保存您的文件以使用终端"
 }

--- a/src/locales/zh-TW/dialog.json
+++ b/src/locales/zh-TW/dialog.json
@@ -67,6 +67,8 @@
   "toast.quarantineClearedDesc": "macOS 會在某些應用程式下載的檔案上加上一個標記，導致 VMark 執行時 Finder 雙擊開啟會被靜默攔截。VMark 已為你清除該標記，讓這些檔案可以正常開啟。可在設定 → 進階中關閉。",
   "toast.failedToOpenFilesInNewWindow": "無法在新視窗開啟檔案",
   "toast.workspaceMoveFailed": "將工作區移動到新視窗失敗",
+  "toast.workspaceCloseBusy": "工作區正忙於其他操作 — 請再次嘗試關閉",
+  "toast.workspaceCloseFailed": "無法關閉工作區",
   "toast.workspaceDuplicateFailed": "複製工作區失敗",
   "toast.workspaceDuplicateSkipped_one": "已複製工作區,並略過 1 個未儲存、未命名或遺失的分頁。",
   "toast.workspaceDuplicateSkipped_other": "已複製工作區,並略過 {{count}} 個未儲存、未命名或遺失的分頁。",

--- a/src/locales/zh-TW/statusbar.json
+++ b/src/locales/zh-TW/statusbar.json
@@ -98,5 +98,6 @@
   "scrollTabsLeft": "向左捲動分頁",
   "scrollTabsRight": "向右捲動分頁",
   "terminal.sessionExited": "{{name}}（已退出）",
-  "terminal.backgroundActivity": "背景活動"
+  "terminal.backgroundActivity": "背景活動",
+  "terminal.noWorkspaceSession": "請開啟資料夾或儲存檔案以使用終端機"
 }

--- a/src/services/terminal/closeTerminalSession.test.ts
+++ b/src/services/terminal/closeTerminalSession.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment node
+// Audit 20260831 R2-2 — the ONE remove-session + panel-hide policy:
+// onlyIfVisible refuses hidden targets, last-VISIBLE closes hide the panel,
+// and a hidden panel is never toggled back on (the journey-35 resurrect).
+// Real stores; nothing terminal-side mocked.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+import { removeTerminalSessionWithPanelPolicy } from "./closeTerminalSession";
+
+const W = "main";
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function addWorkspace(id: string, rootPath: string): void {
+  const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+  if (!root.ok) throw new Error("bad test root");
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: id,
+      root: root.root,
+      ownerWindowLabel: W,
+      createdFrom: "open",
+    }),
+  );
+}
+
+function createOwned(owner?: string): string {
+  const created = useUIStore
+    .getState()
+    .terminalCreateSession(owner ? { ownerInstanceId: owner } : undefined);
+  if (!created) throw new Error("cap hit in test setup");
+  return created.id;
+}
+
+function showPanel(): void {
+  if (!useUIStore.getState().terminalVisible) useUIStore.getState().toggleTerminal();
+}
+
+const term = () => useUIStore.getState().terminal;
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  useWorkspaceStore.getState().closeWorkspace();
+  if (useUIStore.getState().terminalVisible) useUIStore.getState().toggleTerminal();
+  setRail(true);
+  addWorkspace("wsi-a", "/repo-a");
+  addWorkspace("wsi-b", "/repo-b");
+  useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+});
+
+afterEach(() => {
+  setRail(false);
+});
+
+describe("removeTerminalSessionWithPanelPolicy", () => {
+  it("onlyIfVisible refuses a HIDDEN session — nothing removed, panel untouched", () => {
+    const hidden = createOwned("wsi-b"); // active scope is wsi-a
+    createOwned("wsi-a");
+    showPanel();
+
+    removeTerminalSessionWithPanelPolicy(hidden, { onlyIfVisible: true });
+
+    expect(term().sessions.map((s) => s.id)).toContain(hidden);
+    expect(useUIStore.getState().terminalVisible).toBe(true);
+  });
+
+  it("without the flag a hidden session IS removed (clean exit) — panel stays", () => {
+    const hidden = createOwned("wsi-b");
+    createOwned("wsi-a");
+    showPanel();
+
+    removeTerminalSessionWithPanelPolicy(hidden);
+
+    expect(term().sessions.map((s) => s.id)).not.toContain(hidden);
+    expect(useUIStore.getState().terminalVisible).toBe(true);
+  });
+
+  it("closing the last VISIBLE session hides the panel", () => {
+    createOwned("wsi-b"); // hidden survivor — must not keep the panel open
+    const visible = createOwned("wsi-a");
+    showPanel();
+
+    removeTerminalSessionWithPanelPolicy(visible, { onlyIfVisible: true });
+
+    expect(term().sessions.map((s) => s.id)).not.toContain(visible);
+    expect(useUIStore.getState().terminalVisible).toBe(false);
+  });
+
+  it("never TOGGLES a hidden panel back on (the journey-35 resurrect)", () => {
+    const visible = createOwned("wsi-a");
+    expect(useUIStore.getState().terminalVisible).toBe(false);
+
+    removeTerminalSessionWithPanelPolicy(visible);
+
+    expect(term().sessions).toHaveLength(0);
+    expect(useUIStore.getState().terminalVisible).toBe(false);
+  });
+
+  it("fallback-active is picked from the VISIBLE population, never a hidden scope", () => {
+    const hidden = createOwned("wsi-b");
+    const a1 = createOwned("wsi-a");
+    const a2 = createOwned("wsi-a");
+    useUIStore.getState().terminalSetActiveSession(a2);
+    showPanel();
+
+    removeTerminalSessionWithPanelPolicy(a2, { onlyIfVisible: true });
+
+    expect(term().activeSessionId).toBe(a1);
+    expect(term().activeSessionId).not.toBe(hidden);
+  });
+
+  it("an unknown session id is a no-op under onlyIfVisible", () => {
+    createOwned("wsi-a");
+    showPanel();
+    const before = term().sessions;
+
+    removeTerminalSessionWithPanelPolicy("term-nope", { onlyIfVisible: true });
+
+    expect(term().sessions).toBe(before);
+    expect(useUIStore.getState().terminalVisible).toBe(true);
+  });
+});

--- a/src/services/terminal/closeTerminalSession.ts
+++ b/src/services/terminal/closeTerminalSession.ts
@@ -1,0 +1,42 @@
+/**
+ * closeTerminalSession — the ONE remove-session + panel-hide policy
+ * (audit 20260831 #32).
+ *
+ * Purpose: TerminalPanel's close button and the clean-exit path had grown
+ * near-identical copies of "remove the session, pick a visible fallback,
+ * hide the panel when it was the last visible one" — and the predicates had
+ * already drifted (`<= 1` versus exact visible membership).
+ *
+ * Semantics:
+ *   - `onlyIfVisible` (the UI close button): a stale active id pointing at a
+ *     HIDDEN session is refused outright — clicking close must never remove
+ *     a session the user cannot see.
+ *   - Without it (clean exit): the session is removed regardless — a hidden
+ *     scope's shell exiting cleanly still closes its tab — but the panel
+ *     hides only when the closed session was the last VISIBLE one (D-T7).
+ *   - The hide re-reads visibility and never TOGGLES a hidden panel back on
+ *     (the journey-35 resurrect).
+ *
+ * @coordinates-with components/Terminal/TerminalPanel.tsx — close button
+ * @coordinates-with components/Terminal/useTerminalShellLifecycle.ts — clean exit
+ * @module services/terminal/closeTerminalSession
+ */
+import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
+import { useUIStore } from "@/stores/uiStore";
+import { getVisibleTerminalSessions } from "./visibleTerminalSessions";
+
+export function removeTerminalSessionWithPanelPolicy(
+  sessionId: string,
+  opts?: { onlyIfVisible?: boolean },
+): void {
+  const visibleIds = getVisibleTerminalSessions(getCurrentWindowLabel()).map(
+    (s) => s.id,
+  );
+  const isMember = visibleIds.includes(sessionId);
+  if (opts?.onlyIfVisible && !isMember) return;
+  const wasLastVisible = isMember && visibleIds.length === 1;
+  useUIStore.getState().terminalRemoveSession(sessionId, { visibleIds });
+  if (!wasLastVisible) return;
+  const now = useUIStore.getState();
+  if (now.terminalVisible) now.toggleTerminal();
+}

--- a/src/services/terminal/createTerminalSession.test.ts
+++ b/src/services/terminal/createTerminalSession.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment node
+// WI-TS1.1 / audit 20260831 R2-1 — the ONE owner-aware creation service:
+// canCreateTerminalSessionHere must agree with createTerminalSessionInScope
+// in EVERY resolvable state (a UI gate that says yes while creation says no
+// renders a live "+" that does nothing). Real stores; nothing mocked.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import {
+  MAX_TERMINAL_SESSIONS,
+  resetTerminalSessionStore,
+  useUIStore,
+} from "@/stores/uiStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+import {
+  beginWindowContextRestore,
+  endWindowContextRestore,
+} from "@/services/workspaces/switchWorkspaceInstance";
+import {
+  canCreateTerminalSessionHere,
+  createTerminalSessionInScope,
+} from "./createTerminalSession";
+
+const W = "main";
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function addWorkspace(id: string, rootPath: string): void {
+  const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+  if (!root.ok) throw new Error("bad test root");
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: id,
+      root: root.root,
+      ownerWindowLabel: W,
+      createdFrom: "open",
+    }),
+  );
+}
+
+const sessions = () => useUIStore.getState().terminal.sessions;
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  useWorkspaceStore.getState().closeWorkspace();
+  setRail(true);
+});
+
+afterEach(() => {
+  endWindowContextRestore(W);
+  setRail(false);
+});
+
+describe("createTerminalSessionInScope — owner stamping (D-T1)", () => {
+  it("stamps the active workspace instance's id", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    const created = createTerminalSessionInScope(W);
+    expect(created?.workspaceInstanceId).toBe("wsi-a");
+  });
+
+  it("leaves the session window-scoped with the rail off (carve-out 3)", () => {
+    setRail(false);
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    const created = createTerminalSessionInScope(W);
+    expect(created?.workspaceInstanceId).toBeUndefined();
+  });
+
+  it("leaves the session window-scoped on a placeholder (carve-out 1)", () => {
+    useWorkspaceInstancesStore
+      .getState()
+      .ensurePlaceholderInstance(W, "wsi-placeholder-1");
+    const created = createTerminalSessionInScope(W);
+    expect(created?.workspaceInstanceId).toBeUndefined();
+  });
+
+  it("leaves the session window-scoped mid-restore (carve-out 2)", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    beginWindowContextRestore(W);
+    const created = createTerminalSessionInScope(W);
+    expect(created?.workspaceInstanceId).toBeUndefined();
+  });
+
+  it("threads requestedCwd through to the created session", () => {
+    const created = createTerminalSessionInScope(W, { requestedCwd: "/w/pkg" });
+    expect(created?.requestedCwd).toBe("/w/pkg");
+  });
+});
+
+describe("predicate/action parity (R2-1)", () => {
+  /** Assert canCreate ⇔ (create succeeds), rolling the trial session back. */
+  function expectParity(expected: boolean): void {
+    expect(canCreateTerminalSessionHere(W)).toBe(expected);
+    const created = createTerminalSessionInScope(W);
+    expect(created !== null).toBe(expected);
+    if (created) useUIStore.getState().terminalRemoveSession(created.id);
+  }
+
+  it("agrees below and at the cap in a plain workspace scope", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    for (let i = 0; i < MAX_TERMINAL_SESSIONS - 1; i++) {
+      expect(createTerminalSessionInScope(W)).not.toBeNull();
+    }
+    expectParity(true);
+    // Fill the last slot for real, then both must refuse.
+    expect(createTerminalSessionInScope(W)).not.toBeNull();
+    expectParity(false);
+  });
+
+  it("a hidden scope's sessions do not consume this scope's headroom", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    addWorkspace("wsi-b", "/repo-b");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-b");
+    for (let i = 0; i < MAX_TERMINAL_SESSIONS; i++) {
+      expect(createTerminalSessionInScope(W)).not.toBeNull();
+    }
+    expectParity(false); // wsi-b itself is full…
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    expectParity(true); // …but wsi-a has full headroom.
+  });
+
+  it("window-scoped sessions count against every scope (the visible union)", () => {
+    setRail(false);
+    for (let i = 0; i < MAX_TERMINAL_SESSIONS; i++) {
+      expect(createTerminalSessionInScope(W)).not.toBeNull();
+    }
+    setRail(true);
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    // All five are window-scoped ⇒ visible in wsi-a's union ⇒ full.
+    expectParity(false);
+  });
+
+  it("an unscoped creation (rail off) counts ALL sessions", () => {
+    // Seed a stamped session while scoped, then turn the rail off: the
+    // unscoped union counts it (creationUnion's documented equivalence only
+    // claims stamped sessions cannot exist in the REACHABLE unscoped states —
+    // this pins the conservative behavior for the unreachable one).
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    for (let i = 0; i < MAX_TERMINAL_SESSIONS; i++) {
+      expect(createTerminalSessionInScope(W)).not.toBeNull();
+    }
+    setRail(false);
+    expect(sessions()).toHaveLength(MAX_TERMINAL_SESSIONS);
+    expectParity(false);
+  });
+});

--- a/src/services/terminal/createTerminalSession.ts
+++ b/src/services/terminal/createTerminalSession.ts
@@ -1,0 +1,42 @@
+/**
+ * createTerminalSession — THE owner-aware creation service (audit 20260831
+ * #17/#20).
+ *
+ * Purpose: every production creator of a terminal session goes through this
+ * one function, so "resolve the owner, stamp the options" cannot drift
+ * between call sites — the panel/init auto-create, the tab bar's +,
+ * "Open Terminal Here", and Run-in-Terminal's reuse-or-create all did it by
+ * hand before. `canCreateTerminalSessionHere` is the AUTHORITATIVE can-create
+ * predicate: it computes the same creation-time union (D-T5) the slice's cap
+ * gate applies, owner included, so a UI gate can never say yes while creation
+ * says no.
+ *
+ * @coordinates-with stores/uiStore/terminalSlice.ts — terminalCreateSession + creationUnion
+ * @coordinates-with resolveTerminalOwnerInstanceId.ts — the D-T1 carve-outs
+ * @module services/terminal/createTerminalSession
+ */
+import { MAX_TERMINAL_SESSIONS, useUIStore } from "@/stores/uiStore";
+import { creationUnion } from "@/stores/uiStore/terminalSlice";
+import type { TerminalSession } from "@/stores/uiStore/types";
+import { resolveTerminalOwnerInstanceId } from "./resolveTerminalOwnerInstanceId";
+
+/** Whether a session created NOW in this window would pass the cap gate —
+ *  the SAME union the slice applies, owner and all (never a bare count). */
+export function canCreateTerminalSessionHere(windowLabel: string): boolean {
+  const owner = resolveTerminalOwnerInstanceId(windowLabel);
+  const sessions = useUIStore.getState().terminal.sessions;
+  return creationUnion(sessions, owner).length < MAX_TERMINAL_SESSIONS;
+}
+
+/** Create a session in the active scope (owner stamped per D-T1's carve-outs).
+ *  Returns null at the creation-union cap, exactly like the slice action. */
+export function createTerminalSessionInScope(
+  windowLabel: string,
+  options?: { requestedCwd?: string },
+): TerminalSession | null {
+  const owner = resolveTerminalOwnerInstanceId(windowLabel);
+  return useUIStore.getState().terminalCreateSession({
+    ...(options?.requestedCwd ? { requestedCwd: options.requestedCwd } : {}),
+    ...(owner ? { ownerInstanceId: owner } : {}),
+  });
+}

--- a/src/services/terminal/maybeAutoCreateTerminalSession.test.ts
+++ b/src/services/terminal/maybeAutoCreateTerminalSession.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment node
+// WI-TS3.2 — the ONE auto-create gate (D-T8): scope-aware, checked against
+// the SYNCHRONOUS instance-backed scope, never the legacy store the async
+// refresh owns. Real stores throughout.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useTabStore } from "@/stores/tabStore";
+import { useDocumentStore } from "@/stores/documentStore";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+import { canOpenTerminal } from "./terminalGate";
+import {
+  canAutoCreateInScope,
+  maybeAutoCreateTerminalSession,
+} from "./maybeAutoCreateTerminalSession";
+
+const W = "main";
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function addWorkspace(id: string, rootPath: string): void {
+  const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+  if (!root.ok) throw new Error("bad test root");
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: id,
+      root: root.root,
+      ownerWindowLabel: W,
+      createdFrom: "open",
+    }),
+  );
+}
+
+const sessions = () => useUIStore.getState().terminal.sessions;
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  useWorkspaceStore.getState().closeWorkspace();
+  useTabStore.setState({ tabs: {}, activeTabId: {}, untitledCounter: 0 });
+  useDocumentStore.setState({ documents: {} });
+  setRail(true);
+});
+
+afterEach(() => {
+  setRail(false);
+});
+
+describe("canAutoCreateInScope (pure gate)", () => {
+  it("workspace mode OR a saved active file; neither refuses", () => {
+    expect(canAutoCreateInScope({ isWorkspaceMode: true }, false)).toBe(true);
+    expect(canAutoCreateInScope({ isWorkspaceMode: false }, true)).toBe(true);
+    expect(canAutoCreateInScope({ isWorkspaceMode: false }, false)).toBe(false);
+  });
+});
+
+describe("maybeAutoCreateTerminalSession (WI-TS3.2)", () => {
+  it("empty workspace scope → exactly one session, stamped with the scope", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+
+    expect(maybeAutoCreateTerminalSession(W)).toBe(true);
+
+    expect(sessions()).toHaveLength(1);
+    expect(sessions()[0]?.workspaceInstanceId).toBe("wsi-a");
+  });
+
+  it("refusing scope with the legacy refresh UNRESOLVED → no create (the case canOpenTerminal cannot gate)", () => {
+    // Instance-backed truth: a loose instance — not a workspace, no file.
+    useWorkspaceInstancesStore.getState().ensureLooseInstance(W);
+    // Legacy store still says workspace-mode: the async refresh has not
+    // landed (and never runs after a close). The old gate reads THIS.
+    useWorkspaceStore.setState({ isWorkspaceMode: true, rootPath: "/stale-root" });
+    expect(canOpenTerminal()).toBe(true); // the legacy gate would say yes…
+
+    expect(maybeAutoCreateTerminalSession(W)).toBe(false); // …and we refuse
+    expect(sessions()).toHaveLength(0);
+  });
+
+  it("no re-create when the visible scope is non-empty", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    expect(maybeAutoCreateTerminalSession(W)).toBe(true);
+
+    expect(maybeAutoCreateTerminalSession(W)).toBe(false);
+    expect(sessions()).toHaveLength(1);
+  });
+
+  it("a HIDDEN scope's sessions do not block creation in an empty scope", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    addWorkspace("wsi-b", "/repo-b");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    useUIStore.getState().terminalCreateSession({ ownerInstanceId: "wsi-b" });
+
+    expect(maybeAutoCreateTerminalSession(W)).toBe(true);
+
+    expect(sessions()).toHaveLength(2);
+    expect(sessions()[1]?.workspaceInstanceId).toBe("wsi-a");
+  });
+
+  it("rail off + legacy workspace mode → creates an UNSCOPED session (today's behavior)", () => {
+    setRail(false);
+    useWorkspaceStore.setState({ isWorkspaceMode: true, rootPath: "/repo-legacy" });
+
+    expect(maybeAutoCreateTerminalSession(W)).toBe(true);
+
+    expect(sessions()).toHaveLength(1);
+    expect(Object.keys(sessions()[0] ?? {})).not.toContain("workspaceInstanceId");
+  });
+
+  it("no workspace but a saved active file → creates (file-anchored cwd case)", () => {
+    setRail(false);
+    const tabId = useTabStore.getState().createTab(W, "/notes/saved.md");
+    useDocumentStore
+      .getState()
+      .initDocument(tabId, "x", "/notes/saved.md", { savedContent: "x" });
+    useTabStore.getState().setActiveTab(W, tabId);
+
+    expect(maybeAutoCreateTerminalSession(W)).toBe(true);
+    expect(sessions()).toHaveLength(1);
+  });
+
+  it("no workspace, no saved file → refuses and creates nothing", () => {
+    setRail(false);
+    expect(maybeAutoCreateTerminalSession(W)).toBe(false);
+    expect(sessions()).toHaveLength(0);
+  });
+});

--- a/src/services/terminal/maybeAutoCreateTerminalSession.ts
+++ b/src/services/terminal/maybeAutoCreateTerminalSession.ts
@@ -1,0 +1,55 @@
+/**
+ * maybeAutoCreateTerminalSession — THE auto-create gate (WI-TS3.2, D-T8).
+ *
+ * Purpose: both auto-creators — the panel's visibility effect and the
+ * mount-time creator in useTerminalSessionsInit — go through this one
+ * helper, so the gate cannot fork between them.
+ *
+ * The gate is `canAutoCreateInScope` over `getActiveWorkspaceScope` — the
+ * SYNCHRONOUS, instance-backed scope. It deliberately never consults
+ * `canOpenTerminal()`: that reads the LEGACY workspace store, which only the
+ * async `syncLegacyWorkspaceContext` refresh updates (and never after a
+ * close), so gating on it races the very scope it gates (D-T8). A refusal
+ * creates nothing — the panel renders its empty-state hint instead of
+ * spawning a shell into $HOME.
+ *
+ * @coordinates-with components/Terminal/TerminalPanel.tsx — visibility-effect creator
+ * @coordinates-with components/Terminal/useTerminalSessionsInit.ts — mount-time creator
+ * @module services/terminal/maybeAutoCreateTerminalSession
+ */
+import {
+  getActiveWorkspaceScope,
+  type ActiveWorkspaceScope,
+} from "@/services/workspaces/activeWorkspaceScope";
+import { useDocumentStore } from "@/stores/documentStore";
+import { useTabStore } from "@/stores/tabStore";
+import { getVisibleTerminalSessions } from "./visibleTerminalSessions";
+import { createTerminalSessionInScope } from "./createTerminalSession";
+
+/** Pure gate (D-T8): a workspace scope, or a saved file to anchor a cwd. */
+export function canAutoCreateInScope(
+  scope: Pick<ActiveWorkspaceScope, "isWorkspaceMode">,
+  activeTabHasSavedFile: boolean,
+): boolean {
+  return scope.isWorkspaceMode || activeTabHasSavedFile;
+}
+
+function activeTabHasSavedFile(windowLabel: string): boolean {
+  const activeTabId = useTabStore.getState().activeTabId[windowLabel];
+  if (!activeTabId) return false;
+  return Boolean(useDocumentStore.getState().getDocument(activeTabId)?.filePath);
+}
+
+/**
+ * Create one session in the active scope when the VISIBLE population is
+ * empty and the scope can host a terminal. Returns true iff a session was
+ * created. Idempotent across both creators: whichever runs second sees a
+ * non-empty visible population and does nothing.
+ */
+export function maybeAutoCreateTerminalSession(windowLabel: string): boolean {
+  if (getVisibleTerminalSessions(windowLabel).length > 0) return false;
+  const scope = getActiveWorkspaceScope(windowLabel);
+  if (!canAutoCreateInScope(scope, activeTabHasSavedFile(windowLabel))) return false;
+  // The ONE owner-aware creation service (audit 20260831 #17).
+  return createTerminalSessionInScope(windowLabel) !== null;
+}

--- a/src/services/terminal/openTerminalHere.test.ts
+++ b/src/services/terminal/openTerminalHere.test.ts
@@ -8,6 +8,12 @@ import {
 } from "@/stores/uiStore";
 import { openTerminalHere, canOpenTerminalHere } from "./openTerminalHere";
 
+/** Narrow the discriminated result (audit 20260831 #21) — throws on refusal. */
+function sessionIdOf(result: ReturnType<typeof openTerminalHere>): string {
+  if (!result.ok) throw new Error(`expected ok, got ${result.reason}`);
+  return result.sessionId;
+}
+
 describe("openTerminalHere (WI-4.2)", () => {
   beforeEach(() => {
     resetTerminalSessionStore();
@@ -20,7 +26,7 @@ describe("openTerminalHere (WI-4.2)", () => {
     expect(result.ok).toBe(true);
     const session = useUIStore
       .getState()
-      .terminal.sessions.find((s) => s.id === result.sessionId);
+      .terminal.sessions.find((s) => s.id === sessionIdOf(result));
     expect(session?.requestedCwd).toBe("/w/pkg/api");
   });
 
@@ -41,8 +47,8 @@ describe("openTerminalHere (WI-4.2)", () => {
     openTerminalHere("/w/a");
     const first = useUIStore.getState().terminal.activeSessionId;
     const second = openTerminalHere("/w/b");
-    expect(useUIStore.getState().terminal.activeSessionId).toBe(second.sessionId);
-    expect(second.sessionId).not.toBe(first);
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(sessionIdOf(second));
+    expect(sessionIdOf(second)).not.toBe(first);
   });
 
   it("refuses at the session cap instead of silently doing nothing", () => {
@@ -85,7 +91,7 @@ describe("openTerminalHere (WI-4.2)", () => {
     const result = openTerminalHere("/Users/me/My 项目");
     const session = useUIStore
       .getState()
-      .terminal.sessions.find((s) => s.id === result.sessionId);
+      .terminal.sessions.find((s) => s.id === sessionIdOf(result));
     expect(session?.requestedCwd).toBe("/Users/me/My 项目");
   });
 
@@ -95,7 +101,7 @@ describe("openTerminalHere (WI-4.2)", () => {
     const result = openTerminalHere("/w/ notes ");
     const session = useUIStore
       .getState()
-      .terminal.sessions.find((s) => s.id === result.sessionId);
+      .terminal.sessions.find((s) => s.id === sessionIdOf(result));
     expect(session?.requestedCwd).toBe("/w/ notes ");
   });
 
@@ -104,7 +110,7 @@ describe("openTerminalHere (WI-4.2)", () => {
     // session would leave the user in whatever directory it was already in.
     const first = openTerminalHere("/w/a");
     const second = openTerminalHere("/w/b");
-    expect(second.sessionId).not.toBe(first.sessionId);
+    expect(sessionIdOf(second)).not.toBe(sessionIdOf(first));
     expect(useUIStore.getState().terminal.sessions).toHaveLength(2);
   });
 });
@@ -117,15 +123,15 @@ describe("requestedCwd peek/clear (WI-4.2)", () => {
   it("peeking does NOT consume the requested cwd", () => {
     // The spawn path peeks before spawning and clears only on success — a
     // failed first spawn must still be retryable in the requested directory.
-    const { sessionId } = openTerminalHere("/w/pkg");
-    expect(useUIStore.getState().terminalPeekRequestedCwd(sessionId!)).toBe("/w/pkg");
-    expect(useUIStore.getState().terminalPeekRequestedCwd(sessionId!)).toBe("/w/pkg");
+    const sessionId = sessionIdOf(openTerminalHere("/w/pkg"));
+    expect(useUIStore.getState().terminalPeekRequestedCwd(sessionId)).toBe("/w/pkg");
+    expect(useUIStore.getState().terminalPeekRequestedCwd(sessionId)).toBe("/w/pkg");
   });
 
   it("clearing releases it, so a later restart resolves normally", () => {
-    const { sessionId } = openTerminalHere("/w/pkg");
-    useUIStore.getState().terminalClearRequestedCwd(sessionId!);
-    expect(useUIStore.getState().terminalPeekRequestedCwd(sessionId!)).toBeUndefined();
+    const sessionId = sessionIdOf(openTerminalHere("/w/pkg"));
+    useUIStore.getState().terminalClearRequestedCwd(sessionId);
+    expect(useUIStore.getState().terminalPeekRequestedCwd(sessionId)).toBeUndefined();
   });
 
   it("returns undefined for a session created without one", () => {
@@ -146,8 +152,8 @@ describe("requestedCwd peek/clear (WI-4.2)", () => {
   });
 
   it("clearing one session does not disturb another", () => {
-    const a = openTerminalHere("/w/a").sessionId!;
-    const b = openTerminalHere("/w/b").sessionId!;
+    const a = sessionIdOf(openTerminalHere("/w/a"));
+    const b = sessionIdOf(openTerminalHere("/w/b"));
     useUIStore.getState().terminalClearRequestedCwd(a);
     expect(useUIStore.getState().terminalPeekRequestedCwd(b)).toBe("/w/b");
   });

--- a/src/services/terminal/openTerminalHere.ts
+++ b/src/services/terminal/openTerminalHere.ts
@@ -25,23 +25,24 @@
  * @coordinates-with services/terminal/revealTerminalSession.ts — shared create + reveal
  * @module services/terminal/openTerminalHere
  */
-import { useUIStore, MAX_TERMINAL_SESSIONS } from "@/stores/uiStore";
+import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
+import { canCreateTerminalSessionHere } from "./createTerminalSession";
 import { createTerminalSessionAt } from "./revealTerminalSession";
 
 /** Why an "Open Terminal Here" request could not be satisfied. */
 type OpenTerminalHereFailure = "no-directory" | "max-sessions";
 
-export interface OpenTerminalHereResult {
-  ok: boolean;
-  /** Set when `ok` is false. */
-  reason?: OpenTerminalHereFailure;
-  /** The new session's id, when one was created. */
-  sessionId?: string;
-}
+/** Discriminated on `ok` (audit 20260831 #21): `{ok:true}` without a session
+ *  id, or `{ok:false}` with one, are unrepresentable. */
+export type OpenTerminalHereResult =
+  | { ok: true; sessionId: string }
+  | { ok: false; reason: OpenTerminalHereFailure };
 
-/** True when another terminal session can still be created. */
+/** True when another terminal session can still be created — the
+ *  AUTHORITATIVE creation predicate (audit 20260831 #20): the same
+ *  owner-aware union the slice's cap gate applies, never a bare count. */
 export function canOpenTerminalHere(): boolean {
-  return useUIStore.getState().terminal.sessions.length < MAX_TERMINAL_SESSIONS;
+  return canCreateTerminalSessionHere(getCurrentWindowLabel());
 }
 
 /**

--- a/src/services/terminal/resolveTerminalOwnerInstanceId.test.ts
+++ b/src/services/terminal/resolveTerminalOwnerInstanceId.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+// WI-TS1.1 — the ONE owner-stamping rule and its three carve-outs (D-T1):
+// placeholder, mid-restore, rail-off. Real stores; nothing terminal-side mocked.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+import {
+  beginWindowContextRestore,
+  endWindowContextRestore,
+} from "@/services/workspaces/switchWorkspaceInstance";
+import { resolveTerminalOwnerInstanceId } from "./resolveTerminalOwnerInstanceId";
+
+const W = "main";
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function addWorkspace(id: string, rootPath: string): void {
+  const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+  if (!root.ok) throw new Error("bad test root");
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: id,
+      root: root.root,
+      ownerWindowLabel: W,
+      createdFrom: "open",
+    }),
+  );
+}
+
+beforeEach(() => {
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  useWorkspaceStore.getState().closeWorkspace();
+  setRail(true);
+});
+
+afterEach(() => {
+  endWindowContextRestore(W);
+  setRail(false);
+});
+
+describe("resolveTerminalOwnerInstanceId (D-T1)", () => {
+  it("returns the active workspace instance's id in the ordinary case", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    expect(resolveTerminalOwnerInstanceId(W)).toBe("wsi-a");
+  });
+
+  it("returns a LOOSE instance's id — loose is a real owner (D-T6 rekey merges follow it)", () => {
+    const loose = useWorkspaceInstancesStore.getState().ensureLooseInstance(W);
+    expect(resolveTerminalOwnerInstanceId(W)).toBe(loose.workspaceInstanceId);
+  });
+
+  it("carve-out 1: never stamps a placeholder instance's id", () => {
+    useWorkspaceInstancesStore
+      .getState()
+      .ensurePlaceholderInstance(W, "wsi-placeholder-1");
+    expect(resolveTerminalOwnerInstanceId(W)).toBeUndefined();
+  });
+
+  it("carve-out 2: never stamps while the window's restore is in flight", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+
+    beginWindowContextRestore(W);
+    expect(resolveTerminalOwnerInstanceId(W)).toBeUndefined();
+
+    endWindowContextRestore(W);
+    expect(resolveTerminalOwnerInstanceId(W)).toBe("wsi-a");
+  });
+
+  it("carve-out 3: never stamps while the rail is off", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+    setRail(false);
+    expect(resolveTerminalOwnerInstanceId(W)).toBeUndefined();
+  });
+
+  it("returns undefined on the legacy fallback (rail on, no active instance)", () => {
+    expect(resolveTerminalOwnerInstanceId(W)).toBeUndefined();
+  });
+});

--- a/src/services/terminal/resolveTerminalOwnerInstanceId.ts
+++ b/src/services/terminal/resolveTerminalOwnerInstanceId.ts
@@ -1,0 +1,36 @@
+/**
+ * resolveTerminalOwnerInstanceId — THE owner-stamping rule (WI-TS1.1, D-T1).
+ *
+ * Purpose: every terminal-session creator resolves the session's owning
+ * workspace instance through this ONE helper, so the three carve-outs cannot
+ * drift between call sites:
+ *
+ *   1. Never stamp a PLACEHOLDER instance's id — placeholders are deleted
+ *      silently by addWorkspaceInstance/ensureLooseInstance with no lifecycle
+ *      follower, which would strand a stamped session invisibly with a live
+ *      PTY (invariant 3: every stamped owner exists).
+ *   2. Never stamp while the window's hot-exit restore is in flight — a
+ *      mid-restore auto-create would bind to the pre-reconcile active id.
+ *   3. Never stamp while the rail is OFF — rail-off behaves exactly as today
+ *      (D-T15); scoping is a rail-mode concept.
+ *
+ * Returns undefined in every carve-out ⇒ the session is window-scoped and
+ * gets ADOPTED by the active instance on the next switch/hydrate.
+ *
+ * @coordinates-with stores/uiStore/terminalSlice.ts — terminalCreateSession consumer
+ * @module services/terminal/resolveTerminalOwnerInstanceId
+ */
+import { isWorkspaceRailEnabled } from "@/services/featureFlags/workspaceRailFeatureFlag";
+import { isWindowContextRestoring } from "@/services/workspaces/switchWorkspaceInstance";
+import { getActiveWorkspaceScope } from "@/services/workspaces/activeWorkspaceScope";
+
+/** Owner instance id for a session created NOW in this window, or undefined
+ *  (window-scoped) per the three D-T1 carve-outs. */
+export function resolveTerminalOwnerInstanceId(windowLabel: string): string | undefined {
+  if (!isWorkspaceRailEnabled()) return undefined;
+  if (isWindowContextRestoring(windowLabel)) return undefined;
+  const scope = getActiveWorkspaceScope(windowLabel);
+  if (!scope.workspaceInstanceId) return undefined;
+  if (scope.kind === "placeholder") return undefined;
+  return scope.workspaceInstanceId;
+}

--- a/src/services/terminal/revealTerminalSession.test.ts
+++ b/src/services/terminal/revealTerminalSession.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+// WI-TS4.2 / audit 20260831 R2-4 — reuse-or-create over the VISIBLE
+// population. The membership check is the point (#18): a rail toggle
+// sequence can leave activeSessionId pointing at a HIDDEN session, and
+// reusing it would paste into a shell the user cannot see. Real stores.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import {
+  MAX_TERMINAL_SESSIONS,
+  resetTerminalSessionStore,
+  useUIStore,
+} from "@/stores/uiStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+import {
+  createTerminalSessionAt,
+  reuseOrCreateTerminalSession,
+} from "./revealTerminalSession";
+
+const W = "main";
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function addWorkspace(id: string, rootPath: string): void {
+  const root = createWorkspaceRootIdentity(rootPath, { platform: "macos" });
+  if (!root.ok) throw new Error("bad test root");
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: id,
+      root: root.root,
+      ownerWindowLabel: W,
+      createdFrom: "open",
+    }),
+  );
+}
+
+function createOwned(owner?: string): string {
+  const created = useUIStore
+    .getState()
+    .terminalCreateSession(owner ? { ownerInstanceId: owner } : undefined);
+  if (!created) throw new Error("cap hit in test setup");
+  return created.id;
+}
+
+const term = () => useUIStore.getState().terminal;
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+  useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+  useWorkspaceStore.getState().closeWorkspace();
+  if (useUIStore.getState().terminalVisible) useUIStore.getState().toggleTerminal();
+  setRail(true);
+  addWorkspace("wsi-a", "/repo-a");
+  addWorkspace("wsi-b", "/repo-b");
+  useWorkspaceInstancesStore.getState().activateWorkspaceInstance(W, "wsi-a");
+});
+
+afterEach(() => {
+  setRail(false);
+});
+
+describe("reuseOrCreateTerminalSession", () => {
+  it("reuses a VISIBLE active session and reveals the panel", () => {
+    const a1 = createOwned("wsi-a");
+    expect(reuseOrCreateTerminalSession()).toBe(a1);
+    expect(term().activeSessionId).toBe(a1);
+    expect(useUIStore.getState().terminalVisible).toBe(true);
+  });
+
+  it("falls back past a STALE HIDDEN active to the first visible session (R2-4)", () => {
+    const a1 = createOwned("wsi-a");
+    const b1 = createOwned("wsi-b"); // hidden — wsi-a is active
+    useUIStore.getState().terminalSetActiveSession(b1); // the stale state
+
+    const chosen = reuseOrCreateTerminalSession();
+
+    expect(chosen).toBe(a1);
+    // The fallback is ACTIVATED, so the command lands in the session on screen.
+    expect(term().activeSessionId).toBe(a1);
+  });
+
+  it("creates an owner-stamped session over an empty visible scope", () => {
+    createOwned("wsi-b"); // hidden; the visible scope is empty
+    const chosen = reuseOrCreateTerminalSession();
+    const created = term().sessions.find((s) => s.id === chosen);
+    expect(created?.workspaceInstanceId).toBe("wsi-a");
+    expect(term().activeSessionId).toBe(chosen);
+    expect(useUIStore.getState().terminalVisible).toBe(true);
+  });
+});
+
+describe("createTerminalSessionAt", () => {
+  it("creates a new pinned session even when one is active, stamped to the scope", () => {
+    const a1 = createOwned("wsi-a");
+    const id = createTerminalSessionAt("/w/pkg");
+    expect(id).not.toBeNull();
+    expect(id).not.toBe(a1);
+    const created = term().sessions.find((s) => s.id === id);
+    expect(created?.requestedCwd).toBe("/w/pkg");
+    expect(created?.workspaceInstanceId).toBe("wsi-a");
+    expect(useUIStore.getState().terminalVisible).toBe(true);
+  });
+
+  it("returns null at the creation-union cap and does not reveal the panel", () => {
+    for (let i = 0; i < MAX_TERMINAL_SESSIONS; i++) createOwned("wsi-a");
+    expect(createTerminalSessionAt("/w/pkg")).toBeNull();
+    expect(useUIStore.getState().terminalVisible).toBe(false);
+  });
+});

--- a/src/services/terminal/revealTerminalSession.ts
+++ b/src/services/terminal/revealTerminalSession.ts
@@ -17,6 +17,9 @@
  * @module services/terminal/revealTerminalSession
  */
 import { useUIStore } from "@/stores/uiStore";
+import { getCurrentWindowLabel } from "@/services/persistence/workspaceStorage";
+import { getVisibleTerminalSessions } from "./visibleTerminalSessions";
+import { createTerminalSessionInScope } from "./createTerminalSession";
 
 /** Make the panel visible. Revealing nothing looks like the command failed. */
 function revealPanel(): void {
@@ -26,30 +29,53 @@ function revealPanel(): void {
 }
 
 /**
- * Take the active session, or create one on an empty panel, and reveal the
- * panel. Returns a session id ALWAYS — the two outcomes are exhaustive: a
- * non-empty panel has a session to reuse, and an empty panel is by definition
- * below MAX_TERMINAL_SESSIONS so creation cannot fail. Typing it non-nullable
- * means callers have no dead "couldn't get one" branch to carry.
+ * Take the active session — verified to be VISIBLE — or the first visible
+ * one, or create one on an empty visible scope, and reveal the panel
+ * (WI-TS4.2/D-T10). The membership check matters (audit 20260831 #18): the
+ * active id is normally a member of the visible population (invariant 2),
+ * but a rail toggle sequence (off → activate another scope's session → on)
+ * can leave it pointing at a HIDDEN session, and reusing that would paste
+ * into a shell the user cannot see. A fallback pick is also activated, so
+ * the session that receives the command is the session on screen.
  */
 export function reuseOrCreateTerminalSession(): string {
   const store = useUIStore.getState();
+  const windowLabel = getCurrentWindowLabel();
+  const visible = getVisibleTerminalSessions(windowLabel);
+  const activeId = store.terminal.activeSessionId;
   const existing =
-    store.terminal.activeSessionId ?? store.terminal.sessions[0]?.id ?? null;
-  // Non-null assertion is sound: `sessions` is empty here, so the cap check
-  // inside terminalCreateSession cannot trip.
-  const sessionId = existing ?? store.terminalCreateSession()!.id;
+    activeId && visible.some((s) => s.id === activeId)
+      ? activeId
+      : visible[0]?.id ?? null;
+  if (existing) {
+    if (existing !== activeId) store.terminalSetActiveSession(existing);
+    revealPanel();
+    return existing;
+  }
+  const created = createTerminalSessionInScope(windowLabel);
+  if (!created) {
+    // Unreachable by construction: an empty visible population is below the
+    // creation-union cap in every state that resolves no owner (D-T5). Fail
+    // loud at the origin rather than dereferencing null if that argument
+    // ever stops holding (audit 20260831 #19).
+    throw new Error(
+      "reuseOrCreateTerminalSession: creation refused over an empty visible scope",
+    );
+  }
   revealPanel();
-  return sessionId;
+  return created.id;
 }
 
 /**
  * Create a NEW session pinned to `requestedCwd` and reveal the panel — what
- * "Open Terminal Here" means, even when other sessions are running. Returns
- * null at MAX_TERMINAL_SESSIONS, which is a state the user can really reach.
+ * "Open Terminal Here" means, even when other sessions are running. Stamped
+ * with the active scope's owner (D-T1). Returns null at the creation-union
+ * cap, which is a state the user can really reach.
  */
 export function createTerminalSessionAt(requestedCwd: string): string | null {
-  const created = useUIStore.getState().terminalCreateSession({ requestedCwd });
+  const created = createTerminalSessionInScope(getCurrentWindowLabel(), {
+    requestedCwd,
+  });
   if (!created) return null;
   revealPanel();
   return created.id;

--- a/src/services/terminal/runInTerminal.test.ts
+++ b/src/services/terminal/runInTerminal.test.ts
@@ -6,6 +6,8 @@
 //   2. a multi-line payload is REFUSED when the shell has not enabled
 //      bracketed paste — because term.paste rewrites "\n" to "\r", and without
 //      bracketed paste each "\r" executes the line on arrival.
+// WI-TS4.2 — delivery stays PINNED to the session id captured at request
+// time: a rail switch mid-delivery must not redirect the payload.
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const { mockGetTerminal } = vi.hoisted(() => ({ mockGetTerminal: vi.fn() }));
@@ -372,5 +374,38 @@ describe("runInTerminal (WI-4.3)", () => {
     expect(result).toEqual({ ok: true });
     expect(paste).toHaveBeenCalledWith("echo hi");
     raf.mockRestore();
+  });
+});
+
+describe("id-pinned delivery across a rail switch (WI-TS4.2, D-T10)", () => {
+  beforeEach(() => {
+    resetTerminalSessionStore();
+    if (useUIStore.getState().terminalVisible) useUIStore.getState().toggleTerminal();
+    mockGetTerminal.mockReset();
+  });
+
+  it("delivers to the ORIGINALLY targeted session after the visible scope swaps mid-delivery", async () => {
+    const first = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-a" })!;
+    const paste = vi.fn();
+    const focus = vi.fn();
+    let frames = 0;
+    // The terminal only becomes reachable a few frames in — the window in
+    // which a real user can click another workspace on the rail.
+    mockGetTerminal.mockImplementation(() =>
+      ++frames >= 3 ? { paste, focus, modes: { bracketedPasteMode: true } } : null,
+    );
+
+    const pending = runInTerminal("make build", "bash");
+    // Rail switch lands mid-delivery: A's scope hides, nothing is active.
+    useUIStore.getState().terminalSwitchScope("wsi-a", "wsi-b");
+    expect(useUIStore.getState().terminal.activeSessionId).toBeNull();
+
+    const result = await pending;
+
+    expect(result).toEqual({ ok: true });
+    expect(mockGetTerminal).toHaveBeenLastCalledWith(first.id);
+    expect(paste).toHaveBeenCalledWith("make build");
   });
 });

--- a/src/services/terminal/terminalCdFollow.test.ts
+++ b/src/services/terminal/terminalCdFollow.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+// WI-TS2.1 / audit 20260831 R2-3 — THE cd-follow predicate. The unknown-id
+// branch is the load-bearing one: a pendingRoot can flush AFTER its session
+// was removed, and writing a cd into a dying shell is wrong in EITHER rail
+// mode (#16 — the rail-off early return used to say yes). Real stores.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import { shouldFollowWorkspaceCd } from "./terminalCdFollow";
+
+function setRail(enabled: boolean): void {
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: enabled },
+  });
+}
+
+function createSession(owner?: string): string {
+  const created = useUIStore
+    .getState()
+    .terminalCreateSession(owner ? { ownerInstanceId: owner } : undefined);
+  if (!created) throw new Error("cap hit in test setup");
+  return created.id;
+}
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+});
+
+afterEach(() => {
+  setRail(false);
+});
+
+describe("shouldFollowWorkspaceCd", () => {
+  it.each([true, false])(
+    "unknown session id never follows (rail %s) — mid-teardown guard",
+    (rail) => {
+      setRail(rail);
+      expect(shouldFollowWorkspaceCd("term-gone")).toBe(false);
+    },
+  );
+
+  it("rail on: a window-scoped session follows", () => {
+    setRail(true);
+    expect(shouldFollowWorkspaceCd(createSession())).toBe(true);
+  });
+
+  it("rail on: an owner-stamped session keeps its own cwd", () => {
+    setRail(true);
+    expect(shouldFollowWorkspaceCd(createSession("wsi-a"))).toBe(false);
+  });
+
+  it("rail off: every EXISTING session follows — stamps are inert (D-T15)", () => {
+    setRail(false);
+    expect(shouldFollowWorkspaceCd(createSession())).toBe(true);
+    expect(shouldFollowWorkspaceCd(createSession("wsi-a"))).toBe(true);
+  });
+
+  it("resolves the owner at CHECK time, not capture time", () => {
+    setRail(true);
+    const id = createSession();
+    expect(shouldFollowWorkspaceCd(id)).toBe(true);
+    // Adoption stamps the session after the pendingRoot was recorded —
+    // the flush must now refuse.
+    useUIStore.getState().terminalAdoptUnscopedSessions("wsi-a");
+    expect(shouldFollowWorkspaceCd(id)).toBe(false);
+  });
+});

--- a/src/services/terminal/terminalCdFollow.ts
+++ b/src/services/terminal/terminalCdFollow.ts
@@ -1,0 +1,38 @@
+/**
+ * terminalCdFollow — THE cd-follow predicate (WI-TS2.1, D-T4/D-T15).
+ *
+ * Purpose: workspace-root changes auto-`cd` only EFFECTIVELY WINDOW-SCOPED
+ * sessions. A session stamped with an owning workspace instance keeps its own
+ * cwd — its workspace never "changes" under it; a rail switch hides it
+ * instead (D-T3). One predicate, applied at every cd site: the syncRoot loop,
+ * the null-root invalidation, the post-spawn catch-up, and inside
+ * flushPendingRoot (the OSC-133 idle flush — an independent cd path).
+ *
+ * Rail-aware (D-T15): with the rail OFF every session is followable — stamps
+ * are inert, never consulted, so behavior is byte-identical to pre-scoping.
+ *
+ * @coordinates-with components/Terminal/terminalSessionStoreSync.ts — sync + flush sites
+ * @coordinates-with components/Terminal/useTerminalShellLifecycle.ts — post-spawn site
+ * @module services/terminal/terminalCdFollow
+ */
+import { isWorkspaceRailEnabled } from "@/services/featureFlags/workspaceRailFeatureFlag";
+import { useUIStore } from "@/stores/uiStore";
+
+/**
+ * Should a workspace-root change write a `cd` into this session?
+ * Owner is resolved from the store AT CHECK TIME (not captured), so a session
+ * adopted after a pendingRoot was recorded is correctly refused at flush.
+ */
+export function shouldFollowWorkspaceCd(sessionId: string): boolean {
+  const session = useUIStore
+    .getState()
+    .terminal.sessions.find((s) => s.id === sessionId);
+  // Unknown id ⇒ the session is mid-teardown; never write into a dying shell
+  // in EITHER rail mode (audit 20260831 #16 — the rail-off early return used
+  // to treat an unknown session as followable, contradicting this guard).
+  if (session === undefined) return false;
+  // Rail off ⇒ every existing session follows, exactly as before scoping —
+  // stamps are inert (D-T15).
+  if (!isWorkspaceRailEnabled()) return true;
+  return !session.workspaceInstanceId;
+}

--- a/src/services/terminal/visibleTerminalSessions.ts
+++ b/src/services/terminal/visibleTerminalSessions.ts
@@ -1,0 +1,44 @@
+/**
+ * visibleTerminalSessions — imperative face of the ONE visibility rule
+ * (WI-TS3.1, plan invariant 7).
+ *
+ * Purpose: non-React callers (key handler, panel-close logic, pickers,
+ * auto-create) resolve the window's visible terminal population here; React
+ * components use useVisibleTerminalSessions. Both delegate to the pure
+ * selector so the rule cannot fork.
+ *
+ * @coordinates-with stores/uiStore/terminalScopeSelectors.ts — the pure rule
+ * @coordinates-with components/Terminal/useVisibleTerminalSessions.ts — React face
+ * @module services/terminal/visibleTerminalSessions
+ */
+import { isWorkspaceRailEnabled } from "@/services/featureFlags/workspaceRailFeatureFlag";
+import { useUIStore } from "@/stores/uiStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { selectVisibleTerminalSessions } from "@/stores/uiStore/terminalScopeSelectors";
+import type { TerminalSession } from "@/stores/uiStore/types";
+
+/** The window's currently-visible terminal sessions (live store read). */
+export function getVisibleTerminalSessions(windowLabel: string): TerminalSession[] {
+  const activeInstanceId =
+    useWorkspaceInstancesStore.getState().windows[windowLabel]
+      ?.activeWorkspaceInstanceId ?? null;
+  return selectVisibleTerminalSessions(
+    useUIStore.getState().terminal,
+    activeInstanceId,
+    isWorkspaceRailEnabled(),
+  );
+}
+
+/**
+ * Realign the active session to the window's CURRENT visible population
+ * (R2-15, audit round 2). A rail-MODE toggle changes what is visible with no
+ * scope switch, so no scope action fires — without this, a session hidden by
+ * the toggle could stay "active" over an empty tab bar, and the emptiness
+ * check in auto-create would see a population it cannot activate. Idempotent:
+ * a visible active session is left alone.
+ */
+export function realignTerminalActiveToVisible(windowLabel: string): void {
+  useUIStore
+    .getState()
+    .terminalRealignActive(getVisibleTerminalSessions(windowLabel).map((s) => s.id));
+}

--- a/src/services/windowClose/windowCloseFlow.ts
+++ b/src/services/windowClose/windowCloseFlow.ts
@@ -39,6 +39,7 @@ import i18n from "@/i18n";
 import { useDocumentStore, type DocumentState } from "@/stores/documentStore";
 import { useTabStore } from "@/stores/tabStore";
 import { usePaneStore } from "@/stores/paneStore";
+import { useClosedTabScopesStore } from "@/stores/tabStoreClosedScopes";
 import {
   promptSaveForDirtyDocument,
   promptSaveForMultipleDocuments,
@@ -142,6 +143,10 @@ async function finalizeWindowClose(
   freshTabs.forEach((tab) => useDocumentStore.getState().removeDocument(tab.id));
   useTabStore.getState().removeWindow(windowLabel);
   usePaneStore.getState().removeWindow(windowLabel); // #1081 M3
+  // R3-5: the closed-tab reopen history is per-window state too — without
+  // this, a surviving process (window closed, app alive) kept every closed
+  // window's scopes forever, and the action had no production caller at all.
+  useClosedTabScopesStore.getState().removeWindowClosedScopes(windowLabel);
   return true;
 }
 

--- a/src/services/workspaces/closeWorkspaceInstance.test.ts
+++ b/src/services/workspaces/closeWorkspaceInstance.test.ts
@@ -22,6 +22,7 @@ import { useTabStore, type Tab } from "@/stores/tabStore";
 import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
 import { createWorkspaceInstance, createWorkspaceRootIdentity } from "@/utils/workspaceIdentity";
 import { closeWorkspaceInstance } from "./closeWorkspaceInstance";
+import { resetInstanceOperationLocks } from "./instanceOperationLock";
 
 function seedInstance(windowLabel: string, instanceId: string, path: string, tabIds: string[]) {
   const rootResult = createWorkspaceRootIdentity(path);
@@ -74,6 +75,7 @@ const idsIn = (windowLabel: string) =>
   useWorkspaceInstancesStore.getState().windows[windowLabel]?.workspaceInstanceIds ?? [];
 
 beforeEach(() => {
+  resetInstanceOperationLocks();
   useWorkspaceInstancesStore.setState({ instances: {}, windows: {} });
   useTabStore.setState({ tabs: {}, activeTabId: {}, untitledCounter: 0, closedTabs: {} });
   closeTabsWithDirtyCheck.mockReset().mockResolvedValue(true);
@@ -203,5 +205,67 @@ describe("closeWorkspaceInstance", () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("missing");
     expect(closeTabsWithDirtyCheck).not.toHaveBeenCalled();
+  });
+});
+
+describe("tabs appearing during the dirty prompt (audit 20260831 #24)", () => {
+  it("re-collects and closes tabs that were opened into the workspace mid-prompt", async () => {
+    seedInstance("doc-1", "wsi-a", "/tmp/alpha", ["tab-1"]);
+    addTab("doc-1", "tab-1", "/tmp/alpha/one.md");
+
+    const closedBatches: string[][] = [];
+    let injected = false;
+    const result = await closeWorkspaceInstance("doc-1", "wsi-a", {
+      closeTabs: async (windowLabel, tabIds) => {
+        closedBatches.push([...tabIds]);
+        // The injected closer actually removes what it was handed.
+        useTabStore.setState((state) => ({
+          tabs: {
+            ...state.tabs,
+            [windowLabel]: (state.tabs[windowLabel] ?? []).filter(
+              (t) => !tabIds.includes(t.id),
+            ),
+          },
+        }));
+        if (!injected) {
+          injected = true;
+          // A tab lands in the workspace WHILE the prompt is up — the old
+          // single-snapshot flow removed the instance and orphaned it.
+          addTab("doc-1", "tab-late", "/tmp/alpha/late.md");
+        }
+        return true;
+      },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(closedBatches[0]).toEqual(["tab-1"]);
+    expect(closedBatches[1]).toEqual(["tab-late"]);
+    expect(useTabStore.getState().tabs["doc-1"] ?? []).toHaveLength(0);
+    expect(idsIn("doc-1")).toEqual([]);
+  });
+});
+
+describe("convergence bound (audit round 2, R2-12)", () => {
+  it("gives up with busy when fresh tabs keep appearing every pass", async () => {
+    seedInstance("doc-1", "wsi-a", "/tmp/alpha", ["tab-1"]);
+    addTab("doc-1", "tab-1", "/tmp/alpha/one.md");
+    // Pathological churn: every prompt round, a NEW owned tab lands in the
+    // workspace, so the re-collect never converges.
+    let n = 0;
+    closeTabsWithDirtyCheck.mockImplementation(async () => {
+      n += 1;
+      addTab("doc-1", `tab-churn-${n}`, `/tmp/alpha/churn-${n}.md`);
+      return true;
+    });
+
+    const result = await closeWorkspaceInstance("doc-1", "wsi-a", {
+      closeTabs: closeTabsWithDirtyCheck,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "busy" });
+    // Bounded: exactly MAX_CLOSE_CONVERGENCE_PASSES rounds, then stop — the
+    // instance survives (the safe side; nothing was force-removed).
+    expect(closeTabsWithDirtyCheck).toHaveBeenCalledTimes(5);
+    expect(idsIn("doc-1")).toContain("wsi-a");
   });
 });

--- a/src/services/workspaces/closeWorkspaceInstance.ts
+++ b/src/services/workspaces/closeWorkspaceInstance.ts
@@ -35,13 +35,13 @@
  * @module services/workspaces/closeWorkspaceInstance
  */
 
-import { invoke } from "@tauri-apps/api/core";
 import { useTabStore } from "@/stores/tabStore";
-import { useWorkspaceInstanceUiStore } from "@/stores/workspaceInstanceUiStore";
-import { useWorkspacePaneLayoutsStore } from "@/stores/workspacePaneLayoutsStore";
 import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
-import { generateUUID } from "@/utils/workspaceIdentity";
-import { workspaceError } from "@/utils/debug";
+import { finalizeInstanceRemoval } from "./finalizeInstanceRemoval";
+import {
+  acquireInstanceOperation,
+  releaseInstanceOperation,
+} from "./instanceOperationLock";
 import { tabBelongsToWorkspace } from "./workspaceTabCollection";
 
 export type CloseWorkspaceInstanceResult =
@@ -62,15 +62,22 @@ export interface CloseWorkspaceInstanceOptions {
   closeTabs: (windowLabel: string, tabIds: string[]) => Promise<boolean>;
 }
 
+// Concurrency: closing awaits a save prompt, during which the menu item can
+// be activated again — the second call would see tabs the first is already
+// closing as "closed" and remove the instance under it. The guard is the
+// SHARED per-instance operation lock (instanceOperationLock.ts, R2-14), so a
+// close is also excluded against an in-flight move/duplicate of the same
+// instance, not merely against another close.
+
 /**
- * Instances with a close in flight.
- *
- * Closing awaits a save prompt, during which the menu item can be activated
- * again. Without this guard the second call sees tabs the first is already
- * closing as "closed", removes the instance and closes the window while the
- * first is still waiting on the user.
+ * How many times the close loop re-collects tabs that appeared DURING a dirty
+ * prompt before giving up with `busy` (R2-12). Each pass only closes NEWLY
+ * appeared ids, so hitting the bound requires fresh tabs to keep landing in
+ * this workspace across five consecutive prompt rounds — pathological churn,
+ * not a user flow. Bounded so it cannot spin forever; `busy` leaves the
+ * instance in place, which is the safe side.
  */
-const closing = new Set<string>();
+const MAX_CLOSE_CONVERGENCE_PASSES = 5;
 
 /** Live owned tab ids, by the same ownership rule transfer uses. */
 function ownedTabIds(windowLabel: string, workspaceInstanceId: string): string[] | null {
@@ -96,51 +103,54 @@ export async function closeWorkspaceInstance(
   workspaceInstanceId: string,
   { closeTabs }: CloseWorkspaceInstanceOptions,
 ): Promise<CloseWorkspaceInstanceResult> {
-  if (closing.has(workspaceInstanceId)) return { ok: false, reason: "busy" };
-
-  const tabIds = ownedTabIds(windowLabel, workspaceInstanceId);
-  if (tabIds === null) return { ok: false, reason: "missing" };
-
-  closing.add(workspaceInstanceId);
+  if (!acquireInstanceOperation(workspaceInstanceId)) {
+    return { ok: false, reason: "busy" };
+  }
   try {
-    const allClosed = await closeTabs(windowLabel, tabIds);
-    if (!allClosed) {
-      // Leave the instance in place. Tabs closed before the cancelled prompt
-      // stay closed (see CANCELLATION above) — the guarantee is that the
-      // workspace and its window survive.
-      return { ok: false, reason: "cancelled" };
-    }
+    const tabIds = ownedTabIds(windowLabel, workspaceInstanceId);
+    if (tabIds === null) return { ok: false, reason: "missing" };
 
-    // Re-validate after the await: the instance may have moved or been removed
-    // while the prompts were open, and the invariants below must not run
-    // against a window this workspace no longer belongs to.
-    if (ownedTabIds(windowLabel, workspaceInstanceId) === null) {
-      return { ok: false, reason: "missing" };
+    // Audit 20260831 #24: tabs can be OPENED into (or reassigned to) this
+    // workspace while a dirty prompt is up, and removing the instance after a
+    // stale snapshot would orphan them. After each pass, re-collect and close
+    // any ids that NEWLY appeared — ids already handed to the injected closer
+    // are its responsibility (the pre-existing contract), so only fresh ones
+    // loop. Bounded so pathological churn cannot spin forever; closeTabs is
+    // always consulted at least once, empty list included — its verdict is
+    // the user's answer.
+    const attempted = new Set<string>();
+    let toClose: string[] = tabIds;
+    let freshRemaining = false;
+    for (let attempt = 0; attempt < MAX_CLOSE_CONVERGENCE_PASSES; attempt++) {
+      for (const id of toClose) attempted.add(id);
+      const allClosed = await closeTabs(windowLabel, toClose);
+      if (!allClosed) {
+        // Leave the instance in place. Tabs closed before the cancelled
+        // prompt stay closed (see CANCELLATION above) — the guarantee is that
+        // the workspace and its window survive.
+        return { ok: false, reason: "cancelled" };
+      }
+      // Re-validate after the await: the instance may have moved or been
+      // removed while the prompts were open.
+      const recollected = ownedTabIds(windowLabel, workspaceInstanceId);
+      if (recollected === null) return { ok: false, reason: "missing" };
+      const fresh = recollected.filter((id) => !attempted.has(id));
+      freshRemaining = fresh.length > 0;
+      if (!freshRemaining) break;
+      toClose = fresh;
     }
+    if (freshRemaining) return { ok: false, reason: "busy" };
 
-    const store = useWorkspaceInstancesStore.getState();
-    store.removeWorkspaceInstance(windowLabel, workspaceInstanceId);
-    // WI-9.1/10.2 lifecycle: a closed instance's parallel per-instance state
-    // (UI, pane snapshot) must not linger as orphans.
-    useWorkspaceInstanceUiStore.getState().removeInstanceUiState(workspaceInstanceId);
-    useWorkspacePaneLayoutsStore.getState().removePaneLayout(workspaceInstanceId);
-
-    if (windowLabel === "main") {
-      // main is never closed, so it must never be left with an empty rail.
-      store.ensurePlaceholderInstance("main", `wsi-placeholder-${generateUUID()}`);
-    } else if (
-      useWorkspaceInstancesStore.getState().windows[windowLabel]?.workspaceInstanceIds
-        .length === 0
-    ) {
-      // Don't drop the rejection — a failed close should surface in logs rather
-      // than become an unhandled promise rejection.
-      void invoke("close_window", { label: windowLabel }).catch((error) => {
-        workspaceError("Failed to close emptied window:", error);
-      });
-    }
+    // The shared post-removal lifecycle (audit #25/#26): store removal,
+    // per-instance UI/pane cleanup, terminal + closed-history cleanup, the
+    // placeholder/empty-window invariants, and FULL successor hydration when
+    // the closed instance was active.
+    await finalizeInstanceRemoval(windowLabel, workspaceInstanceId, {
+      cleanupPerInstanceUi: true,
+    });
 
     return { ok: true };
   } finally {
-    closing.delete(workspaceInstanceId);
+    releaseInstanceOperation(workspaceInstanceId);
   }
 }

--- a/src/services/workspaces/finalizeInstanceRemoval.test.ts
+++ b/src/services/workspaces/finalizeInstanceRemoval.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment node
+// Audit 20260831 R2-10 — the ONE post-removal lifecycle. Close and move had
+// grown drifting copies before it existed; these tests pin the dispatch
+// table: what each mode cleans, what move deliberately leaves (rail-plan gap
+// G2), the main-placeholder / empty-window invariants, and successor
+// hydration only when the removed instance was ACTIVE.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.fn();
+const hydrateWorkspaceInstanceContext = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
+vi.mock("./hydrateWorkspaceInstanceContext", () => ({
+  hydrateWorkspaceInstanceContext: (...args: unknown[]) =>
+    hydrateWorkspaceInstanceContext(...args),
+}));
+
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import { useClosedTabScopesStore } from "@/stores/tabStoreClosedScopes";
+import { useWorkspaceInstanceUiStore } from "@/stores/workspaceInstanceUiStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { useWorkspacePaneLayoutsStore } from "@/stores/workspacePaneLayoutsStore";
+import type { Tab } from "@/stores/tabStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+import { finalizeInstanceRemoval } from "./finalizeInstanceRemoval";
+
+function seedInstance(windowLabel: string, instanceId: string, path: string): void {
+  const rootResult = createWorkspaceRootIdentity(path, { platform: "macos" });
+  if (!rootResult.ok) throw new Error("bad test root");
+  const instance = createWorkspaceInstance({
+    workspaceInstanceId: instanceId,
+    root: rootResult.root,
+    ownerWindowLabel: windowLabel,
+    createdFrom: "open",
+  });
+  useWorkspaceInstancesStore.setState((state) => ({
+    instances: { ...state.instances, [instanceId]: instance },
+    windows: {
+      ...state.windows,
+      [windowLabel]: {
+        windowLabel,
+        workspaceInstanceIds: [
+          ...(state.windows[windowLabel]?.workspaceInstanceIds ?? []),
+          instanceId,
+        ],
+        activeWorkspaceInstanceId:
+          state.windows[windowLabel]?.activeWorkspaceInstanceId ?? instanceId,
+      },
+    },
+  }));
+}
+
+/** Seed the parallel per-instance state the finalizer is expected to manage. */
+function seedParallelState(windowLabel: string, instanceId: string): void {
+  useWorkspaceInstanceUiStore
+    .getState()
+    .updateInstanceUiState(instanceId, { sidebarWidth: 321 });
+  // enabled: true — stashPaneLayout deliberately DELETES a disabled split,
+  // so a disabled seed would never be stored in the first place.
+  useWorkspacePaneLayoutsStore.getState().stashPaneLayout(instanceId, {
+    enabled: true,
+    orientation: "horizontal",
+    fraction: 0.5,
+    primaryTabId: "t-1",
+    secondaryTabId: "t-2",
+    focusedPane: "primary",
+    syncScroll: false,
+  });
+  useUIStore.getState().terminalCreateSession({ ownerInstanceId: instanceId });
+  const tab: Tab = {
+    kind: "document",
+    id: `closed-${instanceId}`,
+    filePath: `/repo/${instanceId}.md`,
+    title: instanceId,
+    isPinned: false,
+    formatId: "markdown",
+  };
+  useClosedTabScopesStore.setState((state) => ({
+    scopesByWindow: {
+      ...state.scopesByWindow,
+      [windowLabel]: {
+        ...state.scopesByWindow[windowLabel],
+        [instanceId]: [{ tab, closedSeq: 1 }],
+      },
+    },
+  }));
+}
+
+const instancesState = () => useWorkspaceInstancesStore.getState();
+const uiStates = () => useWorkspaceInstanceUiStore.getState().instanceUiStates;
+const paneLayout = (id: string) =>
+  useWorkspacePaneLayoutsStore.getState().getPaneLayout(id);
+const terminalScopeSessions = (id: string) =>
+  useUIStore
+    .getState()
+    .terminal.sessions.filter((s) => s.workspaceInstanceId === id);
+const closedScope = (windowLabel: string, id: string) =>
+  useClosedTabScopesStore.getState().scopesByWindow[windowLabel]?.[id];
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+  useWorkspaceInstancesStore.setState({ instances: {}, windows: {} });
+  useWorkspaceInstanceUiStore.getState().resetInstanceUiStates();
+  useWorkspacePaneLayoutsStore.getState().resetPaneLayouts();
+  useClosedTabScopesStore.getState().resetClosedScopes();
+  invoke.mockReset().mockResolvedValue(undefined);
+  hydrateWorkspaceInstanceContext.mockReset().mockResolvedValue(undefined);
+});
+
+describe("finalizeInstanceRemoval — mode dispatch table (R2-10)", () => {
+  it.each([
+    { mode: "close", cleanupPerInstanceUi: true, uiSurvives: false },
+    { mode: "move", cleanupPerInstanceUi: false, uiSurvives: true },
+  ])(
+    "$mode: terminal scope + closed history always cleaned; UI/pane cleaned only on close",
+    async ({ cleanupPerInstanceUi, uiSurvives }) => {
+      seedInstance("main", "wsi-a", "/repo-a");
+      seedInstance("main", "wsi-b", "/repo-b");
+      seedParallelState("main", "wsi-b");
+
+      await finalizeInstanceRemoval("main", "wsi-b", { cleanupPerInstanceUi });
+
+      // Always: instance gone, terminal scope killed, closed history dropped.
+      expect(instancesState().instances["wsi-b"]).toBeUndefined();
+      expect(terminalScopeSessions("wsi-b")).toHaveLength(0);
+      expect(closedScope("main", "wsi-b")).toBeUndefined();
+      // Mode-dependent: move leaves UI/pane snapshots (rail-plan gap G2,
+      // deferred there — the finalizer must not silently half-fix it).
+      expect("wsi-b" in uiStates()).toBe(uiSurvives);
+      expect(paneLayout("wsi-b") !== null).toBe(uiSurvives);
+    },
+  );
+
+  it("main is never left with an empty rail — a placeholder is ensured", async () => {
+    seedInstance("main", "wsi-a", "/repo-a");
+
+    await finalizeInstanceRemoval("main", "wsi-a", { cleanupPerInstanceUi: true });
+
+    const ids = instancesState().windows["main"]?.workspaceInstanceIds ?? [];
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids.some((id) => instancesState().instances[id]?.kind === "placeholder")).toBe(
+      true,
+    );
+    expect(invoke).not.toHaveBeenCalledWith("close_window", expect.anything());
+  });
+
+  it("a non-main window emptied by the removal closes itself", async () => {
+    seedInstance("doc-1", "wsi-a", "/repo-a");
+
+    await finalizeInstanceRemoval("doc-1", "wsi-a", { cleanupPerInstanceUi: true });
+
+    expect(invoke).toHaveBeenCalledWith("close_window", { label: "doc-1" });
+  });
+
+  it("a non-main window with instances left does NOT close", async () => {
+    seedInstance("doc-1", "wsi-a", "/repo-a");
+    seedInstance("doc-1", "wsi-b", "/repo-b");
+
+    await finalizeInstanceRemoval("doc-1", "wsi-b", { cleanupPerInstanceUi: true });
+
+    expect(invoke).not.toHaveBeenCalledWith("close_window", expect.anything());
+  });
+
+  it("removing the ACTIVE instance hydrates the promoted successor's full context", async () => {
+    seedInstance("main", "wsi-a", "/repo-a"); // active (seeded first)
+    seedInstance("main", "wsi-b", "/repo-b");
+
+    await finalizeInstanceRemoval("main", "wsi-a", { cleanupPerInstanceUi: true });
+
+    expect(hydrateWorkspaceInstanceContext).toHaveBeenCalledWith("main");
+  });
+
+  it("removing an INACTIVE instance touches no context", async () => {
+    seedInstance("main", "wsi-a", "/repo-a"); // active
+    seedInstance("main", "wsi-b", "/repo-b");
+
+    await finalizeInstanceRemoval("main", "wsi-b", { cleanupPerInstanceUi: true });
+
+    expect(hydrateWorkspaceInstanceContext).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/workspaces/finalizeInstanceRemoval.ts
+++ b/src/services/workspaces/finalizeInstanceRemoval.ts
@@ -1,0 +1,83 @@
+/**
+ * finalizeInstanceRemoval — the ONE post-removal lifecycle for an instance
+ * leaving its window (audit 20260831 #25/#26): close and move had grown
+ * separate copies that were already drifting in which per-instance stores
+ * they cleaned and how much of the successor's context they restored.
+ *
+ * Covers: store removal, per-scope terminal kill (the reconcile disposes the
+ * PTYs — D-T6), closed-tab history cleanup, optional per-instance UI/pane
+ * cleanup, the main-window placeholder / empty-window-close invariants, and —
+ * when the removed instance was ACTIVE — the FULL context hydration of the
+ * promoted successor (panes, active tab, sidebar root, config, terminal
+ * realign), not just the terminal slice.
+ *
+ * @coordinates-with closeWorkspaceInstance.ts — cleanupPerInstanceUi: true
+ * @coordinates-with workspaceWindowActions.ts — move; UI/pane state stays (rail-plan gap G2, deferred)
+ * @module services/workspaces/finalizeInstanceRemoval
+ */
+import { invoke } from "@tauri-apps/api/core";
+import { useUIStore } from "@/stores/uiStore";
+import { useClosedTabScopesStore } from "@/stores/tabStoreClosedScopes";
+import { useWorkspaceInstanceUiStore } from "@/stores/workspaceInstanceUiStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { useWorkspacePaneLayoutsStore } from "@/stores/workspacePaneLayoutsStore";
+import { generateUUID } from "@/utils/workspaceIdentity";
+import { workspaceError } from "@/utils/debug";
+import { hydrateWorkspaceInstanceContext } from "./hydrateWorkspaceInstanceContext";
+
+export interface FinalizeInstanceRemovalOptions {
+  /** Close cleans the per-instance UI/pane snapshots; move deliberately does
+   *  NOT — the cross-window orphan that leaves behind is rail-plan gap G2,
+   *  explicitly deferred there rather than silently half-fixed here. */
+  cleanupPerInstanceUi: boolean;
+}
+
+/**
+ * Remove `workspaceInstanceId` from `windowLabel` and run every follower.
+ * Resolves once the promoted successor's context hydration settled (or
+ * immediately when the removed instance was not active).
+ */
+export function finalizeInstanceRemoval(
+  windowLabel: string,
+  workspaceInstanceId: string,
+  { cleanupPerInstanceUi }: FinalizeInstanceRemovalOptions,
+): Promise<void> {
+  const store = useWorkspaceInstancesStore.getState();
+  const wasActive =
+    store.windows[windowLabel]?.activeWorkspaceInstanceId === workspaceInstanceId;
+
+  store.removeWorkspaceInstance(windowLabel, workspaceInstanceId);
+  if (cleanupPerInstanceUi) {
+    // WI-9.1/10.2 lifecycle: a closed instance's parallel per-instance state
+    // must not linger as orphans.
+    useWorkspaceInstanceUiStore.getState().removeInstanceUiState(workspaceInstanceId);
+    useWorkspacePaneLayoutsStore.getState().removePaneLayout(workspaceInstanceId);
+  }
+  // WI-TS2.3 (D-T6): the instance's terminal sessions die with it — the store
+  // removal IS the PTY kill — its lastActiveByScope slot drops with them, and
+  // its closed-tab reopen history is cleaned per-instance.
+  useUIStore.getState().terminalRemoveScopeSessions(workspaceInstanceId);
+  useClosedTabScopesStore.getState().removeClosedScope(windowLabel, workspaceInstanceId);
+
+  if (windowLabel === "main") {
+    // main is never closed, so it must never be left with an empty rail.
+    useWorkspaceInstancesStore
+      .getState()
+      .ensurePlaceholderInstance("main", `wsi-placeholder-${generateUUID()}`);
+  } else if (
+    useWorkspaceInstancesStore.getState().windows[windowLabel]?.workspaceInstanceIds
+      .length === 0
+  ) {
+    // Don't drop the rejection — a failed close should surface in logs rather
+    // than become an unhandled promise rejection.
+    void invoke("close_window", { label: windowLabel }).catch((error) => {
+      workspaceError("Failed to close emptied window:", error);
+    });
+  }
+
+  if (!wasActive) return Promise.resolve();
+  // Audit 20260831 #25: the promoted successor (ids[0], promoted with no
+  // switch event) needs its FULL context — panes, active tab, sidebar root,
+  // config, and the terminal realign — not only the terminal slice.
+  return hydrateWorkspaceInstanceContext(windowLabel);
+}

--- a/src/services/workspaces/hydrateWorkspaceInstanceContext.ts
+++ b/src/services/workspaces/hydrateWorkspaceInstanceContext.ts
@@ -15,18 +15,12 @@
  * @coordinates-with syncLegacyWorkspaceContext.ts — sidebar re-root
  * @module services/workspaces/hydrateWorkspaceInstanceContext
  */
-import { useTabStore } from "@/stores/tabStore";
-import { usePaneStore } from "@/stores/paneStore";
+import { useUIStore } from "@/stores/uiStore";
 import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
-import { useWorkspacePaneLayoutsStore } from "@/stores/workspacePaneLayoutsStore";
 import { isWorkspaceRailEnabled } from "@/services/featureFlags/workspaceRailFeatureFlag";
-import {
-  contextKindOf,
-  resolveIncomingActiveTab,
-} from "./workspaceOwnershipKernel";
-import { orderedWindowInstances } from "./workspaceContextOwnership";
+import { contextKindOf } from "./workspaceOwnershipKernel";
 import { bumpContextGeneration } from "./workspaceContextGeneration";
-import { sanitizeSplitForInstance } from "./switchWorkspaceInstance";
+import { restoreInstanceVisualContext } from "./restoreInstanceContext";
 import { syncLegacyWorkspaceContext } from "./syncLegacyWorkspaceContext";
 
 /**
@@ -43,17 +37,20 @@ export function hydrateWorkspaceInstanceContext(windowLabel: string): Promise<vo
 
   const generation = bumpContextGeneration(windowLabel);
 
-  const liveTabs = useTabStore.getState().getTabsByWindow(windowLabel);
-  const instances = orderedWindowInstances(windowLabel);
-  const fallbackActive = resolveIncomingActiveTab(active, liveTabs, instances);
-  const stashed = useWorkspacePaneLayoutsStore.getState().getPaneLayout(activeId);
-  // Audit R2-F4: hydration restores persisted/stashed splits — sanitize
-  // ownership through the same kernel-backed rule as the switch coordinator.
-  usePaneStore.getState().replaceWindowSplit(
-    windowLabel,
-    sanitizeSplitForInstance(stashed, activeId, liveTabs, instances),
-    fallbackActive,
-  );
+  // Audit R2-F4 + 20260831 #22: hydration restores persisted/stashed splits
+  // through the SAME shared restoration (and kernel-backed sanitization) the
+  // switch coordinator uses — the two paths had grown near-identical copies.
+  restoreInstanceVisualContext(windowLabel, activeId);
+
+  // WI-TS2.2 (D-T12): home window-scoped terminal sessions into the FINAL
+  // active instance and realign the shown session. Convergent by design — a
+  // user switch that landed in the restore gap already adopted on its own,
+  // and re-deriving activation from the active id cannot clobber it. A
+  // placeholder active skips adoption (D-T1 carve-out).
+  if (active.kind !== "placeholder") {
+    useUIStore.getState().terminalAdoptUnscopedSessions(activeId);
+  }
+  useUIStore.getState().terminalHydrateScope(activeId);
 
   return syncLegacyWorkspaceContext(
     windowLabel,

--- a/src/services/workspaces/instanceOperationLock.test.ts
+++ b/src/services/workspaces/instanceOperationLock.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+// Audit 20260831 R2-14 — ONE per-instance operation lock across close, move
+// and duplicate. The separate `closing`/`transferring` sets it replaced
+// excluded close-vs-close and move-vs-move but let a close start during a
+// move's ack wait; these tests pin the cross-operation exclusion.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
+
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useTabStore } from "@/stores/tabStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import {
+  createWorkspaceInstance,
+  createWorkspaceRootIdentity,
+} from "@/utils/workspaceIdentity";
+import { closeWorkspaceInstance } from "./closeWorkspaceInstance";
+import {
+  acquireInstanceOperation,
+  releaseInstanceOperation,
+  resetInstanceOperationLocks,
+} from "./instanceOperationLock";
+import {
+  duplicateWorkspaceInstanceToNewWindow,
+  moveWorkspaceInstanceToNewWindow,
+} from "./workspaceWindowActions";
+
+const W = "main";
+
+function seedInstance(instanceId: string, path: string): void {
+  const rootResult = createWorkspaceRootIdentity(path, { platform: "macos" });
+  if (!rootResult.ok) throw new Error("bad test root");
+  useWorkspaceInstancesStore.getState().addWorkspaceInstance(
+    createWorkspaceInstance({
+      workspaceInstanceId: instanceId,
+      root: rootResult.root,
+      ownerWindowLabel: W,
+      createdFrom: "open",
+    }),
+  );
+}
+
+beforeEach(() => {
+  resetInstanceOperationLocks();
+  useWorkspaceInstancesStore.setState({ instances: {}, windows: {} });
+  useTabStore.setState({ tabs: {}, activeTabId: {}, untitledCounter: 0 });
+  useSettingsStore.setState({
+    general: { ...useSettingsStore.getState().general, workspaceRailMode: true },
+  });
+  invoke.mockReset().mockResolvedValue(undefined);
+});
+
+describe("the lock primitive", () => {
+  it("acquire → held → release → acquirable again", () => {
+    expect(acquireInstanceOperation("wsi-a")).toBe(true);
+    expect(acquireInstanceOperation("wsi-a")).toBe(false);
+    releaseInstanceOperation("wsi-a");
+    expect(acquireInstanceOperation("wsi-a")).toBe(true);
+  });
+
+  it("locks are per-instance, not global", () => {
+    expect(acquireInstanceOperation("wsi-a")).toBe(true);
+    expect(acquireInstanceOperation("wsi-b")).toBe(true);
+  });
+});
+
+describe("cross-operation exclusion (R2-14)", () => {
+  it("close reports busy while ANY operation holds the instance's lock", async () => {
+    seedInstance("wsi-a", "/repo-a");
+    expect(acquireInstanceOperation("wsi-a")).toBe(true); // e.g. a move mid-ack
+
+    const result = await closeWorkspaceInstance(W, "wsi-a", {
+      closeTabs: vi.fn(async () => true),
+    });
+
+    expect(result).toEqual({ ok: false, reason: "busy" });
+    // Nothing was removed — the holder still owns the instance.
+    expect(useWorkspaceInstancesStore.getState().instances["wsi-a"]).toBeDefined();
+  });
+
+  it("move reports busy while the lock is held", async () => {
+    seedInstance("wsi-a", "/repo-a");
+    expect(acquireInstanceOperation("wsi-a")).toBe(true); // e.g. a close at a prompt
+
+    const result = await moveWorkspaceInstanceToNewWindow(W, "wsi-a");
+
+    expect(result).toEqual({ ok: false, reason: "busy" });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("duplicate reports busy while the lock is held", async () => {
+    seedInstance("wsi-a", "/repo-a");
+    expect(acquireInstanceOperation("wsi-a")).toBe(true);
+
+    const result = await duplicateWorkspaceInstanceToNewWindow(W, "wsi-a");
+
+    expect(result).toEqual({ ok: false, reason: "busy" });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("a refused operation does NOT release the holder's lock", async () => {
+    seedInstance("wsi-a", "/repo-a");
+    expect(acquireInstanceOperation("wsi-a")).toBe(true);
+
+    await moveWorkspaceInstanceToNewWindow(W, "wsi-a");
+    await duplicateWorkspaceInstanceToNewWindow(W, "wsi-a");
+
+    // Still held — the busy path must not run the release in its finally
+    // against a lock it never acquired.
+    expect(acquireInstanceOperation("wsi-a")).toBe(false);
+  });
+
+  it("operations on DIFFERENT instances do not exclude each other", async () => {
+    seedInstance("wsi-a", "/repo-a");
+    seedInstance("wsi-b", "/repo-b");
+    expect(acquireInstanceOperation("wsi-a")).toBe(true);
+
+    const result = await closeWorkspaceInstance(W, "wsi-b", {
+      closeTabs: vi.fn(async () => true),
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/services/workspaces/instanceOperationLock.ts
+++ b/src/services/workspaces/instanceOperationLock.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-instance operation lock (audit 20260831 round 2, R2-14).
+ *
+ * Purpose: ONE mutual-exclusion set for every long-running workspace-instance
+ * operation — close, move, duplicate. Each of these crosses an await (a dirty
+ * prompt, a transfer ack) during which the others can be activated from the
+ * rail; running two against the same instance concurrently serializes a
+ * payload from a source mid-mutation or removes an instance another operation
+ * is still reading.
+ *
+ * Key decision: close and move/duplicate previously held SEPARATE sets
+ * (`closing` in closeWorkspaceInstance, `transferring` in
+ * workspaceWindowActions), which excluded close-vs-close and move-vs-move but
+ * let a close start during a move's ack wait. One set closes the class.
+ *
+ * The lock is advisory and webview-local — the same trust boundary the two
+ * sets it replaces had. It is not a cross-window mutex.
+ *
+ * @coordinates-with closeWorkspaceInstance.ts — close leg
+ * @coordinates-with workspaceWindowActions.ts — move/duplicate legs
+ * @module services/workspaces/instanceOperationLock
+ */
+
+const inFlight = new Set<string>();
+
+/**
+ * Try to take the instance's operation slot. Returns false when another
+ * close/move/duplicate already holds it — the caller reports `busy`.
+ * A successful acquire MUST be paired with releaseInstanceOperation in a
+ * `finally`.
+ */
+export function acquireInstanceOperation(workspaceInstanceId: string): boolean {
+  if (inFlight.has(workspaceInstanceId)) return false;
+  inFlight.add(workspaceInstanceId);
+  return true;
+}
+
+export function releaseInstanceOperation(workspaceInstanceId: string): void {
+  inFlight.delete(workspaceInstanceId);
+}
+
+/** Test-only: drop all held locks so suites stay isolated. */
+export function resetInstanceOperationLocks(): void {
+  inFlight.clear();
+}

--- a/src/services/workspaces/restoreInstanceContext.ts
+++ b/src/services/workspaces/restoreInstanceContext.ts
@@ -1,0 +1,57 @@
+/**
+ * restoreInstanceContext — the ONE pane/tab restoration for an instance
+ * becoming (or re-becoming) the window's visible context (audit 20260831
+ * #22): the rail-switch coordinator and the hydrate/repair path had grown
+ * near-identical copies of it, and the copies had already forced hydrate to
+ * import a helper out of the switch coordinator.
+ *
+ * @coordinates-with switchWorkspaceInstance.ts — restore-on-switch caller
+ * @coordinates-with hydrateWorkspaceInstanceContext.ts — startup/repair caller
+ * @module services/workspaces/restoreInstanceContext
+ */
+import { useTabStore } from "@/stores/tabStore";
+import { usePaneStore } from "@/stores/paneStore";
+import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { useWorkspacePaneLayoutsStore } from "@/stores/workspacePaneLayoutsStore";
+import { partitionWindowTabs, resolveIncomingActiveTab } from "./workspaceOwnershipKernel";
+import { orderedWindowInstances } from "./workspaceContextOwnership";
+
+/**
+ * Audit R2-F3: a stashed split may reference tabs that were REASSIGNED to
+ * another instance while hidden (Save As, rename). replaceWindowSplit only
+ * checks liveness — ownership must be enforced here, through the kernel.
+ */
+export function sanitizeSplitForInstance(
+  split: import("@/stores/paneStore").WindowSplit | null,
+  instanceId: string,
+  liveTabs: readonly import("@/stores/tabStore").Tab[],
+  instances: readonly import("@/stores/workspaceInstancesStore").WorkspaceInstanceRecord[],
+): import("@/stores/paneStore").WindowSplit | null {
+  if (!split?.enabled) return split;
+  const { ownerOf } = partitionWindowTabs(liveTabs, instances, instanceId);
+  const owned = (tabId: string | null) =>
+    tabId !== null && ownerOf.get(tabId) === instanceId ? tabId : null;
+  return {
+    ...split,
+    primaryTabId: owned(split.primaryTabId),
+    secondaryTabId: owned(split.secondaryTabId),
+  };
+}
+
+/** Restore `instanceId`'s stashed panes and active tab onto the window's
+ *  visible surfaces via the ONE atomic pane action. No-op for a missing
+ *  record. */
+export function restoreInstanceVisualContext(windowLabel: string, instanceId: string): void {
+  const record = useWorkspaceInstancesStore.getState().instances[instanceId];
+  if (!record) return;
+
+  const liveTabs = useTabStore.getState().getTabsByWindow(windowLabel);
+  const instances = orderedWindowInstances(windowLabel);
+  const fallbackActive = resolveIncomingActiveTab(record, liveTabs, instances);
+  const stashed = useWorkspacePaneLayoutsStore.getState().getPaneLayout(instanceId);
+  usePaneStore.getState().replaceWindowSplit(
+    windowLabel,
+    sanitizeSplitForInstance(stashed, instanceId, liveTabs, instances),
+    fallbackActive,
+  );
+}

--- a/src/services/workspaces/switchWorkspaceInstance.test.ts
+++ b/src/services/workspaces/switchWorkspaceInstance.test.ts
@@ -2,6 +2,8 @@
 // WI-2R — the rail-switch coordinator: stash outgoing (live ownership,
 // closed projection preserved), activate, pane-aware restore of the incoming
 // context, generation-guarded legacy sync. Real stores; Tauri mocked.
+// WI-TS2.2 — terminal scope wiring: adoption into the outgoing instance,
+// visible-set swap on switch, and hydrate's convergent realign (D-T12).
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockInvoke } = vi.hoisted(() => ({
@@ -22,10 +24,10 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { createWorkspaceInstance, createWorkspaceRootIdentity } from "@/utils/workspaceIdentity";
 import { resetContextGenerations } from "./workspaceContextGeneration";
 import { orderedWindowInstances } from "./workspaceContextOwnership";
-import {
-  sanitizeSplitForInstance,
-  switchWorkspaceInstance,
-} from "./switchWorkspaceInstance";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import { hydrateWorkspaceInstanceContext } from "./hydrateWorkspaceInstanceContext";
+import { sanitizeSplitForInstance } from "./restoreInstanceContext";
+import { switchWorkspaceInstance } from "./switchWorkspaceInstance";
 
 const W = "main";
 
@@ -59,6 +61,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockInvoke.mockResolvedValue(null);
   resetContextGenerations();
+  resetTerminalSessionStore();
   useTabStore.setState({ tabs: {}, activeTabId: {}, untitledCounter: 0 });
   useDocumentStore.setState({ documents: {} });
   usePaneStore.setState({ byWindow: {} });
@@ -279,5 +282,61 @@ describe("sanitizeSplitForInstance (audit R2-F3)", () => {
       syncScroll: false,
     };
     expect(sanitizeSplitForInstance(single, "wsi-a", [], [])).toBe(single);
+  });
+});
+
+describe("terminal scope wiring (WI-TS2.2)", () => {
+  const term = () => useUIStore.getState().terminal;
+  const createTerm = (owner?: string) =>
+    useUIStore
+      .getState()
+      .terminalCreateSession(owner ? { ownerInstanceId: owner } : undefined)!;
+
+  it("A→B hides A's set: active swaps, membership UNCHANGED (invariant 1)", () => {
+    const sa = createTerm("wsi-a");
+    const sb = createTerm("wsi-b");
+    useUIStore.getState().terminalSetActiveSession(sa.id);
+
+    switchWorkspaceInstance(W, "wsi-b");
+    expect(term().sessions.map((s) => s.id).sort()).toEqual([sa.id, sb.id].sort());
+    expect(term().activeSessionId).toBe(sb.id);
+
+    switchWorkspaceInstance(W, "wsi-a");
+    expect(term().activeSessionId).toBe(sa.id);
+    expect(term().sessions).toHaveLength(2);
+  });
+
+  it("adopts window-scoped sessions into the OUTGOING instance", () => {
+    const su = createTerm(); // created under wsi-a's watch, unscoped
+
+    switchWorkspaceInstance(W, "wsi-b");
+
+    expect(term().sessions.find((s) => s.id === su.id)?.workspaceInstanceId).toBe(
+      "wsi-a",
+    );
+    // …and it is therefore hidden in B: nothing to show.
+    expect(term().activeSessionId).toBeNull();
+  });
+
+  it("hydrate adopts into the final active instance and activates (no double-create)", async () => {
+    const su = createTerm(); // restore carve-out: unscoped
+
+    await hydrateWorkspaceInstanceContext(W); // active is wsi-a
+
+    expect(term().sessions).toHaveLength(1);
+    expect(term().sessions[0]?.workspaceInstanceId).toBe("wsi-a");
+    expect(term().activeSessionId).toBe(su.id);
+  });
+
+  it("user-switch-then-hydrate converges — hydrate cannot clobber the switch (D-T12)", async () => {
+    const su = createTerm(); // unscoped, created pre-switch
+    switchWorkspaceInstance(W, "wsi-b"); // user switch adopts into wsi-a
+
+    await hydrateWorkspaceInstanceContext(W); // re-derives from wsi-b
+
+    expect(term().sessions.find((s) => s.id === su.id)?.workspaceInstanceId).toBe(
+      "wsi-a",
+    );
+    expect(term().activeSessionId).toBeNull(); // still B's (empty) view
   });
 });

--- a/src/services/workspaces/switchWorkspaceInstance.ts
+++ b/src/services/workspaces/switchWorkspaceInstance.ts
@@ -26,6 +26,7 @@
  * @module services/workspaces/switchWorkspaceInstance
  */
 import { useTabStore } from "@/stores/tabStore";
+import { useUIStore } from "@/stores/uiStore";
 import { usePaneStore } from "@/stores/paneStore";
 import {
   useWorkspaceInstancesStore,
@@ -36,10 +37,10 @@ import { isWorkspaceRailEnabled } from "@/services/featureFlags/workspaceRailFea
 import {
   contextKindOf,
   partitionWindowTabs,
-  resolveIncomingActiveTab,
 } from "./workspaceOwnershipKernel";
 import { orderedWindowInstances } from "./workspaceContextOwnership";
 import { bumpContextGeneration } from "./workspaceContextGeneration";
+import { restoreInstanceVisualContext } from "./restoreInstanceContext";
 import { syncLegacyWorkspaceContext } from "./syncLegacyWorkspaceContext";
 
 export interface SwitchWorkspaceResult {
@@ -108,43 +109,6 @@ function stashOutgoingInstance(windowLabel: string, outgoingId: string): void {
     .stashPaneLayout(outgoingId, usePaneStore.getState().getSplit(windowLabel));
 }
 
-/** Restore the incoming instance's panes/active tab via the atomic pane action. */
-function restoreIncomingInstance(windowLabel: string, instanceId: string): void {
-  const incoming = useWorkspaceInstancesStore.getState().instances[instanceId];
-  if (!incoming) return;
-
-  const liveTabs = useTabStore.getState().getTabsByWindow(windowLabel);
-  const instances = orderedWindowInstances(windowLabel);
-  const fallbackActive = resolveIncomingActiveTab(incoming, liveTabs, instances);
-  const stashed = useWorkspacePaneLayoutsStore.getState().getPaneLayout(instanceId);
-  usePaneStore.getState().replaceWindowSplit(
-    windowLabel,
-    sanitizeSplitForInstance(stashed, instanceId, liveTabs, instances),
-    fallbackActive,
-  );
-}
-
-/**
- * Audit R2-F3: a stashed split may reference tabs that were REASSIGNED to
- * another instance while hidden (Save As, rename). replaceWindowSplit only
- * checks liveness — ownership must be enforced here, through the kernel.
- */
-export function sanitizeSplitForInstance(
-  split: import("@/stores/paneStore").WindowSplit | null,
-  instanceId: string,
-  liveTabs: readonly import("@/stores/tabStore").Tab[],
-  instances: readonly import("@/stores/workspaceInstancesStore").WorkspaceInstanceRecord[],
-): import("@/stores/paneStore").WindowSplit | null {
-  if (!split?.enabled) return split;
-  const { ownerOf } = partitionWindowTabs(liveTabs, instances, instanceId);
-  const owned = (tabId: string | null) =>
-    tabId !== null && ownerOf.get(tabId) === instanceId ? tabId : null;
-  return {
-    ...split,
-    primaryTabId: owned(split.primaryTabId),
-    secondaryTabId: owned(split.secondaryTabId),
-  };
-}
 
 export interface SwitchWorkspaceOptions {
   /**
@@ -170,16 +134,39 @@ export function switchWorkspaceInstance(
   const store = useWorkspaceInstancesStore.getState();
   const windowState = store.windows[windowLabel];
   if (!windowState?.workspaceInstanceIds.includes(instanceId)) return declined();
+  // Audit 20260831 #23: membership without a RECORD is a corrupt store —
+  // decline rather than restore a context that cannot resolve.
+  if (!store.instances[instanceId]) return declined();
 
   const outgoingId = windowState.activeWorkspaceInstanceId;
   if (outgoingId === instanceId) return declined(instanceId);
 
   if (outgoingId) stashOutgoingInstance(windowLabel, outgoingId);
+  // WI-TS2.2 (D-T1): window-scoped terminal sessions are adopted by the
+  // OUTGOING instance — they were created under it and belong to it. A
+  // placeholder outgoing is skipped (placeholders are deleted silently with
+  // no lifecycle follower; adopting into one would strand live PTYs) — and so
+  // is a MISSING outgoing record (audit #23: `undefined !== "placeholder"`
+  // used to stamp sessions with a dead owner).
+  const outgoingRecord = outgoingId ? store.instances[outgoingId] : undefined;
+  const outgoingIsReal =
+    outgoingRecord !== undefined && outgoingRecord.kind !== "placeholder";
+  if (outgoingIsReal && outgoingId) {
+    useUIStore.getState().terminalAdoptUnscopedSessions(outgoingId);
+  }
 
   useWorkspaceInstancesStore.getState().activateWorkspaceInstance(windowLabel, instanceId);
   const generation = bumpContextGeneration(windowLabel);
 
-  restoreIncomingInstance(windowLabel, instanceId);
+  restoreInstanceVisualContext(windowLabel, instanceId);
+
+  // WI-TS2.2: swap the visible terminal set — record the outgoing scope's
+  // shown session, activate the incoming scope's remembered ?? first ?? null
+  // (D-T2, activity cleared per D-T11). Synchronous store op (invariant 6).
+  // A placeholder outgoing writes no memory: its slot could never be read.
+  useUIStore
+    .getState()
+    .terminalSwitchScope(outgoingIsReal ? outgoingId : null, instanceId);
 
   const incoming = useWorkspaceInstancesStore.getState().instances[instanceId];
   const refresh = incoming

--- a/src/services/workspaces/workspaceSwitchInterplay.test.ts
+++ b/src/services/workspaces/workspaceSwitchInterplay.test.ts
@@ -3,6 +3,9 @@
 // not break close, move/duplicate collection, or hot-exit capture, and the
 // exclusive-ownership + browser-exclusion invariants must hold after
 // arbitrary switch sequences.
+// WI-TS2.2 / WI-TS2.3 — set-level terminal owner-exists invariant (plan
+// invariant 3) over lifecycle sequences including placeholder churn, close,
+// and loose-instance rekey; close-of-active realigns to the successor.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockInvoke } = vi.hoisted(() => ({
@@ -22,7 +25,10 @@ import { useWorkspaceInstanceUiStore } from "@/stores/workspaceInstanceUiStore";
 import { useWorkspacePaneLayoutsStore } from "@/stores/workspacePaneLayoutsStore";
 import { useClosedTabScopesStore } from "@/stores/tabStoreClosedScopes";
 import { createWorkspaceInstance, createWorkspaceRootIdentity } from "@/utils/workspaceIdentity";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import { resolveTerminalOwnerInstanceId } from "@/services/terminal/resolveTerminalOwnerInstanceId";
 import { resetContextGenerations } from "./workspaceContextGeneration";
+import { hydrateWorkspaceInstanceContext } from "./hydrateWorkspaceInstanceContext";
 import { switchWorkspaceInstance } from "./switchWorkspaceInstance";
 import { closeWorkspaceInstance } from "./closeWorkspaceInstance";
 import { collectWorkspaceTabs } from "./workspaceTabCollection";
@@ -74,6 +80,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockInvoke.mockResolvedValue(null);
   resetContextGenerations();
+  resetTerminalSessionStore();
   useTabStore.setState({ tabs: {}, activeTabId: {}, untitledCounter: 0 });
   useDocumentStore.setState({ documents: {} });
   usePaneStore.setState({ byWindow: {} });
@@ -195,5 +202,99 @@ describe("workspaceSwitchInterplay (WI-7R)", () => {
     expect(switchWorkspaceInstance(W, "wsi-a").switched).toBe(false);
     expect(useTabStore.getState().getTabsByWindow(W).map((t) => t.id)).toEqual([idB]);
     assertExclusiveOwnership();
+  });
+});
+
+/** Every stamped owner must exist and never be a placeholder (invariant 3). */
+function assertTerminalOwnersExist(): void {
+  const instances = useWorkspaceInstancesStore.getState().instances;
+  for (const s of useUIStore.getState().terminal.sessions) {
+    if (!s.workspaceInstanceId) continue;
+    const owner = instances[s.workspaceInstanceId];
+    expect(
+      owner,
+      `session ${s.id} stamped with dead owner ${s.workspaceInstanceId}`,
+    ).toBeDefined();
+    expect(owner?.kind).not.toBe("placeholder");
+  }
+}
+
+describe("terminal owner-exists invariant (WI-TS2.2/WI-TS2.3, invariant 3)", () => {
+  /** Create a session the way production creators do: owner via the resolver. */
+  const createTermHere = () => {
+    const owner = resolveTerminalOwnerInstanceId(W);
+    return useUIStore
+      .getState()
+      .terminalCreateSession(owner ? { ownerInstanceId: owner } : undefined);
+  };
+
+  it("holds across placeholder churn, switches, rekey, and close", async () => {
+    // Placeholder churn: a fresh window holds only a placeholder.
+    useWorkspaceInstancesStore.getState().resetWorkspaceInstances();
+    useWorkspaceInstancesStore.getState().ensurePlaceholderInstance(W, "wsi-ph");
+    const s0 = createTermHere();
+    expect(s0?.workspaceInstanceId).toBeUndefined(); // carve-out 1
+    assertTerminalOwnersExist();
+
+    // A real workspace arrives — the placeholder is deleted silently. The
+    // session must be window-scoped, visible, and adoptable — not stranded.
+    addWorkspace("wsi-a", "/repo-a");
+    expect(useWorkspaceInstancesStore.getState().instances["wsi-ph"]).toBeUndefined();
+    assertTerminalOwnersExist();
+    await hydrateWorkspaceInstanceContext(W);
+    const adopted = useUIStore
+      .getState()
+      .terminal.sessions.find((s) => s.id === s0?.id);
+    expect(adopted?.workspaceInstanceId).toBe("wsi-a");
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(s0?.id);
+    assertTerminalOwnersExist();
+
+    // Second workspace + switch + scoped creation.
+    addWorkspace("wsi-b", "/repo-b");
+    switchWorkspaceInstance(W, "wsi-b");
+    const s1 = createTermHere();
+    expect(s1?.workspaceInstanceId).toBe("wsi-b");
+    assertTerminalOwnersExist();
+
+    // Loose-instance identity rekey follows the terminal stamps (D-T6).
+    const loose = useWorkspaceInstancesStore.getState().ensureLooseInstance(W);
+    switchWorkspaceInstance(W, loose.workspaceInstanceId);
+    const s2 = createTermHere();
+    expect(s2?.workspaceInstanceId).toBe(loose.workspaceInstanceId);
+    useWorkspaceInstancesStore.getState().ensureLooseInstance(W, "wsi-loose-renamed");
+    assertTerminalOwnersExist();
+    expect(
+      useUIStore.getState().terminal.sessions.find((s) => s.id === s2?.id)
+        ?.workspaceInstanceId,
+    ).toBe("wsi-loose-renamed");
+
+    // Close a hidden instance: exactly its session dies; owners stay valid.
+    await closeWorkspaceInstance(W, "wsi-b", { closeTabs: async () => true });
+    assertTerminalOwnersExist();
+    expect(
+      useUIStore.getState().terminal.sessions.find((s) => s.id === s1?.id),
+    ).toBeUndefined();
+    expect(
+      useUIStore.getState().terminal.sessions.map((s) => s.id).sort(),
+    ).toEqual([s0?.id, s2?.id].sort());
+  });
+
+  it("close of the ACTIVE instance realigns to the successor's remembered session (the blank-panel case)", async () => {
+    const sa = createTermHere(); // stamped wsi-a (active)
+    switchWorkspaceInstance(W, "wsi-b");
+    const sb = createTermHere(); // stamped wsi-b
+    switchWorkspaceInstance(W, "wsi-a"); // memory: wsi-b → sb
+
+    await closeWorkspaceInstance(W, "wsi-a", { closeTabs: async () => true });
+
+    expect(
+      useWorkspaceInstancesStore.getState().windows[W].activeWorkspaceInstanceId,
+    ).toBe("wsi-b");
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(sb?.id);
+    expect(useUIStore.getState().terminal.sessions.map((s) => s.id)).toEqual([
+      sb?.id,
+    ]);
+    expect(sa?.id).toBeDefined(); // sa existed and died with its instance
+    assertTerminalOwnersExist();
   });
 });

--- a/src/services/workspaces/workspaceWindowActions.duplicate.test.ts
+++ b/src/services/workspaces/workspaceWindowActions.duplicate.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
+// WI-TS2.3 — duplicate copies/kills NO terminal sessions (D-T6).
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDocumentStore } from "@/stores/documentStore";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
 import {
   selectWindowWorkspaceState,
   useWorkspaceInstancesStore,
@@ -137,5 +139,30 @@ describe("workspace window duplicate and loose transfer actions", () => {
       reason: "timeout",
       targetWindowLabel: "doc-2",
     });
+  });
+});
+
+describe("terminal sessions on duplicate (WI-TS2.3, D-T6)", () => {
+  beforeEach(() => {
+    resetTerminalSessionStore();
+  });
+
+  it("copies and kills NOTHING — the source scope's sessions are untouched", async () => {
+    setRailMode(true);
+    addInstance("main", "wsi-repo", "/repo");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance("main", "wsi-repo");
+    const s = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-repo" })!;
+    mockInvoke.mockResolvedValueOnce("doc-2");
+
+    const dup = duplicateWorkspaceInstanceToNewWindow("main", "wsi-repo");
+    await vi.waitFor(() => expect(mockInvoke).toHaveBeenCalled());
+    ackTransfer(mockInvoke.mock.calls[0][1].data as WorkspaceTransferPayload);
+    await expect(dup).resolves.toMatchObject({ ok: true });
+
+    const sessions = useUIStore.getState().terminal.sessions;
+    expect(sessions.map((x) => x.id)).toEqual([s.id]);
+    expect(sessions[0]?.workspaceInstanceId).toBe("wsi-repo");
   });
 });

--- a/src/services/workspaces/workspaceWindowActions.test.ts
+++ b/src/services/workspaces/workspaceWindowActions.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment node
+// WI-TS2.3 — moving an instance out kills its terminal sessions AFTER the
+// ack (never on timeout/cancel) and realigns to the promoted successor.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDocumentStore } from "@/stores/documentStore";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
 import {
   selectWindowWorkspaceState,
   useWorkspaceInstancesStore,
@@ -200,5 +203,62 @@ describe("workspace window actions", () => {
       .resolves.toEqual({ ok: false, reason: "timeout", targetWindowLabel: "doc-2" });
     expect(selectWindowWorkspaceState(useWorkspaceInstancesStore.getState(), "main"))
       .toMatchObject({ workspaceInstanceIds: ["wsi-repo"] });
+  });
+});
+
+describe("terminal scope lifecycle on move (WI-TS2.3, D-T6)", () => {
+  const termIds = () => useUIStore.getState().terminal.sessions.map((s) => s.id);
+
+  beforeEach(() => {
+    resetTerminalSessionStore();
+  });
+
+  it("kills the moved instance's sessions only AFTER the ack, and realigns to the successor", async () => {
+    setRailMode(true);
+    addInstance("main", "wsi-repo", "/repo");
+    addInstance("main", "wsi-stay", "/stay");
+    useWorkspaceInstancesStore.getState().activateWorkspaceInstance("main", "wsi-repo");
+    const moved = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-repo" })!;
+    const stay = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-stay" })!;
+    useUIStore.getState().terminalSetActiveSession(moved.id);
+    mockInvoke.mockResolvedValueOnce("doc-2");
+
+    const move = moveWorkspaceInstanceToNewWindow("main", "wsi-repo");
+    await vi.waitFor(() => expect(mockInvoke).toHaveBeenCalled());
+    // NOT before the ack: the sessions are still alive while the target has
+    // not confirmed receipt.
+    expect(termIds().sort()).toEqual([moved.id, stay.id].sort());
+
+    ackTransfer(mockInvoke.mock.calls[0][1].data as WorkspaceTransferPayload);
+    await expect(move).resolves.toMatchObject({ ok: true });
+
+    expect(termIds()).toEqual([stay.id]);
+    // The moved instance was ACTIVE — realign shows the successor's session
+    // instead of a blank panel over hidden PTYs.
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(stay.id);
+    expect(
+      "wsi-repo" in useUIStore.getState().terminal.lastActiveByScope,
+    ).toBe(false);
+  });
+
+  it("timeout before ack kills NO terminal sessions", async () => {
+    vi.useFakeTimers();
+    setRailMode(true);
+    addInstance("main", "wsi-repo", "/repo");
+    const s = useUIStore
+      .getState()
+      .terminalCreateSession({ ownerInstanceId: "wsi-repo" })!;
+    mockInvoke.mockResolvedValueOnce("doc-2");
+
+    const move = moveWorkspaceInstanceToNewWindow("main", "wsi-repo", { timeoutMs: 25 });
+    await vi.waitFor(() => expect(mockInvoke).toHaveBeenCalled());
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(move).resolves.toMatchObject({ ok: false, reason: "timeout" });
+
+    expect(termIds()).toEqual([s.id]);
   });
 });

--- a/src/services/workspaces/workspaceWindowActions.ts
+++ b/src/services/workspaces/workspaceWindowActions.ts
@@ -3,6 +3,11 @@ import { isWorkspaceRailEnabled } from "@/services/featureFlags/workspaceRailFea
 import { useDocumentStore } from "@/stores/documentStore";
 import { useTabStore } from "@/stores/tabStore";
 import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
+import { finalizeInstanceRemoval } from "./finalizeInstanceRemoval";
+import {
+  acquireInstanceOperation,
+  releaseInstanceOperation,
+} from "./instanceOperationLock";
 import type {
   WorkspaceActionOptions,
   WorkspaceOpener,
@@ -18,34 +23,47 @@ import { waitForWorkspaceAck } from "./workspaceTransferAck";
 
 const DEFAULT_ACK_TIMEOUT_MS = 8_000;
 
+// Concurrency: both actions cross an acknowledgement wait; a second
+// activation during it would serialize a second payload from a source
+// mid-mutation. The guard is the SHARED per-instance operation lock
+// (instanceOperationLock.ts, R2-14) — one set across close, move and
+// duplicate, so a close cannot start during a move's ack wait either.
+
 export async function moveWorkspaceInstanceToNewWindow(
   windowLabel: string,
   workspaceInstanceId: string,
   options: WorkspaceActionOptions = {},
 ): Promise<WorkspaceWindowActionResult> {
-  const payload = buildWorkspacePayload(windowLabel, workspaceInstanceId, "move");
-  if (!payload) return disabledOrMissingResult(workspaceInstanceId);
-
-  const result = await createWindowAndWaitForAck(payload, options.timeoutMs);
-  if (!result.ok) return result;
-
-  for (const tab of payload.tabs) {
-    useTabStore.getState().detachTab(windowLabel, tab.tabId);
-    cleanupMovedTab(tab.tabId, options.cleanupTab);
+  if (!acquireInstanceOperation(workspaceInstanceId)) {
+    return { ok: false, reason: "busy" };
   }
-  const store = useWorkspaceInstancesStore.getState();
-  store.removeWorkspaceInstance(windowLabel, workspaceInstanceId);
-  if (windowLabel === "main") {
-    store.ensurePlaceholderInstance("main", `wsi-placeholder-${generateUUID()}`);
-  } else if (useWorkspaceInstancesStore.getState().windows[windowLabel]?.workspaceInstanceIds.length === 0) {
-    // Don't drop the rejection — a failed close should surface in logs rather
-    // than become an unhandled promise rejection.
-    void invoke("close_window", { label: windowLabel }).catch((error) => {
-      workspaceError("Failed to close emptied source window:", error);
+  try {
+    const payload = buildWorkspacePayload(windowLabel, workspaceInstanceId, "move");
+    if (!payload) return disabledOrMissingResult(workspaceInstanceId);
+
+    const result = await createWindowAndWaitForAck(payload, options.timeoutMs);
+    if (!result.ok) return result;
+
+    for (const tab of payload.tabs) {
+      useTabStore.getState().detachTab(windowLabel, tab.tabId);
+      cleanupMovedTab(tab.tabId, options.cleanupTab);
+    }
+    // WI-TS2.3 (D-T6): PTY/xterm state cannot cross webviews, so the moved
+    // instance's terminal sessions are killed in the SOURCE, strictly after
+    // the ack (the timeout/cancel path above returns before reaching here and
+    // kills nothing). The shared finalizer (audit #26) also cleans its
+    // closed-tab history, keeps the placeholder/empty-window invariants, and
+    // fully hydrates the promoted successor when the moved instance was
+    // active. Per-instance UI/pane snapshots deliberately stay: rail-plan gap
+    // G2 (cross-window orphan) is deferred there, not silently half-fixed.
+    await finalizeInstanceRemoval(windowLabel, workspaceInstanceId, {
+      cleanupPerInstanceUi: false,
     });
-  }
 
-  return result;
+    return result;
+  } finally {
+    releaseInstanceOperation(workspaceInstanceId);
+  }
 }
 
 export async function duplicateWorkspaceInstanceToNewWindow(
@@ -53,17 +71,24 @@ export async function duplicateWorkspaceInstanceToNewWindow(
   workspaceInstanceId: string,
   options: WorkspaceActionOptions = {},
 ): Promise<WorkspaceWindowActionResult> {
-  const payload = buildWorkspacePayload(windowLabel, workspaceInstanceId, "duplicate");
-  if (!payload) return disabledOrMissingResult(workspaceInstanceId);
+  if (!acquireInstanceOperation(workspaceInstanceId)) {
+    return { ok: false, reason: "busy" };
+  }
+  try {
+    const payload = buildWorkspacePayload(windowLabel, workspaceInstanceId, "duplicate");
+    if (!payload) return disabledOrMissingResult(workspaceInstanceId);
 
-  const result = await createWindowAndWaitForAck(payload, options.timeoutMs);
-  if (!result.ok) return result;
-  return {
-    ...result,
-    skippedDirtyCount: payload.skippedDirtyCount,
-    skippedUntitledCount: payload.skippedUntitledCount,
-    skippedMissingCount: payload.skippedMissingCount,
-  };
+    const result = await createWindowAndWaitForAck(payload, options.timeoutMs);
+    if (!result.ok) return result;
+    return {
+      ...result,
+      skippedDirtyCount: payload.skippedDirtyCount,
+      skippedUntitledCount: payload.skippedUntitledCount,
+      skippedMissingCount: payload.skippedMissingCount,
+    };
+  } finally {
+    releaseInstanceOperation(workspaceInstanceId);
+  }
 }
 
 export async function claimWorkspaceTransferForWindow(

--- a/src/stores/instanceRekeyBus.ts
+++ b/src/stores/instanceRekeyBus.ts
@@ -1,0 +1,38 @@
+/**
+ * instanceRekeyBus — decoupled fan-out for loose-instance identity re-keys
+ * (audit 20260831 #9).
+ *
+ * Purpose: `ensureLooseInstance` re-keys an instance's identity and every
+ * per-instance store must follow. Most followers are imported directly by the
+ * instances store (acyclic), but `tabStoreClosedScopes` IMPORTS the instances
+ * store for scope resolution — a direct call back would create an import
+ * cycle. Same pattern as tabRemovalBus: the store that owns the event
+ * notifies; interested stores subscribe at module scope.
+ *
+ * @coordinates-with stores/workspaceInstancesStore.ts — the notifier
+ * @coordinates-with stores/tabStoreClosedScopes.ts — rekeys its scope slot
+ * @module stores/instanceRekeyBus
+ */
+
+type InstanceRekeyListener = (
+  windowLabel: string,
+  oldId: string,
+  newId: string,
+) => void;
+
+const listeners = new Set<InstanceRekeyListener>();
+
+/** Subscribe to identity re-keys. Returns an unsubscribe function. */
+export function onInstanceRekeyed(listener: InstanceRekeyListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** Notify every follower that `oldId` is now `newId` in `windowLabel`. */
+export function notifyInstanceRekeyed(
+  windowLabel: string,
+  oldId: string,
+  newId: string,
+): void {
+  for (const listener of listeners) listener(windowLabel, oldId, newId);
+}

--- a/src/stores/tabStoreClosedScopes.test.ts
+++ b/src/stores/tabStoreClosedScopes.test.ts
@@ -3,6 +3,7 @@
 // per scopeKey (workspace instance id, browser-global, or window-all when the
 // rail is off), monotonic close sequence, one cap policy per scope. Replaces
 // the old flat closedTabs pool.
+// WI-TS2.3 — removeClosedScope: per-instance history cleanup on close/move.
 import { beforeEach, describe, expect, it } from "vitest";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useWorkspaceInstancesStore } from "@/stores/workspaceInstancesStore";
@@ -16,11 +17,30 @@ import {
 } from "./tabStoreClosedScopes";
 
 function doc(id: string, filePath: string | null): Tab {
-  return { id, kind: "document", title: id, filePath, isPinned: false } as Tab;
+  // Complete DocumentTab shape (R3-6): hydration validates the FULL required
+  // shape now, so a fixture missing formatId would test nothing but its own
+  // incompleteness.
+  return {
+    id,
+    kind: "document",
+    title: id,
+    filePath,
+    isPinned: false,
+    formatId: "markdown",
+  } as Tab;
 }
 
 function browserTab(id: string): Tab {
-  return { id, kind: "browser", title: id, isPinned: false } as unknown as Tab;
+  // Complete BrowserTab shape (R3-6).
+  return {
+    id,
+    kind: "browser",
+    title: id,
+    isPinned: false,
+    url: "https://ok.example/",
+    automationMode: "human",
+    persistPolicy: "restore-human",
+  } as unknown as Tab;
 }
 
 function setRail(enabled: boolean): void {
@@ -177,12 +197,33 @@ describe("hydrateWindowClosedScopes hardening (R2-F13/F14/F15)", () => {
   const ids = (scope: string) =>
     useClosedTabScopesStore.getState().closedIdsForScope("main", scope);
   const docEntry = (id: string, seq: number) => ({
-    tab: { id, kind: "document", title: id, filePath: `/x/${id}.md`, isPinned: false },
+    tab: {
+      id,
+      kind: "document",
+      title: id,
+      filePath: `/x/${id}.md`,
+      isPinned: false,
+      formatId: "markdown",
+    },
     closedSeq: seq,
   });
   const webEntry = (id: string, url: string, seq: number) => ({
-    tab: { id, kind: "browser", title: id, url, isPinned: false },
+    tab: {
+      id,
+      kind: "browser",
+      title: id,
+      url,
+      isPinned: false,
+      automationMode: "human",
+      persistPolicy: "restore-human",
+    },
     closedSeq: seq,
+  });
+  // Hydration whitelists scope keys to THIS window's instances (R3-4), so
+  // every test that hydrates into wsi-a/wsi-b must actually have them.
+  beforeEach(() => {
+    addWorkspace("wsi-a", "/repo-a");
+    addWorkspace("wsi-b", "/repo-b");
   });
 
   it("drops browser entries whose URL is not canonical http(s)", () => {
@@ -265,5 +306,291 @@ describe("closed-scope guards on unknown state", () => {
     } finally {
       useSettingsStore.setState({ general: saved });
     }
+  });
+});
+
+describe("removeClosedScope (WI-TS2.3)", () => {
+  it("drops exactly one scope's history, leaving siblings intact", () => {
+    setRail(true);
+    addWorkspace("wsi-a", "/repo-a");
+    addWorkspace("wsi-b", "/repo-b");
+    useClosedTabScopesStore.getState().recordClosedTab("main", doc("t-a", "/repo-a/x.md"));
+    useClosedTabScopesStore.getState().recordClosedTab("main", doc("t-b", "/repo-b/y.md"));
+
+    useClosedTabScopesStore.getState().removeClosedScope("main", "wsi-a");
+
+    expect(
+      useClosedTabScopesStore.getState().closedIdsForScope("main", "wsi-a"),
+    ).toEqual([]);
+    expect(
+      useClosedTabScopesStore.getState().closedIdsForScope("main", "wsi-b"),
+    ).toEqual(["t-b"]);
+  });
+
+  it("is a no-op for an unknown scope or window (no store wake)", () => {
+    const before = useClosedTabScopesStore.getState().scopesByWindow;
+    useClosedTabScopesStore.getState().removeClosedScope("main", "wsi-ghost");
+    useClosedTabScopesStore.getState().removeClosedScope("nowhere", "wsi-a");
+    expect(useClosedTabScopesStore.getState().scopesByWindow).toBe(before);
+  });
+});
+
+describe("rekeyClosedScope (audit 20260831 #9)", () => {
+  it("carries a loose instance's reopen history through an identity re-key", () => {
+    setRail(true);
+    addWorkspace("wsi-a", "/repo-a");
+    useClosedTabScopesStore.getState().recordClosedTab("main", doc("t-a", "/repo-a/x.md"));
+
+    useClosedTabScopesStore.getState().rekeyClosedScope("main", "wsi-a", "wsi-renamed");
+
+    expect(useClosedTabScopesStore.getState().closedIdsForScope("main", "wsi-a")).toEqual([]);
+    expect(
+      useClosedTabScopesStore.getState().closedIdsForScope("main", "wsi-renamed"),
+    ).toEqual(["t-a"]);
+  });
+
+  it("merges into an existing target newest-first and keeps the cap", () => {
+    // Hydration whitelists scope keys to real window instances (R3-4).
+    addWorkspace("wsi-old", "/repo-old");
+    addWorkspace("wsi-new", "/repo-new");
+    useClosedTabScopesStore.getState().hydrateWindowClosedScopes("main", {
+      "wsi-old": [{ tab: doc("t-1", "/a.md"), closedSeq: 5 }],
+      "wsi-new": [{ tab: doc("t-2", "/b.md"), closedSeq: 9 }],
+    });
+
+    useClosedTabScopesStore.getState().rekeyClosedScope("main", "wsi-old", "wsi-new");
+
+    expect(
+      useClosedTabScopesStore.getState().closedIdsForScope("main", "wsi-new"),
+    ).toEqual(["t-2", "t-1"]);
+  });
+
+  it("fires through the instances store's loose-instance re-key (bus wiring)", () => {
+    setRail(true);
+    useWorkspaceInstancesStore.getState().ensureLooseInstance("main");
+    const looseId = useWorkspaceInstancesStore
+      .getState()
+      .windows["main"]!.workspaceInstanceIds.find((id) =>
+        useWorkspaceInstancesStore.getState().instances[id]?.kind === "loose",
+      )!;
+    useClosedTabScopesStore.getState().hydrateWindowClosedScopes("main", {
+      [looseId]: [{ tab: doc("t-l", "/loose.md"), closedSeq: 3 }],
+    });
+
+    useWorkspaceInstancesStore.getState().ensureLooseInstance("main", "wsi-loose-renamed");
+
+    expect(
+      useClosedTabScopesStore.getState().closedIdsForScope("main", "wsi-loose-renamed"),
+    ).toEqual(["t-l"]);
+    expect(useClosedTabScopesStore.getState().closedIdsForScope("main", looseId)).toEqual([]);
+  });
+});
+
+describe("hydration ordering + sequence headroom (audit 20260831 #13/#14)", () => {
+  beforeEach(() => {
+    addWorkspace("wsi-a", "/repo-a");
+  });
+
+  it("sorts by closedSeq before applying the per-scope cap", () => {
+    const entries = Array.from({ length: 12 }, (_, i) => ({
+      tab: doc(`t-${i}`, `/f${i}.md`),
+      closedSeq: i + 1, // ascending — oldest first, the adversarial order
+    }));
+    useClosedTabScopesStore.getState().hydrateWindowClosedScopes("main", {
+      "wsi-a": entries,
+    });
+
+    const ids = useClosedTabScopesStore.getState().closedIdsForScope("main", "wsi-a");
+    // Newest 10 survive, newest-first — not the first 10 of the payload.
+    expect(ids).toEqual(
+      Array.from({ length: 10 }, (_, i) => `t-${11 - i}`),
+    );
+  });
+
+  it("rejects entries whose closedSeq has no safe increment headroom", () => {
+    useClosedTabScopesStore.getState().hydrateWindowClosedScopes("main", {
+      "wsi-a": [
+        { tab: doc("t-max", "/max.md"), closedSeq: Number.MAX_SAFE_INTEGER },
+        { tab: doc("t-ok", "/ok.md"), closedSeq: 7 },
+      ],
+    });
+
+    expect(
+      useClosedTabScopesStore.getState().closedIdsForScope("main", "wsi-a"),
+    ).toEqual(["t-ok"]);
+    // nextSeq derived from the sane entry, not the ceiling.
+    useClosedTabScopesStore.getState().recordClosedTab("main", doc("t-next", "/n.md"));
+    const win = useClosedTabScopesStore.getState().scopesByWindow["main"]!;
+    const all = Object.values(win).flat();
+    expect(Math.max(...all.map((e) => e.closedSeq))).toBe(8);
+  });
+});
+
+describe("placeholder-active fallback (audit round 2, R2-8)", () => {
+  it("an unowned doc under a placeholder-ACTIVE window lands in window-all, not the placeholder", () => {
+    setRail(true);
+    useWorkspaceInstancesStore
+      .getState()
+      .ensurePlaceholderInstance("main", "wsi-placeholder-1");
+
+    useClosedTabScopesStore.getState().recordClosedTab("main", doc("t-x", "/any/x.md"));
+
+    // A placeholder is evicted the moment a real workspace arrives and its
+    // closed scope is dropped with it — history under its id is orphaned.
+    expect(
+      useClosedTabScopesStore.getState().closedIdsForScope("main", "wsi-placeholder-1"),
+    ).toEqual([]);
+    expect(
+      useClosedTabScopesStore.getState().closedIdsForScope("main", WINDOW_ALL_SCOPE),
+    ).toEqual(["t-x"]);
+  });
+});
+
+describe("hydration dedup at ACCEPTANCE, not while filtering (audit round 2, R2-9)", () => {
+  beforeEach(() => {
+    addWorkspace("wsi-a", "/repo-a");
+    addWorkspace("wsi-b", "/repo-b");
+  });
+
+  it("an id capped OUT of one scope is not suppressed from a later scope", () => {
+    // 11 entries in wsi-a; the OLDEST (t-dup, seq 1) falls beyond the cap.
+    // The same id also appears in wsi-b, where it should survive.
+    const aEntries = [
+      { tab: doc("t-dup", "/dup.md"), closedSeq: 1 },
+      ...Array.from({ length: 10 }, (_, i) => ({
+        tab: doc(`a-${i}`, `/a${i}.md`),
+        closedSeq: i + 2,
+      })),
+    ];
+    useClosedTabScopesStore.getState().hydrateWindowClosedScopes("main", {
+      "wsi-a": aEntries,
+      "wsi-b": [{ tab: doc("t-dup", "/dup.md"), closedSeq: 20 }],
+    });
+
+    const store = useClosedTabScopesStore.getState();
+    expect(store.closedIdsForScope("main", "wsi-a")).not.toContain("t-dup");
+    // Before R2-9 the capped-out t-dup still entered seenIds and silently
+    // deleted this entry — the exclusivity invariant only ever meant "one
+    // scope per SURVIVING id".
+    expect(store.closedIdsForScope("main", "wsi-b")).toEqual(["t-dup"]);
+  });
+
+  it("still keeps one scope per id when the id SURVIVES in an earlier scope", () => {
+    useClosedTabScopesStore.getState().hydrateWindowClosedScopes("main", {
+      "wsi-a": [{ tab: doc("t-dup", "/dup.md"), closedSeq: 5 }],
+      "wsi-b": [{ tab: doc("t-dup", "/dup.md"), closedSeq: 9 }],
+    });
+
+    const store = useClosedTabScopesStore.getState();
+    expect(store.closedIdsForScope("main", "wsi-a")).toEqual(["t-dup"]);
+    expect(store.closedIdsForScope("main", "wsi-b")).toEqual([]);
+  });
+
+  it("duplicates INSIDE one scope beyond the cap do not shrink the survivor set", () => {
+    // 10 unique newest + the same stale id repeated below them: cap keeps
+    // exactly the 10 unique newest.
+    const entries = [
+      ...Array.from({ length: 10 }, (_, i) => ({
+        tab: doc(`u-${i}`, `/u${i}.md`),
+        closedSeq: 100 + i,
+      })),
+      { tab: doc("t-old", "/old.md"), closedSeq: 1 },
+      { tab: doc("t-old", "/old.md"), closedSeq: 2 },
+    ];
+    useClosedTabScopesStore.getState().hydrateWindowClosedScopes("main", {
+      "wsi-a": entries,
+    });
+    const ids = useClosedTabScopesStore.getState().closedIdsForScope("main", "wsi-a");
+    expect(ids).toHaveLength(10);
+    expect(ids).not.toContain("t-old");
+    expect(new Set(ids).size).toBe(10);
+  });
+});
+
+describe("hydration scope whitelist (audit round 3, R3-4)", () => {
+  it("drops scopes keyed by instances this window does not have, keeping siblings", () => {
+    addWorkspace("wsi-a", "/repo-a");
+    useClosedTabScopesStore.getState().hydrateWindowClosedScopes("main", {
+      "wsi-a": [{ tab: doc("t-a", "/a.md"), closedSeq: 1 }],
+      "wsi-ghost": [{ tab: doc("t-ghost", "/g.md"), closedSeq: 2 }],
+      [WINDOW_ALL_SCOPE]: [{ tab: doc("t-all", "/w.md"), closedSeq: 3 }],
+      [BROWSER_SCOPE]: [{ tab: browserTab("t-web"), closedSeq: 4 }],
+    });
+
+    const store = useClosedTabScopesStore.getState();
+    expect(store.closedIdsForScope("main", "wsi-a")).toEqual(["t-a"]);
+    // Unreachable history — nothing could ever reopen it — is rejected, not
+    // retained and re-persisted forever.
+    expect(store.closedIdsForScope("main", "wsi-ghost")).toEqual([]);
+    expect(store.closedIdsForScope("main", WINDOW_ALL_SCOPE)).toEqual(["t-all"]);
+    expect(store.closedIdsForScope("main", BROWSER_SCOPE)).toEqual(["t-web"]);
+  });
+});
+
+describe("full Tab-shape validation (audit round 3, R3-2/R3-3)", () => {
+  const hydrate = (scopes: Record<string, unknown>) =>
+    useClosedTabScopesStore.getState().hydrateWindowClosedScopes("main", scopes);
+  const winIds = () =>
+    useClosedTabScopesStore.getState().closedIdsForScope("main", WINDOW_ALL_SCOPE);
+
+  it.each([
+    ["missing title", { id: "t-x", kind: "document", filePath: "/x.md", isPinned: false, formatId: "markdown" }],
+    ["missing isPinned", { id: "t-x", kind: "document", title: "t-x", filePath: "/x.md", formatId: "markdown" }],
+    ["missing formatId", { id: "t-x", kind: "document", title: "t-x", filePath: "/x.md", isPinned: false }],
+    ["non-string formatId", { id: "t-x", kind: "document", title: "t-x", filePath: "/x.md", isPinned: false, formatId: 7 }],
+  ])("rejects a document entry with %s — reopen restores entries VERBATIM", (_label, tab) => {
+    hydrate({ [WINDOW_ALL_SCOPE]: [{ tab, closedSeq: 1 }] });
+    expect(winIds()).toEqual([]);
+  });
+
+  it.each([
+    ["missing automationMode", { persistPolicy: "restore-human" }],
+    ["missing persistPolicy", { automationMode: "human" }],
+    ["invalid automationMode", { automationMode: "root", persistPolicy: "restore-human" }],
+    ["invalid persistPolicy", { automationMode: "human", persistPolicy: "forever" }],
+  ])("rejects a browser entry with %s", (_label, fields) => {
+    hydrate({
+      [BROWSER_SCOPE]: [
+        {
+          tab: {
+            id: "t-w",
+            kind: "browser",
+            title: "t-w",
+            isPinned: false,
+            url: "https://ok.example/",
+            ...fields,
+          },
+          closedSeq: 1,
+        },
+      ],
+    });
+    expect(
+      useClosedTabScopesStore.getState().closedIdsForScope("main", BROWSER_SCOPE),
+    ).toEqual([]);
+  });
+
+  it("stores the CANONICAL URL, not the persisted spelling (R3-3)", () => {
+    hydrate({
+      [BROWSER_SCOPE]: [
+        {
+          tab: {
+            id: "t-w",
+            kind: "browser",
+            title: "t-w",
+            isPinned: false,
+            url: "https://Ok.Example/page#frag",
+            automationMode: "human",
+            persistPolicy: "restore-human",
+          },
+          closedSeq: 1,
+        },
+      ],
+    });
+    const entry =
+      useClosedTabScopesStore.getState().scopesByWindow["main"]?.[BROWSER_SCOPE]?.[0];
+    expect(entry?.tab.kind).toBe("browser");
+    expect(entry?.tab.kind === "browser" && entry.tab.url).toBe(
+      "https://ok.example/page",
+    );
   });
 });

--- a/src/stores/tabStoreClosedScopes.ts
+++ b/src/stores/tabStoreClosedScopes.ts
@@ -24,24 +24,29 @@
 import { create } from "zustand";
 import type { Tab } from "@/stores/tabStoreTypes";
 import { onTabRemoved } from "./tabRemovalBus";
+import { onInstanceRekeyed } from "./instanceRekeyBus";
 import { useSettingsStore } from "./settingsStore";
 import { useWorkspaceInstancesStore } from "./workspaceInstancesStore";
 import {
   BROWSER_SCOPE,
   partitionWindowTabs,
 } from "@/services/workspaces/workspaceOwnershipKernel";
-import { canonicalizeBrowserUrl } from "@/lib/browser/url";
+import {
+  isValidClosedEntry,
+  normalizeAcceptedEntry,
+  type ClosedTabEntry,
+} from "./tabStoreClosedScopesValidation";
+
+export type { ClosedTabEntry } from "./tabStoreClosedScopesValidation";
 
 /** Scope for closed tabs with no owning instance (incl. rail-off mode). */
 export const WINDOW_ALL_SCOPE = "window:all" as const;
 
 const MAX_PER_SCOPE = 10;
 
-export interface ClosedTabEntry {
-  tab: Tab;
-  /** Monotonic close order across ALL scopes of the app session. */
-  closedSeq: number;
-}
+/** Hydrated closedSeq values need increment headroom — see audit #14. */
+const SAFE_SEQ_HEADROOM = Number.MAX_SAFE_INTEGER - 1_000_000;
+
 
 interface ClosedTabScopesState {
   /** windowLabel → scopeKey → entries, newest first. */
@@ -56,6 +61,15 @@ interface ClosedTabScopesState {
     scopeKeys: readonly string[],
   ) => { scopeKey: string; entry: ClosedTabEntry } | null;
   closedIdsForScope: (windowLabel: string, scopeKey: string) => string[];
+  /** Drop ONE scope's closed history (WI-TS2.3): called when its workspace
+   *  instance leaves the window (close/move) — without this, per-instance
+   *  scopes leaked forever (removeWindowClosedScopes has no per-instance
+   *  counterpart and zero production callers). */
+  removeClosedScope: (windowLabel: string, scopeKey: string) => void;
+  /** Follow a loose-instance identity re-key (audit 20260831 #9): merge the
+   *  old scope's history into the new key, newest-first, capped. Without
+   *  this the reopen history was orphaned under an id nothing reads. */
+  rekeyClosedScope: (windowLabel: string, oldId: string, newId: string) => void;
   removeWindowClosedScopes: (windowLabel: string) => void;
   /** WI-9.4: rehydrate a window's scopes from a hot-exit payload (validated). */
   hydrateWindowClosedScopes: (
@@ -63,42 +77,6 @@ interface ClosedTabScopesState {
     scopes: Record<string, unknown>,
   ) => void;
   resetClosedScopes: () => void;
-}
-
-/**
- * Shape guard for a persisted closed-tab entry (audit R2-F13/F14): per-kind
- * validation — a document needs a string-or-null filePath; a browser entry
- * needs a CANONICAL http(s) URL (the same gate the live browser applies), so
- * a hand-edited hot-exit payload can never smuggle `javascript:`/`file://`
- * into a later reopen. Kind/scope coherence is enforced at hydrate.
- */
-function isValidClosedEntry(raw: unknown, scopeKey: string): raw is ClosedTabEntry {
-  if (typeof raw !== "object" || raw === null) return false;
-  const e = raw as {
-    tab?: { id?: unknown; kind?: unknown; filePath?: unknown; url?: unknown };
-    closedSeq?: unknown;
-  };
-  if (
-    typeof e.closedSeq !== "number" ||
-    !Number.isSafeInteger(e.closedSeq) ||
-    e.closedSeq < 0 ||
-    typeof e.tab !== "object" ||
-    e.tab === null ||
-    typeof e.tab.id !== "string"
-  ) {
-    return false;
-  }
-  if (e.tab.kind === "document") {
-    // Documents never hydrate into the browser-global scope.
-    if (scopeKey === BROWSER_SCOPE) return false;
-    return e.tab.filePath === null || typeof e.tab.filePath === "string";
-  }
-  if (e.tab.kind === "browser") {
-    // Browser entries ONLY in the browser-global scope, with a safe URL.
-    if (scopeKey !== BROWSER_SCOPE) return false;
-    return typeof e.tab.url === "string" && canonicalizeBrowserUrl(e.tab.url) !== null;
-  }
-  return false;
 }
 
 /** Resolve which scope a closing tab's history belongs to. */
@@ -118,11 +96,16 @@ function resolveScopeKey(windowLabel: string, tab: Tab): string {
     instances,
     windowState?.activeWorkspaceInstanceId ?? null,
   );
-  return (
-    ownerOf.get(tab.id) ??
-    windowState?.activeWorkspaceInstanceId ??
-    WINDOW_ALL_SCOPE
-  );
+  // Fallback for an unowned tab: the ACTIVE instance's scope — unless that
+  // instance is a placeholder (R2-8, audit round 2). A placeholder is evicted
+  // the moment a real workspace arrives, and removeClosedScope drops its
+  // history with it, so recording under a placeholder id orphans the entry.
+  // WINDOW_ALL_SCOPE is the reachable home for ownerless history.
+  const activeId = windowState?.activeWorkspaceInstanceId ?? null;
+  const activeRecord = activeId ? state.instances[activeId] : undefined;
+  const activeScope =
+    activeRecord && activeRecord.kind !== "placeholder" ? activeId : null;
+  return ownerOf.get(tab.id) ?? activeScope ?? WINDOW_ALL_SCOPE;
 }
 
 export const useClosedTabScopesStore = create<ClosedTabScopesState>()((set, get) => ({
@@ -185,13 +168,45 @@ export const useClosedTabScopesStore = create<ClosedTabScopesState>()((set, get)
       const valid: Record<string, ClosedTabEntry[]> = {};
       const seenIds = new Set<string>();
       let maxSeq = state.nextSeq - 1;
+      // Scope keys are whitelisted (R3-4): the two well-known scopes, or a
+      // workspace instance THIS window actually has. Instances hydrate before
+      // closed scopes in the restore sequence (instanceContextState.ts, the
+      // same ordering R2-F16's instance-ui whitelist relies on), so a key
+      // this rejects is junk or cross-window — history nothing could ever
+      // reopen, retained and re-persisted forever.
+      const windowInstanceIds = new Set(
+        useWorkspaceInstancesStore.getState().windows[windowLabel]
+          ?.workspaceInstanceIds ?? [],
+      );
       for (const [scopeKey, rawEntries] of Object.entries(scopes)) {
         if (!Array.isArray(rawEntries)) continue;
-        const entries = rawEntries
+        if (
+          scopeKey !== WINDOW_ALL_SCOPE &&
+          scopeKey !== BROWSER_SCOPE &&
+          !windowInstanceIds.has(scopeKey)
+        ) {
+          continue;
+        }
+        const candidates = rawEntries
           .filter((raw): raw is ClosedTabEntry => isValidClosedEntry(raw, scopeKey))
-          // One scope per id across the whole payload (exclusivity).
-          .filter((entry) => !seenIds.has(entry.tab.id) && (seenIds.add(entry.tab.id), true))
-          .slice(0, MAX_PER_SCOPE);
+          // A closedSeq at the integer ceiling would break the monotonic
+          // nextSeq derived below (audit 20260831 #14) — reject entries with
+          // no increment headroom rather than corrupt ordering forever.
+          .filter((entry) => entry.closedSeq < SAFE_SEQ_HEADROOM)
+          // The store contract is newest-first; a reordered persisted payload
+          // must not decide which entries survive the cap (audit #13).
+          .sort((a, b) => b.closedSeq - a.closedSeq);
+        // One scope per id across the whole payload (exclusivity) — marked at
+        // ACCEPTANCE, not while filtering (R2-9, audit round 2): an id whose
+        // only occurrence in this scope falls beyond the cap must not be
+        // suppressed from every later scope by an entry that never survived.
+        const entries: ClosedTabEntry[] = [];
+        for (const entry of candidates) {
+          if (entries.length >= MAX_PER_SCOPE) break;
+          if (seenIds.has(entry.tab.id)) continue;
+          seenIds.add(entry.tab.id);
+          entries.push(normalizeAcceptedEntry(entry));
+        }
         if (entries.length === 0) continue;
         valid[scopeKey] = entries;
         for (const entry of entries) maxSeq = Math.max(maxSeq, entry.closedSeq);
@@ -201,6 +216,33 @@ export const useClosedTabScopesStore = create<ClosedTabScopesState>()((set, get)
       return {
         nextSeq: maxSeq + 1,
         scopesByWindow: { ...state.scopesByWindow, [windowLabel]: valid },
+      };
+    }),
+
+  removeClosedScope: (windowLabel, scopeKey) =>
+    set((state) => {
+      const windowScopes = state.scopesByWindow[windowLabel];
+      if (!windowScopes || !(scopeKey in windowScopes)) return {};
+      const { [scopeKey]: _removed, ...rest } = windowScopes;
+      return {
+        scopesByWindow: { ...state.scopesByWindow, [windowLabel]: rest },
+      };
+    }),
+
+  rekeyClosedScope: (windowLabel, oldId, newId) =>
+    set((state) => {
+      const windowScopes = state.scopesByWindow[windowLabel];
+      const oldEntries = windowScopes?.[oldId];
+      if (!windowScopes || !oldEntries) return {};
+      const { [oldId]: _moved, ...rest } = windowScopes;
+      const merged = [...(rest[newId] ?? []), ...oldEntries]
+        .sort((a, b) => b.closedSeq - a.closedSeq)
+        .slice(0, MAX_PER_SCOPE);
+      return {
+        scopesByWindow: {
+          ...state.scopesByWindow,
+          [windowLabel]: { ...rest, [newId]: merged },
+        },
       };
     }),
 
@@ -220,4 +262,11 @@ onTabRemoved((windowLabel, _tabId, info) => {
   if (info?.reason === "close") {
     useClosedTabScopesStore.getState().recordClosedTab(windowLabel, info.tab);
   }
+});
+
+// A loose-instance identity re-key must carry its reopen history with it
+// (audit 20260831 #9) — bus-driven because this store imports the instances
+// store, so a direct call back would be an import cycle.
+onInstanceRekeyed((windowLabel, oldId, newId) => {
+  useClosedTabScopesStore.getState().rekeyClosedScope(windowLabel, oldId, newId);
 });

--- a/src/stores/tabStoreClosedScopesValidation.ts
+++ b/src/stores/tabStoreClosedScopesValidation.ts
@@ -1,0 +1,100 @@
+/**
+ * Closed-tab entry validation (split from tabStoreClosedScopes.ts for the
+ * file-size gate — R3-2 grew the guard to the full per-kind Tab shape).
+ *
+ * Purpose: the pure trust boundary for hydrated closed-tab entries. Hydration
+ * payloads are EXTERNAL input (hot-exit JSON on disk); an accepted entry is
+ * restored verbatim into tabStore on reopen, so acceptance must guarantee the
+ * complete required shape per kind and a canonical, navigable URL.
+ *
+ * @coordinates-with tabStoreClosedScopes.ts — the consuming store
+ * @module stores/tabStoreClosedScopesValidation
+ */
+import { canonicalizeBrowserUrl } from "@/lib/browser/url";
+import type { Tab } from "@/stores/tabStoreTypes";
+import { BROWSER_SCOPE } from "@/services/workspaces/workspaceOwnershipKernel";
+
+// Defined here (not in the store) so the store→validation import stays
+// one-directional — a type-only back-import still counts as a cycle to
+// dependency-cruiser. Re-exported from tabStoreClosedScopes.ts for consumers.
+export interface ClosedTabEntry {
+  tab: Tab;
+  /** Monotonic close order across ALL scopes of the app session. */
+  closedSeq: number;
+}
+
+const AUTOMATION_MODES = new Set(["human", "ai-sandbox", "ai-shared"]);
+const PERSIST_POLICIES = new Set(["restore-human", "transient-ai"]);
+
+/**
+ * Shape guard for a persisted closed-tab entry (audit R2-F13/F14, tightened
+ * by R3-2): a hydrated entry is restored VERBATIM into tabStore on reopen, so
+ * it must satisfy the full required `Tab` shape per kind — not merely the
+ * fields the original guard sampled. A document needs title/isPinned/formatId
+ * plus a string-or-null filePath; a browser entry needs title/isPinned, the
+ * enum-valid automationMode/persistPolicy, and a CANONICAL http(s) URL (the
+ * same gate the live browser applies), so a hand-edited hot-exit payload can
+ * never smuggle `javascript:`/`file://` — or a half-shaped tab — into a later
+ * reopen. Kind/scope coherence is enforced at hydrate.
+ */
+export function isValidClosedEntry(raw: unknown, scopeKey: string): raw is ClosedTabEntry {
+  if (typeof raw !== "object" || raw === null) return false;
+  const e = raw as {
+    tab?: {
+      id?: unknown;
+      kind?: unknown;
+      title?: unknown;
+      isPinned?: unknown;
+      filePath?: unknown;
+      formatId?: unknown;
+      url?: unknown;
+      automationMode?: unknown;
+      persistPolicy?: unknown;
+    };
+    closedSeq?: unknown;
+  };
+  if (
+    typeof e.closedSeq !== "number" ||
+    !Number.isSafeInteger(e.closedSeq) ||
+    e.closedSeq < 0 ||
+    typeof e.tab !== "object" ||
+    e.tab === null ||
+    typeof e.tab.id !== "string" ||
+    typeof e.tab.title !== "string" ||
+    typeof e.tab.isPinned !== "boolean"
+  ) {
+    return false;
+  }
+  if (e.tab.kind === "document") {
+    // Documents never hydrate into the browser-global scope.
+    if (scopeKey === BROWSER_SCOPE) return false;
+    return (
+      (e.tab.filePath === null || typeof e.tab.filePath === "string") &&
+      typeof e.tab.formatId === "string"
+    );
+  }
+  if (e.tab.kind === "browser") {
+    // Browser entries ONLY in the browser-global scope, with a safe URL.
+    if (scopeKey !== BROWSER_SCOPE) return false;
+    return (
+      typeof e.tab.automationMode === "string" &&
+      AUTOMATION_MODES.has(e.tab.automationMode) &&
+      typeof e.tab.persistPolicy === "string" &&
+      PERSIST_POLICIES.has(e.tab.persistPolicy) &&
+      typeof e.tab.url === "string" &&
+      canonicalizeBrowserUrl(e.tab.url) !== null
+    );
+  }
+  return false;
+}
+
+/** Canonicalize a browser entry's URL at acceptance (R3-3): reopen must hand
+ *  tabStore the same normalized value live creation would, not whatever
+ *  spelling the persisted payload carried. Documents pass through untouched. */
+export function normalizeAcceptedEntry(entry: ClosedTabEntry): ClosedTabEntry {
+  if (entry.tab.kind !== "browser") return entry;
+  const canonical = canonicalizeBrowserUrl(entry.tab.url);
+  if (canonical === null || canonical === entry.tab.url) return entry;
+  return { ...entry, tab: { ...entry.tab, url: canonical } };
+}
+

--- a/src/stores/uiStore.slices.test.ts
+++ b/src/stores/uiStore.slices.test.ts
@@ -452,4 +452,14 @@ describe("terminal slice actions", () => {
     useUIStore.getState().terminalSetProgramTitle(s.id, "x".repeat(500));
     expect(useUIStore.getState().terminal.sessions[0].programTitle).toHaveLength(256);
   });
+
+  it("terminalSetProgramTitle strips C1 controls and bidi overrides too (audit 20260831 #3)", () => {
+    const s = useUIStore.getState().terminalCreateSession()!;
+    const C1 = "\u0085";
+    const RLO = "\u202E";
+    const LRI = "\u2066";
+    const PDI = "\u2069";
+    useUIStore.getState().terminalSetProgramTitle(s.id, `${RLO}dm.txet${PDI}${C1}vim ${LRI}\u65E5\u672C\u8A9E`);
+    expect(useUIStore.getState().terminal.sessions[0].programTitle).toBe("dm.txetvim \u65E5\u672C\u8A9E");
+  });
 });

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -34,6 +34,7 @@ import {
   initialTerminal,
   resetTerminalIdCounter,
 } from "./uiStore/terminalSlice";
+import { createTerminalScopeActions } from "./uiStore/terminalScopeActions";
 
 export type { SidebarViewMode, UIStore, FileSearchResult, EffectiveTerminalPosition, LineMatch } from "./uiStore/types";
 export { MAX_TERMINAL_SESSIONS } from "./uiStore/terminalSlice";
@@ -199,7 +200,7 @@ export const useUIStore = create<UIStore>((set, get) => ({
     }),
   setDraggingFiles: (dragging) => set({ isDraggingFiles: dragging }),
   toggleTerminal: () => set((s) => ({ terminalVisible: !s.terminalVisible })),
-  // Only the absolute pixel floor is enforced here; the proportional 50% cap
+  // Only the absolute pixel floor is enforced here; the proportional cap
   // (TERMINAL_MAX_RATIO) is applied by the viewport-aware callers that know the
   // window size — useTerminalPosition (layout) and useTerminalResize (drag).
   setTerminalHeight: (h) =>
@@ -218,6 +219,7 @@ export const useUIStore = create<UIStore>((set, get) => ({
   ...createSearchActions(set, get),
   ...createContentSearchActions(set, get),
   ...createTerminalActions(set, get),
+  ...createTerminalScopeActions(set, get),
 }));
 
 /** Reset terminal slice + ID counter — for tests only. */

--- a/src/stores/uiStore/terminalScopeActions.test.ts
+++ b/src/stores/uiStore/terminalScopeActions.test.ts
@@ -1,0 +1,272 @@
+// @vitest-environment node
+// WI-TS1.2 — scope-transition actions: adopt / switchScope / hydrateScope /
+// removeScopeSessions / rekeyScope (plan 20260831, D-T2/D-T3/D-T5/D-T6/D-T11).
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetTerminalSessionStore, useUIStore } from "@/stores/uiStore";
+import type { TerminalSession } from "@/stores/uiStore/types";
+
+const create = (ownerInstanceId?: string) =>
+  useUIStore
+    .getState()
+    .terminalCreateSession(ownerInstanceId ? { ownerInstanceId } : undefined)!;
+
+const sessions = () => useUIStore.getState().terminal.sessions;
+const activeId = () => useUIStore.getState().terminal.activeSessionId;
+const memory = () => useUIStore.getState().terminal.lastActiveByScope;
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+});
+
+describe("terminalAdoptUnscopedSessions", () => {
+  it("stamps every window-scoped session; scoped sessions untouched (monotone owners)", () => {
+    const su1 = create();
+    const sb = create("wsi-b");
+    const su2 = create();
+
+    useUIStore.getState().terminalAdoptUnscopedSessions("wsi-a");
+
+    const byId = new Map(sessions().map((s) => [s.id, s]));
+    expect(byId.get(su1.id)?.workspaceInstanceId).toBe("wsi-a");
+    expect(byId.get(su2.id)?.workspaceInstanceId).toBe("wsi-a");
+    expect(byId.get(sb.id)?.workspaceInstanceId).toBe("wsi-b");
+  });
+
+  it("is idempotent — a second call does not wake the store", () => {
+    create();
+    useUIStore.getState().terminalAdoptUnscopedSessions("wsi-a");
+    const before = useUIStore.getState().terminal;
+    useUIStore.getState().terminalAdoptUnscopedSessions("wsi-a");
+    expect(useUIStore.getState().terminal).toBe(before);
+  });
+
+  it("renumbers on in-scope ordinal collision, labels untouched", () => {
+    // Colliding ordinals cannot arise from creation alone (the union rule
+    // prevents it), so construct the population directly: an adopted session
+    // whose ordinal collides with a pre-existing scoped one.
+    const mk = (
+      id: string,
+      ordinal: number,
+      workspaceInstanceId?: string,
+    ): TerminalSession => ({
+      id,
+      label: `Terminal ${ordinal}`,
+      ordinal,
+      isAlive: true,
+      ...(workspaceInstanceId ? { workspaceInstanceId } : {}),
+    });
+    useUIStore.setState((s) => ({
+      terminal: {
+        ...s.terminal,
+        sessions: [mk("t-a", 1, "wsi-a"), mk("t-u", 1)],
+        activeSessionId: "t-u",
+      },
+    }));
+
+    useUIStore.getState().terminalAdoptUnscopedSessions("wsi-a");
+
+    const byId = new Map(sessions().map((s) => [s.id, s]));
+    expect(byId.get("t-a")?.ordinal).toBe(1); // pre-existing keeps its ordinal
+    expect(byId.get("t-u")?.ordinal).toBe(2); // adopted takes smallest unused
+    expect(byId.get("t-u")?.label).toBe("Terminal 1"); // label untouched
+  });
+
+  it("never removes a session (D-T3: adoption is not a removal path)", () => {
+    create();
+    create("wsi-b");
+    useUIStore.getState().terminalAdoptUnscopedSessions("wsi-a");
+    expect(sessions()).toHaveLength(2);
+  });
+});
+
+describe("terminalSwitchScope", () => {
+  it("remembers the outgoing scope's shown session and restores it on return", () => {
+    const sa = create("wsi-a");
+    const sb = create("wsi-b");
+    useUIStore.getState().terminalSetActiveSession(sa.id);
+
+    useUIStore.getState().terminalSwitchScope("wsi-a", "wsi-b");
+    expect(memory()["wsi-a"]).toBe(sa.id);
+    expect(activeId()).toBe(sb.id);
+
+    useUIStore.getState().terminalSwitchScope("wsi-b", "wsi-a");
+    expect(memory()["wsi-b"]).toBe(sb.id);
+    expect(activeId()).toBe(sa.id);
+  });
+
+  it("activates null for an empty incoming scope", () => {
+    const sa = create("wsi-a");
+    useUIStore.getState().terminalSetActiveSession(sa.id);
+    useUIStore.getState().terminalSwitchScope("wsi-a", "wsi-empty");
+    expect(activeId()).toBeNull();
+  });
+
+  it("falls back to first-visible when the remembered session was closed", () => {
+    const sa1 = create("wsi-a");
+    const sa2 = create("wsi-a");
+    useUIStore.getState().terminalSetActiveSession(sa2.id);
+    useUIStore.getState().terminalSwitchScope("wsi-a", "wsi-b");
+    useUIStore.getState().terminalRemoveSession(sa2.id);
+
+    useUIStore.getState().terminalSwitchScope("wsi-b", "wsi-a");
+    expect(activeId()).toBe(sa1.id);
+  });
+
+  it("clears hasActivity on the session it activates (D-T11: B→A with a bell on A's remembered)", () => {
+    const sa = create("wsi-a");
+    const sb = create("wsi-b");
+    useUIStore.getState().terminalSetActiveSession(sa.id);
+    useUIStore.getState().terminalSwitchScope("wsi-a", "wsi-b");
+    expect(activeId()).toBe(sb.id);
+
+    // A bell rings on A's remembered (now background) session.
+    useUIStore.getState().terminalMarkActivity(sa.id);
+    expect(sessions().find((s) => s.id === sa.id)?.hasActivity).toBe(true);
+
+    useUIStore.getState().terminalSwitchScope("wsi-b", "wsi-a");
+    expect(activeId()).toBe(sa.id);
+    expect(sessions().find((s) => s.id === sa.id)?.hasActivity).toBe(false);
+  });
+
+  it("records null when the outgoing scope was showing nothing", () => {
+    create("wsi-b");
+    useUIStore.setState((s) => ({
+      terminal: { ...s.terminal, activeSessionId: null },
+    }));
+    useUIStore.getState().terminalSwitchScope("wsi-a", "wsi-b");
+    expect(memory()["wsi-a"]).toBeNull();
+  });
+});
+
+describe("terminalHydrateScope", () => {
+  it("activates like switchScope but writes NO outgoing memory", () => {
+    const sa = create("wsi-a");
+    const sb = create("wsi-b");
+    useUIStore.getState().terminalSetActiveSession(sa.id);
+
+    useUIStore.getState().terminalHydrateScope("wsi-b");
+
+    expect(activeId()).toBe(sb.id);
+    expect(memory()).toEqual({});
+  });
+
+  it("is idempotent/convergent (D-T12): a second hydrate re-derives the same state", () => {
+    create("wsi-a");
+    useUIStore.getState().terminalHydrateScope("wsi-a");
+    const first = useUIStore.getState().terminal;
+    useUIStore.getState().terminalHydrateScope("wsi-a");
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(first.activeSessionId);
+    expect(useUIStore.getState().terminal.sessions).toEqual(first.sessions);
+  });
+});
+
+describe("terminalRemoveScopeSessions", () => {
+  it("removes exactly the scope's sessions and drops its memory slot", () => {
+    const sa = create("wsi-a");
+    const sb = create("wsi-b");
+    const su = create();
+    useUIStore.getState().terminalSetActiveSession(sa.id);
+    useUIStore.getState().terminalSwitchScope("wsi-a", "wsi-b");
+
+    useUIStore.getState().terminalRemoveScopeSessions("wsi-a");
+
+    expect(sessions().map((s) => s.id).sort()).toEqual([sb.id, su.id].sort());
+    expect("wsi-a" in memory()).toBe(false);
+  });
+
+  it("nulls the active session when it was in the removed scope", () => {
+    const sa = create("wsi-a");
+    create("wsi-b");
+    useUIStore.getState().terminalSetActiveSession(sa.id);
+    useUIStore.getState().terminalRemoveScopeSessions("wsi-a");
+    expect(activeId()).toBeNull();
+  });
+});
+
+describe("terminalRekeyScope (D-T6 merge)", () => {
+  it("merges with BOTH scopes populated: stamps moved, renumbers collisions, memory target-wins", () => {
+    const sNew = create("wsi-new"); // ordinal 1 in wsi-new
+    const sOld = create("wsi-old"); // ordinal 1 in wsi-old — collides after merge
+    useUIStore.getState().terminalSetActiveSession(sNew.id);
+    useUIStore.getState().terminalSwitchScope("wsi-new", "wsi-old");
+    useUIStore.getState().terminalSwitchScope("wsi-old", "wsi-new");
+    // memory: { "wsi-new": sNew, "wsi-old": sOld } — target must win.
+
+    useUIStore.getState().terminalRekeyScope("wsi-old", "wsi-new");
+
+    const byId = new Map(sessions().map((s) => [s.id, s]));
+    expect(byId.get(sOld.id)?.workspaceInstanceId).toBe("wsi-new");
+    expect(byId.get(sNew.id)?.ordinal).toBe(1);
+    expect(byId.get(sOld.id)?.ordinal).toBe(2); // renumbered on collision
+    expect(memory()).toEqual({ "wsi-new": sNew.id });
+  });
+
+  it("moves the old slot when the target has none", () => {
+    const sOld = create("wsi-old");
+    useUIStore.getState().terminalSetActiveSession(sOld.id);
+    useUIStore.getState().terminalSwitchScope("wsi-old", "wsi-elsewhere");
+
+    useUIStore.getState().terminalRekeyScope("wsi-old", "wsi-new");
+
+    expect(memory()).toEqual({ "wsi-new": sOld.id });
+  });
+
+  it("cap is unaffected: the merged scope can exceed it (creation gate only)", () => {
+    for (let i = 0; i < 3; i++) create("wsi-new");
+    for (let i = 0; i < 3; i++) create("wsi-old");
+    useUIStore.getState().terminalRekeyScope("wsi-old", "wsi-new");
+    expect(sessions()).toHaveLength(6);
+    const ordinals = sessions().map((s) => s.ordinal);
+    expect(new Set(ordinals).size).toBe(6); // in-scope uniqueness restored
+  });
+});
+
+describe("terminalRealignActive (audit round 2, R2-15)", () => {
+  it("keeps a still-visible active session untouched (idempotent)", () => {
+    const a = create("wsi-a");
+    useUIStore.getState().terminalSetActiveSession(a.id);
+    const before = useUIStore.getState().terminal;
+
+    useUIStore.getState().terminalRealignActive([a.id]);
+
+    // No store wake for the no-op case.
+    expect(useUIStore.getState().terminal).toBe(before);
+    expect(activeId()).toBe(a.id);
+  });
+
+  it("moves a newly-HIDDEN active onto the first visible session, clearing its activity dot", () => {
+    const a = create("wsi-a");
+    const b = create("wsi-b");
+    useUIStore.getState().terminalSetActiveSession(b.id);
+    // Give the realign target a pending activity dot (D-T11: activation clears it).
+    useUIStore.getState().terminalMarkActivity(a.id);
+
+    useUIStore.getState().terminalRealignActive([a.id]);
+
+    expect(activeId()).toBe(a.id);
+    expect(sessions().find((s) => s.id === a.id)?.hasActivity).toBe(false);
+    // The hidden session is untouched — hidden, not removed (D-T3).
+    expect(sessions().some((s) => s.id === b.id)).toBe(true);
+  });
+
+  it("clears active to null when nothing is visible", () => {
+    const a = create("wsi-a");
+    useUIStore.getState().terminalSetActiveSession(a.id);
+
+    useUIStore.getState().terminalRealignActive([]);
+
+    expect(activeId()).toBeNull();
+    expect(sessions().some((s) => s.id === a.id)).toBe(true);
+  });
+
+  it("a null active over an empty visible population stays a no-op", () => {
+    create("wsi-a");
+    useUIStore.getState().terminalRealignActive([]);
+    const before = useUIStore.getState().terminal;
+    expect(activeId()).toBeNull();
+
+    useUIStore.getState().terminalRealignActive([]);
+
+    expect(useUIStore.getState().terminal).toBe(before);
+  });
+});

--- a/src/stores/uiStore/terminalScopeActions.ts
+++ b/src/stores/uiStore/terminalScopeActions.ts
@@ -1,0 +1,196 @@
+/**
+ * uiStore `terminal` slice — scope-transition actions (WI-TS1.2, the kernel).
+ *
+ * Purpose: the actions the rail coordinator and the instance lifecycle call
+ * to move terminal sessions between per-workspace-instance scopes. Split from
+ * terminalSlice.ts to keep both files under the size gate.
+ *
+ * Key decisions (plan 20260831-terminal-per-instance-sessions):
+ *   - D-T3: a scope switch NEVER removes sessions from the store — hiding is
+ *     the activeSessionId change; only remove/rekey touch membership.
+ *   - D-T5: adoption/rekey never kill and never consult the cap; ordinals are
+ *     renumbered only on in-scope collision, labels untouched.
+ *   - D-T11: every action that activates a session clears its hasActivity,
+ *     the same rule terminalSetActiveSession applies.
+ *   - Invariant 7: the owner-exact filters here are action-internal — the
+ *     exported COUNT vocabulary lives in terminalScopeSelectors.ts.
+ *
+ * @coordinates-with terminalSlice.ts — base session actions
+ * @coordinates-with services/workspaces/switchWorkspaceInstance.ts — caller
+ * @module stores/uiStore/terminalScopeActions
+ */
+import type {
+  TerminalScopeActions,
+  TerminalSession,
+  TerminalSlice,
+  UIGet,
+  UISet,
+} from "./types";
+import { isSessionVisibleInScope } from "./terminalScopeSelectors";
+import { smallestUnusedOrdinal, withActiveSession } from "./terminalSlice";
+
+/** The scope's visible population: window-scoped ∪ scope-stamped. */
+function visibleIn(sessions: TerminalSession[], scopeId: string): TerminalSession[] {
+  return sessions.filter((s) => isSessionVisibleInScope(s, scopeId));
+}
+
+/**
+ * Renumber `movedIds` sessions so no ordinal collides inside `scopeId`'s
+ * visible union. Non-moved sessions keep their ordinals; a moved session
+ * keeps its own unless it collides, in which case it takes the smallest
+ * unused (labels untouched — the ordinal is the identity, D-T5).
+ */
+function renumberIntoScope(
+  sessions: TerminalSession[],
+  movedIds: ReadonlySet<string>,
+  scopeId: string,
+): TerminalSession[] {
+  const used = new Set(
+    sessions
+      .filter((s) => !movedIds.has(s.id) && isSessionVisibleInScope(s, scopeId))
+      .map((s) => s.ordinal),
+  );
+  return sessions.map((s) => {
+    if (!movedIds.has(s.id)) return s;
+    if (!used.has(s.ordinal)) {
+      used.add(s.ordinal);
+      return s;
+    }
+    const n = smallestUnusedOrdinal(used);
+    used.add(n);
+    return { ...s, ordinal: n };
+  });
+}
+
+/** Remembered-live ?? first-visible ?? null (WI-TS1.2 activation rule). */
+function activationFor(terminal: TerminalSlice, scopeId: string): string | null {
+  const visible = visibleIn(terminal.sessions, scopeId);
+  const remembered = terminal.lastActiveByScope[scopeId];
+  if (remembered && visible.some((s) => s.id === remembered)) return remembered;
+  return visible[0]?.id ?? null;
+}
+
+// Activation goes through the slice's ONE transition, withActiveSession
+// (audit R2-6) — a restored session never keeps a stale activity dot, by the
+// same rule terminalSetActiveSession applies.
+
+export function createTerminalScopeActions(set: UISet, get: UIGet): TerminalScopeActions {
+  return {
+    terminalAdoptUnscopedSessions: (instanceId) => {
+      const movedIds = new Set(
+        get()
+          .terminal.sessions.filter((s) => !s.workspaceInstanceId)
+          .map((s) => s.id),
+      );
+      // Idempotent: nothing window-scoped, nothing to do (no store wake).
+      if (movedIds.size === 0) return;
+      set((s) => {
+        const stamped = s.terminal.sessions.map((session) =>
+          movedIds.has(session.id)
+            ? { ...session, workspaceInstanceId: instanceId }
+            : session,
+        );
+        return {
+          terminal: {
+            ...s.terminal,
+            sessions: renumberIntoScope(stamped, movedIds, instanceId),
+          },
+        };
+      });
+    },
+
+    terminalSwitchScope: (outgoingId, incomingId) => {
+      set((s) => {
+        const lastActiveByScope = outgoingId
+          ? {
+              ...s.terminal.lastActiveByScope,
+              [outgoingId]: s.terminal.activeSessionId,
+            }
+          : s.terminal.lastActiveByScope;
+        const next = { ...s.terminal, lastActiveByScope };
+        return { terminal: withActiveSession(next, activationFor(next, incomingId)) };
+      });
+    },
+
+    terminalHydrateScope: (instanceId) => {
+      // Distinct from terminalSwitchScope(null, id) only in intent today, but
+      // kept separate because hydrate is CONVERGENT (D-T12): calling it twice,
+      // or after a user switch already adopted, re-derives the same state.
+      set((s) => ({
+        terminal: withActiveSession(s.terminal, activationFor(s.terminal, instanceId)),
+      }));
+    },
+
+    terminalRealignActive: (visibleIds) => {
+      // R2-15 (audit 20260831 round 2): after a rail-MODE toggle the visible
+      // population changes with no scope switch, so nothing realigned the
+      // active session — a stale hidden active over an empty tab bar blocked
+      // auto-create. Keep the current active if still visible; otherwise the
+      // first visible session, else null. Idempotent by construction.
+      const { activeSessionId } = get().terminal;
+      if (activeSessionId && visibleIds.includes(activeSessionId)) return;
+      const next = visibleIds[0] ?? null;
+      if (next === activeSessionId) return;
+      set((s) => ({ terminal: withActiveSession(s.terminal, next) }));
+    },
+
+    terminalRemoveScopeSessions: (instanceId) => {
+      set((s) => {
+        const sessions = s.terminal.sessions.filter(
+          (session) => session.workspaceInstanceId !== instanceId,
+        );
+        if (
+          sessions.length === s.terminal.sessions.length &&
+          !(instanceId in s.terminal.lastActiveByScope)
+        ) {
+          return s;
+        }
+        const { [instanceId]: _dropped, ...lastActiveByScope } =
+          s.terminal.lastActiveByScope;
+        return {
+          terminal: {
+            ...s.terminal,
+            sessions,
+            // The reconcile disposes removed sessions' xterm+PTY (D-T3's
+            // removal path — correct here). Never leave active pointing at a
+            // removed id; the caller realigns via terminalHydrateScope.
+            activeSessionId: sessions.some(
+              (session) => session.id === s.terminal.activeSessionId,
+            )
+              ? s.terminal.activeSessionId
+              : null,
+            lastActiveByScope,
+          },
+        };
+      });
+    },
+
+    terminalRekeyScope: (oldId, newId) => {
+      set((s) => {
+        const movedIds = new Set(
+          s.terminal.sessions
+            .filter((session) => session.workspaceInstanceId === oldId)
+            .map((session) => session.id),
+        );
+        const stamped = s.terminal.sessions.map((session) =>
+          movedIds.has(session.id)
+            ? { ...session, workspaceInstanceId: newId }
+            : session,
+        );
+        const sessions =
+          movedIds.size > 0
+            ? renumberIntoScope(stamped, movedIds, newId)
+            : s.terminal.sessions;
+        const { [oldId]: oldSlot, ...rest } = s.terminal.lastActiveByScope;
+        // Target-wins merge — mirrors workspaceInstanceUiStore.rekeyInstanceUiState.
+        const lastActiveByScope =
+          newId in rest
+            ? rest
+            : oldSlot !== undefined
+              ? { ...rest, [newId]: oldSlot }
+              : rest;
+        return { terminal: { ...s.terminal, sessions, lastActiveByScope } };
+      });
+    },
+  };
+}

--- a/src/stores/uiStore/terminalScopeSelectors.test.ts
+++ b/src/stores/uiStore/terminalScopeSelectors.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+// WI-TS1.3 — scoped visibility selectors (plan 20260831, invariant 4/7, D-T15).
+import { describe, expect, it } from "vitest";
+import {
+  selectVisibleSessionCount,
+  selectVisibleTerminalSessions,
+} from "./terminalScopeSelectors";
+import type { TerminalSession } from "./types";
+
+const mk = (id: string, workspaceInstanceId?: string): TerminalSession => ({
+  id,
+  label: id,
+  ordinal: 1,
+  isAlive: true,
+  ...(workspaceInstanceId ? { workspaceInstanceId } : {}),
+});
+
+const population = {
+  sessions: [mk("u1"), mk("a1", "wsi-a"), mk("a2", "wsi-a"), mk("b1", "wsi-b")],
+};
+
+describe("selectVisibleTerminalSessions", () => {
+  it("rail on: active-instance scope ∪ window-scoped", () => {
+    const visible = selectVisibleTerminalSessions(population, "wsi-a", true);
+    expect(visible.map((s) => s.id)).toEqual(["u1", "a1", "a2"]);
+  });
+
+  it("rail on with no active instance: window-scoped only", () => {
+    const visible = selectVisibleTerminalSessions(population, null, true);
+    expect(visible.map((s) => s.id)).toEqual(["u1"]);
+  });
+
+  it("rail off: ALL sessions, stamped included (D-T15 — stamps are inert)", () => {
+    const visible = selectVisibleTerminalSessions(population, "wsi-a", false);
+    expect(visible.map((s) => s.id)).toEqual(["u1", "a1", "a2", "b1"]);
+  });
+
+  it("invariant 4: stamp → rail off → all visible → rail on → scoped again", () => {
+    const on = selectVisibleTerminalSessions(population, "wsi-b", true);
+    expect(on.map((s) => s.id)).toEqual(["u1", "b1"]);
+
+    const off = selectVisibleTerminalSessions(population, "wsi-b", false);
+    expect(off).toHaveLength(4);
+
+    // The toggle is involutive — stamps survived untouched.
+    const onAgain = selectVisibleTerminalSessions(population, "wsi-b", true);
+    expect(onAgain.map((s) => s.id)).toEqual(["u1", "b1"]);
+  });
+});
+
+describe("selectVisibleSessionCount (invariant 7 — the one exported count)", () => {
+  it("equals the visible population's size in both rail modes", () => {
+    expect(selectVisibleSessionCount(population, "wsi-a", true)).toBe(3);
+    expect(selectVisibleSessionCount(population, "wsi-b", true)).toBe(2);
+    expect(selectVisibleSessionCount(population, null, true)).toBe(1);
+    expect(selectVisibleSessionCount(population, null, false)).toBe(4);
+  });
+});

--- a/src/stores/uiStore/terminalScopeSelectors.ts
+++ b/src/stores/uiStore/terminalScopeSelectors.ts
@@ -1,0 +1,55 @@
+/**
+ * uiStore `terminal` slice — scoped visibility selectors (WI-TS1.3).
+ *
+ * Purpose: THE one count vocabulary for terminal scoping (plan invariant 7).
+ * The visible population drives tab-bar rendering, the session cap gate,
+ * last-session panel-hide, and auto-create alike. Owner-exact enumeration is
+ * deliberately NOT exported — it exists only inside remove/rekey/adopt
+ * actions (terminalScopeActions.ts).
+ *
+ * Pure over the slice: rail state and the active instance id are parameters,
+ * so React hooks and imperative services share one rule (D-T15: rail off ⇒
+ * every session is visible, stamped or not — stamps are inert, never erased).
+ *
+ * @coordinates-with terminalScopeActions.ts — action-internal counterparts
+ * @module stores/uiStore/terminalScopeSelectors
+ */
+import type { TerminalSession, TerminalSlice } from "./types";
+
+/**
+ * THE scope-visibility predicate: a session is visible in `scopeId`'s scope
+ * when it is window-scoped (no stamp) or stamped with that scope. Every other
+ * rule in this module — and the slice's creation union and the scope actions'
+ * internal filters — builds on this ONE predicate, so the visibility rule
+ * cannot fork (audit 20260831 #2/#4).
+ */
+export function isSessionVisibleInScope(
+  session: TerminalSession,
+  scopeId: string | null,
+): boolean {
+  return !session.workspaceInstanceId || session.workspaceInstanceId === scopeId;
+}
+
+/**
+ * The sessions visible in the window right now: with the rail on, the active
+ * instance's scope ∪ window-scoped; with it off, ALL sessions (D-T15 — a
+ * stamped session's stamp is inert while the rail is disabled, and reactivates
+ * on re-enable).
+ */
+export function selectVisibleTerminalSessions(
+  terminal: Pick<TerminalSlice, "sessions">,
+  activeInstanceId: string | null,
+  railEnabled: boolean,
+): TerminalSession[] {
+  if (!railEnabled) return terminal.sessions;
+  return terminal.sessions.filter((s) => isSessionVisibleInScope(s, activeInstanceId));
+}
+
+/** Invariant 7: the ONLY exported session count. */
+export function selectVisibleSessionCount(
+  terminal: Pick<TerminalSlice, "sessions">,
+  activeInstanceId: string | null,
+  railEnabled: boolean,
+): number {
+  return selectVisibleTerminalSessions(terminal, activeInstanceId, railEnabled).length;
+}

--- a/src/stores/uiStore/terminalSlice.scope.test.ts
+++ b/src/stores/uiStore/terminalSlice.scope.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+// WI-TS1.1 — owner stamping + union cap/ordinal allocation on
+// terminalCreateSession (plan 20260831-terminal-per-instance-sessions, D-T1/D-T5).
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_TERMINAL_SESSIONS,
+  resetTerminalSessionStore,
+  useUIStore,
+} from "@/stores/uiStore";
+
+function create(ownerInstanceId?: string) {
+  return useUIStore
+    .getState()
+    .terminalCreateSession(ownerInstanceId ? { ownerInstanceId } : undefined);
+}
+
+beforeEach(() => {
+  resetTerminalSessionStore();
+});
+
+describe("terminalCreateSession — owner stamping (D-T1)", () => {
+  it("stamps workspaceInstanceId when ownerInstanceId is given", () => {
+    const s = create("wsi-a");
+    expect(s?.workspaceInstanceId).toBe("wsi-a");
+  });
+
+  it("leaves the key ABSENT (not undefined) without an owner — window-scoped", () => {
+    const s = create();
+    expect(s).not.toBeNull();
+    expect(Object.keys(s ?? {})).not.toContain("workspaceInstanceId");
+  });
+
+  it("preserves lastActiveByScope across creations", () => {
+    useUIStore.setState((state) => ({
+      terminal: { ...state.terminal, lastActiveByScope: { "wsi-a": null } },
+    }));
+    create("wsi-a");
+    expect(useUIStore.getState().terminal.lastActiveByScope).toEqual({ "wsi-a": null });
+  });
+});
+
+describe("terminalCreateSession — union cap (D-T5, creation-time gate only)", () => {
+  it("caps per visible union: a full scope blocks, a fresh scope does not", () => {
+    for (let i = 0; i < MAX_TERMINAL_SESSIONS; i++) {
+      expect(create("wsi-a")).not.toBeNull();
+    }
+    expect(create("wsi-a")).toBeNull();
+    // Another scope's union is empty — creation proceeds.
+    expect(create("wsi-b")).not.toBeNull();
+  });
+
+  it("window-scoped sessions count toward every scope's union", () => {
+    create(); // window-scoped — visible in every scope
+    for (let i = 0; i < MAX_TERMINAL_SESSIONS - 1; i++) {
+      expect(create("wsi-a")).not.toBeNull();
+    }
+    expect(create("wsi-a")).toBeNull();
+  });
+
+  it("an unscoped creation counts every session (exact for rail-off and both rail-on carve-outs)", () => {
+    for (let i = 0; i < MAX_TERMINAL_SESSIONS; i++) create("wsi-a");
+    expect(create()).toBeNull();
+  });
+
+  it("cap is a creation gate, not a population invariant: rekey can exceed it and kills nothing", () => {
+    for (let i = 0; i < 3; i++) create("wsi-a");
+    for (let i = 0; i < 3; i++) create("wsi-old");
+    useUIStore.getState().terminalRekeyScope("wsi-old", "wsi-a");
+
+    const sessions = useUIStore.getState().terminal.sessions;
+    expect(sessions).toHaveLength(6);
+    expect(sessions.every((s) => s.workspaceInstanceId === "wsi-a")).toBe(true);
+    // Over-cap population is representable; creation stays blocked.
+    expect(create("wsi-a")).toBeNull();
+  });
+});
+
+describe("terminalCreateSession — union ordinals (D-T5)", () => {
+  it("allocates the smallest unused ordinal across the visible union", () => {
+    create("wsi-a"); // A:1
+    create("wsi-a"); // A:2
+    const b = create("wsi-b");
+    expect(b?.ordinal).toBe(1); // B's union is empty — reuses 1 invisibly to A
+
+    const unscoped = create();
+    // Window-scoped: visible in every scope, so distinct from EVERY ordinal.
+    expect(unscoped?.ordinal).toBe(3);
+  });
+
+  it("no two co-visible sessions share an ordinal", () => {
+    create("wsi-a");
+    create("wsi-b");
+    create();
+    create("wsi-a");
+    const sessions = useUIStore.getState().terminal.sessions;
+    const visibleInA = sessions.filter(
+      (s) => !s.workspaceInstanceId || s.workspaceInstanceId === "wsi-a",
+    );
+    const ordinals = visibleInA.map((s) => s.ordinal);
+    expect(new Set(ordinals).size).toBe(ordinals.length);
+  });
+
+  it("rail-off allocation is identical to today: 1..5 then null", () => {
+    const ordinals: number[] = [];
+    for (let i = 0; i < MAX_TERMINAL_SESSIONS; i++) {
+      const s = create();
+      if (s) ordinals.push(s.ordinal);
+    }
+    expect(ordinals).toEqual([1, 2, 3, 4, 5]);
+    expect(create()).toBeNull();
+  });
+});
+
+describe("terminalRemoveSession — visible-population fallback (WI-TS1.2)", () => {
+  it("falls back to the last remaining VISIBLE session when visibleIds is given", () => {
+    const sa = create("wsi-a")!;
+    const sb = create("wsi-b")!;
+    const su = create()!;
+    useUIStore.getState().terminalSetActiveSession(sa.id);
+
+    // A's visible population is {sa, su} — sb is another scope's session.
+    useUIStore.getState().terminalRemoveSession(sa.id, { visibleIds: [sa.id, su.id] });
+
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(su.id);
+    expect(useUIStore.getState().terminal.sessions.map((s) => s.id)).toEqual([
+      sb.id,
+      su.id,
+    ]);
+  });
+
+  it("without the hint, behaves exactly as before (last remaining)", () => {
+    const s1 = create()!;
+    const s2 = create()!;
+    useUIStore.getState().terminalSetActiveSession(s1.id);
+    useUIStore.getState().terminalRemoveSession(s1.id);
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(s2.id);
+  });
+
+  it("falls back to null when nothing visible remains", () => {
+    const sa = create("wsi-a")!;
+    const sb = create("wsi-b")!;
+    useUIStore.getState().terminalSetActiveSession(sa.id);
+    useUIStore.getState().terminalRemoveSession(sa.id, { visibleIds: [sa.id] });
+    expect(useUIStore.getState().terminal.activeSessionId).toBeNull();
+    expect(useUIStore.getState().terminal.sessions.map((s) => s.id)).toEqual([sb.id]);
+  });
+});
+
+describe("terminalRemoveSession — fallback activation clears activity (R3-1)", () => {
+  it("the fallback session's pending activity dot clears on activation (D-T11)", () => {
+    const s1 = create()!;
+    const s2 = create()!; // active
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(s2.id);
+    // s1 is NOT active, so it can carry an activity dot.
+    useUIStore.getState().terminalMarkActivity(s1.id);
+    expect(
+      useUIStore.getState().terminal.sessions.find((s) => s.id === s1.id)?.hasActivity,
+    ).toBe(true);
+
+    useUIStore.getState().terminalRemoveSession(s2.id);
+
+    // s1 became the visible active session — a stale dot on the session the
+    // user is now LOOKING AT is the exact state D-T11 forbids.
+    const terminal = useUIStore.getState().terminal;
+    expect(terminal.activeSessionId).toBe(s1.id);
+    expect(terminal.sessions.find((s) => s.id === s1.id)?.hasActivity).toBe(false);
+  });
+
+  it("removing a NON-active session leaves the active session untouched", () => {
+    const s1 = create()!;
+    const s2 = create()!; // active
+    useUIStore.getState().terminalRemoveSession(s1.id);
+    expect(useUIStore.getState().terminal.activeSessionId).toBe(s2.id);
+  });
+});

--- a/src/stores/uiStore/terminalSlice.ts
+++ b/src/stores/uiStore/terminalSlice.ts
@@ -28,12 +28,14 @@ import type {
   UIGet,
   UISet,
 } from "./types";
+import { isSessionVisibleInScope } from "./terminalScopeSelectors";
 
 export const MAX_TERMINAL_SESSIONS = 5;
 
 export const initialTerminal: TerminalSlice = {
   sessions: [],
   activeSessionId: null,
+  lastActiveByScope: {},
 };
 
 let nextTerminalId = 1;
@@ -42,16 +44,63 @@ function generateTerminalId(): string {
   return `term-${nextTerminalId++}`;
 }
 
+/** THE smallest-unused allocation rule (audit 20260831 R2-5): creation and
+ *  the scope actions' renumbering share it, so the rules cannot diverge. */
+export function smallestUnusedOrdinal(used: ReadonlySet<number>): number {
+  let n = 1;
+  while (used.has(n)) n++;
+  return n;
+}
+
 /**
  * Smallest unused 1-based ordinal. Read from the sessions' own `ordinal`
  * field, not scraped back out of their labels: the label is display text and a
  * rename or a translation would make that parse meaningless.
  */
 function nextTerminalOrdinal(sessions: TerminalSession[]): number {
-  const used = new Set(sessions.map((s) => s.ordinal));
-  let n = 1;
-  while (used.has(n)) n++;
-  return n;
+  return smallestUnusedOrdinal(new Set(sessions.map((s) => s.ordinal)));
+}
+
+/**
+ * Activate `activeId` on the slice, clearing the activated session's
+ * hasActivity (D-T11). THE one activation transition (audit R2-6):
+ * terminalSetActiveSession and every scope action apply it, so the
+ * activity-clear rule cannot fork.
+ */
+export function withActiveSession(
+  terminal: TerminalSlice,
+  activeId: string | null,
+): TerminalSlice {
+  return {
+    ...terminal,
+    activeSessionId: activeId,
+    sessions: activeId
+      ? terminal.sessions.map((s) =>
+          s.id === activeId && s.hasActivity ? { ...s, hasActivity: false } : s,
+        )
+      : terminal.sessions,
+  };
+}
+
+/**
+ * The creation-time union (WI-TS1.1, D-T5): the sessions a new session owned
+ * by `ownerInstanceId` will be visible alongside — same-scope ∪ window-scoped.
+ * Cap and ordinal allocation both run over this union, so no two co-visible
+ * sessions share an ordinal and the `+` gate counts what the user can see.
+ *
+ * An UNSCOPED creation counts every session. That is exact for rail-off
+ * (D-T15: everything is visible), and exact for the rail-on carve-outs too:
+ * a placeholder-active window has no real instances (placeholders are sole
+ * occupants), and a mid-restore window starts from an empty terminal store
+ * (no session persistence, D-T12) — in both states no stamped session can
+ * exist, so "all sessions" IS the window-scoped population.
+ */
+export function creationUnion(
+  sessions: TerminalSession[],
+  ownerInstanceId?: string,
+): TerminalSession[] {
+  if (!ownerInstanceId) return sessions;
+  return sessions.filter((s) => isSessionVisibleInScope(s, ownerInstanceId));
 }
 
 /** Reset the session ID counter — for tests only (via resetTerminalSessionStore). */
@@ -98,8 +147,12 @@ export function createTerminalActions(set: UISet, get: UIGet): TerminalActions {
   return {
     terminalCreateSession: (options) => {
       const state = get().terminal;
-      if (state.sessions.length >= MAX_TERMINAL_SESSIONS) return null;
-      const ordinal = nextTerminalOrdinal(state.sessions);
+      // Cap and ordinal run over the VISIBLE union (D-T5), a creation-time
+      // gate only — adoption/rekey never consult it, so a scope can
+      // transiently exceed the cap without anything being killed.
+      const union = creationUnion(state.sessions, options?.ownerInstanceId);
+      if (union.length >= MAX_TERMINAL_SESSIONS) return null;
+      const ordinal = nextTerminalOrdinal(union);
       const session: TerminalSession = {
         id: generateTerminalId(),
         // Default display text. The identity that survives translation is
@@ -111,46 +164,50 @@ export function createTerminalActions(set: UISet, get: UIGet): TerminalActions {
         // "Open Terminal Here" pins the start directory (WI-4.2); the spawn
         // path takes it exactly once.
         ...(options?.requestedCwd ? { requestedCwd: options.requestedCwd } : {}),
+        // Owner stamp (WI-TS1.1, D-T1). Key absent ⇒ window-scoped.
+        ...(options?.ownerInstanceId
+          ? { workspaceInstanceId: options.ownerInstanceId }
+          : {}),
       };
       set((s) => ({
         terminal: {
+          ...s.terminal,
           sessions: [...s.terminal.sessions, session],
           activeSessionId: session.id,
         },
       }));
       return session;
     },
-    terminalRemoveSession: (id) => {
+    terminalRemoveSession: (id, opts) => {
       const state = get().terminal;
       const remaining = state.sessions.filter((s) => s.id !== id);
       let activeId = state.activeSessionId;
       if (activeId === id) {
+        // Fallback-active picks from the caller's VISIBLE population when
+        // given (WI-TS1.2) — activating a hidden scope's session would show
+        // nothing. Without the hint: all remaining (rail-off behavior).
+        const candidates = opts?.visibleIds
+          ? remaining.filter((s) => opts.visibleIds?.includes(s.id))
+          : remaining;
         activeId =
-          remaining.length > 0 ? remaining[remaining.length - 1].id : null;
+          candidates.length > 0 ? candidates[candidates.length - 1].id : null;
       }
+      // The fallback is an ACTIVATION, so it goes through the one transition
+      // (audit round 3, R3-1): a fallback session carrying an activity dot
+      // has just become the visible session, and the dot must clear (D-T11).
       set((s) => ({
-        terminal: {
-          ...s.terminal,
-          sessions: remaining,
-          activeSessionId: activeId,
-        },
+        terminal: withActiveSession(
+          { ...s.terminal, sessions: remaining },
+          activeId,
+        ),
       }));
     },
     terminalSetActiveSession: (id) => {
       const state = get().terminal;
       if (state.sessions.some((s) => s.id === id)) {
-        // Activating a session clears its background-activity flag (WI-4.3).
-        set((s) => ({
-          terminal: {
-            ...s.terminal,
-            activeSessionId: id,
-            sessions: s.terminal.sessions.map((session) =>
-              session.id === id && session.hasActivity
-                ? { ...session, hasActivity: false }
-                : session,
-            ),
-          },
-        }));
+        // Activating a session clears its background-activity flag (WI-4.3)
+        // — via the ONE activation transition (withActiveSession).
+        set((s) => ({ terminal: withActiveSession(s.terminal, id) }));
       }
     },
     terminalMarkSessionDead: (id) => {
@@ -168,10 +225,16 @@ export function createTerminalActions(set: UISet, get: UIGet): TerminalActions {
       // A program controls this via OSC 0/2 — strip control chars, collapse
       // whitespace, and cap length so a hostile/garbled title can't bloat the
       // store or corrupt the tab UI / screen-reader output (Codex audit).
+      // C1 controls and bidi overrides are stripped too (audit 20260831 #3):
+      // a bidi override in a tab label can visually reverse the strip's text.
       const clean = Array.from(title)
         .filter((ch) => {
           const c = ch.codePointAt(0) ?? 0;
-          return c > 0x1f && c !== 0x7f; // drop C0 control chars + DEL
+          if (c <= 0x1f || c === 0x7f) return false; // C0 + DEL
+          if (c >= 0x80 && c <= 0x9f) return false; // C1
+          if (c >= 0x202a && c <= 0x202e) return false; // bidi embeddings/overrides
+          if (c >= 0x2066 && c <= 0x2069) return false; // bidi isolates
+          return true;
         })
         .join("")
         .replace(/\s+/g, " ")

--- a/src/stores/uiStore/types.ts
+++ b/src/stores/uiStore/types.ts
@@ -138,19 +138,42 @@ export interface TerminalSession {
    *  over the sibling-cwd inheritance that otherwise wins. Cleared on spawn so
    *  a later restart does not silently re-anchor the shell. */
   requestedCwd?: string;
+  /** Owning workspace instance (WI-TS1.1, D-T1/D-T2). Stamped at creation from
+   *  the active scope (via resolveTerminalOwnerInstanceId), or later by
+   *  adoption/rekey. ABSENT ⇒ window-scoped: visible in every scope and
+   *  followable by the workspace-cd sync. Never a placeholder id, and never
+   *  cleared once set — owner changes are monotone (invariant 3). */
+  workspaceInstanceId?: string;
 }
 
 export interface TerminalSlice {
   sessions: TerminalSession[];
   activeSessionId: string | null;
+  /** Per-scope "last shown session" memory (WI-TS1.2, D-T2): workspace
+   *  instance id → session id, or null when the scope was showing nothing.
+   *  Written by terminalSwitchScope for the OUTGOING scope; slots are dropped
+   *  with their instance (close/move) and merged target-wins on rekey. */
+  lastActiveByScope: Record<string, string | null>;
 }
 
 export interface TerminalActions {
   /** Create a session. `requestedCwd` pins its starting directory (WI-4.2);
    *  without it the spawn path inherits a sibling's cwd or resolves the
-   *  workspace/file default. Returns null at MAX_TERMINAL_SESSIONS. */
-  terminalCreateSession: (options?: { requestedCwd?: string }) => TerminalSession | null;
-  terminalRemoveSession: (id: string) => void;
+   *  workspace/file default. `ownerInstanceId` stamps the session's owning
+   *  workspace instance (WI-TS1.1) — callers resolve it via the ONE shared
+   *  helper `resolveTerminalOwnerInstanceId(windowLabel)`; the slice never
+   *  imports workspace stores. Returns null when the creation-time union
+   *  (D-T5: same scope ∪ window-scoped; all sessions when unscoped) is at
+   *  MAX_TERMINAL_SESSIONS. */
+  terminalCreateSession: (options?: {
+    requestedCwd?: string;
+    ownerInstanceId?: string;
+  }) => TerminalSession | null;
+  /** Remove a session. When the removed session was active, the fallback
+   *  active is picked from `opts.visibleIds` (the caller's visible population,
+   *  D-T7/WI-TS1.2) when given, else from all remaining sessions (rail-off
+   *  behavior, identical to before scoping). */
+  terminalRemoveSession: (id: string, opts?: { visibleIds?: readonly string[] }) => void;
   terminalSetActiveSession: (id: string) => void;
   terminalMarkSessionDead: (id: string) => void;
   terminalMarkSessionAlive: (id: string) => void;
@@ -162,6 +185,36 @@ export interface TerminalActions {
   /** Clear it — only after the spawn that used it actually succeeded, so a
    *  failed spawn can still be retried in the directory the user asked for. */
   terminalClearRequestedCwd: (id: string) => void;
+}
+
+/** Scope-transition actions (WI-TS1.2) — the kernel the rail coordinator and
+ *  instance lifecycle call. Implementations in terminalScopeActions.ts. */
+export interface TerminalScopeActions {
+  /** Stamp every window-scoped session with `instanceId` (absent →
+   *  instanceId), renumbering ordinals on in-scope collision. Labels are
+   *  untouched; never kills; idempotent. Callers guarantee `instanceId` is
+   *  never a placeholder (D-T1). */
+  terminalAdoptUnscopedSessions: (instanceId: string) => void;
+  /** Record the outgoing scope's shown session into lastActiveByScope, then
+   *  activate the incoming scope's remembered-live ?? first-visible ?? null,
+   *  clearing hasActivity on the session it activates (D-T11). */
+  terminalSwitchScope: (outgoingId: string | null, incomingId: string) => void;
+  /** Same activation as terminalSwitchScope WITHOUT writing any outgoing
+   *  memory — hydrate/close/move have no outgoing context. Idempotent. */
+  terminalHydrateScope: (instanceId: string) => void;
+  /** Remove every session stamped `instanceId` (the reconcile disposes their
+   *  xterm + PTY) and drop the scope's lastActiveByScope slot. Callers realign
+   *  via terminalHydrateScope(successor) when the closed scope was active. */
+  terminalRemoveScopeSessions: (instanceId: string) => void;
+  /** Re-stamp every oldId session to newId (loose-instance identity rekey,
+   *  D-T6), renumbering ordinals on in-scope collision; lastActiveByScope
+   *  merges target-wins. */
+  terminalRekeyScope: (oldId: string, newId: string) => void;
+  /** Realign the active session to the caller's VISIBLE population (R2-15):
+   *  keep the current active if it is in `visibleIds`, else activate the
+   *  first visible session, else null. Covers the rail-MODE toggle, where the
+   *  visible population changes with no scope switch. Idempotent. */
+  terminalRealignActive: (visibleIds: readonly string[]) => void;
 }
 
 /* ──────────────────────────── ui slice shape ──────────────────────────── */
@@ -199,7 +252,11 @@ interface UIState {
   terminal: TerminalSlice;
 }
 
-interface UIActions extends SearchActions, ContentSearchActions, TerminalActions {
+interface UIActions
+  extends SearchActions,
+    ContentSearchActions,
+    TerminalActions,
+    TerminalScopeActions {
   toggleSidebar: () => void;
   toggleSidebarView: (mode: SidebarViewMode) => void;
   setSidebarViewMode: (mode: SidebarViewMode) => void;

--- a/src/stores/workspaceInstancesStore.test.ts
+++ b/src/stores/workspaceInstancesStore.test.ts
@@ -341,3 +341,29 @@ describe("workspaceInstancesStore", () => {
       .toBeNull();
   });
 });
+
+describe("same-id placeholder→real replacement (audit 20260831 #10)", () => {
+  it("keeps membership, the record, and activation when a real instance reuses a placeholder's id", () => {
+    useWorkspaceInstancesStore.getState().ensurePlaceholderInstance("main", "wsi-x");
+    expect(useWorkspaceInstancesStore.getState().instances["wsi-x"]?.kind).toBe("placeholder");
+
+    useWorkspaceInstancesStore.getState().addWorkspaceInstance(instance("wsi-x", "main"));
+
+    const state = useWorkspaceInstancesStore.getState();
+    // The old flow filtered the id out of membership, then deleted the record
+    // it had just written — an active id pointing at nothing.
+    expect(state.instances["wsi-x"]?.kind).toBe("workspace");
+    expect(state.windows["main"]?.workspaceInstanceIds).toEqual(["wsi-x"]);
+    expect(state.windows["main"]?.activeWorkspaceInstanceId).toBe("wsi-x");
+  });
+
+  it("still evicts OTHER placeholders when a real instance arrives", () => {
+    useWorkspaceInstancesStore.getState().ensurePlaceholderInstance("main", "wsi-ph");
+    useWorkspaceInstancesStore.getState().addWorkspaceInstance(instance("wsi-real", "main"));
+
+    const state = useWorkspaceInstancesStore.getState();
+    expect(state.instances["wsi-ph"]).toBeUndefined();
+    expect(state.windows["main"]?.workspaceInstanceIds).toEqual(["wsi-real"]);
+    expect(state.windows["main"]?.activeWorkspaceInstanceId).toBe("wsi-real");
+  });
+});

--- a/src/stores/workspaceInstancesStore.ts
+++ b/src/stores/workspaceInstancesStore.ts
@@ -1,11 +1,13 @@
 import { create } from "zustand";
 import { createWorkspaceInstance, generateUUID } from "@/utils/workspaceIdentity";
+import { notifyInstanceRekeyed } from "@/stores/instanceRekeyBus";
+import { useUIStore } from "@/stores/uiStore";
 import { useWorkspaceInstanceUiStore } from "@/stores/workspaceInstanceUiStore";
 import { useWorkspacePaneLayoutsStore } from "@/stores/workspacePaneLayoutsStore";
 import {
+  applyAddWorkspaceInstance,
   emptyWindowState,
   removeFromWindow,
-  removePlaceholdersFromWindow,
   uniqueIds,
   type WindowWorkspaceState,
   type WorkspaceInstanceRecord,
@@ -35,47 +37,9 @@ export const useWorkspaceInstancesStore = create<WorkspaceInstancesState>()((set
   instances: {},
   windows: {},
 
+  // Reducer body lives in helpers.ts (WI-TS0.3 pre-split) — pure, store-free.
   addWorkspaceInstance: (instance) =>
-    set((state) => {
-      const previous = state.instances[instance.workspaceInstanceId];
-      const windows = { ...state.windows };
-      if (previous && previous.ownerWindowLabel !== instance.ownerWindowLabel) {
-        windows[previous.ownerWindowLabel] = removeFromWindow(
-          windows[previous.ownerWindowLabel] ?? emptyWindowState(previous.ownerWindowLabel),
-          instance.workspaceInstanceId
-        );
-      }
-
-      const target = windows[instance.ownerWindowLabel] ?? emptyWindowState(instance.ownerWindowLabel);
-      const realInstance = instance.kind !== "placeholder";
-      const targetWithoutPlaceholders = realInstance
-        ? removePlaceholdersFromWindow(target, state.instances)
-        : target;
-      const placeholderIds = realInstance
-        ? target.workspaceInstanceIds.filter(
-          (id) => state.instances[id]?.kind === "placeholder",
-        )
-        : [];
-      const ids = target.workspaceInstanceIds.includes(instance.workspaceInstanceId)
-        ? targetWithoutPlaceholders.workspaceInstanceIds
-        : [...targetWithoutPlaceholders.workspaceInstanceIds, instance.workspaceInstanceId];
-      const nextInstances = { ...state.instances, [instance.workspaceInstanceId]: instance };
-      for (const id of placeholderIds) {
-        delete nextInstances[id];
-      }
-      windows[instance.ownerWindowLabel] = {
-        ...targetWithoutPlaceholders,
-        workspaceInstanceIds: ids,
-        activeWorkspaceInstanceId: ids.includes(target.activeWorkspaceInstanceId ?? "")
-          ? target.activeWorkspaceInstanceId
-          : instance.workspaceInstanceId,
-      };
-
-      return {
-        instances: nextInstances,
-        windows,
-      };
-    }),
+    set((state) => applyAddWorkspaceInstance(state, instance)),
 
   activateWorkspaceInstance: (windowLabel, instanceId) =>
     set((state) => {
@@ -255,6 +219,14 @@ export const useWorkspaceInstancesStore = create<WorkspaceInstancesState>()((set
     if (rekeyedFrom && instanceId) {
       useWorkspaceInstanceUiStore.getState().rekeyInstanceUiState(rekeyedFrom, instanceId);
       useWorkspacePaneLayoutsStore.getState().rekeyPaneLayout(rekeyedFrom, instanceId);
+      // WI-TS2.3 (D-T6): terminal sessions follow the identity re-key too —
+      // merge semantics (re-stamp, ordinal renumber, memory target-wins)
+      // live in terminalRekeyScope.
+      useUIStore.getState().terminalRekeyScope(rekeyedFrom, instanceId);
+      // Closed-tab reopen history follows via the bus (audit 20260831 #9 —
+      // tabStoreClosedScopes imports this store, so a direct call back would
+      // be an import cycle).
+      notifyInstanceRekeyed(windowLabel, rekeyedFrom, instanceId);
     }
     return result;
   },

--- a/src/stores/workspaceInstancesStore/helpers.ts
+++ b/src/stores/workspaceInstancesStore/helpers.ts
@@ -40,22 +40,6 @@ export function removeFromWindow(
   };
 }
 
-export function removePlaceholdersFromWindow(
-  windowState: WindowWorkspaceState,
-  instances: Record<string, WorkspaceInstanceRecord>,
-): WindowWorkspaceState {
-  const ids = windowState.workspaceInstanceIds.filter(
-    (id) => instances[id]?.kind !== "placeholder",
-  );
-  return {
-    ...windowState,
-    workspaceInstanceIds: ids,
-    activeWorkspaceInstanceId: ids.includes(windowState.activeWorkspaceInstanceId ?? "")
-      ? windowState.activeWorkspaceInstanceId
-      : ids[0] ?? null,
-  };
-}
-
 export function uniqueIds(ids: string[]): string[] {
   const seen = new Set<string>();
   const result: string[] = [];
@@ -65,4 +49,66 @@ export function uniqueIds(ids: string[]): string[] {
     result.push(id);
   }
   return result;
+}
+
+/**
+ * Pure reducer for `addWorkspaceInstance` (WI-TS0.3 pre-split). Adding a REAL
+ * instance deletes any placeholder instances from the target window silently;
+ * a placeholder being added never displaces anything.
+ *
+ * The incoming instance's OWN id is never treated as an evictable placeholder
+ * (audit 20260831 #10): when a real instance reuses a placeholder's id, the
+ * old flow filtered that id out of the membership list and then deleted the
+ * record it had just written — leaving an active id with no membership and
+ * no record.
+ */
+export function applyAddWorkspaceInstance(
+  state: {
+    instances: Record<string, WorkspaceInstanceRecord>;
+    windows: Record<string, WindowWorkspaceState>;
+  },
+  instance: WorkspaceInstanceRecord,
+): {
+  instances: Record<string, WorkspaceInstanceRecord>;
+  windows: Record<string, WindowWorkspaceState>;
+} {
+  const previous = state.instances[instance.workspaceInstanceId];
+  const windows = { ...state.windows };
+  if (previous && previous.ownerWindowLabel !== instance.ownerWindowLabel) {
+    windows[previous.ownerWindowLabel] = removeFromWindow(
+      windows[previous.ownerWindowLabel] ?? emptyWindowState(previous.ownerWindowLabel),
+      instance.workspaceInstanceId
+    );
+  }
+
+  const target = windows[instance.ownerWindowLabel] ?? emptyWindowState(instance.ownerWindowLabel);
+  const realInstance = instance.kind !== "placeholder";
+  const isEvictablePlaceholder = (id: string): boolean =>
+    id !== instance.workspaceInstanceId &&
+    state.instances[id]?.kind === "placeholder";
+  const keptIds = realInstance
+    ? target.workspaceInstanceIds.filter((id) => !isEvictablePlaceholder(id))
+    : target.workspaceInstanceIds;
+  const placeholderIds = realInstance
+    ? target.workspaceInstanceIds.filter(isEvictablePlaceholder)
+    : [];
+  const ids = keptIds.includes(instance.workspaceInstanceId)
+    ? keptIds
+    : [...keptIds, instance.workspaceInstanceId];
+  const nextInstances = { ...state.instances, [instance.workspaceInstanceId]: instance };
+  for (const id of placeholderIds) {
+    delete nextInstances[id];
+  }
+  windows[instance.ownerWindowLabel] = {
+    ...target,
+    workspaceInstanceIds: ids,
+    activeWorkspaceInstanceId: ids.includes(target.activeWorkspaceInstanceId ?? "")
+      ? target.activeWorkspaceInstanceId
+      : instance.workspaceInstanceId,
+  };
+
+  return {
+    instances: nextInstances,
+    windows,
+  };
 }

--- a/src/styles/button-shared.css
+++ b/src/styles/button-shared.css
@@ -76,6 +76,14 @@
   font-size: var(--font-size-xs);
 }
 
+/* Capsule shape (maintainer direction, 2026-08-31 — the welcome front door).
+   Promoted onto the primitive (rule 32's middle path) so a pill-shaped action
+   exists exactly once: a per-wrapper border-radius override would register as
+   shape drift in check-bespoke-buttons' maxShapeDriftClasses, and rightly so. */
+.vm-btn--pill {
+  border-radius: var(--radius-pill);
+}
+
 /* Emphasised action (confirm, start, submit). */
 .vm-btn--primary {
   border-color: var(--primary-color);

--- a/src/types/workspaceTransfer.ts
+++ b/src/types/workspaceTransfer.ts
@@ -52,7 +52,10 @@ type WorkspaceActionFailureReason =
   | "disabled"
   | "missingInstance"
   | "invokeFailed"
-  | "timeout";
+  | "timeout"
+  /** A move/duplicate for this instance is already in flight (audit
+   *  20260831 #28 — mirrors closeWorkspaceInstance's `closing` guard). */
+  | "busy";
 
 export type WorkspaceWindowActionResult =
   | {

--- a/website/guide/terminal.md
+++ b/website/guide/terminal.md
@@ -28,6 +28,16 @@ Each tab reflects the running program's title (set by tools that emit a terminal
 
 **Open Terminal Here:** right-click any folder in the file explorer and choose **Open Terminal Here** to start a session in that directory. The new session opens there regardless of where your other sessions happen to be. At five sessions the item is greyed out.
 
+## Terminal sessions and the workspace rail
+
+With the [workspace rail](/guide/workspace-rail) enabled, each workspace on the rail owns its **own set** of terminal sessions. Switching workspaces swaps the visible terminal tabs — the hidden workspace's shells stay exactly where they were: alive, same working directory, nothing typed into them. Switching back reveals the same shells again, and the session you were looking at is remembered per workspace.
+
+- New sessions belong to the workspace that was active when they were created, and start in that workspace's root.
+- The 5-session cap and the `Terminal 1…5` numbering apply to the **visible** set — hidden workspaces' sessions do not consume the active workspace's headroom.
+- Opening the panel over a workspace with no sessions creates one there automatically; without a workspace (or a saved file to anchor a directory) the panel shows a hint instead.
+- Closing a workspace from the rail, or moving it to its own window, closes its terminal sessions with it.
+- With the rail **off**, everything behaves as before: one window-wide session set whose idle shells follow workspace switches with a `cd`.
+
 ## Keyboard Shortcuts
 
 These shortcuts work when the terminal panel is focused:

--- a/website/guide/workspace-rail.md
+++ b/website/guide/workspace-rail.md
@@ -53,6 +53,10 @@ AI clients opening documents through MCP never yank your visible workspace: `wor
 | Duplicate to a new window | The **⧉** button on hover |
 | Close a workspace | Right-click → Close (prompts per dirty tab) |
 
+## Terminal sessions
+
+Each railed workspace owns its own terminal sessions. A rail switch swaps the visible terminal tabs; hidden workspaces' shells keep running untouched — no `cd` is typed into them, busy or idle — and switching back reveals the same shells with the session you were on remembered per workspace. New sessions (the **+** button, "Open Terminal Here", "Run in Terminal") are created in the active workspace and start in its root; closing a workspace or moving it to its own window closes its sessions with it. Details in the [terminal guide](/guide/terminal#terminal-sessions-and-the-workspace-rail).
+
 ## Known limitation
 
 On macOS, two spellings of the same folder that differ only in letter case (possible on case-insensitive volumes) are treated as **different** workspaces. This is deliberate: workspace identity is byte-exact on macOS and Linux, and case-folded on Windows.


### PR DESCRIPTION
## Per-workspace-instance terminal session sets (WI-TS)

With the workspace rail on, each workspace instance now owns its terminal
sessions: switching workspaces hides the outgoing scope's sessions (they
keep running — nothing is killed by a switch), closing or moving an
instance kills its sessions through one shared removal lifecycle, and
loose-instance rekeys carry sessions and closed-tab reopen history along.
Rail off remains byte-identical to pre-scoping behavior.

**Mechanism.** An owner stamp on `TerminalSession` + scope-transition
actions (`adopt`/`switch`/`hydrate`/`remove`/`rekey`/`realign`) + ONE
visibility predicate shared by every consumer (tab bar, Cmd+1..5, pickers,
auto-create, spawn context, close policy). Creation caps and ordinals run
over the visible union (D-T5); cd-follow is gated per session (D-T4);
spawn context resolves once, pre-await (D-T9). Placeholder, mid-restore,
and rail-off states never stamp (D-T1 carve-outs).

**Hardening.** Three audit-fix rounds over the train (52 findings fixed;
ledgers in `.cc-suite/audits/`): one per-instance operation lock across
close/move/duplicate, a shared removal finalizer, closed-tab history
validation (full per-kind Tab shape, canonical URLs, scope whitelist,
acceptance-time dedup, placeholder-fallback fix, window teardown wiring),
rail-toggle active-session realign, rejection-safe rail handlers with
busy/failed toasts (new keys in all ten locales), and presence-faithful
loud e2e rail-mode restore.

**Also**: welcome-screen actions become `.vm-btn--pill` pills, and
status-bar tab pills go borderless with negative hover (ink/page token
swap) — pinned by `tabPillSurface.test.ts`, recorded in rules 31/32.

**Verification.** `check:predelta` 41/41; full `pnpm check:all` green
(36,825 passed | 1 expected fail | 82 skipped); journeys 35/17/18 run
green against a live debug app; new journey `terminal-rail-scoping` wired
into tier0.

Known deferrals (recorded with reasons in the audit ledgers): the Rust
transfer state machine class, rail-plan gap G2, and one drag-semantics
claim needing live verification.
