### PR TITLE
fix(explorer): stop the file tree's self-perpetuating rescan loop (#1357)

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -178,7 +178,12 @@ module.exports = [
     // boundary (type-aware gate: String(detail) on a typed rejection renders
     // "[object Object]") — landed the chunk 23 B over. Kept tight so the next
     // unjustified growth still trips.
-    limit: "612 kB",
+    // 612 → 614 kB (2026-09-05, #1357): the file explorer's rescan scheduler —
+    // debounce, no-starvation bound and back-off under churn, replacing the
+    // rescan-per-event loop that pinned a core — landed the chunk 1.17 kB over.
+    // Same discipline: the smallest raise that fits, so growth without a reason
+    // still trips.
+    limit: "614 kB",
     brotli: false,
   },
 

--- a/src-tauri/src/command_registry.rs
+++ b/src-tauri/src/command_registry.rs
@@ -78,6 +78,7 @@ macro_rules! all_commands {
             watcher::start_watching,
             watcher::stop_watching,
             file_tree::list_directory_entries,
+            file_tree_walk::list_directory_tree,
             file_ops::get_file_size_bytes,
             file_ops::move_paths_to_trash,
             live_docs::collect_live_document_refs,

--- a/src-tauri/src/content_search.rs
+++ b/src-tauri/src/content_search.rs
@@ -45,7 +45,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 #[path = "content_search_match.rs"]
-mod matching;
+pub(crate) mod matching; // `ALWAYS_SKIP` is shared with the file-tree walker (#1357)
 pub(crate) use matching::LineMatch;
 use matching::{build_regex, is_binary, matches_extensions, search_line, should_skip_dir};
 

--- a/src-tauri/src/file_tree.rs
+++ b/src-tauri/src/file_tree.rs
@@ -2,7 +2,8 @@
 //!
 //! Purpose: Lists directory contents for the sidebar file explorer.
 //!
-//! Pipeline: Frontend invoke("list_directory_entries") → this module → filesystem readdir
+//! Pipeline: Frontend invoke("list_directory_entries") → this module → filesystem readdir.
+//! `file_tree_walk.rs` (the one-call tree listing, #1357) reuses `compute_is_hidden`.
 //!
 //! Key decisions:
 //!   - Hidden file detection is cross-platform: dot-prefix on all OSes,
@@ -42,7 +43,7 @@ fn is_hidden_by_metadata(metadata: &fs::Metadata) -> bool {
 /// Cross-platform hidden check: dot-prefix everywhere, plus the
 /// FILE_ATTRIBUTE_HIDDEN/SYSTEM attributes on Windows (stat only when the
 /// cheap name check didn't already decide).
-fn compute_is_hidden(name: &str, entry: &fs::DirEntry) -> bool {
+pub(crate) fn compute_is_hidden(name: &str, entry: &fs::DirEntry) -> bool {
     if is_hidden_by_name(name) {
         return true;
     }

--- a/src-tauri/src/file_tree_walk.rs
+++ b/src-tauri/src/file_tree_walk.rs
@@ -1,0 +1,183 @@
+//! # File Tree Walk
+//!
+//! Purpose: list a workspace's WHOLE tree for the sidebar in one command, off the
+//! IPC thread, with the directories nobody wants to see pruned before they are
+//! read (#1357).
+//!
+//! Pipeline: Frontend invoke("list_directory_tree") → this module → one blocking
+//! recursive readdir → nested `TreeEntry` nodes.
+//!
+//! Key decisions:
+//!   - ONE round trip per refresh. The explorer used to recurse in JavaScript with
+//!     one `list_directory_entries` IPC per directory, serially awaited; a
+//!     Downloads-sized root took seconds per scan, and that slowness was the fuel
+//!     of the rescan loop in #1357 (a scan long enough for an fs event to land
+//!     during it re-armed itself forever). Here the walk is a single
+//!     `spawn_blocking` task.
+//!   - Directories are PRUNED, files are not filtered: the file-type filter is a
+//!     registry-driven JavaScript predicate and stays client-side. What never gets
+//!     descended: `content_search::matching::ALWAYS_SKIP` (the same floor the workspace
+//!     search applies — the file tree was the one traversal without it), the
+//!     user's `excludeFolders`, and hidden directories when hidden entries are off.
+//!   - Bounded: at most `MAX_TREE_NODES` entries and `MAX_TREE_DEPTH` levels; past
+//!     either, `truncated` is reported so the UI can say the tree is partial rather
+//!     than lie about an absence. A symlink is never descended (`file_type()` of
+//!     the link itself is not a directory), so a link cycle cannot recurse.
+//!   - An unreadable SUBdirectory renders as an empty folder flagged `unreadable`
+//!     (one TCC-denied folder must not blank the tree); an unreadable ROOT is the
+//!     command's error, so the user is told rather than shown an empty workspace.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+
+use crate::command_error::{CommandError, ErrorCode};
+use crate::content_search::matching::ALWAYS_SKIP;
+
+/// One node of the listed tree; folders carry their (pruned) children.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct TreeEntry {
+    pub name: String,
+    pub path: String,
+    #[serde(rename = "isDirectory")]
+    pub is_directory: bool,
+    #[serde(rename = "isHidden")]
+    pub is_hidden: bool,
+    /// The directory could not be read (permission, TCC, vanished): shown empty.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub unreadable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub children: Option<Vec<TreeEntry>>,
+}
+
+/// What the caller asks the walk to leave out.
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TreeOptions {
+    /// User-configured folder names never descended (in addition to ALWAYS_SKIP).
+    #[serde(default)]
+    pub exclude_folders: Vec<String>,
+    /// Descend hidden directories too. Hidden FILES are always listed with their
+    /// flag; the client decides whether to show them.
+    #[serde(default)]
+    pub show_hidden: bool,
+}
+
+/// The walk's result: the root's children and whether a bound was hit.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct TreeListing {
+    pub entries: Vec<TreeEntry>,
+    pub truncated: bool,
+}
+
+/// Total entries one listing may carry — bounds the IPC payload and the memory of
+/// a root like `~` (#1357). The workspace search's own cap is the same order.
+pub const MAX_TREE_NODES: usize = 50_000;
+/// Nesting levels descended below the root.
+pub const MAX_TREE_DEPTH: usize = 64;
+
+/// List the whole tree under `path` in one call. See the module doc.
+///
+/// # Errors
+/// `io` when the ROOT itself cannot be read (the message is the OS's), `internal`
+/// when the blocking task itself failed.
+#[tauri::command]
+pub async fn list_directory_tree(
+    path: String,
+    options: TreeOptions,
+) -> Result<TreeListing, CommandError> {
+    tokio::task::spawn_blocking(move || list_directory_tree_blocking(&path, &options))
+        .await
+        .map_err(|e| {
+            CommandError::new(
+                ErrorCode::Internal,
+                format!("Directory tree task failed: {e}"),
+            )
+        })?
+        .map_err(|message| CommandError::new(ErrorCode::Io, message))
+}
+
+struct Walk<'a> {
+    options: &'a TreeOptions,
+    nodes: usize,
+    truncated: bool,
+}
+
+impl Walk<'_> {
+    fn descends(&self, name: &str, is_hidden: bool) -> bool {
+        if ALWAYS_SKIP.contains(&name) {
+            return false;
+        }
+        if self.options.exclude_folders.iter().any(|f| f == name) {
+            return false;
+        }
+        self.options.show_hidden || !is_hidden
+    }
+
+    /// Children of `dir`, or `Err` when it cannot be read.
+    fn list(&mut self, dir: &str, depth: usize) -> Result<Vec<TreeEntry>, String> {
+        let read = fs::read_dir(dir).map_err(|e| format!("Failed to read dir: {e}"))?;
+        let mut out = Vec::new();
+        for entry in read.flatten() {
+            if self.nodes >= MAX_TREE_NODES {
+                self.truncated = true;
+                break;
+            }
+            self.nodes += 1;
+            let name = entry.file_name().to_string_lossy().to_string();
+            let path = entry.path().to_string_lossy().to_string();
+            let is_directory = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+            let is_hidden = crate::file_tree::compute_is_hidden(&name, &entry);
+            let mut node = TreeEntry {
+                name,
+                path,
+                is_directory,
+                is_hidden,
+                unreadable: false,
+                children: None,
+            };
+            if is_directory && self.descends(&node.name, is_hidden) {
+                if depth >= MAX_TREE_DEPTH {
+                    self.truncated = true;
+                    node.children = Some(Vec::new());
+                } else {
+                    match self.list(&node.path, depth + 1) {
+                        Ok(children) => node.children = Some(children),
+                        Err(e) => {
+                            log::warn!("[file-tree] unreadable directory {}: {e}", node.path);
+                            node.unreadable = true;
+                            node.children = Some(Vec::new());
+                        }
+                    }
+                }
+            } else if is_directory {
+                node.children = Some(Vec::new()); // pruned: listed, never descended
+            }
+            out.push(node);
+        }
+        Ok(out)
+    }
+}
+
+/// Synchronous core of `list_directory_tree` (runs inside `spawn_blocking`).
+pub(crate) fn list_directory_tree_blocking(
+    path: &str,
+    options: &TreeOptions,
+) -> Result<TreeListing, String> {
+    let mut walk = Walk {
+        options,
+        nodes: 0,
+        truncated: false,
+    };
+    let entries = walk.list(path, 0)?;
+    if walk.truncated {
+        log::warn!("[file-tree] listing truncated for {path}: {MAX_TREE_NODES} nodes / {MAX_TREE_DEPTH} levels");
+    }
+    Ok(TreeListing {
+        entries,
+        truncated: walk.truncated,
+    })
+}
+
+#[cfg(test)]
+#[path = "file_tree_walk.test.rs"]
+mod tests;

--- a/src-tauri/src/file_tree_walk.test.rs
+++ b/src-tauri/src/file_tree_walk.test.rs
@@ -1,0 +1,183 @@
+//! #1357 — the one-call tree walk: pruning, bounds, and the two kinds of "cannot read".
+use super::*;
+use std::fs;
+use tempfile::tempdir;
+
+fn names(entries: &[TreeEntry]) -> Vec<&str> {
+    entries.iter().map(|e| e.name.as_str()).collect()
+}
+
+fn find<'a>(entries: &'a [TreeEntry], name: &str) -> &'a TreeEntry {
+    entries
+        .iter()
+        .find(|e| e.name == name)
+        .unwrap_or_else(|| panic!("no entry {name}"))
+}
+
+#[test]
+fn lists_the_whole_tree_in_one_call_with_children_nested() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    fs::create_dir_all(root.join("docs/deep")).unwrap();
+    fs::write(root.join("a.md"), "").unwrap();
+    fs::write(root.join("docs/b.md"), "").unwrap();
+    fs::write(root.join("docs/deep/c.md"), "").unwrap();
+    let listing =
+        list_directory_tree_blocking(root.to_str().unwrap(), &TreeOptions::default()).unwrap();
+    assert!(!listing.truncated);
+    let docs = find(&listing.entries, "docs");
+    assert!(docs.is_directory);
+    let deep = find(docs.children.as_ref().unwrap(), "deep");
+    assert_eq!(names(deep.children.as_ref().unwrap()), vec!["c.md"]);
+}
+
+#[test]
+fn never_descends_the_always_skipped_directories_nor_the_users_exclusions() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    for skipped in ["node_modules", ".git", "target", "vendor"] {
+        fs::create_dir_all(root.join(skipped).join("inner")).unwrap();
+        fs::write(root.join(skipped).join("inner/x.md"), "").unwrap();
+    }
+    let options = TreeOptions {
+        exclude_folders: vec!["vendor".into()],
+        show_hidden: true,
+    };
+    let listing = list_directory_tree_blocking(root.to_str().unwrap(), &options).unwrap();
+    // Listed (so the user can see they exist), but never read into.
+    for skipped in ["node_modules", ".git", "target", "vendor"] {
+        let node = find(&listing.entries, skipped);
+        assert!(node.is_directory);
+        assert_eq!(
+            node.children.as_deref(),
+            Some(&[][..]),
+            "{skipped} must be pruned"
+        );
+        assert!(!node.unreadable, "pruned is not unreadable");
+    }
+    assert!(
+        ALWAYS_SKIP.contains(&"node_modules"),
+        "the list is the search's own"
+    );
+}
+
+#[test]
+fn hidden_directories_are_pruned_unless_hidden_entries_are_shown() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    fs::create_dir_all(root.join(".notes")).unwrap();
+    fs::write(root.join(".notes/secret.md"), "").unwrap();
+    fs::write(root.join(".dotfile.md"), "").unwrap();
+    let hidden_off =
+        list_directory_tree_blocking(root.to_str().unwrap(), &TreeOptions::default()).unwrap();
+    let notes = find(&hidden_off.entries, ".notes");
+    assert!(notes.is_hidden);
+    assert_eq!(notes.children.as_deref(), Some(&[][..]));
+    // Hidden FILES are still listed with their flag — the client decides.
+    assert!(find(&hidden_off.entries, ".dotfile.md").is_hidden);
+    let hidden_on = list_directory_tree_blocking(
+        root.to_str().unwrap(),
+        &TreeOptions {
+            exclude_folders: vec![],
+            show_hidden: true,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        names(
+            find(&hidden_on.entries, ".notes")
+                .children
+                .as_ref()
+                .unwrap()
+        ),
+        vec!["secret.md"]
+    );
+}
+
+#[test]
+fn an_unreadable_root_is_the_error_and_an_unreadable_subdirectory_is_a_flagged_empty_folder() {
+    let missing = tempdir().unwrap().path().join("gone");
+    assert!(
+        list_directory_tree_blocking(missing.to_str().unwrap(), &TreeOptions::default()).is_err()
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        let locked = root.join("locked");
+        fs::create_dir(&locked).unwrap();
+        fs::write(locked.join("inside.md"), "").unwrap();
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+        let listing = list_directory_tree_blocking(root.to_str().unwrap(), &TreeOptions::default());
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).unwrap();
+        let listing = listing.unwrap();
+        let node = find(&listing.entries, "locked");
+        // Root-owned test runners can read anything; the flag is asserted only
+        // when the read really failed.
+        if node.unreadable {
+            assert_eq!(node.children.as_deref(), Some(&[][..]));
+        }
+    }
+}
+
+#[test]
+fn a_symlink_to_a_directory_is_listed_but_never_descended() {
+    #[cfg(unix)]
+    {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir(root.join("real")).unwrap();
+        fs::write(root.join("real/x.md"), "").unwrap();
+        std::os::unix::fs::symlink(root, root.join("real/loop")).unwrap();
+        let listing =
+            list_directory_tree_blocking(root.to_str().unwrap(), &TreeOptions::default()).unwrap();
+        let real = find(&listing.entries, "real");
+        let link = find(real.children.as_ref().unwrap(), "loop");
+        assert!(
+            !link.is_directory,
+            "a symlink's own file type is not a directory"
+        );
+        assert!(link.children.is_none());
+        assert!(!listing.truncated);
+    }
+}
+
+#[test]
+fn the_node_budget_truncates_and_says_so() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    for i in 0..(MAX_TREE_NODES / 1000).max(3) {
+        fs::write(root.join(format!("f{i}.md")), "").unwrap();
+    }
+    let small =
+        list_directory_tree_blocking(root.to_str().unwrap(), &TreeOptions::default()).unwrap();
+    assert!(!small.truncated);
+    // The bound itself, exercised on the counter rather than on 50k real files.
+    let mut walk = Walk {
+        options: &TreeOptions::default(),
+        nodes: MAX_TREE_NODES,
+        truncated: false,
+    };
+    let entries = walk.list(root.to_str().unwrap(), 0).unwrap();
+    assert!(entries.is_empty());
+    assert!(walk.truncated);
+}
+
+#[test]
+fn the_depth_bound_stops_descending_and_says_so() {
+    let dir = tempdir().unwrap();
+    let mut deep = dir.path().to_path_buf();
+    for i in 0..(MAX_TREE_DEPTH + 2) {
+        deep = deep.join(format!("d{i}"));
+    }
+    fs::create_dir_all(&deep).unwrap();
+    fs::write(deep.join("leaf.md"), "").unwrap();
+    let listing =
+        list_directory_tree_blocking(dir.path().to_str().unwrap(), &TreeOptions::default())
+            .unwrap();
+    assert!(
+        listing.truncated,
+        "past MAX_TREE_DEPTH the walk must report a partial tree"
+    );
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ mod external_editor;
 mod file_open;
 mod file_ops;
 mod file_tree;
+mod file_tree_walk;
 mod file_write;
 mod fs_scope;
 pub mod genies;

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -7,6 +7,8 @@
 //! debounce + filter → `app.emit("fs:changed", ...)` → frontend `useFileTree`.
 //!
 //! Key decisions:
+//!   - Paths are reported under the root the caller asked to watch, not the
+//!     realpath the OS returns (see `rebase_onto_root`).
 //!   - Debouncing (200ms) keyed by (watch_id, path, kind) suppresses duplicate
 //!     events from macOS FSEvents, which fires multiple events for a single
 //!     write. Kind is part of the key so a `create` followed by a `remove`
@@ -152,7 +154,39 @@ fn should_emit_and_record(
 
 /// Handle a notify event and emit it to the frontend.
 /// Deduplicates same-kind events for the same path within DEBOUNCE_INTERVAL.
-fn handle_event(app: &AppHandle, watch_id: &str, root_path: &str, event: Event) {
+/// Spell a path the watcher reported under the root the caller asked to watch.
+///
+/// The OS reports the REAL path (`/private/var/…` for a root given as
+/// `/var/…`, the target for a root reached through any symlink), while the
+/// window's scope filter compares against the root string it started the watch
+/// with. Every event under a symlinked root therefore fell out of scope, the
+/// explorer never refreshed on fs events there, and only the window-focus refresh
+/// masked it (found by #1357's live check, whose workspace lived under macOS's
+/// `/var` → `/private/var` link). `canonical_root` is the resolved root; a
+/// reported path under it is rebased onto `root`; anything else is returned as
+/// it came. The prefix must end at a path separator so `/root2/x` never matches
+/// `/root`.
+fn rebase_onto_root(path: &str, root: &str, canonical_root: &str) -> String {
+    if canonical_root == root || !path.starts_with(canonical_root) {
+        return path.to_string();
+    }
+    let rest = &path[canonical_root.len()..];
+    if rest.is_empty() {
+        return root.to_string();
+    }
+    if !rest.starts_with(std::path::MAIN_SEPARATOR) && !rest.starts_with('/') {
+        return path.to_string();
+    }
+    format!("{root}{rest}")
+}
+
+fn handle_event(
+    app: &AppHandle,
+    watch_id: &str,
+    root_path: &str,
+    canonical_root: &str,
+    event: Event,
+) {
     let Some(kind_str) = event_kind_to_string(&event.kind) else {
         return;
     };
@@ -173,7 +207,7 @@ fn handle_event(app: &AppHandle, watch_id: &str, root_path: &str, event: Event) 
         .iter()
         .filter(|p| !should_ignore_path(p))
         .filter_map(|p| {
-            let path_str = p.to_string_lossy().to_string();
+            let path_str = rebase_onto_root(&p.to_string_lossy(), root_path, canonical_root);
             should_emit_and_record(map, watch_id, &path_str, kind_str, now).then_some(path_str)
         })
         .collect();
@@ -213,11 +247,21 @@ pub fn start_watching(app: AppHandle, watch_id: String, path: String) -> Result<
     let app_handle = app.clone();
     let watch_id_clone = watch_id.clone();
     let root_path_clone = path.clone();
+    // Resolved once: the spelling the OS will report events under.
+    let canonical_root = std::fs::canonicalize(watch_path)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| path.clone());
 
     let mut watcher = RecommendedWatcher::new(
         move |res: Result<Event, notify::Error>| {
             if let Ok(event) = res {
-                handle_event(&app_handle, &watch_id_clone, &root_path_clone, event);
+                handle_event(
+                    &app_handle,
+                    &watch_id_clone,
+                    &root_path_clone,
+                    &canonical_root,
+                    event,
+                );
             }
         },
         Config::default(),

--- a/src-tauri/src/watcher.test.rs
+++ b/src-tauri/src/watcher.test.rs
@@ -193,3 +193,61 @@ fn test_fs_change_event_serialization() {
     assert!(json.contains("\"rootPath\":\"/Users/test\""));
     assert!(json.contains("\"kind\":\"modify\""));
 }
+
+// ── #1357 live check: events under a symlinked root must stay in scope ────────
+
+#[test]
+fn a_path_reported_under_the_canonical_root_is_rebased_onto_the_requested_root() {
+    // macOS: a root given as /var/… is reported as /private/var/….
+    assert_eq!(
+        rebase_onto_root(
+            "/private/var/folders/x/ws/new.md",
+            "/var/folders/x/ws",
+            "/private/var/folders/x/ws"
+        ),
+        "/var/folders/x/ws/new.md"
+    );
+    // The root itself.
+    assert_eq!(
+        rebase_onto_root("/private/var/ws", "/var/ws", "/private/var/ws"),
+        "/var/ws"
+    );
+}
+
+#[test]
+fn a_canonical_root_leaves_paths_untouched_and_a_sibling_prefix_never_matches() {
+    assert_eq!(
+        rebase_onto_root("/home/me/ws/a.md", "/home/me/ws", "/home/me/ws"),
+        "/home/me/ws/a.md"
+    );
+    // `/root2/…` is not under `/root`.
+    assert_eq!(
+        rebase_onto_root("/real/root2/a.md", "/link/root", "/real/root"),
+        "/real/root2/a.md"
+    );
+    // A path outside the root comes back as reported.
+    assert_eq!(
+        rebase_onto_root("/elsewhere/a.md", "/link/root", "/real/root"),
+        "/elsewhere/a.md"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_root_reached_through_a_real_symlink_rebases_the_os_spelling() {
+    let dir = tempfile::tempdir().unwrap();
+    let real = dir.path().join("real");
+    std::fs::create_dir(&real).unwrap();
+    let link = dir.path().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    let requested = link.to_string_lossy().to_string();
+    let canonical = std::fs::canonicalize(&link)
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let reported = format!("{canonical}/note.md");
+    assert_eq!(
+        rebase_onto_root(&reported, &requested, &canonical),
+        format!("{requested}/note.md")
+    );
+}

--- a/src/components/Sidebar/FileExplorer/fileTreeFilters.test.ts
+++ b/src/components/Sidebar/FileExplorer/fileTreeFilters.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { shouldIncludeEntry, type FileTreeFilterOptions } from "./fileTreeFilters";
+import { readFileSync } from "node:fs";
+import { FILE_TREE_ALWAYS_SKIP, shouldIncludeEntry, type FileTreeFilterOptions } from "./fileTreeFilters";
 import type { DirectoryEntry } from "./types";
 
 const mdFilter = (name: string, isFolder: boolean) =>
@@ -86,5 +87,25 @@ describe("shouldIncludeEntry", () => {
     expect(
       shouldIncludeEntry(entry, { ...baseOptions, showAllFiles: true, excludeFolders: ["node_modules"] })
     ).toBe(false);
+  });
+});
+
+describe("the always-skipped directories (#1357)", () => {
+  it("are skipped whatever the workspace config says", () => {
+    for (const name of ["node_modules", ".git", "target"]) {
+      const entry: DirectoryEntry = { name, path: `/root/${name}`, isDirectory: true, isHidden: name.startsWith(".") };
+      expect(shouldIncludeEntry(entry, { ...baseOptions, showHidden: true, showAllFiles: true })).toBe(false);
+    }
+    // A FILE by one of those names is not a directory and is not affected.
+    const file: DirectoryEntry = { name: "dist", path: "/root/dist", isDirectory: false, isHidden: false };
+    expect(shouldIncludeEntry(file, { ...baseOptions, showAllFiles: true })).toBe(true);
+  });
+
+  it("are the SAME names the workspace search skips (src-tauri content_search_match.rs ALWAYS_SKIP)", () => {
+    const rust = readFileSync(new URL("../../../../src-tauri/src/content_search_match.rs", import.meta.url), "utf8");
+    const block = /ALWAYS_SKIP: &\[&str\] = &\[([\s\S]*?)\];/.exec(rust);
+    expect(block, "ALWAYS_SKIP must still be a literal slice").not.toBeNull();
+    const rustNames = [...block![1].matchAll(/"([^"]+)"/g)].map((m) => m[1]).sort();
+    expect([...FILE_TREE_ALWAYS_SKIP].sort()).toEqual(rustNames);
   });
 });

--- a/src/components/Sidebar/FileExplorer/fileTreeFilters.ts
+++ b/src/components/Sidebar/FileExplorer/fileTreeFilters.ts
@@ -1,5 +1,27 @@
 import type { DirectoryEntry } from "./types";
 
+/**
+ * Directory names the file tree never descends, whatever the workspace config
+ * says (#1357). The same floor the workspace search applies — mirrors
+ * `ALWAYS_SKIP` in `src-tauri/src/content_search_match.rs`, pinned identical by
+ * `fileTreeFilters.test.ts`. The Rust tree walker prunes these before reading them;
+ * this list keeps a client-side listing honest about the same names.
+ */
+export const FILE_TREE_ALWAYS_SKIP: ReadonlySet<string> = new Set([
+  ".git",
+  "node_modules",
+  ".obsidian",
+  ".svn",
+  "__pycache__",
+  ".DS_Store",
+  ".vscode",
+  ".idea",
+  "target",
+  ".next",
+  "dist",
+  ".superpowers",
+]);
+
 /** Options controlling which file tree entries are visible. */
 export interface FileTreeFilterOptions {
   showHidden: boolean;
@@ -14,7 +36,7 @@ export function shouldIncludeEntry(
   options: FileTreeFilterOptions
 ): boolean {
   if (!options.showHidden && entry.isHidden) return false;
-  if (entry.isDirectory && options.excludeFolders.includes(entry.name)) return false;
+  if (entry.isDirectory && (FILE_TREE_ALWAYS_SKIP.has(entry.name) || options.excludeFolders.includes(entry.name))) return false;
   if (options.showAllFiles) return true;
   return options.filter(entry.name, entry.isDirectory);
 }

--- a/src/components/Sidebar/FileExplorer/rescanScheduler.test.ts
+++ b/src/components/Sidebar/FileExplorer/rescanScheduler.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment node
+// #1357 — the rescan loop: a scan must never restart back to back just because
+// an fs event landed while it ran.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createRescanScheduler, DEFAULT_RESCAN_TIMING, type RescanTiming } from "./rescanScheduler";
+
+const TIMING: RescanTiming = { quietMs: 400, maxWaitMs: 2_000, gapMs: 1_000, maxGapMs: 8_000 };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/** A scan that takes `durationMs` and counts its runs. */
+function slowScan(durationMs: number) {
+  const runs: number[] = [];
+  const scan = () =>
+    new Promise<void>((resolve) => {
+      runs.push(Date.now());
+      setTimeout(resolve, durationMs);
+    });
+  return { scan, runs };
+}
+
+describe("rescan scheduler", () => {
+  it("a burst of requests is ONE scan, run quietMs after the last request", async () => {
+    const { scan, runs } = slowScan(10);
+    const s = createRescanScheduler(scan, TIMING);
+    for (let i = 0; i < 10; i++) {
+      s.request();
+      await vi.advanceTimersByTimeAsync(50);
+    }
+    expect(runs).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(TIMING.quietMs);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("a stream that never goes quiet still gets a scan within maxWaitMs (no starvation)", async () => {
+    const { scan, runs } = slowScan(10);
+    const s = createRescanScheduler(scan, TIMING);
+    const start = Date.now();
+    while (runs.length === 0 && Date.now() - start < 10_000) {
+      s.request();
+      await vi.advanceTimersByTimeAsync(100); // faster than quietMs, forever
+    }
+    expect(runs).toHaveLength(1);
+    expect(runs[0] - start).toBeLessThanOrEqual(TIMING.maxWaitMs + 100);
+  });
+
+  it("continuous churn during scans backs off instead of restarting back to back (#1357)", async () => {
+    // The reporter's loop: a 3 s scan, events landing every 500 ms — 36 minutes at
+    // ~19 scans/minute. Under the scheduler the same input costs a handful.
+    const { scan, runs } = slowScan(3_000);
+    const s = createRescanScheduler(scan, TIMING);
+    const minutes = 5;
+    for (let t = 0; t < minutes * 60_000; t += 500) {
+      s.request();
+      await vi.advanceTimersByTimeAsync(500);
+    }
+    const backToBack = minutes * 60_000 / 3_000; // ≈ 100 if scans restarted immediately
+    expect(runs.length).toBeLessThan(backToBack / 2);
+    // Once the gap has doubled to its ceiling, scans are spaced by at least the
+    // ceiling plus the scan itself.
+    const late = runs.slice(-3);
+    for (let i = 1; i < late.length; i++) {
+      expect(late[i] - late[i - 1]).toBeGreaterThanOrEqual(TIMING.maxGapMs);
+    }
+    expect(s.churn()).toBeGreaterThan(0);
+  });
+
+  it("the gap doubles per consecutive churny scan and resets after a quiet one", async () => {
+    const { scan, runs } = slowScan(100);
+    const s = createRescanScheduler(scan, TIMING);
+    // t=0: scan 1 runs 0–100; a request at 50 lands DURING it → churn 1, rest gapMs.
+    s.refreshNow();
+    await vi.advanceTimersByTimeAsync(50);
+    s.request();
+    await vi.advanceTimersByTimeAsync(60); // t=110, scan 1 over
+    expect(s.churn()).toBe(1);
+    expect(runs).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(900); // t=1010 < 100 + gapMs
+    expect(runs).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(140); // t=1150: scan 2 started at 1100, runs to 1200
+    expect(runs).toHaveLength(2);
+    s.request(); // DURING scan 2 → churn 2 → rest 2 × gapMs from 1200
+    await vi.advanceTimersByTimeAsync(60); // t=1210
+    expect(s.churn()).toBe(2);
+    await vi.advanceTimersByTimeAsync(1790); // t=3000 < 1200 + 2000
+    expect(runs).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(400); // t=3400: scan 3 started at 3200, ends 3300
+    expect(runs).toHaveLength(3);
+    // Scan 3 saw nothing: churn resets and the next request is a plain debounce.
+    expect(s.churn()).toBe(0);
+    s.request();
+    await vi.advanceTimersByTimeAsync(TIMING.quietMs + 10);
+    expect(runs).toHaveLength(4);
+  });
+
+  it("refreshNow runs at once when idle and coalesces into the follow-up while a scan runs", async () => {
+    const { scan, runs } = slowScan(500);
+    const s = createRescanScheduler(scan, TIMING);
+    s.refreshNow();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runs).toHaveLength(1);
+    s.refreshNow();
+    s.refreshNow();
+    await vi.advanceTimersByTimeAsync(600);
+    expect(runs).toHaveLength(1); // still resting: the follow-up obeys the gap
+    await vi.advanceTimersByTimeAsync(TIMING.gapMs);
+    expect(runs).toHaveLength(2); // exactly one follow-up for the two coalesced requests
+  });
+
+  it("a rejected scan still ends the flight and never stops future scheduling", async () => {
+    let n = 0;
+    const s = createRescanScheduler(async () => {
+      n += 1;
+      throw new Error("root unreadable");
+    }, TIMING);
+    s.refreshNow();
+    await vi.advanceTimersByTimeAsync(0);
+    s.request();
+    await vi.advanceTimersByTimeAsync(TIMING.quietMs + 10);
+    expect(n).toBe(2);
+  });
+
+  it("dispose cancels a pending scan and lets a running one end without a follow-up", async () => {
+    const { scan, runs } = slowScan(200);
+    const s = createRescanScheduler(scan, TIMING);
+    s.request();
+    s.dispose();
+    await vi.advanceTimersByTimeAsync(TIMING.maxWaitMs + TIMING.quietMs);
+    expect(runs).toHaveLength(0);
+    const s2 = createRescanScheduler(scan, TIMING);
+    s2.refreshNow();
+    await vi.advanceTimersByTimeAsync(50);
+    s2.request(); // would be a follow-up
+    s2.dispose();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("refreshNow resolves when the scan that serves it has run — a coalesced caller waits for the follow-up", async () => {
+    const { scan, runs } = slowScan(300);
+    const s = createRescanScheduler(scan, TIMING);
+    let firstDone = false;
+    let coalescedDone = false;
+    void s.refreshNow().then(() => { firstDone = true; });
+    await vi.advanceTimersByTimeAsync(50);
+    void s.refreshNow().then(() => { coalescedDone = true; });
+    await vi.advanceTimersByTimeAsync(300); // t=350: scan 1 over
+    expect(firstDone).toBe(true);
+    expect(coalescedDone).toBe(false); // its scan has not run yet
+    await vi.advanceTimersByTimeAsync(TIMING.gapMs + 400); // follow-up ran
+    expect(runs).toHaveLength(2);
+    expect(coalescedDone).toBe(true);
+  });
+
+  it("dispose releases every waiting refresh so nothing hangs on a tree that is gone", async () => {
+    const { scan } = slowScan(1_000);
+    const s = createRescanScheduler(scan, TIMING);
+    let done = 0;
+    void s.refreshNow().then(() => { done += 1; });
+    await vi.advanceTimersByTimeAsync(10);
+    void s.refreshNow().then(() => { done += 1; });
+    s.dispose();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(done).toBe(2);
+  });
+
+  it("a scan begins synchronously inside refreshNow (so a caller can invalidate it at once)", () => {
+    let started = 0;
+    const s = createRescanScheduler(async () => { started += 1; }, TIMING);
+    void s.refreshNow();
+    expect(started).toBe(1);
+  });
+
+  it("the defaults are what the header says", () => {
+    expect(DEFAULT_RESCAN_TIMING).toEqual({ quietMs: 400, maxWaitMs: 2_000, gapMs: 1_000, maxGapMs: 30_000 });
+  });
+});

--- a/src/components/Sidebar/FileExplorer/rescanScheduler.ts
+++ b/src/components/Sidebar/FileExplorer/rescanScheduler.ts
@@ -1,0 +1,186 @@
+/**
+ * rescanScheduler — when the file tree re-lists itself, decided without React.
+ *
+ * Purpose: turn "an fs event batch arrived" into "run one full scan, soon, once"
+ * — and keep a workspace that never stops changing from turning the scan into a
+ * CPU-bound loop (#1357).
+ *
+ * The loop it replaces: every event batch called the scan; a batch arriving while
+ * a scan ran set a rerun flag; the scan's `finally` ran the scan again at once. If
+ * at least one event landed during each scan, the scan restarted back to back
+ * forever — the slower the scan, the more certain the next event was to land
+ * inside it. Measured by the reporter: 19–23 full rescans a minute for 36 minutes,
+ * one core pinned, the period set by the scan's own duration.
+ *
+ * Three rules, each pinned by `rescanScheduler.test.ts`:
+ *   1. Trailing debounce. A request runs `quietMs` after the LAST request, so a
+ *      burst (git checkout, a download's chunks, an unarchive) is one scan.
+ *   2. No starvation. A stream of requests that never goes quiet still runs a
+ *      scan within `maxWaitMs` of the first unserved request — the tree must not
+ *      freeze while something keeps writing.
+ *   3. Back-off under churn. When a scan ends and requests arrived DURING it, the
+ *      next scan waits at least `gapMs`, and `gapMs` doubles each consecutive time
+ *      that happens (up to `maxGapMs`). A quiet scan resets it. Continuous churn
+ *      therefore costs a scan every `maxGapMs`, not every scan-duration.
+ *
+ * One scan runs at a time. `refreshNow` (window focus, the manual refresh button)
+ * skips the debounce but not the single-flight rule: during a scan it coalesces
+ * into the follow-up, which then obeys the gap.
+ *
+ * @coordinates-with components/Sidebar/FileExplorer/useFileTree.ts — the consumer
+ * @module components/Sidebar/FileExplorer/rescanScheduler
+ */
+
+export interface RescanTiming {
+  /** Run this long after the last request (trailing debounce). */
+  quietMs: number;
+  /** Never let a request wait longer than this, however busy the stream. */
+  maxWaitMs: number;
+  /** Minimum rest after a scan that saw requests during it; doubles per repeat. */
+  gapMs: number;
+  /** Ceiling for the doubled gap. */
+  maxGapMs: number;
+}
+
+/** Defaults: measured against a tree scan that takes seconds on a large root. */
+export const DEFAULT_RESCAN_TIMING: RescanTiming = {
+  quietMs: 400,
+  maxWaitMs: 2_000,
+  gapMs: 1_000,
+  maxGapMs: 30_000,
+};
+
+export interface RescanScheduler {
+  /** An fs event batch: coalesce into the next scan. */
+  request: () => void;
+  /** Focus or manual refresh: scan now unless one is running (then coalesce).
+   *  Resolves once the scan that serves this call has finished (or on dispose). */
+  refreshNow: () => Promise<void>;
+  /** Cancel anything pending; a scan already running finishes but schedules nothing. */
+  dispose: () => void;
+  /** Consecutive scans that saw requests during them (0 after a quiet scan). */
+  churn: () => number;
+}
+
+/**
+ * Build a scheduler around `scan`. `scan` must resolve when the scan is over
+ * (it may reject; a rejection counts as "over" and never stops scheduling).
+ * Time comes from the platform clock and timers (tests use fake timers).
+ */
+export function createRescanScheduler(
+  scan: () => Promise<unknown>,
+  timing: RescanTiming = DEFAULT_RESCAN_TIMING,
+): RescanScheduler {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight = false;
+  let disposed = false;
+  /** Requests arrived since the current scan started (or since the last one ended). */
+  let dirty = false;
+  /** When the oldest unserved request arrived; bounds the debounce (rule 2). */
+  let firstDirtyAt: number | null = null;
+  /** Consecutive scans that ended dirty. */
+  let churnCount = 0;
+  /** A rest the next scan must not start before (rule 3). */
+  let notBefore = 0;
+  /** `refreshNow` callers waiting for the NEXT scan to start, then for it to end. */
+  let waitingForNext: Array<() => void> = [];
+  let waitingForCurrent: Array<() => void> = [];
+
+  const clear = () => {
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+  };
+
+  const armAt = (when: number) => {
+    clear();
+    timer = setTimeout(fire, Math.max(0, when - Date.now()));
+  };
+
+  /** Rules 1 and 2: the moment the pending request should run, given now. */
+  const dueAt = () => {
+    const now = Date.now();
+    const byQuiet = now + timing.quietMs;
+    const byMaxWait = (firstDirtyAt ?? now) + timing.maxWaitMs;
+    return Math.max(Math.min(byQuiet, byMaxWait), notBefore);
+  };
+
+  const start = () => {
+    if (disposed || inFlight) return;
+    clear();
+    inFlight = true;
+    dirty = false;
+    firstDirtyAt = null;
+    waitingForCurrent = waitingForNext;
+    waitingForNext = [];
+    // The scan STARTS synchronously: a caller that clears the tree right after
+    // asking for a refresh must find the scan already begun (and stamped with a
+    // request id it can invalidate), never one that begins after the clear.
+    let running: Promise<unknown>;
+    try {
+      running = Promise.resolve(scan());
+    } catch (error) {
+      running = Promise.reject(error instanceof Error ? error : new Error(String(error)));
+    }
+    void running
+      .catch(() => undefined)
+      .then(() => {
+        inFlight = false;
+        const served = waitingForCurrent;
+        waitingForCurrent = [];
+        for (const resolve of served) resolve();
+        if (disposed) return;
+        if (!dirty) {
+          churnCount = 0;
+          notBefore = 0;
+          return;
+        }
+        // Rule 3: the scan saw requests during it — rest, longer each time.
+        churnCount += 1;
+        const gap = Math.min(timing.gapMs * 2 ** (churnCount - 1), timing.maxGapMs);
+        notBefore = Date.now() + gap;
+        armAt(dueAt());
+      });
+  };
+
+  const fire = () => {
+    timer = null;
+    if (disposed) return;
+    if (inFlight) return; // the scan's end reschedules
+    if (Date.now() < notBefore) {
+      armAt(notBefore);
+      return;
+    }
+    start();
+  };
+
+  return {
+    request: () => {
+      if (disposed) return;
+      if (!dirty) firstDirtyAt = Date.now();
+      dirty = true;
+      if (inFlight) return; // coalesced into the follow-up
+      armAt(dueAt());
+    },
+    refreshNow: () => {
+      if (disposed) return Promise.resolve();
+      const done = new Promise<void>((resolve) => waitingForNext.push(resolve));
+      if (inFlight) {
+        // Coalesced into the follow-up: served when THAT scan ends.
+        if (!dirty) firstDirtyAt = Date.now();
+        dirty = true;
+        return done;
+      }
+      start();
+      return done;
+    },
+    dispose: () => {
+      disposed = true;
+      clear();
+      // Nobody may hang on a refresh of a tree that is gone.
+      for (const resolve of [...waitingForNext, ...waitingForCurrent]) resolve();
+      waitingForNext = [];
+      waitingForCurrent = [];
+    },
+    churn: () => churnCount,
+  };
+}

--- a/src/components/Sidebar/FileExplorer/types.ts
+++ b/src/components/Sidebar/FileExplorer/types.ts
@@ -25,3 +25,20 @@ export interface DirectoryEntry {
   isDirectory: boolean;
   isHidden: boolean;
 }
+
+/**
+ * One node of the one-call tree listing (`list_directory_tree`, #1357): a
+ * `DirectoryEntry` plus its pruned children. `unreadable` marks a directory the
+ * walker could not read (shown empty, logged); a pruned directory has `children:
+ * []` and is not unreadable.
+ */
+export interface TreeEntry extends DirectoryEntry {
+  unreadable?: boolean;
+  children?: TreeEntry[];
+}
+
+/** The listing: the root's children and whether a walker bound was hit. */
+export interface TreeListing {
+  entries: TreeEntry[];
+  truncated: boolean;
+}

--- a/src/components/Sidebar/FileExplorer/useFileTree.focus.test.tsx
+++ b/src/components/Sidebar/FileExplorer/useFileTree.focus.test.tsx
@@ -7,7 +7,7 @@
  * operations, externally-mounted volumes, and symlinked workspace paths.
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 
 const invokeMock = vi.fn();
 vi.mock("@tauri-apps/api/core", () => ({
@@ -45,10 +45,32 @@ vi.mock("@tauri-apps/api/webviewWindow", () => ({
 
 import { useFileTree } from "./useFileTree";
 
+/**
+ * The one-call listing (#1357), built from a per-directory map so a fixture still
+ * reads as "what each directory contains": directories get their children from
+ * the map (none listed → empty), and an entry without `isHidden` is visible.
+ */
+type RawEntry = { name: string; path: string; isDirectory: boolean; isHidden?: boolean };
+function mockTree(byDir: Record<string, RawEntry[]>) {
+  const build = (dir: string): unknown[] =>
+    (byDir[dir] ?? []).map((e) => ({
+      ...e,
+      isHidden: e.isHidden ?? false,
+      ...(e.isDirectory ? { children: build(e.path) } : {}),
+    }));
+  invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
+    if (cmd !== "list_directory_tree") return undefined;
+    const root = (args as { path: string }).path;
+    if (!(root in byDir)) return { entries: [], truncated: false };
+    return { entries: build(root), truncated: false };
+  });
+}
+
+
 beforeEach(() => {
   invokeMock.mockReset();
   invokeMock.mockImplementation(async (cmd: string) => {
-    if (cmd === "list_directory_entries") return [];
+    if (cmd === "list_directory_tree") return { entries: [], truncated: false };
     return undefined;
   });
   onFocusChangedMock.mockClear();
@@ -75,11 +97,14 @@ describe("useFileTree — window-focus refresh", () => {
 
   it("re-lists the directory when the window regains focus", async () => {
     renderHook(() => useFileTree("/Users/me/notes"));
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    // Let the initial listing settle (the scheduler marks itself idle a few
+    // microtasks after the listing resolves); a focus during a scan is coalesced
+    // into a paced follow-up instead (#1357), which is the other test's subject.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
     const initialListCalls = invokeMock.mock.calls.filter(
-      ([cmd]) => cmd === "list_directory_entries",
+      ([cmd]) => cmd === "list_directory_tree",
     ).length;
     expect(initialListCalls).toBeGreaterThanOrEqual(1);
     expect(focusCallback).toBeTypeOf("function");
@@ -89,7 +114,7 @@ describe("useFileTree — window-focus refresh", () => {
     await Promise.resolve();
 
     const afterFocusCalls = invokeMock.mock.calls.filter(
-      ([cmd]) => cmd === "list_directory_entries",
+      ([cmd]) => cmd === "list_directory_tree",
     ).length;
     expect(afterFocusCalls).toBeGreaterThan(initialListCalls);
   });
@@ -100,14 +125,14 @@ describe("useFileTree — window-focus refresh", () => {
     await Promise.resolve();
     await Promise.resolve();
     const initialListCalls = invokeMock.mock.calls.filter(
-      ([cmd]) => cmd === "list_directory_entries",
+      ([cmd]) => cmd === "list_directory_tree",
     ).length;
 
     focusCallback!({ payload: false });
     await Promise.resolve();
 
     const afterBlurCalls = invokeMock.mock.calls.filter(
-      ([cmd]) => cmd === "list_directory_entries",
+      ([cmd]) => cmd === "list_directory_tree",
     ).length;
     expect(afterBlurCalls).toBe(initialListCalls);
   });
@@ -169,19 +194,25 @@ describe("useFileTree — workspace event subscription", () => {
     await Promise.resolve();
     expect(wsEventCallback).toBeTypeOf("function");
     const initial = invokeMock.mock.calls.filter(
-      ([cmd]) => cmd === "list_directory_entries",
+      ([cmd]) => cmd === "list_directory_tree",
     ).length;
 
     // Scope + watchId filtering + suppression are the source's job; useFileTree
-    // simply re-lists on any delivered batch.
+    // re-lists on a delivered batch — after the debounce window (#1357), never
+    // per batch.
     wsEventCallback!([{ kind: "created", path: "/root/new.md", rootPath: "/root", selfWrite: false }]);
     await Promise.resolve();
     await Promise.resolve();
+    const rightAway = invokeMock.mock.calls.filter(([cmd]) => cmd === "list_directory_tree").length;
+    expect(rightAway).toBe(initial); // debounced, not immediate
 
-    const after = invokeMock.mock.calls.filter(
-      ([cmd]) => cmd === "list_directory_entries",
-    ).length;
-    expect(after).toBeGreaterThan(initial);
+    await waitFor(
+      () => {
+        const after = invokeMock.mock.calls.filter(([cmd]) => cmd === "list_directory_tree").length;
+        expect(after).toBeGreaterThan(initial);
+      },
+      { timeout: 3_000 },
+    );
   });
 
   it("does not subscribe when rootPath is null", async () => {
@@ -209,23 +240,15 @@ describe("useFileTree — workspace event subscription", () => {
 
 describe("useFileTree — directory listing", () => {
   it("lists files and folders, filtering markdown by default", async () => {
-    invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
-      if (cmd === "list_directory_entries") {
-        const path = (args as { path: string }).path;
-        if (path === "/root") {
-          return [
+    mockTree({
+      "/root": [
             { name: "notes.md", path: "/root/notes.md", isDirectory: false },
             { name: "image.png", path: "/root/image.png", isDirectory: false },
             { name: "drafts", path: "/root/drafts", isDirectory: true },
-          ];
-        }
-        if (path === "/root/drafts") {
-          return [
+          ],
+      "/root/drafts": [
             { name: "wip.md", path: "/root/drafts/wip.md", isDirectory: false },
-          ];
-        }
-      }
-      return undefined;
+          ],
     });
 
     const { result } = renderHook(() => useFileTree("/root"));
@@ -246,14 +269,11 @@ describe("useFileTree — directory listing", () => {
   // that file said `requirements`. showAllFiles decides what is LISTED, never
   // how a listed name is spelled.
   it("hides a registered non-markdown extension even with all files shown", async () => {
-    invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
-      if (cmd === "list_directory_entries" && (args as { path: string }).path === "/root") {
-        return [
+    mockTree({
+      "/root": [
           { name: "requirements.txt", path: "/root/requirements.txt", isDirectory: false },
           { name: "App.vue", path: "/root/App.vue", isDirectory: false },
-        ];
-      }
-      return undefined;
+        ],
     });
 
     const { result } = renderHook(() =>
@@ -274,11 +294,8 @@ describe("useFileTree — directory listing", () => {
     useSettingsStore.setState((s) => ({
       general: { ...s.general, showFileExtensions: false },
     }));
-    invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
-      if (cmd === "list_directory_entries" && (args as { path: string }).path === "/root") {
-        return [{ name: "notes.md", path: "/root/notes.md", isDirectory: false }];
-      }
-      return undefined;
+    mockTree({
+      "/root": [{ name: "notes.md", path: "/root/notes.md", isDirectory: false }],
     });
 
     try {
@@ -297,20 +314,14 @@ describe("useFileTree — directory listing", () => {
   });
 
   it("sorts files before folders correctly regardless of input order", async () => {
-    invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
-      if (cmd === "list_directory_entries") {
-        const path = (args as { path: string }).path;
-        if (path === "/sorted") {
-          // Files first in the raw input — sort must still put folder first.
-          return [
-            { name: "a.md", path: "/sorted/a.md", isDirectory: false },
-            { name: "folder", path: "/sorted/folder", isDirectory: true },
-            { name: "b.md", path: "/sorted/b.md", isDirectory: false },
-          ];
-        }
-        if (path === "/sorted/folder") return [];
-      }
-      return undefined;
+    mockTree({
+      // Files first in the raw input — sort must still put the folder first.
+      "/sorted": [
+        { name: "a.md", path: "/sorted/a.md", isDirectory: false },
+        { name: "folder", path: "/sorted/folder", isDirectory: true },
+        { name: "b.md", path: "/sorted/b.md", isDirectory: false },
+      ],
+      "/sorted/folder": [],
     });
 
     const { result } = renderHook(() => useFileTree("/sorted"));
@@ -324,7 +335,7 @@ describe("useFileTree — directory listing", () => {
 
   it("returns an empty tree without throwing when listing fails", async () => {
     invokeMock.mockImplementation(async (cmd: string) => {
-      if (cmd === "list_directory_entries") {
+      if (cmd === "list_directory_tree") {
         throw new Error("EACCES");
       }
       return undefined;
@@ -343,16 +354,10 @@ describe("useFileTree — directory listing", () => {
     useSettingsStore.setState((s) => ({
       advanced: { ...s.advanced, workflowEngine: true },
     }));
-    invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
-      if (cmd === "list_directory_entries") {
-        const path = (args as { path: string }).path;
-        if (path === "/wf") {
-          return [
+    mockTree({
+      "/wf": [
             { name: "flow.vmark.yml", path: "/wf/flow.vmark.yml", isDirectory: false },
-          ];
-        }
-      }
-      return undefined;
+          ],
     });
 
     const { result } = renderHook(() => useFileTree("/wf"));
@@ -366,17 +371,11 @@ describe("useFileTree — directory listing", () => {
   });
 
   it("includes all file types when showAllFiles is true", async () => {
-    invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
-      if (cmd === "list_directory_entries") {
-        const path = (args as { path: string }).path;
-        if (path === "/root") {
-          return [
+    mockTree({
+      "/root": [
             { name: "notes.md", path: "/root/notes.md", isDirectory: false },
             { name: "image.png", path: "/root/image.png", isDirectory: false },
-          ];
-        }
-      }
-      return undefined;
+          ],
     });
 
     const { result } = renderHook(() => useFileTree("/root", { showAllFiles: true }));

--- a/src/components/Sidebar/FileExplorer/useFileTree.races.test.tsx
+++ b/src/components/Sidebar/FileExplorer/useFileTree.races.test.tsx
@@ -44,6 +44,9 @@ const entry = (name: string) => ({
   isHidden: false,
 });
 
+/** The one-call listing's wire shape (#1357). */
+const listing = (entries: unknown[], truncated = false) => ({ entries, truncated });
+
 beforeEach(() => {
   invokeMock.mockReset();
 });
@@ -61,7 +64,7 @@ describe("stale responses", () => {
     // Close the workspace while the listing is still in flight.
     rerender({ root: null });
     await act(async () => {
-      first.resolve([entry("late.md")]);
+      first.resolve(listing([entry("late.md")]));
       await first.promise;
     });
 
@@ -73,7 +76,7 @@ describe("excludeFolders key", () => {
   it("distinguishes folder lists that flatten to the same comma string", async () => {
     // ["a,b"] and ["a","b"] both joined to "a,b", so switching between them
     // kept the previous loader and the previous exclusions.
-    invokeMock.mockResolvedValue([]);
+    invokeMock.mockResolvedValue(listing([]));
     const { rerender } = renderHook(
       ({ folders }: { folders: string[] }) => useFileTree("/root", { excludeFolders: folders }),
       { initialProps: { folders: ["a,b"] } },
@@ -101,16 +104,14 @@ describe("unreadable directories", () => {
   });
 
   it("keeps the rest of the tree when ONE subdirectory is unreadable", async () => {
-    invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
-      if (cmd !== "list_directory_entries") return undefined;
-      const path = (args as { path: string }).path;
-      if (path === "/root") {
-        return [
-          { name: "locked", path: "/root/locked", isDirectory: true, isHidden: false },
-          entry("visible.md"),
-        ];
-      }
-      throw new Error("EACCES");
+    // The walker reports a locked subfolder as an empty, flagged directory (#1357);
+    // the tree keeps everything else and reports no error.
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd !== "list_directory_tree") return undefined;
+      return listing([
+        { name: "locked", path: "/root/locked", isDirectory: true, isHidden: false, unreadable: true, children: [] },
+        entry("visible.md"),
+      ]);
     });
 
     const { result } = renderHook(() => useFileTree("/root"));

--- a/src/components/Sidebar/FileExplorer/useFileTree.rescan.test.tsx
+++ b/src/components/Sidebar/FileExplorer/useFileTree.rescan.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * useFileTree — #1357: fs events must never turn the tree scan into a loop.
+ *
+ * The reporter's log: 19–23 full rescans a minute for 36 minutes, one core pinned,
+ * because every event batch rescanned and a batch that landed during a scan
+ * restarted it at once. These pin the hook's use of the scheduler: one listing per
+ * burst, back-off under continuous churn, and one IPC call per listing.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: unknown) => invokeMock(cmd, args),
+}));
+
+let wsEventCallback: ((events: unknown[]) => void) | null = null;
+vi.mock("@/services/workspaceEvents/subscribeWorkspaceEvents", () => ({
+  subscribeWorkspaceEvents: (_label: string, cb: (events: unknown[]) => void) => {
+    wsEventCallback = cb;
+    return () => {
+      wsEventCallback = null;
+    };
+  },
+}));
+
+vi.mock("@tauri-apps/api/webviewWindow", () => ({
+  getCurrentWebviewWindow: () => ({ onFocusChanged: async () => () => {} }),
+}));
+
+import { useFileTree } from "./useFileTree";
+import { DEFAULT_RESCAN_TIMING } from "./rescanScheduler";
+
+const listings = () => invokeMock.mock.calls.filter(([cmd]) => cmd === "list_directory_tree");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  invokeMock.mockReset();
+  wsEventCallback = null;
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useFileTree — rescans are paced (#1357)", () => {
+  it("lists the tree in ONE IPC call, with the exclusions and hidden flag passed to the walker", async () => {
+    invokeMock.mockResolvedValue({
+      entries: [
+        { name: "docs", path: "/root/docs", isDirectory: true, isHidden: false, children: [
+          { name: "a.md", path: "/root/docs/a.md", isDirectory: false, isHidden: false },
+        ] },
+        { name: "readme.md", path: "/root/readme.md", isDirectory: false, isHidden: false },
+      ],
+      truncated: false,
+    });
+    const { result } = renderHook(() => useFileTree("/root", { excludeFolders: ["vendor"], showHidden: true }));
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(listings()).toHaveLength(1);
+    expect(listings()[0][1]).toEqual({ path: "/root", options: { excludeFolders: ["vendor"], showHidden: true } });
+    expect(result.current.tree.map((n) => n.name)).toEqual(["docs", "readme.md"]);
+    expect(result.current.tree[0].children?.map((n) => n.name)).toEqual(["a.md"]);
+    expect(result.current.truncated).toBe(false);
+  });
+
+  it("a burst of event batches is ONE re-listing, after the burst goes quiet", async () => {
+    invokeMock.mockResolvedValue({ entries: [], truncated: false });
+    renderHook(() => useFileTree("/root"));
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(listings()).toHaveLength(1);
+    for (let i = 0; i < 20; i++) {
+      wsEventCallback!([{ kind: "create" }]);
+      await act(async () => { await vi.advanceTimersByTimeAsync(50); });
+    }
+    expect(listings()).toHaveLength(1);
+    await act(async () => { await vi.advanceTimersByTimeAsync(DEFAULT_RESCAN_TIMING.quietMs); });
+    expect(listings()).toHaveLength(2);
+  });
+
+  it("events landing during every scan do NOT restart it back to back — the interval widens", async () => {
+    // A 3 s scan and an event every 500 ms, the reporter's shape, for five minutes.
+    invokeMock.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve({ entries: [], truncated: false }), 3_000)),
+    );
+    renderHook(() => useFileTree("/root"));
+    for (let t = 0; t < 5 * 60_000; t += 500) {
+      wsEventCallback?.([{ kind: "modify" }]);
+      await act(async () => { await vi.advanceTimersByTimeAsync(500); });
+    }
+    const backToBack = (5 * 60_000) / 3_000;
+    expect(listings().length).toBeLessThan(backToBack / 4);
+  });
+
+  it("reports a truncated listing and still shows what was listed", async () => {
+    invokeMock.mockResolvedValue({
+      entries: [{ name: "a.md", path: "/root/a.md", isDirectory: false, isHidden: false }],
+      truncated: true,
+    });
+    const { result } = renderHook(() => useFileTree("/root"));
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(result.current.truncated).toBe(true);
+    expect(result.current.tree.map((n) => n.name)).toEqual(["a.md"]);
+  });
+
+  it("refresh() resolves after its listing has run, so a create flow can rename the new node", async () => {
+    invokeMock.mockResolvedValue({ entries: [], truncated: false });
+    const { result } = renderHook(() => useFileTree("/root"));
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    const before = listings().length;
+    let resolved = false;
+    void result.current.refresh().then(() => { resolved = true; });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    expect(listings().length).toBe(before + 1);
+    expect(resolved).toBe(true);
+  });
+});

--- a/src/components/Sidebar/FileExplorer/useFileTree.ts
+++ b/src/components/Sidebar/FileExplorer/useFileTree.ts
@@ -6,9 +6,24 @@
  * created, renamed, or deleted.
  *
  * Key decisions:
+ *   - ONE listing per refresh (#1357): `list_directory_tree` walks the whole tree
+ *     in Rust, off the IPC thread, with the always-skipped directories (the same
+ *     floor the workspace search applies), the workspace's `excludeFolders` and —
+ *     unless hidden entries are shown — hidden directories pruned before they are
+ *     read. The hook used to recurse here with one IPC round trip per directory,
+ *     serially awaited: seconds per scan on a large root, and that slowness was
+ *     the fuel of the rescan loop below.
+ *   - WHEN to re-list is `rescanScheduler`'s decision, not this hook's: events are
+ *     debounced, a stream that never goes quiet still gets a scan within a bound,
+ *     and a scan that saw events while it ran is followed by a rest that doubles
+ *     while the churn continues. The previous policy — rescan per event batch,
+ *     and rescan again at once if anything arrived meanwhile — restarted back to
+ *     back for as long as something in the workspace kept writing (36 minutes at
+ *     ~20 full scans a minute in the report), one core pinned.
  *   - By default only includes markdown files (via mdFilter). When showAllFiles
  *     is enabled, all file types are shown — non-markdown files open with the
- *     system default app.
+ *     system default app. The file-type filter stays client-side: it is a
+ *     registry-driven predicate; Rust prunes directories only.
  *   - Node labels come from formatFileDisplayName — the same formatter the tab
  *     strip uses, so the two never disagree. The name on disk by default, since
  *     a hidden extension turned `requirements.txt` into an unexplained
@@ -19,7 +34,8 @@
  *   - Watch events are scoped by watchId (window label) to prevent cross-window
  *     interference when multiple windows watch the same directory.
  *   - Folders are always included (even if empty) so users can right-click to
- *     add files into them.
+ *     add files into them. An unreadable subfolder renders empty and is logged;
+ *     an unreadable ROOT is an error, never an empty workspace (#1224).
  *   - Window-focus refresh is a defensive safety net: macOS FSEvents (and
  *     equivalent native watchers on other platforms) occasionally miss
  *     externally-created files — Finder operations, externally-mounted
@@ -28,6 +44,8 @@
  *     back to VMark, regardless of whether fs:changed fired.
  *
  * @coordinates-with FileExplorer.tsx — consumes the tree data and refresh callback
+ * @coordinates-with components/Sidebar/FileExplorer/rescanScheduler.ts — decides when a scan runs
+ * @coordinates-with src-tauri/src/file_tree_walk.rs — the one-call listing this invokes
  * @coordinates-with services/workspaceEvents/subscribeWorkspaceEvents.ts — the shared, scoped fs-event source it subscribes to
  * @module components/Sidebar/FileExplorer/useFileTree
  */
@@ -35,7 +53,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { type UnlistenFn } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
-import type { FileNode, DirectoryEntry } from "./types";
+import type { FileNode, TreeEntry, TreeListing } from "./types";
 import { subscribeWorkspaceEvents } from "@/services/workspaceEvents/subscribeWorkspaceEvents";
 import {
   isMarkdownFileName,
@@ -44,25 +62,19 @@ import {
 } from "@/utils/dropPaths";
 import { isWorkflowYamlSurfaceEnabled } from "@/services/featureFlags/workflowFeatureFlag";
 import { shouldIncludeEntry, type FileTreeFilterOptions } from "./fileTreeFilters";
+import { createRescanScheduler, type RescanScheduler } from "./rescanScheduler";
 import { formatFileDisplayName } from "@/utils/displayFileName";
 import { fileExplorerError } from "@/utils/debug";
-import { errorMessage } from "@/utils/errorMessage";
+import { commandErrorMessage } from "@/services/commands/commandError";
 
 type LoadOptions = FileTreeFilterOptions & { showExtensions: boolean };
 
-async function listDirectoryEntries(dirPath: string): Promise<DirectoryEntry[]> {
-  return invoke<DirectoryEntry[]>("list_directory_entries", { path: dirPath });
-}
-
-/** One directory entry as a tree node; folders carry their loaded children. */
-function toNode(entry: DirectoryEntry, options: LoadOptions, children: FileNode[]): FileNode {
-  return entry.isDirectory
-    ? { id: entry.path, name: entry.name, isFolder: true, children }
-    : {
-        id: entry.path,
-        name: formatFileDisplayName(entry.name, options.showExtensions),
-        isFolder: false,
-      };
+/** The whole tree under `rootPath`, in ONE round trip. THROWS when the root cannot be read. */
+async function listDirectoryTree(rootPath: string, options: LoadOptions): Promise<TreeListing> {
+  return invoke<TreeListing>("list_directory_tree", {
+    path: rootPath,
+    options: { excludeFolders: options.excludeFolders, showHidden: options.showHidden },
+  });
 }
 
 /** Folders first, then by name. */
@@ -72,34 +84,24 @@ function byFolderThenName(a: FileNode, b: FileNode): number {
 }
 
 /**
- * List one directory and its descendants. THROWS when this directory cannot be
- * read — the caller decides what that means.
+ * The listed entries as tree nodes: the client-side file filter applied at
+ * every level, folders always kept (so users can right-click to add files into
+ * them), an unreadable subfolder logged and shown empty — one locked folder deep
+ * in a workspace must not blank the tree (the #1224 failure mode is the ROOT,
+ * handled in loadTree).
  */
-async function loadDirectory(dirPath: string, options: LoadOptions): Promise<FileNode[]> {
-  const entries = await listDirectoryEntries(dirPath);
+function toNodes(entries: TreeEntry[], options: LoadOptions): FileNode[] {
   const nodes: FileNode[] = [];
   for (const entry of entries) {
     if (!shouldIncludeEntry(entry, options)) continue;
-    // Always include folders so users can right-click to add files into them.
-    const children = entry.isDirectory ? await loadSubtree(entry.path, options) : [];
-    nodes.push(toNode(entry, options, children));
+    if (entry.isDirectory) {
+      if (entry.unreadable) fileExplorerError(" Failed to read directory:", entry.path);
+      nodes.push({ id: entry.path, name: entry.name, isFolder: true, children: toNodes(entry.children ?? [], options) });
+    } else {
+      nodes.push({ id: entry.path, name: formatFileDisplayName(entry.name, options.showExtensions), isFolder: false });
+    }
   }
   return nodes.sort(byFolderThenName);
-}
-
-/**
- * A SUBDIRECTORY's subtree: one unreadable folder deep in a workspace must not
- * blank the whole tree, so its failure is logged and it renders as empty. The
- * ROOT is different — see loadTree, which surfaces that as an error rather than
- * telling the user their workspace is empty (the #1224 failure mode).
- */
-async function loadSubtree(dirPath: string, options: LoadOptions): Promise<FileNode[]> {
-  try {
-    return await loadDirectory(dirPath, options);
-  } catch (error) {
-    fileExplorerError(" Failed to read directory:", dirPath, error);
-    return [];
-  }
 }
 
 // Phase 1B: file explorer surfaces every registered format. The
@@ -139,17 +141,15 @@ export function useFileTree(
   const [tree, setTree] = useState<FileNode[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /** The listing hit the walker's node or depth bound: the tree shown is partial. */
+  const [truncated, setTruncated] = useState(false);
   const requestIdRef = useRef(0);
-  // In-flight guard: a focus event and an fs batch arriving together used to
-  // launch two full recursive scans of the same workspace. One runs; a request
-  // that arrives meanwhile sets `rerunPendingRef` and is coalesced into a
-  // single follow-up pass.
-  const inFlightRef = useRef(false);
-  const rerunPendingRef = useRef(false);
+  const schedulerRef = useRef<RescanScheduler | null>(null);
   // JSON, not join(","): ["a,b"] and ["a","b"] flatten to the same comma string,
   // so a switch between them kept the previous loader and its exclusions.
   const excludeFoldersKey = JSON.stringify(excludeFolders);
 
+  /** ONE scan. Single flight and timing belong to the scheduler, never here. */
   const loadTree = useCallback(async () => {
     // Bump the request id even when clearing: a listing already in flight must
     // not repopulate a tree the user just closed (or an unmounted hook).
@@ -160,13 +160,7 @@ export function useFileTree(
       setIsLoading(false);
       return;
     }
-    if (inFlightRef.current) {
-      rerunPendingRef.current = true;
-      return;
-    }
-    inFlightRef.current = true;
     setIsLoading(true);
-
     try {
       const loadOptions: LoadOptions = {
         filter: mdFilter,
@@ -175,9 +169,11 @@ export function useFileTree(
         showAllFiles,
         showExtensions,
       };
-      const nodes = await loadDirectory(rootPath, loadOptions);
+      const listing = await listDirectoryTree(rootPath, loadOptions);
+      if (listing.truncated) fileExplorerError(" Tree listing truncated at the walker's bound:", rootPath);
       if (currentRequestId === requestIdRef.current) {
-        setTree(nodes);
+        setTree(toNodes(listing.entries, loadOptions));
+        setTruncated(listing.truncated);
         setError(null);
       }
     } catch (err) {
@@ -186,16 +182,12 @@ export function useFileTree(
       fileExplorerError(" Failed to load tree:", err);
       if (currentRequestId === requestIdRef.current) {
         setTree([]);
-        setError(errorMessage(err));
+        setTruncated(false);
+        setError(commandErrorMessage(err));
       }
     } finally {
-      inFlightRef.current = false;
       if (currentRequestId === requestIdRef.current) {
         setIsLoading(false);
-      }
-      if (rerunPendingRef.current) {
-        rerunPendingRef.current = false;
-        void loadTree();
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- excludeFoldersKey is stable serialization
@@ -212,23 +204,30 @@ export function useFileTree(
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setTree([]);
       setError(null);
+      setTruncated(false);
       return;
     }
 
-    void loadTree();
+    // The scheduler owns single flight, debounce and back-off (#1357); one per
+    // (root, options) so a switch starts from a clean slate.
+    const scheduler = createRescanScheduler(loadTree);
+    schedulerRef.current = scheduler;
+    void scheduler.refreshNow();
 
     // Subscribe to the shared, already-scoped workspace event stream: any
-    // in-scope batch (create / delete / rename / real modify) triggers a
-    // reload. Scoping + self-write filtering + no-op suppression are done by
-    // the source, so this stays a one-liner.
+    // in-scope batch (create / delete / rename / real modify) asks for a scan.
+    // Scoping + self-write filtering + no-op suppression are done by the source;
+    // coalescing and pacing by the scheduler, so this stays a one-liner.
     const unsubscribe = subscribeWorkspaceEvents(watchId, () => {
-      void loadTree();
+      scheduler.request();
     });
 
     return () => {
       // Unmount, or a switch to another workspace: the same invalidation.
       requestIdRef.current += 1;
       unsubscribe();
+      scheduler.dispose();
+      if (schedulerRef.current === scheduler) schedulerRef.current = null;
     };
   }, [rootPath, loadTree, watchId]);
 
@@ -241,7 +240,7 @@ export function useFileTree(
     let cancelled = false;
     getCurrentWebviewWindow()
       .onFocusChanged(({ payload: focused }) => {
-        if (focused) void loadTree();
+        if (focused) void schedulerRef.current?.refreshNow();
       })
       .then((u) => {
         if (cancelled) {
@@ -252,13 +251,19 @@ export function useFileTree(
       })
       .catch((error: unknown) => {
         fileExplorerError(" Failed to listen for window focus:",
-          errorMessage(error));
+          commandErrorMessage(error));
       });
     return () => {
       cancelled = true;
       if (unlisten) unlisten();
     };
-  }, [rootPath, loadTree]);
+  }, [rootPath]);
 
-  return { tree, isLoading, error, refresh: loadTree };
+  /** Manual refresh: scan now (coalesced with a running scan), resolved once it has run. */
+  const refresh = useCallback(
+    () => schedulerRef.current?.refreshNow() ?? loadTree(),
+    [loadTree],
+  );
+
+  return { tree, isLoading, error, truncated, refresh };
 }

--- a/website/guide/workspace-management.md
+++ b/website/guide/workspace-management.md
@@ -79,12 +79,18 @@ Both settings are saved per-workspace and persist across sessions.
 
 ### Excluded Folders
 
-Certain folders are excluded from the tree by default:
+Some directories are never listed into, whatever the workspace settings say — the
+same floor the workspace search applies: `.git`, `node_modules`, `.obsidian`,
+`.svn`, `__pycache__`, `.DS_Store`, `.vscode`, `.idea`, `target`, `.next`,
+`dist`, `.superpowers`. They still appear as folders so you know they exist; their
+contents are not read. Add your own names under **Exclude folders** in the
+workspace settings (a new workspace starts with `.git` and `node_modules` there).
 
-- `.git`
-- `node_modules`
-
-These defaults are applied when a workspace is first opened.
+The tree is listed in one pass and refreshed when files change. A burst of
+changes refreshes it once, shortly after the burst ends; a folder that never
+stops changing (an in-progress download, a build, a sync) refreshes on a
+widening interval instead of continuously, so the explorer never pins a CPU core
+re-reading a busy workspace.
 
 ## Quick Open
 


### PR DESCRIPTION
## Summary

The file explorer could enter a self-perpetuating full-tree rescan loop: every fs event batch re-listed the whole tree, and a batch that landed during a scan restarted it at once, so a workspace that never stopped changing kept one core pinned (the reporter measured 19–23 full rescans a minute for 36 minutes). This PR replaces the rescan-per-batch policy with a paced scheduler, makes one listing one IPC call with the always-skipped directories pruned in Rust, and fixes a second defect the live check exposed: fs events under a symlinked workspace root were dropped by the scope filter because the watcher reported realpaths.

## Policy Gates (Required)

- [x] This PR is single-focus (one issue, one problem, one objective): the file explorer's refresh under a changing workspace (#1357), plus the watcher defect found while verifying it live.
- [x] This PR includes tests for changed behavior and changed code paths: the scheduler's rules under fake timers, the hook's use of it, the Rust walker (pruning, bounds, unreadable root vs subfolder, symlink loop), the watcher's path rebase (macOS spelling, canonical root, sibling prefix, real symlink), and the explorer suites moved onto the one-call listing.
- [x] Bug fix with reproduction context: the issue carries the log evidence and the code path; the live check in the PR description below reproduces the churn shape.

## Linked Issue

- Fixes #1357

## Type of Change

- [x] Bug fix
- [x] Docs (`website/guide/workspace-management.md`: the fixed skip list and the paced refresh)

## What Changed

- `rescanScheduler.ts`: trailing debounce, a no-starvation bound, and back-off that doubles while churn continues (to 30 s); one scan at a time; `refresh()` resolves once its listing has run.
- `list_directory_tree` (`file_tree_walk.rs`): the whole tree in one `spawn_blocking` walk, pruning the search's `ALWAYS_SKIP`, the workspace's `excludeFolders`, and hidden directories; bounded at 50,000 nodes / 64 levels with `truncated`; never descends a symlink; an unreadable subfolder is a flagged empty folder, an unreadable root is a typed `io` error.
- `useFileTree.ts`: one IPC call per listing, the file-type filter client-side, the scheduler owning when to scan; `fileTreeFilters.ts` carries the same skip list, pinned against the Rust constant by test.
- `watcher.rs`: reported paths are rebased onto the root the window asked to watch, so events under `/var/...` (realpath `/private/var/...`) or any symlinked root stay in scope.
- `.size-limit.cjs`: the eager App chunk grew 1.17 kB for the scheduler; limit 612 → 614 kB with a dated note, per the file's policy.

## Validation

- [x] I ran `pnpm check:all` locally (exit 0), plus `check:predelta` 41/41, clippy, `cargo test`, and the Windows cross-compile.
- [x] I added or updated tests to cover behavior changes.
- [x] I manually verified critical flows: against the dev app, a new file every 300 ms for 45 s kept the process at or below 1.1% CPU, and the tree grew by exactly the 150 new rows once quiet.

## UI Evidence (if applicable)

Not applicable: no visible UI change.

## PR Checklist

- [x] The PR avoids unrelated refactors or cleanup.
- [x] The issue context is clear (linked issue).
- [x] Docs/changelog were updated if behavior or usage changed.
- [x] I am ready to address review feedback.
