### PR TITLE
Release 0.9.59: browser chrome fixes + version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.58",
+  "version": "0.9.59",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.58';
+const VERSION = '0.9.59';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6415,7 +6415,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.58"
+version = "0.9.59"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.58"
+version = "0.9.59"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/TitleBar/title-bar.css
+++ b/src/components/TitleBar/title-bar.css
@@ -31,14 +31,19 @@
 }
 
 /* Keep the application chrome legible around a native webpage even when the
-   editor is using a colored or dark theme. The page itself is not recolored. */
+   editor is using a colored or dark theme. The page itself is not recolored.
+
+   The strip is OPAQUE only here (the base rule above paints nothing), so it
+   must start where the leading column ends or it overpaints the card — a rule
+   that restated the offset as the bare rail width survived the leading-card
+   redesign and bit a white notch out of the card's rounded top corner.
+   --shell-side-width is the whole column (inset + rail + sidebar + inset),
+   published by AppShell from the same prop that sizes the aside, so this edge
+   tracks the card by construction. 0px when no leading column is mounted. */
 .browser-workspace-active .title-bar {
   background: var(--browser-bg-color);
   color: var(--browser-text-color);
-}
-
-.browser-workspace-active.workspace-rail-visible .title-bar {
-  left: var(--workspace-rail-width);
+  left: var(--shell-side-width, 0px);
 }
 
 .title-bar--browser {
@@ -54,20 +59,21 @@
    published from shell/trafficLights.ts so it follows the position the app asks
    AppKit for instead of being re-guessed here. It replaces a 72 here and a 70
    below, which disagreed with each other and were both too small once the
-   buttons moved onto Finder's line. */
+   buttons moved onto Finder's line.
+
+   The bar itself starts at --shell-side-width (rule above), so subtracting it
+   holds the content's absolute start on the lights' line for EVERY leading
+   column — the two rules this formula replaced encoded that invariant once per
+   rail state and could disagree. max() because a wide sidebar pushes the bar
+   past the zone entirely and a negative pad would drop the declaration; the
+   leading spacer element still provides the resting gap there. */
 .title-bar-browser {
   display: flex;
   align-items: stretch;
   width: 100%;
   min-width: 0;
   min-height: 0;
-  padding: 0 var(--space-2) 0 var(--traffic-lights-zone);
-}
-
-.workspace-rail-visible .title-bar-browser {
-  /* The same distance from the WINDOW's left edge, but the bar now starts beside
-     the rail, so the rail's width comes off the pad rather than adding to it. */
-  padding-left: calc(var(--traffic-lights-zone) - var(--workspace-rail-width));
+  padding: 0 var(--space-2) 0 max(0px, calc(var(--traffic-lights-zone) - var(--shell-side-width, 0px)));
 }
 
 .title-bar-browser-leading {

--- a/src/components/TitleBar/titleBarShellOffset.test.ts
+++ b/src/components/TitleBar/titleBarShellOffset.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+/**
+ * titleBarShellOffset — pins the browser-mode title bar's left offset to the
+ * shell's PUBLISHED side width, never a restatement of the layout arithmetic.
+ *
+ * The defect this kills: `left: var(--workspace-rail-width)` was written for
+ * the pre-card flush 30px rail (7cdd260c2). The leading-card redesign
+ * (89c9d0b1c, v0.9.47) moved the rail inside an 8px inset — the card spans
+ * inset + rail + sidebar + inset — and the restated offset was not updated, so
+ * the opaque browser-mode strip overpainted the card's top-right corner: a
+ * white notch below the traffic lights, chopping the card's 13px arc mid-curve.
+ *
+ * The fix consumes `--shell-side-width`, which AppShell publishes from the
+ * same prop that sizes the aside (see AppShell.test.tsx), so the offset cannot
+ * drift from the card again. This file reads the stylesheet at runtime, which
+ * the vitest import graph cannot see — run it directly after editing the CSS.
+ */
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+
+const css = readFileSync(new URL("./title-bar.css", import.meta.url), "utf8");
+
+describe("browser-mode title bar offset", () => {
+  it("offsets the opaque strip by the published side width", () => {
+    expect(css).toMatch(/left:\s*var\(--shell-side-width,\s*0px\)/);
+  });
+
+  it("never restates the offset from the bare rail width", () => {
+    // The class, not the instance: ANY read of --workspace-rail-width here is
+    // a hand-computed fragment of a sum the shell already publishes whole.
+    expect(css).not.toMatch(/var\(--workspace-rail-width/);
+  });
+
+  it("keeps the omnibox content's absolute start on the traffic-lights line", () => {
+    // Invariant: bar left (--shell-side-width) + this pad = --traffic-lights-zone,
+    // clamped at 0 for a leading column wider than the zone. The two rules it
+    // replaced encoded the same invariant separately per rail state and could
+    // disagree; one formula cannot.
+    expect(css).toMatch(
+      /padding:\s*0\s+var\(--space-2\)\s+0\s+max\(0px,\s*calc\(var\(--traffic-lights-zone\)\s*-\s*var\(--shell-side-width,\s*0px\)\)\)/
+    );
+  });
+});

--- a/src/shell/AppShell.test.tsx
+++ b/src/shell/AppShell.test.tsx
@@ -91,6 +91,30 @@ describe("AppShell", () => {
     expect(aside.style.width).toBe(`${TEST_SIDEBAR_WIDTH}px`);
   });
 
+  // The browser-mode title bar is opaque and must start where the leading
+  // column ends, so its stylesheet needs the column's width. Publishing it
+  // from the SAME prop that sizes the aside is what keeps the two from
+  // drifting: title-bar.css once restated the offset as the bare rail width,
+  // and when the leading-card redesign moved the rail 8px inboard the stale
+  // restatement overpainted the card's top corner (the white-notch defect).
+  it("publishes the side width as --shell-side-width for the chrome's stylesheet", () => {
+    const { container } = render(
+      <AppShell
+        sidebar={<div>rail</div>}
+        sidebarWidth={TEST_SIDEBAR_WIDTH}
+        primary={<div>main</div>}
+      />
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root.style.getPropertyValue("--shell-side-width")).toBe(`${TEST_SIDEBAR_WIDTH}px`);
+  });
+
+  it("publishes --shell-side-width: 0px when no sidebar is mounted", () => {
+    const { container } = render(<AppShell primary={<div>main</div>} />);
+    const root = container.firstChild as HTMLElement;
+    expect(root.style.getPropertyValue("--shell-side-width")).toBe("0px");
+  });
+
   // #1296 — the reserved strip and the thing that fills it must be one decision.
   // The shell reserved 40px unconditionally, so on Windows/Linux — where the OS
   // draws its own title bar and no chrome is passed — the top of every window

--- a/src/shell/AppShell.tsx
+++ b/src/shell/AppShell.tsx
@@ -84,7 +84,15 @@ export function AppShell({
   const rootClass = ["app-shell", className].filter(Boolean).join(" ");
   // The caller's style wins on every key it sets; --chrome-height is the
   // shell's own, so it is applied after (see CHROME_HEIGHT).
-  const rootStyle: CSSProperties = { ...style, "--chrome-height": `${CHROME_HEIGHT}px` } as CSSProperties;
+  // --shell-side-width publishes the same number that sizes the aside below,
+  // because the browser-mode title bar must start where the leading column
+  // ends (title-bar.css) — restating that offset from parts is how the strip
+  // once overpainted the leading card's top corner.
+  const rootStyle: CSSProperties = {
+    ...style,
+    "--chrome-height": `${CHROME_HEIGHT}px`,
+    "--shell-side-width": `${sidebarWidth}px`,
+  } as CSSProperties;
 
   return (
     <div className={rootClass} style={rootStyle}>

--- a/src/shell/app-shell.css
+++ b/src/shell/app-shell.css
@@ -44,8 +44,13 @@
 
 /* Browser pages are native content, so the VMark shell around them stays
    neutral even when the selected editor theme is colored or dark. Scope the
-   token aliases to the primary and document sidebar only: the workspace rail
-   remains the user's persistent colored identity strip. */
+   token aliases to the PRIMARY column only: the leading card — rail and
+   sidebar together — keeps the user's theme. The sidebar used to be
+   neutralized too, which painted an opaque pure-white column inside the
+   theme-grey card (the browser history pane read as a white slab against the
+   sidepane); the card owns the frame and its children go flat (rule 32), so
+   the sidebar now renders in browser mode exactly as it does in document
+   mode. */
 .browser-workspace-active .app-shell__primary {
   --bg-color: var(--browser-bg-color);
   --bg-secondary: var(--browser-bg-secondary);
@@ -61,21 +66,6 @@
   --primary-color: var(--browser-accent-primary);
   background-color: var(--browser-bg-color);
   color: var(--browser-text-color);
-}
-
-.browser-workspace-active .app-sidebar-stack__sidebar {
-  --sidebar-bg: var(--browser-bg-color);
-  --bg-color: var(--browser-bg-color);
-  --bg-secondary: var(--browser-bg-secondary);
-  --bg-tertiary: var(--browser-bg-tertiary);
-  --text-color: var(--browser-text-color);
-  --text-secondary: var(--browser-text-secondary);
-  --text-tertiary: var(--browser-text-tertiary);
-  --border-color: var(--browser-border-color);
-  --selection-color: var(--browser-accent-bg);
-  --accent-primary: var(--browser-accent-primary);
-  --primary-color: var(--browser-accent-primary);
-  background-color: var(--browser-bg-color);
 }
 
 /* THE LEADING CARD. The workspace rail and the sidebar are one surface, so they


### PR DESCRIPTION
Release 0.9.59 — two browser-workspace chrome fixes plus the version bump.

## Fixes

**Browser title bar overpainted the leading card's top corner.** The browser-mode strip's `left` was a stale restatement of the pre-card flush rail (bare `--workspace-rail-width`); the leading-card redesign (v0.9.47) moved the rail 8px inboard and the opaque bar bit a white notch out of the card's rounded top-right corner, directly below the traffic lights. `AppShell` now publishes `--shell-side-width` from the same prop that sizes the aside, and `title-bar.css` consumes it — the bar starts where the leading column ends in every state, and one padding formula keeps the omnibox content on the traffic-lights line (left + pad = `--traffic-lights-zone`). Pinned by `titleBarShellOffset.test.ts` and two new `AppShell` tests; verified live in the debug app across the none / rail / rail+sidebar states.

**Browsing-history pane rendered as a pure-white slab in the sidepane.** The browser-workspace neutralization painted the whole sidebar column opaque `--browser-bg-color` inside the theme-colored card. The sidebar now renders in browser mode exactly as in document mode — transparent over the card's own surface, one card with the rail (rule 32 frame ownership). Cures History, Bookmarks, Permissions and Sessions views; verified live in white and night themes. Browser-mode neutrality stays scoped to the primary column.

## Gates

`check:predelta` 41/41 and full `check:all` green locally before the bump.
