### PR TITLE
fix(window-ready): survive StrictMode simulated unmount so dev builds announce

### DIFF
--- a/src/contexts/useWindowReady.test.tsx
+++ b/src/contexts/useWindowReady.test.tsx
@@ -5,7 +5,8 @@
  * 100 ms delay could never close.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, render, act } from "@testing-library/react";
+import { StrictMode, useEffect } from "react";
 
 const mockWindowContextError = vi.fn();
 vi.mock("@/utils/debug", () => ({ windowContextError: (...a: unknown[]) => mockWindowContextError(...a) }));
@@ -222,5 +223,70 @@ describe("useWindowReady", () => {
     await mountMenuListener();
     expect(emit).toHaveBeenCalled();
     expect(mockWindowContextError).not.toHaveBeenCalled();
+  });
+});
+
+describe("StrictMode double-mount (tier-0 CI run 33367721596)", () => {
+  // Dev builds — which `pnpm tauri:dev` and the tier-0 CI job both are — run
+  // under React.StrictMode: mount → simulated unmount (cleanups run) →
+  // remount, with REFS PERSISTING. The cleanup set unmountedRef and nothing
+  // ever reset it, so `announce` refused forever on a live window: the app
+  // shell rendered, but the ready attribute (and the `ready` emit to Rust)
+  // never happened, and CI's wait-ready gate timed out at 300s. Reproduced
+  // live on macOS `pnpm tauri:dev` before this fix.
+  //
+  // HARNESS NOTE, measured: `renderHook` does NOT double-invoke effects under
+  // a StrictMode wrapper in this environment, while `render` does (probe:
+  // renders=2 setups=2 cleanups=1). These tests must use `render`, or they
+  // pass vacuously against the broken code.
+  function Harness({ label, emit }: { label: string; emit: (e: string, p?: unknown) => unknown }) {
+    const { isReady, markReady } = useWindowReady();
+    useEffect(() => {
+      markReady({ label, emit });
+    }, [markReady, label, emit]);
+    return isReady ? <div data-testid="shell" /> : null;
+  }
+
+  it("still announces a document window after the simulated unmount/remount", async () => {
+    const emit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <StrictMode>
+        <Harness label="main" emit={emit} />
+      </StrictMode>,
+    );
+
+    await mountMenuListener();
+
+    expect(readyAttr()).toBe("true");
+    expect(emit).toHaveBeenCalledTimes(1); // announced, and not doubled
+  });
+
+  it("still announces a settings window after the simulated unmount/remount", async () => {
+    const emit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <StrictMode>
+        <Harness label="settings" emit={emit} />
+      </StrictMode>,
+    );
+
+    await settle(200);
+
+    expect(readyAttr()).toBe("true");
+    expect(emit).toHaveBeenCalledTimes(1);
+  });
+
+  it("a REAL unmount still suppresses the announcement", async () => {
+    const emit = vi.fn().mockResolvedValue(undefined);
+    const { unmount } = render(
+      <StrictMode>
+        <Harness label="main" emit={emit} />
+      </StrictMode>,
+    );
+
+    unmount();
+    await mountMenuListener();
+
+    expect(readyAttr()).toBeNull();
+    expect(emit).not.toHaveBeenCalled();
   });
 });

--- a/src/contexts/useWindowReady.ts
+++ b/src/contexts/useWindowReady.ts
@@ -79,9 +79,15 @@ export function useWindowReady(): { isReady: boolean; markReady: (w: ReadyTarget
   // records unmount so a barrier that resolves afterwards writes nothing.
   const announcingRef = useRef(false);
   const unmountedRef = useRef(false);
+  // True once the announcement actually PUBLISHED (emit dispatched, attribute
+  // set) — distinct from announcingRef, which only means a chain was started.
+  // The StrictMode re-arm below needs the distinction: a started-but-swallowed
+  // chain must be restartable, a completed one must never run twice.
+  const announcedRef = useRef(false);
 
   const announce = useCallback((w: ReadyTarget) => {
-    if (unmountedRef.current) return;
+    if (unmountedRef.current || announcedRef.current) return;
+    announcedRef.current = true;
     try {
       // `Promise.resolve` wraps because `emit` is not guaranteed to return
       // one; the try/catch is for the case it does not return at all. A
@@ -129,9 +135,23 @@ export function useWindowReady(): { isReady: boolean; markReady: (w: ReadyTarget
     });
   }, [announce]);
 
-  useEffect(() => () => {
-    unmountedRef.current = true;
-    if (timerRef.current !== null) clearTimeout(timerRef.current);
+  useEffect(() => {
+    // Re-arm on (re)mount. Dev builds run under React.StrictMode, whose
+    // simulated unmount executes the cleanup below and then REMOUNTS WITH THE
+    // SAME REFS — without this reset, `unmountedRef` stayed true on a live
+    // window and `announce` refused forever: no `ready` emit to Rust, no DOM
+    // attribute, and the tier-0 wait-ready gate hung its full 300s budget
+    // (CI run 33367721596; reproduced locally on `pnpm tauri:dev`).
+    // `announcingRef` is re-armed too — but only when nothing actually
+    // published — so the second lifecycle's markReady can restart a chain the
+    // simulated unmount swallowed, while a COMPLETED announcement stays
+    // latched (announcedRef) and can never emit twice.
+    unmountedRef.current = false;
+    if (!announcedRef.current) announcingRef.current = false;
+    return () => {
+      unmountedRef.current = true;
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
   }, []);
 
   return { isReady, markReady };


### PR DESCRIPTION
Root cause of the tier-0 scheduled failure (run 33367721596, tracking issue #1347).

**Why the run failed**: the app booted, React mounted the shell, but `data-vmark-window-ready` never appeared, so `wait-ready` timed out at 300s and the journeys never ran.

**Mechanism** (confirmed by RED test + live repro on macOS `pnpm tauri:dev`): dev builds run under `React.StrictMode`, whose simulated unmount executes `useWindowReady`'s cleanup — `unmountedRef.current = true` — and then remounts **with the same refs**. Nothing reset the flag, so `announce()` refused forever on a live window: no `ready` emit to Rust, no DOM attribute. Deterministic in every dev build; invisible until 8/26, when the wait-ready gate started reading the attribute (be47edff2) — this scheduled run was that gate's first exercise.

**Fix**: the effect re-arms on (re)mount (`unmountedRef` reset; the announcement latch re-opens only when nothing actually published, via a new `announcedRef` that also guarantees at-most-one emit). A real unmount still suppresses everything.

**Verified**: 3 new regression tests (RED against old code — note they must use `render`, not `renderHook`, which measurably does not double-invoke effects under StrictMode here); the previously-hanging `wait-ready` gate now reports drivable in ~7 attempts against a relaunched dev app; `boot-editor-ready` passes; contexts suite 101/101; `check:predelta` 41/41.

Not auto-closing #1347 — the workflow's own close job handles it once a tier-0 run goes green (will dispatch one after merge).
