### PR TITLE
fix(homebrew): curl refuses --fail and --fail-with-body together

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -121,7 +121,13 @@ jobs:
           fetch_dmg() {
             local url="$1" out="$2" label="$3"
             echo "Downloading $label DMG..."
-            if ! curl -fL --fail-with-body --retry 3 --retry-delay 5 \
+            # NOT `-f`: that IS `--fail`, and curl refuses `--fail` and
+            # `--fail-with-body` together ("is badly used here"), which failed
+            # the v0.9.65 publish. `--fail-with-body` is the one wanted — it
+            # still exits non-zero on HTTP >= 400 but keeps the response body,
+            # so a diagnosis does not need a second request. Verified against a
+            # real 404 (exit 22) and a real DMG (exit 0).
+            if ! curl -L --fail-with-body --retry 3 --retry-delay 5 \
                  --retry-all-errors -o "$out" "$url"; then
               echo "::error::$label DMG download failed: $url"
               return 1


### PR DESCRIPTION
The download hardening from the 20260906 audit (C6) wrote `curl -fL --fail-with-body`. `-f` **is** `--fail`, and curl rejects the pair outright — *"You must select either --fail or --fail-with-body, not both"* — so every download failed at argument parsing and the v0.9.65 tap update never ran.

`--fail-with-body` is the one wanted: it still exits non-zero on HTTP >= 400, but keeps the response body, so diagnosing a failure does not need a second request.

**The gate behaved correctly.** It refused to continue rather than hashing whatever came back, and the tap was left untouched at 0.9.64 with its checksums intact — which is exactly the property C6 was added for, arrived at the hard way.

Verified by running, not by reading:

| | |
|---|---|
| real 404 | exit **22** |
| published v0.9.65 arm64 DMG | exit **0**, 39 MB on disk |

After merge, the tap update needs a manual dispatch for v0.9.65 since the release has already published.