### PR TITLE
φ radius ladder + Windows swallowed-keystroke fix (#1354), v0.9.61

### DIFF
--- a/.claude/rules/31-design-tokens.md
+++ b/.claude/rules/31-design-tokens.md
@@ -165,7 +165,7 @@ no interactive element takes a smaller hit box; paint-small controls centre a
 | `--spacing-2` | `8px` | Standard gaps |
 | `--spacing-3` | `12px` | Larger spacing |
 
-**Use `--spacing-*` for `padding`, `margin`, and `gap` only.** A `4px` border-radius is `--radius-sm`, not `--spacing-1`. The numeric value coincidence does not imply semantic equivalence — see "Tokenize value vs. tokenize intent" below.
+**Use `--spacing-*` for `padding`, `margin`, and `gap` only.** A border-radius is a `--radius-*` token, never `--spacing-1`. The numeric value coincidence does not imply semantic equivalence — see "Tokenize value vs. tokenize intent" below.
 
 ## Icon Size Tokens
 
@@ -194,14 +194,21 @@ no interactive element takes a smaller hit box; paint-small controls centre a
 
 | Token | Value | Use For |
 |-------|-------|---------|
-| `--radius-sm` | `4px` | Small buttons, toggles |
-| `--radius-md` | `6px` | Inputs, medium containers |
-| `--radius-lg` | `8px` | Popups, dialogs, menus |
+| `--radius-sm` | `3px` | Controls: buttons, icon squares, selects, field inputs, chips — and rows INSIDE floating surfaces (near-concentric) |
+| `--radius-md` | `5px` | Content blocks (code, alerts, details…) and page/panel rows |
+| `--radius-lg` | `8px` | Floating surfaces: popups, dialogs, menus, dropdowns |
 | `--radius-pill` | `100px` | Pill shapes, tags, `.vm-btn--pill` capsule buttons |
+
+**The φ curvature ladder (2026-09-02)**: window `21` → shell card `13` →
+`--radius-lg 8` → `--radius-md 5` → `--radius-sm 3` — each step ≈ ×0.62
+(Fibonacci: 3, 5, 8, 13, 21). Pick radius by TIER, never by taste; pills and
+circles stay off-ladder. Bare Tailwind `rounded` (a 0.25rem literal) is
+BANNED — `tailwindTheme.test.ts` enforces it; use `rounded-sm/md/lg`, which
+resolve through these tokens.
 
 **Acceptable hardcoded values** (do not tokenize):
 - `0.5px` for retina sub-pixel borders
-- `1px` or `2px` for borders, dividers, and inline elements (code spans, cursor indicators, focus underlines)
+- `1px` or `2px` for borders, dividers, and inline elements (code spans, cursor indicators, focus underlines, scrollbar thumbs)
 - `3px` for fine positioning offsets (e.g., `top: 3px` on a dot indicator)
 - Focus indicator geometry (e.g., `0 0 4px 4px` for the U-shape underline)
 - `@media print` blocks (color-mix() may not render in all print pipelines)

--- a/.claude/rules/32-component-patterns.md
+++ b/.claude/rules/32-component-patterns.md
@@ -176,7 +176,7 @@ Position is calculated in JS based on selection/cursor coordinates.
   gap: var(--space-half);
   padding: var(--space-1-5);                  /* 6px */
   border: var(--border-thin) solid var(--border-color);
-  border-radius: var(--radius-lg);            /* 8px */
+  border-radius: var(--radius-lg);            /* 8px — floating-surface tier */
   background: var(--bg-color);
   box-shadow: var(--popup-shadow);
   animation: popup-fade-in var(--duration-fast) ease-out;
@@ -200,7 +200,7 @@ Position is calculated in JS based on selection/cursor coordinates.
 **Rules:**
 - Compact padding (6px via `--space-1-5`; the older `--popup-padding` token still exists for legacy consumers but `.popup-container` no longer reads it)
 - 1px border with `--border-color`
-- Radius 8px (use `--radius-lg`)
+- Radius `--radius-lg` (8px — the floating-surface tier of the φ ladder)
 - Shadow via `--popup-shadow`
 - 0.1s fade-in animation
 
@@ -251,7 +251,7 @@ Position is calculated in JS based on selection/cursor coordinates.
   height: 26px;
   padding: 0;
   border: none;
-  border-radius: var(--radius-sm);            /* 4px */
+  border-radius: var(--radius-sm);            /* 3px — control tier */
   background: transparent;
   color: var(--text-secondary);
   display: flex;
@@ -379,7 +379,7 @@ Position is calculated in JS based on selection/cursor coordinates.
 
 .context-menu-item {
   padding: 5px 10px;
-  border-radius: 5px;
+  border-radius: var(--radius-sm); /* row inside a floating lg surface */
   font-size: 13px;
   display: flex;
   align-items: center;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,7 +607,7 @@ Shared instructions for all AI agents (Claude, Codex, etc.).
 
   - **Dark theme**: Use `.dark-theme` selector (not `[data-theme]`).
 
-  - **Border radius**: `4px` (small), `6px` (medium), `8px` (popups/dialogs).
+  - **Border radius**: the φ ladder — `--radius-sm` 3px (controls), `--radius-md` 5px (blocks/rows), `--radius-lg` 8px (floating surfaces); window 21 → card 13 → 8 → 5 → 3, each ≈ ×0.62. Pick by tier (rule 31).
 
   - **Shadows**: Use `--popup-shadow` token, not hardcoded values.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.60",
+  "version": "0.9.61",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.60",
+  "version": "0.9.61",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.60';
+const VERSION = '0.9.61';
 
 /**
  * Handle --version flag.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6415,7 +6415,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.60"
+version = "0.9.61"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.60"
+version = "0.9.61"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/locales/de.yml
+++ b/src-tauri/locales/de.yml
@@ -48,6 +48,10 @@ menu:
 
   # === Edit menu ===
   edit: "Bearbeiten"
+  edit.cut: "Ausschneiden"
+  edit.copy: "Kopieren"
+  edit.paste: "Einfügen"
+  edit.selectAll: "Alles auswählen"
   edit.undo: "Rückgängig"
   edit.redo: "Wiederholen"
   edit.find: "Suchen"

--- a/src-tauri/locales/en.yml
+++ b/src-tauri/locales/en.yml
@@ -48,6 +48,10 @@ menu:
 
   # === Edit menu ===
   edit: "Edit"
+  edit.cut: "Cut"
+  edit.copy: "Copy"
+  edit.paste: "Paste"
+  edit.selectAll: "Select All"
   edit.undo: "Undo"
   edit.redo: "Redo"
   edit.find: "Find"

--- a/src-tauri/locales/es.yml
+++ b/src-tauri/locales/es.yml
@@ -48,6 +48,10 @@ menu:
 
   # === Edit menu ===
   edit: "Editar"
+  edit.cut: "Cortar"
+  edit.copy: "Copiar"
+  edit.paste: "Pegar"
+  edit.selectAll: "Seleccionar todo"
   edit.undo: "Deshacer"
   edit.redo: "Rehacer"
   edit.find: "Buscar"

--- a/src-tauri/locales/fr.yml
+++ b/src-tauri/locales/fr.yml
@@ -48,6 +48,10 @@ menu:
 
   # === Edit menu ===
   edit: "Édition"
+  edit.cut: "Couper"
+  edit.copy: "Copier"
+  edit.paste: "Coller"
+  edit.selectAll: "Tout sélectionner"
   edit.undo: "Annuler"
   edit.redo: "Rétablir"
   edit.find: "Rechercher"

--- a/src-tauri/locales/it.yml
+++ b/src-tauri/locales/it.yml
@@ -48,6 +48,10 @@ menu:
 
   # === Edit menu ===
   edit: "Modifica"
+  edit.cut: "Taglia"
+  edit.copy: "Copia"
+  edit.paste: "Incolla"
+  edit.selectAll: "Seleziona tutto"
   edit.undo: "Annulla"
   edit.redo: "Ripeti"
   edit.find: "Trova"

--- a/src-tauri/locales/ja.yml
+++ b/src-tauri/locales/ja.yml
@@ -48,6 +48,10 @@ menu:
 
   # === 編集メニュー ===
   edit: "編集"
+  edit.cut: "切り取り"
+  edit.copy: "コピー"
+  edit.paste: "貼り付け"
+  edit.selectAll: "すべて選択"
   edit.undo: "元に戻す"
   edit.redo: "やり直す"
   edit.find: "検索"

--- a/src-tauri/locales/ko.yml
+++ b/src-tauri/locales/ko.yml
@@ -48,6 +48,10 @@ menu:
 
   # === 편집 메뉴 ===
   edit: "편집"
+  edit.cut: "잘라내기"
+  edit.copy: "복사"
+  edit.paste: "붙여넣기"
+  edit.selectAll: "모두 선택"
   edit.undo: "실행 취소"
   edit.redo: "다시 실행"
   edit.find: "찾기"

--- a/src-tauri/locales/pt-BR.yml
+++ b/src-tauri/locales/pt-BR.yml
@@ -48,6 +48,10 @@ menu:
 
   # === Edit menu ===
   edit: "Editar"
+  edit.cut: "Recortar"
+  edit.copy: "Copiar"
+  edit.paste: "Colar"
+  edit.selectAll: "Selecionar tudo"
   edit.undo: "Desfazer"
   edit.redo: "Refazer"
   edit.find: "Localizar"

--- a/src-tauri/locales/zh-CN.yml
+++ b/src-tauri/locales/zh-CN.yml
@@ -48,6 +48,10 @@ menu:
 
   # === 编辑菜单 ===
   edit: "编辑"
+  edit.cut: "剪切"
+  edit.copy: "复制"
+  edit.paste: "粘贴"
+  edit.selectAll: "全选"
   edit.undo: "撤销"
   edit.redo: "重做"
   edit.find: "查找"

--- a/src-tauri/locales/zh-TW.yml
+++ b/src-tauri/locales/zh-TW.yml
@@ -48,6 +48,10 @@ menu:
 
   # === 編輯選單 ===
   edit: "編輯"
+  edit.cut: "剪下"
+  edit.copy: "複製"
+  edit.paste: "貼上"
+  edit.selectAll: "全選"
   edit.undo: "復原"
   edit.redo: "取消復原"
   edit.find: "尋找"

--- a/src-tauri/src/menu/localized/edit_menu.rs
+++ b/src-tauri/src/menu/localized/edit_menu.rs
@@ -206,9 +206,47 @@ pub(super) fn build(app: &tauri::AppHandle, accel: &AccelFn) -> tauri::Result<Su
                 accel("redo", "CmdOrCtrl+Shift+Z"),
             )?,
             &PredefinedMenuItem::separator(app)?,
+            // #1354 — Windows gets accelerator-FREE custom items instead of
+            // the predefined ones. muda's predefined clipboard items carry
+            // built-in Ctrl+C/X/V/A accelerators that enter the Win32
+            // accelerator table (intercepting the user's PHYSICAL keystroke
+            // before WebView2 sees it) and then re-emit it via SendInput —
+            // whose synthetic Ctrl-up, while the user still holds Ctrl,
+            // desyncs the webview's modifier state: typed characters arrive
+            // as phantom-Ctrl chords and vanish, paste mistargets, and IME
+            // composition breaks until a focus cycle. With no accelerator,
+            // the shortcuts flow natively to WebView2; a menu CLICK emits
+            // menu:edit-* and the frontend routes it through the same
+            // clipboard bridge the editor context menu uses.
+            // macOS keeps the predefined items: its responder-chain path is
+            // correct and native-fidelity (never break macOS to fix Windows).
+            #[cfg(target_os = "windows")]
+            &MenuItem::with_id(app, "edit-cut", &t!("menu.edit.cut"), true, None::<&str>)?,
+            #[cfg(target_os = "windows")]
+            &MenuItem::with_id(app, "edit-copy", &t!("menu.edit.copy"), true, None::<&str>)?,
+            #[cfg(target_os = "windows")]
+            &MenuItem::with_id(
+                app,
+                "edit-paste",
+                &t!("menu.edit.paste"),
+                true,
+                None::<&str>,
+            )?,
+            #[cfg(target_os = "windows")]
+            &MenuItem::with_id(
+                app,
+                "edit-select-all",
+                &t!("menu.edit.selectAll"),
+                true,
+                None::<&str>,
+            )?,
+            #[cfg(not(target_os = "windows"))]
             &PredefinedMenuItem::cut(app, None)?,
+            #[cfg(not(target_os = "windows"))]
             &PredefinedMenuItem::copy(app, None)?,
+            #[cfg(not(target_os = "windows"))]
             &PredefinedMenuItem::paste(app, None)?,
+            #[cfg(not(target_os = "windows"))]
             &PredefinedMenuItem::select_all(app, None)?,
             &PredefinedMenuItem::separator(app)?,
             &find_submenu,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.60",
+  "version": "0.9.61",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/Editor/EditorContextMenu/clipboardBridge.ts
+++ b/src/components/Editor/EditorContextMenu/clipboardBridge.ts
@@ -1,108 +1,15 @@
 /**
- * Clipboard bridge for the editor context menu.
+ * Re-export shim — the clipboard bridge moved to services/editor/ in the
+ * #1354 fix (it is service-shaped; services/commands must reach it without
+ * an upward components import). Context-menu callers and the codemirror
+ * plugin keep this path so their import graph — and the per-channel plugin
+ * coupling baseline keyed on it — stays unchanged.
  *
- * Purpose: Cut/Copy/Paste/Select-All are native webview roles, not
- * toolbar-adapter actions. On macOS this invokes `trigger_webview_edit`
- * (Rust sends the matching selector down the responder chain — identical
- * to the Edit menu's PredefinedMenuItems, so paste keeps full HTML/image
- * fidelity through the existing paste plugins). Elsewhere, best-effort
- * fallbacks: `document.execCommand` for cut/copy/select-all and a
- * plain-text clipboard read for paste.
- *
- * Focus contract (plan ADR-3, validated by the Phase 0 spike): the native
- * action targets the first responder, so the editor surface is refocused
- * BEFORE the command fires. ProseMirror/CodeMirror restore their own
- * selection on focus — no selection bookkeeping needed here.
- *
- * @coordinates-with src-tauri/src/webview_edit.rs — the macOS command
- * @coordinates-with menuModel.ts — emits the clipboard run entries
  * @module components/Editor/EditorContextMenu/clipboardBridge
  */
-
-import { invoke } from "@tauri-apps/api/core";
-import { readText } from "@tauri-apps/plugin-clipboard-manager";
-import type { EditorView as CodeMirrorView } from "@codemirror/view";
-import { useEditorStore } from "@/stores/editorStore";
-import { isMacPlatform } from "@/utils/platform";
-import type { EditorMenuSurface } from "@/types/editorContextMenu";
-
-export type ClipboardCommand = "cut" | "copy" | "paste" | "selectAll";
-
-/**
- * Source-view override for surfaces that are not registered in
- * editorStore — SplitPaneEditor source panes run their own minimal
- * CodeMirror instances. The pane's trigger sets this when it opens the
- * menu (and clears it on destroy) so focus/paste target the right view.
- */
-let sourceViewOverride: CodeMirrorView | null = null;
-
-export function setContextMenuSourceView(view: CodeMirrorView | null): void {
-  sourceViewOverride = view;
-}
-
-/** Clear the override only if it still points at `view` (a newer pane may
- *  have registered since — never clobber it). */
-export function clearContextMenuSourceView(view: CodeMirrorView): void {
-  if (sourceViewOverride === view) sourceViewOverride = null;
-}
-
-function getSourceView(): CodeMirrorView | null {
-  return sourceViewOverride ?? useEditorStore.getState().source.editorView;
-}
-
-/** Refocus the editing surface so it is the first responder / execCommand
- *  target. Exported for the adapter/link runners, which share the
- *  "menu stole focus, give it back" concern. */
-export function focusEditorSurface(surface: EditorMenuSurface): void {
-  if (surface === "source") {
-    getSourceView()?.focus();
-    return;
-  }
-  useEditorStore.getState().tiptap.editorView?.focus();
-}
-
-async function pasteFallback(surface: EditorMenuSurface): Promise<void> {
-  let text: string;
-  try {
-    text = await readText();
-  } catch {
-    // Clipboard unreadable (empty, non-text, or permission) — nothing to paste.
-    return;
-  }
-  if (!text) return;
-
-  if (surface === "source") {
-    const view = getSourceView();
-    if (!view) return;
-    view.dispatch(view.state.replaceSelection(text));
-    return;
-  }
-  useEditorStore.getState().tiptap.editorView?.pasteText(text);
-}
-
-/**
- * Run a clipboard command for the given surface. macOS: native responder
- * chain (full fidelity); other platforms or native failure: fallbacks
- * (plain-text paste — a documented cross-platform limitation).
- */
-export async function runClipboardCommand(
-  command: ClipboardCommand,
-  surface: EditorMenuSurface
-): Promise<void> {
-  focusEditorSurface(surface);
-
-  if (isMacPlatform()) {
-    try {
-      await invoke("trigger_webview_edit", { action: command });
-      return;
-    } catch {
-      // Fall through to the DOM/plugin fallback below.
-    }
-  }
-
-  if (command === "paste") {
-    await pasteFallback(surface);
-    return;
-  }
-  document.execCommand(command === "selectAll" ? "selectAll" : command);
-}
+export {
+  runClipboardCommand,
+  focusEditorSurface,
+  setContextMenuSourceView,
+  clearContextMenuSourceView,
+} from "@/services/editor/clipboardBridge";

--- a/src/components/Editor/UniversalToolbar/universal-toolbar.css
+++ b/src/components/Editor/UniversalToolbar/universal-toolbar.css
@@ -113,7 +113,7 @@
   height: 4px;
   background: transparent;
   border-bottom: var(--border-medium) solid var(--accent-primary);
-  border-radius: 0 0 4px 4px;
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
 }
 
 /* Also show on :focus-visible for keyboard accessibility */
@@ -132,7 +132,7 @@
   height: 4px;
   background: transparent;
   border-bottom: var(--border-medium) solid var(--accent-primary);
-  border-radius: 0 0 4px 4px;
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
 }
 
 /* Focused + Active: dot stays visible (same accent color) */
@@ -176,7 +176,7 @@
   padding: 0 var(--space-2);
   padding-left: var(--space-4); /* Space for checkmark */
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm); /* row inside a floating lg surface — near-concentric (radius ladder, 2026-09-02) */
   background: transparent;
   color: var(--text-color);
   cursor: pointer;

--- a/src/components/FindBar/FindBar.css
+++ b/src/components/FindBar/FindBar.css
@@ -111,7 +111,7 @@
   height: 4px;
   background: transparent;
   border-bottom: var(--border-medium) solid var(--accent-primary);
-  border-radius: 0 0 4px 4px;
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
 }
 
 .find-bar-nav {

--- a/src/components/WorkspaceRail/WorkspaceRailContextMenu.css
+++ b/src/components/WorkspaceRail/WorkspaceRailContextMenu.css
@@ -21,7 +21,7 @@
   gap: var(--spacing-2);
   padding: var(--space-1-5) var(--space-2-5);
   border: 0;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm); /* row inside a floating lg surface — near-concentric (radius ladder, 2026-09-02) */
   color: var(--text-color);
   background: transparent;
   font-family: var(--font-ui);

--- a/src/export/primitiveTokens.ts
+++ b/src/export/primitiveTokens.ts
@@ -76,9 +76,9 @@ const PRIMITIVES = `
   --popup-shadow-dark: 0 4px 12px rgba(0, 0, 0, 0.4);
   --primary-color: var(--accent-primary);
   --radius-lg: 8px;
-  --radius-md: 6px;
+  --radius-md: 5px;
   --radius-pill: 100px;
-  --radius-sm: 4px;
+  --radius-sm: 3px;
   --selection-color: rgba(0, 102, 204, 0.2);
   --space-1: 4px;
   --space-1-5: 6px;

--- a/src/export/reader/vmark-reader.css
+++ b/src/export/reader/vmark-reader.css
@@ -77,7 +77,7 @@
   width: 24px;
   height: 24px;
   border: none;
-  border-radius: 6px;
+  border-radius: 5px;
   background: transparent;
   color: var(--text-secondary);
   font-size: 18px;
@@ -123,7 +123,7 @@
   width: 28px;
   height: 28px;
   border: none;
-  border-radius: 6px;
+  border-radius: 5px;
   background: transparent;
   color: var(--text-color);
   font-size: 16px;
@@ -187,7 +187,7 @@
   width: 100%;
   padding: 6px 8px;
   border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border-radius: 5px;
   background: var(--bg-color);
   color: var(--text-color);
   font-size: 12px;
@@ -240,7 +240,7 @@
   width: 100%;
   padding: 8px 12px;
   border: none;
-  border-radius: 6px;
+  border-radius: 5px;
   background: transparent;
   color: var(--text-secondary);
   font-size: 12px;
@@ -321,7 +321,7 @@
   width: 28px;
   height: 28px;
   border: none;
-  border-radius: 4px;
+  border-radius: 3px;
   background: transparent;
   color: var(--text-secondary);
   font-size: 20px;
@@ -394,7 +394,7 @@
   width: 24px;
   height: 48px;
   border: none;
-  border-radius: 0 6px 6px 0;
+  border-radius: 0 5px 5px 0;
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-left: none;
@@ -523,7 +523,7 @@
   height: 28px;
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: 3px;
   background: var(--bg-secondary);
   color: var(--text-secondary);
   cursor: pointer;
@@ -683,7 +683,7 @@
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
-  border-radius: 4px;
+  border-radius: 3px;
   cursor: default;
 }
 

--- a/src/hooks/useCommandBootstrap.ts
+++ b/src/hooks/useCommandBootstrap.ts
@@ -24,6 +24,7 @@ import { mountMenuCommands, type MenuCommandBinding } from "@/services/commands/
 import { MENU_TO_ACTION } from "@/plugins/actions/actionRegistry";
 import { registerExportCommands, registerPandocFormatCommands } from "@/services/commands/exportCommands";
 import { registerMiscCommands } from "@/services/commands/miscCommands";
+import { registerClipboardCommands } from "@/services/commands/clipboardCommands";
 import { registerRecentFilesCommands } from "@/services/commands/recentFilesCommands";
 import { registerRecentWorkspacesCommands } from "@/services/commands/recentWorkspacesCommands";
 import { registerClaimCommands } from "@/services/commands/claimCommands";
@@ -57,6 +58,13 @@ const EXPORT_BINDINGS: MenuCommandBinding[] = [
 ];
 
 const MISC_BINDINGS: MenuCommandBinding[] = [
+  // #1354 — Windows-only menu items (macOS keeps PredefinedMenuItems, whose
+  // responder-chain path never emits these ids). Bound unconditionally: an id
+  // that never fires costs nothing, and the binding stays platform-symmetric.
+  { menuEvent: "menu:edit-cut", commandId: "edit.cut" },
+  { menuEvent: "menu:edit-copy", commandId: "edit.copy" },
+  { menuEvent: "menu:edit-paste", commandId: "edit.paste" },
+  { menuEvent: "menu:edit-select-all", commandId: "edit.selectAll" },
   { menuEvent: "menu:new", commandId: "file.new" },
   { menuEvent: "menu:open", commandId: "file.open" },
   { menuEvent: "menu:save", commandId: "file.save" },
@@ -136,6 +144,7 @@ const EDITOR_ACTION_BINDINGS: MenuCommandBinding[] = Object.entries(MENU_TO_ACTI
 export function useCommandBootstrap(): void {
   useEffect(() => {
     registerMiscCommands();
+    registerClipboardCommands();
     registerExportCommands();
     registerWorkspaceCommands();
     registerRecentFilesCommands();

--- a/src/locales/de/commands.json
+++ b/src/locales/de/commands.json
@@ -194,5 +194,9 @@
   "tab.close": "Tab schließen",
   "commandPalette.hintNavigate": "navigieren",
   "commandPalette.hintRun": "ausführen",
-  "commandPalette.hintClose": "schließen"
+  "commandPalette.hintClose": "schließen",
+  "edit.cut": "Ausschneiden",
+  "edit.copy": "Kopieren",
+  "edit.paste": "Einfügen",
+  "edit.selectAll": "Alles auswählen"
 }

--- a/src/locales/en/commands.json
+++ b/src/locales/en/commands.json
@@ -194,5 +194,9 @@
   "tab.close": "Close Tab",
   "commandPalette.hintNavigate": "navigate",
   "commandPalette.hintRun": "run",
-  "commandPalette.hintClose": "close"
+  "commandPalette.hintClose": "close",
+  "edit.cut": "Cut",
+  "edit.copy": "Copy",
+  "edit.paste": "Paste",
+  "edit.selectAll": "Select All"
 }

--- a/src/locales/es/commands.json
+++ b/src/locales/es/commands.json
@@ -194,5 +194,9 @@
   "tab.close": "Cerrar pestaña",
   "commandPalette.hintNavigate": "navegar",
   "commandPalette.hintRun": "ejecutar",
-  "commandPalette.hintClose": "cerrar"
+  "commandPalette.hintClose": "cerrar",
+  "edit.cut": "Cortar",
+  "edit.copy": "Copiar",
+  "edit.paste": "Pegar",
+  "edit.selectAll": "Seleccionar todo"
 }

--- a/src/locales/fr/commands.json
+++ b/src/locales/fr/commands.json
@@ -194,5 +194,9 @@
   "tab.close": "Fermer l'onglet",
   "commandPalette.hintNavigate": "naviguer",
   "commandPalette.hintRun": "exécuter",
-  "commandPalette.hintClose": "fermer"
+  "commandPalette.hintClose": "fermer",
+  "edit.cut": "Couper",
+  "edit.copy": "Copier",
+  "edit.paste": "Coller",
+  "edit.selectAll": "Tout sélectionner"
 }

--- a/src/locales/it/commands.json
+++ b/src/locales/it/commands.json
@@ -194,5 +194,9 @@
   "tab.close": "Chiudi scheda",
   "commandPalette.hintNavigate": "naviga",
   "commandPalette.hintRun": "esegui",
-  "commandPalette.hintClose": "chiudi"
+  "commandPalette.hintClose": "chiudi",
+  "edit.cut": "Taglia",
+  "edit.copy": "Copia",
+  "edit.paste": "Incolla",
+  "edit.selectAll": "Seleziona tutto"
 }

--- a/src/locales/ja/commands.json
+++ b/src/locales/ja/commands.json
@@ -194,5 +194,9 @@
   "tab.close": "タブを閉じる",
   "commandPalette.hintNavigate": "移動",
   "commandPalette.hintRun": "実行",
-  "commandPalette.hintClose": "閉じる"
+  "commandPalette.hintClose": "閉じる",
+  "edit.cut": "切り取り",
+  "edit.copy": "コピー",
+  "edit.paste": "貼り付け",
+  "edit.selectAll": "すべて選択"
 }

--- a/src/locales/ko/commands.json
+++ b/src/locales/ko/commands.json
@@ -194,5 +194,9 @@
   "tab.close": "탭 닫기",
   "commandPalette.hintNavigate": "이동",
   "commandPalette.hintRun": "실행",
-  "commandPalette.hintClose": "닫기"
+  "commandPalette.hintClose": "닫기",
+  "edit.cut": "잘라내기",
+  "edit.copy": "복사",
+  "edit.paste": "붙여넣기",
+  "edit.selectAll": "모두 선택"
 }

--- a/src/locales/pt-BR/commands.json
+++ b/src/locales/pt-BR/commands.json
@@ -194,5 +194,9 @@
   "tab.close": "Fechar aba",
   "commandPalette.hintNavigate": "navegar",
   "commandPalette.hintRun": "executar",
-  "commandPalette.hintClose": "fechar"
+  "commandPalette.hintClose": "fechar",
+  "edit.cut": "Recortar",
+  "edit.copy": "Copiar",
+  "edit.paste": "Colar",
+  "edit.selectAll": "Selecionar tudo"
 }

--- a/src/locales/zh-CN/commands.json
+++ b/src/locales/zh-CN/commands.json
@@ -194,5 +194,9 @@
   "tab.close": "关闭标签页",
   "commandPalette.hintNavigate": "导航",
   "commandPalette.hintRun": "执行",
-  "commandPalette.hintClose": "关闭"
+  "commandPalette.hintClose": "关闭",
+  "edit.cut": "剪切",
+  "edit.copy": "复制",
+  "edit.paste": "粘贴",
+  "edit.selectAll": "全选"
 }

--- a/src/locales/zh-TW/commands.json
+++ b/src/locales/zh-TW/commands.json
@@ -194,5 +194,9 @@
   "tab.close": "關閉分頁",
   "commandPalette.hintNavigate": "導覽",
   "commandPalette.hintRun": "執行",
-  "commandPalette.hintClose": "關閉"
+  "commandPalette.hintClose": "關閉",
+  "edit.cut": "剪下",
+  "edit.copy": "複製",
+  "edit.paste": "貼上",
+  "edit.selectAll": "全選"
 }

--- a/src/pages/settings/IntegrationsSettings.tsx
+++ b/src/pages/settings/IntegrationsSettings.tsx
@@ -176,7 +176,7 @@ export function IntegrationsSettings() {
           <div className="mt-4 pt-3 border-t border-[var(--border-color)]">
             <div className="text-xs text-[var(--text-secondary)] flex items-center gap-1.5">
               <span>{t("integrations.mcpInfo.listeningOn")}</span>
-              <code className="px-1 py-0.5 rounded bg-[var(--bg-tertiary)] font-mono">
+              <code className="px-1 py-0.5 rounded-sm bg-[var(--bg-tertiary)] font-mono">
                 localhost:{port}
               </code>
               <CopyButton text={`localhost:${port}`} />

--- a/src/pages/settings/KeyCapture.tsx
+++ b/src/pages/settings/KeyCapture.tsx
@@ -117,7 +117,7 @@ export function KeyCapture({ shortcut, conflict, onCapture, onCancel }: KeyCaptu
 
         <p className="text-xs text-[var(--text-secondary)] mt-4 text-center">
           {t("shortcuts.capture.pressEsc")}{" "}
-          <kbd className="px-1 bg-[var(--bg-secondary)] rounded">Esc</kbd>{" "}
+          <kbd className="px-1 bg-[var(--bg-secondary)] rounded-sm">Esc</kbd>{" "}
           {t("shortcuts.capture.toCancel")}
         </p>
       </div>

--- a/src/pages/settings/McpConfigPreviewDialog.tsx
+++ b/src/pages/settings/McpConfigPreviewDialog.tsx
@@ -234,7 +234,7 @@ function InfoRow({
       {copyable && <CopyButton text={fullValue || value} />}
       {badge && (
         <span
-          className={`text-xs px-1.5 py-0.5 rounded font-medium ${
+          className={`text-xs px-1.5 py-0.5 rounded-sm font-medium ${
             badgeColor === "amber"
               ? "bg-[var(--warning-bg)] text-[var(--warning-color)]"
               : "bg-[var(--success-color)]/10 text-[var(--success-color)]"

--- a/src/pages/settings/McpProviderRow.tsx
+++ b/src/pages/settings/McpProviderRow.tsx
@@ -56,7 +56,7 @@ export function ProviderRow(props: ProviderRowProps) {
                 {diagnostic.name}
               </span>
               {diagnostic.legacy && (
-                <span className="text-xs px-1.5 py-0.5 rounded font-medium bg-[var(--warning-bg)] text-[var(--warning-color)] flex-shrink-0">
+                <span className="text-xs px-1.5 py-0.5 rounded-sm font-medium bg-[var(--warning-bg)] text-[var(--warning-color)] flex-shrink-0">
                   {t("integrations.installMcp.legacyBadge")}
                 </span>
               )}

--- a/src/pages/settings/ModelComboBox.tsx
+++ b/src/pages/settings/ModelComboBox.tsx
@@ -217,7 +217,7 @@ export function ModelComboBox({
       {open && (
         <ul
           ref={listRef}
-          className={`absolute z-[var(--z-popup)] left-0 right-0 max-h-[140px] overflow-y-auto rounded border border-[var(--border-color)] bg-[var(--bg-color)] shadow-[var(--popup-shadow)] text-xs ${dropPositionClass}`}
+          className={`absolute z-[var(--z-popup)] left-0 right-0 max-h-[140px] overflow-y-auto rounded-sm border border-[var(--border-color)] bg-[var(--bg-color)] shadow-[var(--popup-shadow)] text-xs ${dropPositionClass}`}
           role="listbox"
         >
           {fetching && filtered.length === 0 && (

--- a/src/pages/settings/ShortcutsSettings.tsx
+++ b/src/pages/settings/ShortcutsSettings.tsx
@@ -111,7 +111,7 @@ export function ShortcutsSettings() {
       <div
         key={shortcut.id}
         className={`flex items-center justify-between py-2 px-2 -mx-2
-                   hover:bg-[var(--bg-secondary)]/50 rounded transition-colors`}
+                   hover:bg-[var(--bg-secondary)]/50 rounded-sm transition-colors`}
       >
         <div className="flex-1 min-w-0">
           <div className="text-sm text-[var(--text-color)]">
@@ -128,7 +128,7 @@ export function ShortcutsSettings() {
           {/* Key display/edit button */}
           <button
             onClick={() => setCapturing(shortcut)}
-            className={`px-3 py-1 rounded text-xs font-mono min-w-[90px] text-center
+            className={`px-3 py-1 rounded-sm text-xs font-mono min-w-[90px] text-center
                        ${customized
                          ? "bg-[var(--accent-primary)]/20 text-[var(--accent-primary)] ring-1 ring-[var(--accent-primary)]/30"
                          : "bg-[var(--bg-tertiary)] text-[var(--text-secondary)]"

--- a/src/pages/settings/TagInput.tsx
+++ b/src/pages/settings/TagInput.tsx
@@ -52,7 +52,7 @@ export function TagInput({
 
   return (
     <div
-      className="flex flex-wrap items-center gap-1.5 p-2 rounded border border-[var(--border-color)]
+      className="flex flex-wrap items-center gap-1.5 p-2 rounded-sm border border-[var(--border-color)]
                  bg-[var(--bg-color)] min-h-[38px] cursor-text"
       onClick={() => inputRef.current?.focus()}
     >

--- a/src/plugins/codePreview/code-preview.css
+++ b/src/plugins/codePreview/code-preview.css
@@ -102,7 +102,7 @@
   background-color: var(--bg-secondary);
   border: var(--border-thin) solid var(--border-color);
   border-bottom: none;
-  border-radius: var(--radius-md) var(--radius-md, 6px) 0 0;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
 }
 
 .code-block-edit-title {
@@ -168,7 +168,7 @@
   background-color: var(--bg-color);
   border: var(--border-thin) solid var(--border-color);
   border-top: var(--border-thin) dashed var(--border-color);
-  border-radius: 0 0 var(--radius-md, 6px) var(--radius-md, 6px);
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
   min-height: var(--space-15);
   display: flex;
   align-items: center;

--- a/src/services/commands/clipboardCommands.test.ts
+++ b/src/services/commands/clipboardCommands.test.ts
@@ -1,0 +1,64 @@
+// #1354 — Windows swallowed keystrokes after Ctrl+C: muda's predefined
+// clipboard menu items register Ctrl+C/X/V/A in the Win32 accelerator table
+// (intercepting the REAL keystroke before WebView2 sees it) and then re-emit
+// it via SendInput — whose synthetic Ctrl-up, fired while the user still
+// physically holds Ctrl, desyncs Chromium's modifier state: later typed
+// characters arrive as phantom-Ctrl chords and vanish, and paste mistargets,
+// until a focus cycle resets the webview. The fix replaces those items on
+// Windows with accelerator-FREE menu items routed through these CommandBus
+// commands, so the physical shortcuts flow natively to WebView2.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerClipboardCommands, resolveClipboardSurface } from "./clipboardCommands";
+import { executeCommand, hasCommand } from "./CommandBus";
+import { useUIStore } from "@/stores/uiStore";
+
+describe("clipboard commands (#1354)", () => {
+  const execSpy = vi.fn();
+
+  beforeEach(() => {
+    registerClipboardCommands();
+    // jsdom has no execCommand; the bridge's non-mac fallback calls it, so
+    // the DOM API is the boundary we fake — every store and service runs real.
+    (document as { execCommand?: unknown }).execCommand = execSpy;
+    execSpy.mockClear();
+    useUIStore.setState({ sourceMode: false });
+  });
+
+  afterEach(() => {
+    delete (document as { execCommand?: unknown }).execCommand;
+  });
+
+  it("registers all four edit commands exactly once", () => {
+    for (const id of ["edit.cut", "edit.copy", "edit.paste", "edit.selectAll"]) {
+      expect(hasCommand(id), id).toBe(true);
+    }
+    // Idempotent under HMR re-registration.
+    registerClipboardCommands();
+    expect(hasCommand("edit.copy")).toBe(true);
+  });
+
+  it.each([
+    ["edit.cut", "cut"],
+    ["edit.copy", "copy"],
+    ["edit.selectAll", "selectAll"],
+  ])("%s reaches the webview edit fallback as execCommand(%s)", async (id, domCommand) => {
+    await executeCommand(id, undefined, { windowLabel: "main" });
+    expect(execSpy).toHaveBeenCalledWith(domCommand);
+  });
+
+  it("edit.paste with an empty clipboard is a quiet no-op (fallback path)", async () => {
+    // setup.ts mocks plugin-clipboard-manager; readText yields nothing, so
+    // the paste fallback bails without dispatching anywhere.
+    await expect(
+      executeCommand("edit.paste", undefined, { windowLabel: "main" }),
+    ).resolves.not.toThrow();
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it("resolves the surface from the live mode — source pane when sourceMode is on", () => {
+    expect(resolveClipboardSurface()).toBe("wysiwyg");
+    useUIStore.setState({ sourceMode: true });
+    expect(resolveClipboardSurface()).toBe("source");
+    useUIStore.setState({ sourceMode: false });
+  });
+});

--- a/src/services/commands/clipboardCommands.ts
+++ b/src/services/commands/clipboardCommands.ts
@@ -1,0 +1,70 @@
+/**
+ * Clipboard CommandBus commands (#1354).
+ *
+ * Purpose: the Edit-menu Cut/Copy/Paste/Select-All CLICK path on Windows.
+ * muda's predefined clipboard items were removed there — their built-in
+ * Ctrl+C/X/V/A accelerators entered the Win32 accelerator table, which
+ * intercepted the user's PHYSICAL keystroke before WebView2 saw it and
+ * re-emitted it via SendInput. That synthetic sequence ends with a Ctrl-up
+ * while the user still holds Ctrl, desyncing Chromium's modifier state:
+ * subsequently typed characters arrive as phantom-Ctrl chords and vanish
+ * (issue #1354's 吞字), paste mistargets, and IME composition breaks — until
+ * a focus cycle resets the webview. With the accelerators gone, physical
+ * shortcuts flow natively to WebView2 (full fidelity, IME-safe); these
+ * commands serve only actual menu CLICKS, routed per menu:edit-* event
+ * through the same clipboardBridge the editor context menu uses.
+ *
+ * Key decisions:
+ *   - Surface comes from the live mode (source pane vs WYSIWYG), the same
+ *     signal the status-bar mode toggle shows. A menu click targets the
+ *     editing surface; the terminal keeps its own native shortcuts and
+ *     context menu (a menu-click paste into the terminal was already not a
+ *     path predefined items served well — SendInput went to whatever
+ *     focused — and is out of scope here).
+ *   - macOS keeps PredefinedMenuItems (the responder chain is correct
+ *     there), so these commands are never reached from its menu; they stay
+ *     registered on every platform for the palette and for symmetry.
+ *
+ * @coordinates-with src-tauri/src/menu/localized/edit_menu.rs — emits menu:edit-*
+ * @coordinates-with services/editor/clipboardBridge.ts — the executor
+ * @module services/commands/clipboardCommands
+ */
+import i18n from "@/i18n";
+import { hasCommand, registerCommand } from "./CommandBus";
+import {
+  runClipboardCommand,
+  type ClipboardCommand,
+} from "@/services/editor/clipboardBridge";
+import { useUIStore } from "@/stores/uiStore";
+import type { EditorMenuSurface } from "@/types/editorContextMenu";
+
+/** The editing surface a menu-bar clipboard click should target. */
+export function resolveClipboardSurface(): EditorMenuSurface {
+  return useUIStore.getState().sourceMode ? "source" : "wysiwyg";
+}
+
+const COMMANDS: ReadonlyArray<{ id: string; key: string; command: ClipboardCommand }> = [
+  { id: "edit.cut", key: "edit.cut", command: "cut" },
+  { id: "edit.copy", key: "edit.copy", command: "copy" },
+  { id: "edit.paste", key: "edit.paste", command: "paste" },
+  { id: "edit.selectAll", key: "edit.selectAll", command: "selectAll" },
+];
+
+let registered = false;
+
+/** Register the four clipboard commands (idempotent under HMR). */
+export function registerClipboardCommands(): void {
+  if (registered || hasCommand("edit.copy")) return;
+  registered = true;
+
+  for (const { id, key, command } of COMMANDS) {
+    registerCommand({
+      id,
+      title: () => i18n.t(`commands:${key}`),
+      category: "edit",
+      run: async () => {
+        await runClipboardCommand(command, resolveClipboardSurface());
+      },
+    });
+  }
+}

--- a/src/services/editor/clipboardBridge.ts
+++ b/src/services/editor/clipboardBridge.ts
@@ -1,0 +1,113 @@
+/**
+ * Clipboard bridge for the editor context menu.
+ *
+ * Purpose: Cut/Copy/Paste/Select-All are native webview roles, not
+ * toolbar-adapter actions. On macOS this invokes `trigger_webview_edit`
+ * (Rust sends the matching selector down the responder chain — identical
+ * to the Edit menu's PredefinedMenuItems, so paste keeps full HTML/image
+ * fidelity through the existing paste plugins). Elsewhere, best-effort
+ * fallbacks: `document.execCommand` for cut/copy/select-all and a
+ * plain-text clipboard read for paste.
+ *
+ * Focus contract (plan ADR-3, validated by the Phase 0 spike): the native
+ * action targets the first responder, so the editor surface is refocused
+ * BEFORE the command fires. ProseMirror/CodeMirror restore their own
+ * selection on focus — no selection bookkeeping needed here.
+ *
+ * @coordinates-with src-tauri/src/webview_edit.rs — the macOS command
+ * @coordinates-with menuModel.ts — emits the clipboard run entries
+ * Moved from components/Editor/EditorContextMenu in the #1354 fix: the
+ * module is service-shaped (stores + Tauri invoke, no component nature), and
+ * services/commands/clipboardCommands.ts needs it without an upward import
+ * (dependency-cruiser services-no-upward). The old path re-exports.
+ *
+ * @module services/editor/clipboardBridge
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { readText } from "@tauri-apps/plugin-clipboard-manager";
+import type { EditorView as CodeMirrorView } from "@codemirror/view";
+import { useEditorStore } from "@/stores/editorStore";
+import { isMacPlatform } from "@/utils/platform";
+import type { EditorMenuSurface } from "@/types/editorContextMenu";
+
+export type ClipboardCommand = "cut" | "copy" | "paste" | "selectAll";
+
+/**
+ * Source-view override for surfaces that are not registered in
+ * editorStore — SplitPaneEditor source panes run their own minimal
+ * CodeMirror instances. The pane's trigger sets this when it opens the
+ * menu (and clears it on destroy) so focus/paste target the right view.
+ */
+let sourceViewOverride: CodeMirrorView | null = null;
+
+export function setContextMenuSourceView(view: CodeMirrorView | null): void {
+  sourceViewOverride = view;
+}
+
+/** Clear the override only if it still points at `view` (a newer pane may
+ *  have registered since — never clobber it). */
+export function clearContextMenuSourceView(view: CodeMirrorView): void {
+  if (sourceViewOverride === view) sourceViewOverride = null;
+}
+
+function getSourceView(): CodeMirrorView | null {
+  return sourceViewOverride ?? useEditorStore.getState().source.editorView;
+}
+
+/** Refocus the editing surface so it is the first responder / execCommand
+ *  target. Exported for the adapter/link runners, which share the
+ *  "menu stole focus, give it back" concern. */
+export function focusEditorSurface(surface: EditorMenuSurface): void {
+  if (surface === "source") {
+    getSourceView()?.focus();
+    return;
+  }
+  useEditorStore.getState().tiptap.editorView?.focus();
+}
+
+async function pasteFallback(surface: EditorMenuSurface): Promise<void> {
+  let text: string;
+  try {
+    text = await readText();
+  } catch {
+    // Clipboard unreadable (empty, non-text, or permission) — nothing to paste.
+    return;
+  }
+  if (!text) return;
+
+  if (surface === "source") {
+    const view = getSourceView();
+    if (!view) return;
+    view.dispatch(view.state.replaceSelection(text));
+    return;
+  }
+  useEditorStore.getState().tiptap.editorView?.pasteText(text);
+}
+
+/**
+ * Run a clipboard command for the given surface. macOS: native responder
+ * chain (full fidelity); other platforms or native failure: fallbacks
+ * (plain-text paste — a documented cross-platform limitation).
+ */
+export async function runClipboardCommand(
+  command: ClipboardCommand,
+  surface: EditorMenuSurface
+): Promise<void> {
+  focusEditorSurface(surface);
+
+  if (isMacPlatform()) {
+    try {
+      await invoke("trigger_webview_edit", { action: command });
+      return;
+    } catch {
+      // Fall through to the DOM/plugin fallback below.
+    }
+  }
+
+  if (command === "paste") {
+    await pasteFallback(surface);
+    return;
+  }
+  document.execCommand(command === "selectAll" ? "selectAll" : command);
+}

--- a/src/shared/menu-ids.json
+++ b/src/shared/menu-ids.json
@@ -127,6 +127,10 @@
     "diagram",
     "diagram-preview",
     "duplicate-line",
+    "edit-copy",
+    "edit-cut",
+    "edit-paste",
+    "edit-select-all",
     "expand-selection",
     "export-html",
     "export-pandoc-docx",
@@ -252,5 +256,5 @@
     "zoom-in",
     "zoom-out"
   ],
-  "generatedAt": "2026-08-22T09:13:50.912Z"
+  "generatedAt": "2026-09-02T00:17:58.731Z"
 }

--- a/src/shared/menuIdExtraction.ts
+++ b/src/shared/menuIdExtraction.ts
@@ -67,6 +67,15 @@ export const EXCLUDED_MENU_IDS: ReadonlySet<string> = new Set([
   // Placeholders for empty dynamic submenus
   "no-recent",
   "no-recent-workspace",
+  // #1354 — Windows-only clipboard menu items, routed through the CommandBus
+  // (menu:edit-cut → edit.cut, …). They replace muda's PredefinedMenuItems
+  // there: the predefined accelerators intercepted physical Ctrl+C/X/V/A in
+  // the Win32 accelerator table and re-emitted them via SendInput, whose
+  // synthetic Ctrl-up desynced WebView2's modifier state (swallowed keys).
+  "edit-cut",
+  "edit-copy",
+  "edit-paste",
+  "edit-select-all",
   // File operations (dedicated listeners)
   "new",
   "new-window",

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -132,9 +132,13 @@
   --bg-primary: var(--bg-color); /* token-unused-ok: documented alias name — kept resolvable for consumers that reach for it */
   --text-primary: var(--text-color); /* token-unused-ok: documented alias name — kept resolvable for consumers that reach for it */
 
-  /* Border radius tokens */
-  --radius-sm: 4px;
-  --radius-md: 6px;
+  /* Border radius tokens — the φ curvature ladder (maintainer, 2026-09-02):
+     window 21 → shell card 13 → lg 8 → md 5 → sm 3, each step ≈ ×0.62
+     (Fibonacci: 3, 5, 8, 13, 21). Pick by TIER — floating surface / content
+     block & page row / control — never by taste. Pills stay off-ladder.
+     Runtime values live in tokens.ts sharedPrimitives.radius — keep in sync. */
+  --radius-sm: 3px;
+  --radius-md: 5px;
   --radius-lg: 8px;
   --radius-pill: 100px;
 

--- a/src/test/tailwindTheme.test.ts
+++ b/src/test/tailwindTheme.test.ts
@@ -7,7 +7,7 @@
  * sessions) and asserts each namespace VMark uses resolves onto a token.
  */
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
+import { readFileSync, globSync } from "node:fs";
 
 const css = readFileSync("src/styles/index.css", "utf8");
 const themeBlock = (() => {
@@ -49,11 +49,16 @@ describe("@theme inline bridge (D1)", () => {
     expect(mapped("--shadow-popup")).toBe("var(--shadow-popup)");
   });
 
-  it("bare `rounded` (a 0.25rem Tailwind literal) still equals --radius-sm", () => {
+  it("bare `rounded` is BANNED — the φ ladder moved --radius-sm off Tailwind's 0.25rem literal", () => {
     // rounded-sm/md/lg resolve through our identically-named :root tokens;
-    // bare `rounded` is the one literal. Pin the equality so a --radius-sm
-    // retint cannot silently strand 32 usages at the old 4px.
+    // bare `rounded` compiles to a hardcoded 0.25rem (4px), which equalled
+    // --radius-sm only until the 2026-09-02 φ retune (sm = 3px). The old pin
+    // asserted the equality; this one asserts the escape hatch stays closed.
     const m = /--radius-sm:\s*([^;]+);/.exec(css);
-    expect(m![1].trim()).toBe("4px"); // 0.25rem
+    expect(m![1].trim()).toBe("3px");
+    for (const file of globSync("src/**/*.tsx")) {
+      const src = readFileSync(file, "utf8");
+      expect(/\brounded\b(?!-)/.test(src), `${file} uses bare rounded (4px literal)`).toBe(false);
+    }
   });
 });

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -178,7 +178,7 @@ export const sharedPrimitives = {
     8: "32px",
     10: "40px",
   } satisfies ThemeTokens["space"],
-  radius: { sm: "4px", md: "6px", lg: "8px", pill: "100px" } satisfies ThemeTokens["radius"],
+  radius: { sm: "3px", md: "5px", lg: "8px", pill: "100px" } satisfies ThemeTokens["radius"],
   font: {
     // R3 (WI-UI2.1): sans/mono mirror buildFontStack's system output — the old
     // "SauceCodePro NF" stack was one the runtime never produced. `ui` is the


### PR DESCRIPTION
## Summary

Two changes riding one release: the Windows swallowed-keystroke fix (#1354) and the φ radius unification.

### fix(menu): Windows swallowed keystrokes after Ctrl+C (#1354)

Confirmed in muda 0.19.3's source: predefined clipboard menu items carry built-in Ctrl+X/C/V/A accelerators that enter the Win32 accelerator table — intercepting the user's physical keystroke before WebView2 sees it — and then re-emit it via `SendInput`, whose synthetic Ctrl-up (fired while the user still holds Ctrl) desyncs Chromium's modifier state. Typed characters then arrive as phantom-Ctrl chords and vanish (吞字), paste mistargets, and IME composition breaks until a focus cycle. On Windows the four entries become accelerator-free custom items routed through new CommandBus commands into the existing clipboardBridge; physical shortcuts flow natively to WebView2. macOS untouched (responder chain). Cross-compile, clippy, Rust tests, menu-id contract, and keybinding-manifest all green; labels/titles added to all ten locale bundles on both sides.

Closes #1354

### feat(ui): unify every radius onto the φ curvature ladder

Unifies every radius (pills excepted) onto one φ curvature ladder — each tier ≈ the previous × 0.62, the Fibonacci run **3, 5, 8, 13, 21**:

```
window 21 → shell card 13 → --radius-lg 8 → --radius-md 5 → --radius-sm 3
```

The top of the ladder already existed: 13 is both concentric with the 21pt window (at the 8px card inset) and 21 × 0.62, and 8 is 13 × 0.62 — so popups, menus, and the command palette were already proportionate and keep their value. This PR lands the bottom two tiers and the consistency fixes from the 2026-09-02 radius audit (`dev-docs/artifacts/20260902-radius-audit.html`), then bumps the patch for release.

## Policy Gates (Required)

- [x] This PR is single-focus (one issue, one problem, one objective).
- [x] This PR includes 100% test coverage for changed behavior and changed code paths.
- [x] If this is a bug fix, the linked issue contains detailed reproduction context.

## Linked Issue

Maintainer-directed follow-on to the 20260901 UI audit (the radius finding, reopened with a concrete scheme).

## Type of Change

- [x] Feature
- [x] Bug fix
- [x] Docs

## What Changed

- `--radius-sm` 4 → 3 and `--radius-md` 6 → 5 in all three sources of truth (index.css statics, typed catalog `sharedPrimitives.radius`, PDF-export primitive copy)
- Bare Tailwind `rounded` (hardcoded 0.25rem) migrated to `rounded-sm` at all 8 sites and **banned** — the `tailwindTheme.test.ts` pin flipped from asserting the old 4px equality to enforcing the ban (the retune that pin existed to catch)
- Row-idiom unification: workspace-rail menu + toolbar dropdown items `md` → `sm`, matching every context menu and overlay row (near-concentric inside `lg` surfaces)
- Literal cleanup: directional `0 0 4px 4px` tokenized, `var(--radius-md, 6px)` fallbacks dropped, the token-free standalone reader retuned onto the ladder
- Docs: rule 31 (retuned table + ladder rule + inputs corrected to `sm`, which reality always used), rule 32 snippets, AGENTS.md, design-system.md
- `chore: bump version to 0.9.61` folded in (five files + Cargo.lock)

## Validation

- [x] I ran `pnpm check:all` locally.
- [x] I added or updated tests to fully cover behavior changes.
- [x] I manually verified critical flows.

Bespoke-buttons' three budgets held exactly (37/58/61) — shape-drift resolves `var()` through index.css, so every comparison moved together and no button class drifted. ui-consistency, design-tokens, export CSS-var coverage, and the full ladder (`test:changed` → `check:predelta` ×41 → `check:all`) green.

## UI Evidence (if applicable)

1px-per-tier change; the radius audit artifact documents the before/after system. Verified live via HMR during the session.

## PR Checklist

- [x] The PR avoids unrelated refactors or cleanup.
- [x] The issue context is clear (linked issue or explanation above).
- [x] Docs/changelog were updated if behavior or usage changed.
- [x] I am ready to address review feedback.
