### PR TITLE
fix(windows): uninstalling no longer wipes the file associations it borrowed

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -325,7 +325,14 @@ jobs:
               }
             }
             if ($broken.Count -gt 0) {
-              throw "${stage}: uninstall changed file associations it does not own: $($broken -join '; ')"
+              # Each on its own line BEFORE the throw. PowerShell truncates a
+              # long exception message with an ellipsis, which on the v0.9.66
+              # measurement cut the list off after the second entry and hid the
+              # real blast radius — the throw carries the count, the log carries
+              # the evidence.
+              Write-Host "::error::${stage}: uninstall changed $($broken.Count) file association(s) it does not own"
+              foreach ($line in $broken) { Write-Host "  $line" }
+              throw "${stage}: uninstall changed $($broken.Count) of $($assocExts.Count) file associations it does not own (listed above)"
             }
             Write-Host "${stage}: all $($assocExts.Count) claimed associations unchanged"
           }

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -290,6 +290,46 @@ jobs:
             'Registry::HKEY_CURRENT_USER\Software\Classes\.txt\ShellNew'
           )
 
+          # Every extension VMark claims. This job does no checkout, so the list
+          # is literal here; release-smoke-windows-installer.test.mjs reads
+          # tauri.conf.json and fails if the two disagree, in both directions.
+          # It is the WHOLE list rather than .txt alone because the defect this
+          # catches is per-extension: the uninstaller writes an empty ProgID
+          # into HKCU for each one, and .html/.htm/.svg/.json also commonly have
+          # a machine-wide handler to shadow.
+          $assocExts = @(
+            'md','markdown','mdown','mkd','mdx','txt','json','jsonl',
+            'yaml','yml','toml','mmd','svg','html','htm'
+          )
+
+          # The merged HKCR default ProgID per claimed extension. A missing key
+          # and a missing value both read as '', which is what we want: the
+          # assertion is round-trip equality, not presence, so an extension with
+          # no handler on this runner simply compares '' to ''.
+          function Get-AssocDefaults {
+            $out = @{}
+            foreach ($ext in $assocExts) {
+              $key = "Registry::HKEY_CLASSES_ROOT\.$ext"
+              $value = if (Test-Path $key) { (Get-ItemProperty $key).'(default)' } else { $null }
+              $out[$ext] = [string]$value
+            }
+            return $out
+          }
+
+          function Assert-AssocRestored($before, [string]$stage) {
+            $after = Get-AssocDefaults
+            $broken = @()
+            foreach ($ext in $assocExts) {
+              if ($after[$ext] -ne $before[$ext]) {
+                $broken += ".$ext '$($before[$ext])' -> '$($after[$ext])'"
+              }
+            }
+            if ($broken.Count -gt 0) {
+              throw "${stage}: uninstall changed file associations it does not own: $($broken -join '; ')"
+            }
+            Write-Host "${stage}: all $($assocExts.Count) claimed associations unchanged"
+          }
+
           # Tauri's NSIS template writes the uninstall entry under
           # Software\Microsoft\Windows\CurrentVersion\Uninstall\<productName>,
           # in HKCU for the default currentUser install mode.
@@ -341,8 +381,8 @@ jobs:
             Write-Host "uninstalled cleanly"
           }
 
-          $defaultBefore = (Get-ItemProperty $hkcrTxt).'(default)'
-          Write-Host "HKCR\.txt (default) before: '$defaultBefore'"
+          $assocBefore = Get-AssocDefaults
+          Write-Host "HKCR\.txt (default) before: '$($assocBefore['txt'])'"
           Assert-ShellNew 'before install'
 
           # Cycle 1 - plain: the uninstaller must leave the system as it found it.
@@ -350,10 +390,7 @@ jobs:
           Assert-ShellNew 'after install'
           Uninstall-Silently $entry
           Assert-ShellNew 'after uninstall (cycle 1)'
-          $defaultAfter = (Get-ItemProperty $hkcrTxt).'(default)'
-          if ($defaultAfter -ne $defaultBefore) {
-            throw "uninstall changed the .txt association: '$defaultBefore' -> '$defaultAfter'"
-          }
+          Assert-AssocRestored $assocBefore 'after uninstall (cycle 1)'
 
           # Cycle 2 - the #1142 damage, then the hook: delete ShellNew wherever it
           # lives, uninstall, and require it back. Only the POSTUNINSTALL hook
@@ -366,3 +403,4 @@ jobs:
           Write-Host "removed .txt\ShellNew (the #1142 damage)"
           Uninstall-Silently $entry
           Assert-ShellNew 'after uninstall (cycle 2): restored by the POSTUNINSTALL hook'
+          Assert-AssocRestored $assocBefore 'after uninstall (cycle 2)'

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
       "ws": ">=8.21.0 <9",
       "fast-uri": ">=3.1.4 <5",
       "@modelcontextprotocol/sdk": ">=1.27.1 <2",
-      "hono": ">=4.12.7 <5",
+      "hono": ">=4.13.5 <5",
       "@hono/node-server": ">=1.19.10 <3",
       "express-rate-limit": ">=8.2.2 <9",
       "lodash": ">=4.18.0 <5",
@@ -213,7 +213,10 @@
       "dompurify": ">=3.3.2 <4",
       "qs": ">=6.14.2 <7",
       "picomatch": ">=4.0.4 <5",
-      "path-to-regexp": ">=8.4.0 <9"
+      "path-to-regexp": ">=8.4.0 <9",
+      "js-yaml@3": ">=3.15.2 <4",
+      "js-yaml@4": ">=4.3.2 <5",
+      "baseline-browser-mapping": ">=2.11.0 <3"
     }
   },
   "devDependencies": {
@@ -233,9 +236,9 @@
     "@types/react-dom": "^19.2.4",
     "@types/turndown": "^5.0.6",
     "@vitejs/plugin-react": "^6.0.5",
-    "@vitest/browser": "^4.1.10",
-    "@vitest/browser-playwright": "^4.1.10",
-    "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/browser": "^4.1.11",
+    "@vitest/browser-playwright": "^4.1.11",
+    "@vitest/coverage-v8": "^4.1.11",
     "dependency-cruiser": "^18.2.0",
     "eslint": "^10.8.1",
     "eslint-plugin-react-hooks": "^7.1.1",
@@ -253,7 +256,7 @@
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.67.0",
     "vite": "^8.2.1",
-    "vitest": "^4.1.10",
+    "vitest": "^4.1.11",
     "vitest-axe": "0.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   ws: '>=8.21.0 <9'
   fast-uri: '>=3.1.4 <5'
   '@modelcontextprotocol/sdk': '>=1.27.1 <2'
-  hono: '>=4.12.7 <5'
+  hono: '>=4.13.5 <5'
   '@hono/node-server': '>=1.19.10 <3'
   express-rate-limit: '>=8.2.2 <9'
   lodash: '>=4.18.0 <5'
@@ -25,6 +25,9 @@ overrides:
   qs: '>=6.14.2 <7'
   picomatch: '>=4.0.4 <5'
   path-to-regexp: '>=8.4.0 <9'
+  js-yaml@3: '>=3.15.2 <4'
+  js-yaml@4: '>=4.3.2 <5'
+  baseline-browser-mapping: '>=2.11.0 <3'
 
 importers:
 
@@ -327,7 +330,7 @@ importers:
         version: 9.6.1(@types/node@22.20.1)
       '@stryker-mutator/vitest-runner':
         specifier: 9.6.1
-        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@22.20.1))(vitest@4.1.10)
+        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@22.20.1))(vitest@4.1.11)
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -336,7 +339,7 @@ importers:
         version: 2.11.4
       '@testing-library/jest-dom':
         specifier: ^7.0.1
-        version: 7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.10)
+        version: 7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.11)
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -362,14 +365,14 @@ importers:
         specifier: ^6.0.5
         version: 6.0.5(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/browser':
-        specifier: ^4.1.10
-        version: 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+        specifier: ^4.1.11
+        version: 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
       '@vitest/browser-playwright':
-        specifier: ^4.1.10
-        version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+        specifier: ^4.1.11
+        version: 4.1.11(playwright@1.62.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
       '@vitest/coverage-v8':
-        specifier: ^4.1.10
-        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+        specifier: ^4.1.11
+        version: 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
       dependency-cruiser:
         specifier: ^18.2.0
         version: 18.2.0
@@ -422,20 +425,20 @@ importers:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       vitest-axe:
         specifier: 0.1.0
-        version: 0.1.0(vitest@4.1.10)
+        version: 0.1.0(vitest@4.1.11)
 
   server/content:
     dependencies:
       '@hono/node-server':
         specifier: '>=1.19.10 <3'
-        version: 2.1.0(hono@4.13.1)
+        version: 2.1.0(hono@4.13.7)
       '@slidev/cli':
         specifier: ^52.19.0
-        version: 52.19.0(@nuxt/kit@3.21.11(magicast@0.5.3))(@oxc-project/types@0.144.0)(@types/markdown-it@14.1.2)(@types/node@22.20.1)(@vitejs/devtools-kit@0.4.12(@modelcontextprotocol/server@2.0.0)(cac@7.0.0)(srvx@0.12.5)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(esbuild@0.27.7)(hono@4.13.1)(lightningcss@1.33.0)(magicast@0.5.3)(markdown-it@14.3.0)(oxc-parser@0.131.0)(playwright-chromium@1.62.1)(postcss@8.5.26)(react@19.2.8)(rolldown@1.2.4)(rollup@4.62.4)(sass@1.98.0)(srvx@0.12.5)(terser@5.50.0)(tsx@4.23.12)(vite-plugin-pwa@1.3.0(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))
+        version: 52.19.0(@nuxt/kit@3.21.11(magicast@0.5.3))(@oxc-project/types@0.144.0)(@types/markdown-it@14.1.2)(@types/node@22.20.1)(@vitejs/devtools-kit@0.4.12(@modelcontextprotocol/server@2.0.0)(cac@7.0.0)(srvx@0.12.5)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(esbuild@0.27.7)(hono@4.13.7)(lightningcss@1.33.0)(magicast@0.5.3)(markdown-it@14.3.0)(oxc-parser@0.131.0)(playwright-chromium@1.62.1)(postcss@8.5.26)(react@19.2.8)(rolldown@1.2.4)(rollup@4.62.4)(sass@1.98.0)(srvx@0.12.5)(terser@5.50.0)(tsx@4.23.12)(vite-plugin-pwa@1.3.0(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -446,8 +449,8 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
       hono:
-        specifier: '>=4.12.7 <5'
-        version: 4.13.1
+        specifier: '>=4.13.5 <5'
+        version: 4.13.7
       ignore:
         specifier: ^7.0.6
         version: 7.0.6
@@ -504,8 +507,8 @@ importers:
         specifier: ^22.20.1
         version: 22.20.1
       '@vitest/coverage-v8':
-        specifier: ^4.1.10
-        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+        specifier: ^4.1.11
+        version: 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.12)(typescript@6.0.3)(yaml@2.9.0)
@@ -513,8 +516,8 @@ importers:
         specifier: ~6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   server/mcp:
     dependencies:
@@ -535,8 +538,8 @@ importers:
         specifier: ^8.18.1
         version: 8.18.1
       '@vitest/coverage-v8':
-        specifier: ^4.1.10
-        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+        specifier: ^4.1.11
+        version: 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
       '@yao-pkg/pkg':
         specifier: ^6.22.0
         version: 6.22.0
@@ -547,8 +550,8 @@ importers:
         specifier: ~7.0.2
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   website:
     devDependencies:
@@ -2006,7 +2009,7 @@ packages:
     resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.7 <5'
+      hono: '>=4.13.5 <5'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2315,7 +2318,7 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       '@modelcontextprotocol/server': ^2.0.0
-      hono: '>=4.12.7 <5'
+      hono: '>=4.13.5 <5'
     peerDependenciesMeta:
       hono:
         optional: true
@@ -4366,31 +4369,31 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vitest/browser-playwright@4.1.10':
-    resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
+  '@vitest/browser-playwright@4.1.11':
+    resolution: {integrity: sha512-riLBxPqwnJ0lWs2DN2WeUfYeKLoAjbP2Xx8cLQdSddzMi20sksIa6K2mPz79DyMZKKVKH2ksOC2yJvtNcZg8cg==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.1.10
+      vitest: 4.1.11
 
-  '@vitest/browser@4.1.10':
-    resolution: {integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==}
+  '@vitest/browser@4.1.11':
+    resolution: {integrity: sha512-bwMovvAeuTFOK5kIFevw4VEf+1gVEICv4SYK4k3knJOxl6b1zEWud8mYKD73e1B0odAn174h1MofURy2TPWf3w==}
     peerDependencies:
-      vitest: 4.1.10
+      vitest: 4.1.11
 
-  '@vitest/coverage-v8@4.1.10':
-    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+  '@vitest/coverage-v8@4.1.11':
+    resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
     peerDependencies:
-      '@vitest/browser': 4.1.10
-      vitest: 4.1.10
+      '@vitest/browser': 4.1.11
+      vitest: 4.1.11
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.10':
-    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
-  '@vitest/mocker@4.1.10':
-    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -4400,20 +4403,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.10':
-    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
-  '@vitest/runner@4.1.10':
-    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
 
-  '@vitest/snapshot@4.1.10':
-    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
 
-  '@vitest/spy@4.1.10':
-    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
-  '@vitest/utils@4.1.10':
-    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@viz-js/viz@3.29.0':
     resolution: {integrity: sha512-iq4MTqNCr8pinP4C73JRFx/h2w4QbtHvXINNiPeBv3/C5tSamXwakst6ODlR/l6uh3/SGr7IAGIfSk2qMekiNw==}
@@ -4859,11 +4862,6 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  baseline-browser-mapping@2.10.40:
-    resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   baseline-browser-mapping@2.11.14:
     resolution: {integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==}
@@ -6182,8 +6180,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -6582,12 +6580,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.1:
-    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+  js-yaml@3.15.2:
+    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   js-yaml@5.2.2:
@@ -7392,10 +7390,6 @@ packages:
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
-
-  obug@2.1.3:
-    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
-    engines: {node: '>=12.20.0'}
 
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
@@ -8479,10 +8473,6 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -9118,20 +9108,20 @@ packages:
     peerDependencies:
       vitest: '>=0.16.0'
 
-  vitest@4.1.10:
-    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.10
-      '@vitest/browser-preview': 4.1.10
-      '@vitest/browser-webdriverio': 4.1.10
-      '@vitest/coverage-istanbul': 4.1.10
-      '@vitest/coverage-v8': 4.1.10
-      '@vitest/ui': 4.1.10
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -10696,7 +10686,7 @@ snapshots:
   '@comark/markdown-it@0.3.4(@types/markdown-it@14.1.2)(markdown-it@14.3.0)':
     dependencies:
       '@types/markdown-it': 14.1.2
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       markdown-it: 14.3.0
 
   '@csstools/color-helpers@6.1.0': {}
@@ -11101,9 +11091,9 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
 
-  '@hono/node-server@2.1.0(hono@4.13.1)':
+  '@hono/node-server@2.1.0(hono@4.13.7)':
     dependencies:
-      hono: 4.13.1
+      hono: 4.13.7
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -11462,16 +11452,16 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.1)':
+  '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.7)':
     dependencies:
-      '@hono/node-server': 2.1.0(hono@4.13.1)
+      '@hono/node-server': 2.1.0(hono@4.13.7)
       '@modelcontextprotocol/server': 2.0.0
     optionalDependencies:
-      hono: 4.13.1
+      hono: 4.13.7
 
   '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.1.0(hono@4.13.1)
+      '@hono/node-server': 2.1.0(hono@4.13.7)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -11481,7 +11471,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.1(express@5.2.1)
-      hono: 4.13.1
+      hono: 4.13.7
       jose: 6.2.4
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -11493,7 +11483,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.1.0(hono@4.13.1)
+      '@hono/node-server': 2.1.0(hono@4.13.7)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -11503,7 +11493,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.1(express@5.2.1)
-      hono: 4.13.1
+      hono: 4.13.7
       jose: 6.2.4
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -12220,7 +12210,7 @@ snapshots:
     dependencies:
       size-limit: 13.0.3
 
-  '@slidev/cli@52.19.0(@nuxt/kit@3.21.11(magicast@0.5.3))(@oxc-project/types@0.144.0)(@types/markdown-it@14.1.2)(@types/node@22.20.1)(@vitejs/devtools-kit@0.4.12(@modelcontextprotocol/server@2.0.0)(cac@7.0.0)(srvx@0.12.5)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(esbuild@0.27.7)(hono@4.13.1)(lightningcss@1.33.0)(magicast@0.5.3)(markdown-it@14.3.0)(oxc-parser@0.131.0)(playwright-chromium@1.62.1)(postcss@8.5.26)(react@19.2.8)(rolldown@1.2.4)(rollup@4.62.4)(sass@1.98.0)(srvx@0.12.5)(terser@5.50.0)(tsx@4.23.12)(vite-plugin-pwa@1.3.0(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))':
+  '@slidev/cli@52.19.0(@nuxt/kit@3.21.11(magicast@0.5.3))(@oxc-project/types@0.144.0)(@types/markdown-it@14.1.2)(@types/node@22.20.1)(@vitejs/devtools-kit@0.4.12(@modelcontextprotocol/server@2.0.0)(cac@7.0.0)(srvx@0.12.5)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(esbuild@0.27.7)(hono@4.13.7)(lightningcss@1.33.0)(magicast@0.5.3)(markdown-it@14.3.0)(oxc-parser@0.131.0)(playwright-chromium@1.62.1)(postcss@8.5.26)(react@19.2.8)(rolldown@1.2.4)(rollup@4.62.4)(sass@1.98.0)(srvx@0.12.5)(terser@5.50.0)(tsx@4.23.12)(vite-plugin-pwa@1.3.0(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))':
     dependencies:
       '@antfu/ni': 30.5.0
       '@antfu/utils': 9.3.0
@@ -12229,7 +12219,7 @@ snapshots:
       '@iconify-json/ph': 1.2.2
       '@iconify-json/svg-spinners': 1.2.4
       '@lillallol/outline-pdf': 4.0.0
-      '@modelcontextprotocol/node': 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.1)
+      '@modelcontextprotocol/node': 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.7)
       '@modelcontextprotocol/server': 2.0.0
       '@shikijs/magic-move': 4.4.3(react@19.2.8)(shiki@4.4.3)(vue@3.5.41(typescript@6.0.3))
       '@shikijs/markdown-it': 4.4.3
@@ -12567,14 +12557,14 @@ snapshots:
 
   '@stryker-mutator/util@9.6.1': {}
 
-  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@22.20.1))(vitest@4.1.10)':
+  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@22.20.1))(vitest@4.1.11)':
     dependencies:
       '@stryker-mutator/api': 9.6.1
       '@stryker-mutator/core': 9.6.1(@types/node@22.20.1)
       '@stryker-mutator/util': 9.6.1
       semver: 7.8.5
       tslib: 2.8.1
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@tailwindcss/node@4.3.3':
     dependencies:
@@ -12740,7 +12730,7 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.10)':
+  '@testing-library/jest-dom@7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.11)':
     dependencies:
       '@adobe/css-tools': 4.5.0
       '@testing-library/dom': 10.4.1
@@ -12750,7 +12740,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
     optionalDependencies:
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -13575,13 +13565,13 @@ snapshots:
       vite: 8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vue: 3.5.41(typescript@6.0.3)
 
-  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.11(playwright@1.62.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)':
     dependencies:
-      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/browser': 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/mocker': 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       playwright: 1.62.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13589,29 +13579,29 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.11(playwright@1.62.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)':
     dependencies:
-      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/browser': 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/mocker': 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       playwright: 1.62.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser@4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@vitest/utils': 4.1.10
+      '@vitest/mocker': 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -13620,16 +13610,16 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser@4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@vitest/utils': 4.1.10
+      '@vitest/mocker': 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -13637,68 +13627,68 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
+  '@vitest/coverage-v8@4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.10
+      '@vitest/utils': 4.1.11
       ast-v8-to-istanbul: 1.0.4
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.3
-      obug: 2.1.3
+      obug: 2.1.4
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
 
-  '@vitest/expect@4.1.10':
+  '@vitest/expect@4.1.11':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.10
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.10
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.10':
+  '@vitest/pretty-format@4.1.11':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.10':
+  '@vitest/runner@4.1.11':
     dependencies:
-      '@vitest/utils': 4.1.10
+      '@vitest/utils': 4.1.11
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.10':
+  '@vitest/snapshot@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.10': {}
+  '@vitest/spy@4.1.11': {}
 
-  '@vitest/utils@4.1.10':
+  '@vitest/utils@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.10
+      '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -14235,10 +14225,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.40: {}
-
-  baseline-browser-mapping@2.11.14:
-    optional: true
+  baseline-browser-mapping@2.11.14: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -14293,7 +14280,7 @@ snapshots:
 
   browserslist@4.28.4:
     dependencies:
-      baseline-browser-mapping: 2.10.40
+      baseline-browser-mapping: 2.11.14
       caniuse-lite: 1.0.30001799
       electron-to-chromium: 1.5.380
       node-releases: 2.0.50
@@ -15714,7 +15701,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -15848,7 +15835,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.13.1: {}
+  hono@4.13.7: {}
 
   hookable@5.5.3: {}
 
@@ -16216,12 +16203,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.1:
+  js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -17244,8 +17231,6 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
     optional: true
-
-  obug@2.1.3: {}
 
   obug@2.1.4: {}
 
@@ -18661,8 +18646,6 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyexec@1.2.4: {}
-
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
@@ -19325,7 +19308,7 @@ snapshots:
   vitepress-markmap-preview@0.2.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(markmap-common@0.18.9)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0):
     dependencies:
       '@vitejs/plugin-vue': 6.0.8(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       markdown-it: 14.3.0
       markmap-lib: 0.18.12(markmap-common@0.18.9)
       markmap-toolbar: 0.18.12(markmap-common@0.18.9)
@@ -19405,7 +19388,7 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest-axe@0.1.0(vitest@4.1.10):
+  vitest-axe@0.1.0(vitest@4.1.11):
     dependencies:
       aria-query: 5.3.2
       axe-core: 4.12.1
@@ -19413,64 +19396,64 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.18.1
       redent: 3.0.0
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
-  vitest@4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.1.0
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
-      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.11(playwright@1.62.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/coverage-v8': 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
       jsdom: 30.0.1
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.1.0
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
-      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.11(playwright@1.62.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/coverage-v8': 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
       jsdom: 30.0.1
     transitivePeerDependencies:
       - msw

--- a/scripts/baselineRatchetManifest.mjs
+++ b/scripts/baselineRatchetManifest.mjs
@@ -333,24 +333,10 @@ export const MANIFEST = {
       checks: [{ mode: "custom", comparator: "tsFidelityLedger", onAdd: "report" }],
     },
   ],
-  allowRaise: [
-    // 2026-09-07: check-command-error-ratchet learned the imported `#[command]`
-    // attribute form (17 sites). These three files were legacy all along and
-    // simply invisible — additions of visibility, not regressions (the
-    // baseline's own header note). Each is a NEW key under onAdd "fail", i.e.
-    // a raise from 0; delete these once the base carries them.
-    ...[
-      ["src-tauri/src/ai_provider/mod.rs", 1],
-      ["src-tauri/src/ai_provider/rest_api.rs", 3],
-      ["src-tauri/src/pandoc/commands.rs", 1],
-    ].map(([file, count]) => ({
-      path: "scripts/command-error-baseline.json",
-      key: `files.${file}`,
-      from: 0,
-      to: count,
-      reason:
-        "re-measurement: the gate started seeing the imported `#[command]` attribute form; " +
-        "this file's legacy signatures existed before and were invisible, not introduced",
-    })),
-  ],
+  // Empty by design. An entry here permits exactly ONE re-measurement and is
+  // deleted by the PR that follows the one carrying it — the 2026-09-07 entries
+  // for the three `#[command]`-visibility files in command-error-baseline.json
+  // expired when 76589b510 landed those counts, which is the gate reporting
+  // them stale rather than anyone remembering.
+  allowRaise: [],
 };

--- a/scripts/release-smoke-windows-installer.test.mjs
+++ b/scripts/release-smoke-windows-installer.test.mjs
@@ -42,6 +42,11 @@ const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const workflow = parseYaml(
   readFileSync(path.join(REPO, ".github/workflows/release-smoke.yml"), "utf8"),
 );
+const hooks = readFileSync(path.join(REPO, "src-tauri/windows/installer-hooks.nsh"), "utf8");
+const tauriConf = JSON.parse(readFileSync(path.join(REPO, "src-tauri/tauri.conf.json"), "utf8"));
+
+/** Every extension tauri.conf.json claims — the authority both lists copy. */
+const CLAIMED_EXTS = (tauriConf.bundle?.fileAssociations ?? []).flatMap((a) => a.ext ?? []);
 const job = workflow.jobs["windows-installer"];
 const steps = job?.steps ?? [];
 const runs = steps.map((s) => String(s.run ?? ""));
@@ -115,5 +120,77 @@ describe("release-smoke: windows-installer", () => {
     for (const step of pwshSteps) {
       expect(String(step.run)).toMatch(/^\s*\$ErrorActionPreference = 'Stop'/);
     }
+  });
+
+  it("checks the association round-trip for the WHOLE claimed set, in both cycles", () => {
+    // The v0.9.66 run compared only `.txt`. The defect is per-extension, so a
+    // .txt-only check would pass a build that still shadows .html and .svg.
+    expect(cycle).toMatch(/function Get-AssocDefaults/);
+    expect(cycle).toMatch(/function Assert-AssocRestored/);
+    expect(cycle).toMatch(/Assert-AssocRestored \$assocBefore 'after uninstall \(cycle 1\)'/);
+    expect(cycle).toMatch(/Assert-AssocRestored \$assocBefore 'after uninstall \(cycle 2\)'/);
+    // Snapshot taken BEFORE the first install, or it cannot show a change.
+    expect(cycle.indexOf("$assocBefore = Get-AssocDefaults")).toBeLessThan(
+      cycle.indexOf("Install-Silently\n"),
+    );
+  });
+
+  it("keeps the job's extension list identical to tauri.conf.json", () => {
+    // The job does no checkout, so the list is literal in the workflow. That is
+    // a copy, and a copy drifts — this is the join that stops it.
+    const block = cycle.match(/\$assocExts = @\(([\s\S]*?)\)/);
+    expect(block, "no $assocExts list in the windows-installer job").not.toBeNull();
+    const listed = [...block[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+    expect(listed.slice().sort()).toEqual(CLAIMED_EXTS.slice().sort());
+  });
+});
+
+// The POSTUNINSTALL repair itself. Tauri's APP_UNASSOCIATE writes the backed-up
+// ProgID back UNCONDITIONALLY, and for a per-user install that backup was read
+// from HKCU — a hive that never held the machine-wide association. So it writes
+// an empty default into HKCU, which shadows HKLM in the merged HKCR view and
+// leaves the extension with no handler. The hook deletes that empty value.
+describe("installer-hooks.nsh: the association un-shadow", () => {
+  const covered = [...hooks.matchAll(/!insertmacro VMARK_UNSHADOW_ASSOCIATION "([^"]+)"/g)].map(
+    (m) => m[1],
+  );
+
+  it("covers every claimed extension, and claims no extension that is gone", () => {
+    expect(CLAIMED_EXTS.length).toBeGreaterThan(0);
+    // Both directions: a new fileAssociation that skips the hook reintroduces
+    // the defect for that extension, and a stale entry is a dead line.
+    expect(covered.slice().sort()).toEqual(CLAIMED_EXTS.slice().sort());
+  });
+
+  it("deletes the default value ONLY when it is empty", () => {
+    // A non-empty default means the restore worked (per-machine install) or
+    // another application has claimed the extension. Deleting it either way
+    // would turn a repair into the very defect it fixes.
+    const macro = hooks.match(/!macro VMARK_UNSHADOW_ASSOCIATION[\s\S]*?!macroend/);
+    expect(macro, "no VMARK_UNSHADOW_ASSOCIATION macro").not.toBeNull();
+    const body = macro[0];
+    const deletes = [...body.matchAll(/DeleteRegValue (\w+) "Software\\Classes\\\.\$\{EXT\}" ""/g)];
+    expect(deletes.map((m) => m[1]).sort()).toEqual(["HKCU", "HKLM"]);
+    // Each delete is guarded by an emptiness test on the value just read.
+    expect([...body.matchAll(/\$\{If\} \$R0 == ""/g)]).toHaveLength(2);
+    expect([...body.matchAll(/ReadRegStr \$R0 (HKCU|HKLM) "Software\\Classes\\\.\$\{EXT\}" ""/g)])
+      .toHaveLength(2);
+    // The register is borrowed, not stolen: the uninstall section continues
+    // after the hook.
+    expect(body).toMatch(/Push \$R0[\s\S]*Pop \$R0/);
+  });
+
+  it("still restores the #1142 ShellNew key", () => {
+    // The un-shadow must not have displaced the original repair; cycle 2 of the
+    // smoke job is the only thing that can confirm that line, and it has not
+    // reached a verdict yet.
+    expect(hooks).toMatch(/WriteRegStr HKCR "\.txt\\ShellNew" "NullFile" ""/);
+  });
+
+  it("does not delete the _backup value another Tauri app may own", () => {
+    // Tauri derives the file class from the bare extension when a
+    // fileAssociation declares no `name`, so "txt_backup" is not unique to
+    // VMark. It is inert once the default value is gone.
+    expect(hooks).not.toMatch(/DeleteRegValue[^\n]*_backup/);
   });
 });

--- a/scripts/release-smoke-windows-installer.test.mjs
+++ b/scripts/release-smoke-windows-installer.test.mjs
@@ -135,6 +135,24 @@ describe("release-smoke: windows-installer", () => {
     );
   });
 
+  it("logs every damaged association before throwing, so none is truncated away", () => {
+    // Measured: PowerShell elided the v0.9.66 failure message after two
+    // entries, so the run proved damage existed but not how much. The list has
+    // to reach the log outside the exception text.
+    // The YAML block scalar is parsed with its common indent stripped, so the
+    // function's closing brace sits at column 0.
+    const assertFn = cycle.match(/function Assert-AssocRestored[\s\S]*?\n\}/);
+    expect(assertFn, "no Assert-AssocRestored function").not.toBeNull();
+    const body = assertFn[0];
+    const logLoop = body.indexOf("foreach ($line in $broken)");
+    // `throw "`, not `throw ` — the explanatory comment above the statement
+    // contains the bare word, and a detector that matches prose is the trap
+    // this repo has paid for before.
+    const thrown = body.indexOf('throw "');
+    expect(logLoop, "the broken list is never written to the log").toBeGreaterThan(-1);
+    expect(logLoop, "the list must be logged BEFORE the throw ends the step").toBeLessThan(thrown);
+  });
+
   it("keeps the job's extension list identical to tauri.conf.json", () => {
     // The job does no checkout, so the list is literal in the workflow. That is
     // a copy, and a copy drifts — this is the join that stops it.

--- a/server/content/package.json
+++ b/server/content/package.json
@@ -47,10 +47,10 @@
     "@types/jsdom": "^30.0.0",
     "@types/katex": "^0.16.8",
     "@types/node": "^22.20.1",
-    "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/coverage-v8": "^4.1.11",
     "tsup": "^8.5.1",
     "typescript": "~6.0.3",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.11"
   },
   "engines": {
     "node": ">=20.12"

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -38,11 +38,11 @@
   "devDependencies": {
     "@types/node": "^22.20.1",
     "@types/ws": "^8.18.1",
-    "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/coverage-v8": "^4.1.11",
     "@yao-pkg/pkg": "^6.22.0",
     "esbuild": "^0.28.2",
     "typescript": "~7.0.2",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.11"
   },
   "engines": {
     "node": ">=18"

--- a/src-tauri/src/ai_provider/detection.test.rs
+++ b/src-tauri/src/ai_provider/detection.test.rs
@@ -106,16 +106,60 @@ fn zdotdir_none_for_nonexistent_shell() {
 /// bound, roughly 3× headroom to 64×. The marker below is the part that does
 /// not depend on that being right: whatever the cause, the next occurrence
 /// names itself instead of being blamed on the round-trip.
+///
+/// # It is also the ETXTBSY readiness gate, and on Linux that is its whole job
+///
+/// CI's ubuntu leg failed here on 2026-09-09 with
+/// `Os { code: 26, kind: ExecutableFileBusy }` while macOS and Windows passed.
+/// That is the fork/exec race, not a broken fixture: `execve` returns ETXTBSY
+/// while ANY process holds the file open for writing, and the writer here is
+/// gone by this point (`drop(f)` precedes the call). The holder is a *forked
+/// child of a sibling test* — `Command::spawn` forks, the child inherits every
+/// descriptor including our still-open write fd, and although Rust opens files
+/// `O_CLOEXEC` so the copy dies at the child's own `execve`, it is open for the
+/// window between its `fork` and that `execve`. The cargo test harness runs
+/// these tests on parallel threads, so that window overlaps ours.
+///
+/// The condition is therefore transient BY CONSTRUCTION — it clears when a
+/// child that already exists finishes exec'ing, and nothing in this process can
+/// reopen the fixture for writing afterwards — so retrying is not papering over
+/// a defect. It is also why this helper must keep running on Linux even though
+/// the macOS cold-start cost above does not exist there: a SUCCESSFUL exec here
+/// proves no writer remains, which is what makes the real capture below safe.
+/// Panicking on the first ETXTBSY, as this did, converts a self-clearing race
+/// into a red build.
 #[cfg(unix)]
 fn warm_exec(shell: &std::path::Path) {
-    let status = std::process::Command::new(shell)
-        .arg("--vmark-warmup")
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .expect("warm-up exec of the fixture shell");
-    assert!(status.success(), "warm-up exec failed: {status:?}");
+    // Bounded, and generous against a window that is normally sub-millisecond:
+    // the child holding the descriptor is already running and only has to reach
+    // its own execve. A cap rather than a spin so a genuinely busy file — a
+    // real defect — still fails instead of hanging the suite.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let result = std::process::Command::new(shell)
+            .arg("--vmark-warmup")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        match result {
+            Ok(status) => {
+                assert!(status.success(), "warm-up exec failed: {status:?}");
+                return;
+            }
+            // ETXTBSY is 26 on both Linux and macOS; matched by raw errno
+            // because `ErrorKind::ExecutableFileBusy` is not stable.
+            Err(e) if e.raw_os_error() == Some(libc::ETXTBSY) => {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "fixture shell still ETXTBSY after 5s — a writer that never \
+                     closed, not the fork/exec race this retries for"
+                );
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(e) => panic!("warm-up exec of the fixture shell: {e:?}"),
+        }
+    }
 }
 
 /// Write a fake login "shell" that ignores its args, prints `body`, and
@@ -167,6 +211,72 @@ fn write_fake_shell(
         "the warm-up must not count as a run, or the marker proves nothing"
     );
     (shell, ran)
+}
+
+/// The ETXTBSY retry, exercised against a REAL ETXTBSY.
+///
+/// # Linux only, and that is measured rather than assumed
+///
+/// **macOS does not enforce ETXTBSY**, so this cannot run there. Measured on
+/// 2026-09-09 with a standalone probe: holding a write descriptor open on an
+/// executable and then `execve`-ing it returns `Ok(ExitStatus(0))` on macOS,
+/// while the same condition is what failed CI's ubuntu leg with
+/// `Os { code: 26 }`. A `cfg(unix)` version of this test therefore asserts
+/// nothing on the development machine — worse than nothing, as below.
+///
+/// # Why the fixture is warmed BEFORE the descriptor is held
+///
+/// The first version measured elapsed time across a COLD exec and passed with
+/// the retry disabled: macOS's cold-start evaluation (the cost `warm_exec`'s
+/// header documents at p50 409 ms) alone exceeded the threshold, so the timing
+/// assertion was satisfied by the very latency this helper exists to remove.
+/// Warming first puts that cost outside the measured window, leaving the retry
+/// as the only thing a wait can be attributed to.
+///
+/// The elapsed-time assertion is the load-bearing half: without it this passes
+/// whether or not ETXTBSY ever occurred, which is the shape of false pass this
+/// file already documents twice.
+#[cfg(target_os = "linux")]
+#[test]
+fn warm_exec_retries_through_etxtbsy() {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let shell = dir.path().join("busyshell");
+    let mut f = std::fs::File::create(&shell).unwrap();
+    write!(f, "#!/bin/sh\nexit 0\n").unwrap();
+    drop(f);
+    std::fs::set_permissions(&shell, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Pay any first-exec cost now, with no writer held, so it cannot be
+    // mistaken for retry latency below.
+    warm_exec(&shell);
+
+    // Hold the file open for writing — precisely what execve refuses.
+    let writer = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&shell)
+        .unwrap();
+    let hold = std::time::Duration::from_millis(300);
+    let releaser = std::thread::spawn(move || {
+        std::thread::sleep(hold);
+        drop(writer);
+    });
+
+    let started = std::time::Instant::now();
+    warm_exec(&shell); // must retry, not panic
+    let waited = started.elapsed();
+    releaser.join().unwrap();
+
+    // Proves the retry loop actually ran. Compared against most of the hold
+    // rather than all of it, so scheduler jitter around the release cannot
+    // fail a working retry.
+    assert!(
+        waited >= hold / 2,
+        "warm_exec returned in {waited:?} while the file was held open for \
+         writing — ETXTBSY was never produced, so the retry path is untested"
+    );
 }
 
 #[cfg(unix)]

--- a/src-tauri/windows/installer-hooks.nsh
+++ b/src-tauri/windows/installer-hooks.nsh
@@ -1,4 +1,14 @@
-; VMark NSIS installer hooks — issue #1142.
+; VMark NSIS installer hooks.
+;
+; Both repairs below run from NSIS_HOOK_POSTUNINSTALL, which Tauri inserts at
+; the END of the uninstall section — after the APP_UNASSOCIATE loop that undoes
+; the file associations. That ordering is what makes a repair possible; see
+; crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi (the unassociate
+; loop, then the hook a few dozen lines later).
+;
+; ---------------------------------------------------------------------------
+; 1. Re-create HKCR\.txt\ShellNew — issue #1142
+; ---------------------------------------------------------------------------
 ;
 ; VMark registers a ".txt" file association (see fileAssociations in
 ; tauri.conf.json). Windows' NSIS uninstaller cleanup for that association
@@ -11,16 +21,101 @@
 ; POSTUNINSTALL hook runs AFTER Tauri's association cleanup and re-creates the
 ; OS-default ShellNew template. NullFile="" is exactly what Windows ships.
 ;
-; Writing to HKCR adapts to the install context: an elevated (per-machine)
-; uninstaller resolves it to HKLM\Software\Classes (where the OS default lives
-; and where the deletion happened); a per-user uninstaller resolves it to
-; HKCU\Software\Classes (harmless — the machine-wide key was never touched).
+; Cycle 2 of the release-smoke Windows job is the verdict on this line — it
+; deletes ShellNew from both hives before uninstalling, so its presence
+; afterwards can only mean this write landed. That cycle has not yet reached a
+; verdict: the v0.9.66 run failed in cycle 1 on the separate defect below, so
+; this line is still UNVERIFIED on a real Windows build and is deliberately
+; left exactly as it was rather than adjusted on a guess.
 ;
-; NOTE: authored on a macOS-primary dev machine and NOT yet verified against a
-; real Windows build. Confirm the ShellNew entry is restored after a
-; build → install → uninstall cycle on Windows before a release relies on this.
-; Worst case it is a harmless redundant write.
+; ---------------------------------------------------------------------------
+; 2. Drop the empty ProgID the association cleanup leaves behind
+; ---------------------------------------------------------------------------
+;
+; Found by the release-smoke Windows job on v0.9.66, its first ever run:
+;
+;     HKCR\.txt (default) before: 'txtfile'
+;     uninstall changed the .txt association: 'txtfile' -> ''
+;
+; Tauri's macros back up the previous ProgID by reading from the SAME hive they
+; write to (FileAssociation.nsh):
+;
+;     APP_ASSOCIATE:    ReadRegStr  $R0 SHELL_CONTEXT "Software\Classes\.txt" ""
+;                       WriteRegStr     SHELL_CONTEXT "Software\Classes\.txt" "txt_backup" "$R0"
+;     APP_UNASSOCIATE:  ReadRegStr  $R0 SHELL_CONTEXT "Software\Classes\.txt" "txt_backup"
+;                       WriteRegStr     SHELL_CONTEXT "Software\Classes\.txt" "" "$R0"
+;
+; VMark installs per-user, so SHELL_CONTEXT is HKCU — but the machine-wide
+; "txtfile" association lives in HKLM. The backup therefore records "", and the
+; uninstaller writes that empty string back UNCONDITIONALLY. HKEY_CLASSES_ROOT
+; is a merged view in which HKCU wins, so an empty default value sitting in HKCU
+; SHADOWS the real HKLM one: after uninstalling VMark, .txt had no ProgID.
+;
+; A per-machine install does not have the bug — there the backup reads the hive
+; the value actually lives in and restores it correctly. The defect is specific
+; to the per-user mode VMark ships.
+;
+; Deleting the value (rather than writing HKLM's ProgID into HKCU) is what
+; restores the previous state, and the same run proves the fall-through works:
+; after the install, HKCU\Software\Classes\.txt existed and had no ShellNew
+; subkey, yet "after install: HKCR\.txt\ShellNew\NullFile present" still passed
+; — so HKCR merges per ENTRY, and an entry absent from HKCU resolves to HKLM.
+; Writing a copied ProgID instead would leave a stale duplicate behind that no
+; later uninstall owns.
+;
+; Only an EMPTY default is removed. A non-empty one means either the restore
+; genuinely worked (per-machine install) or another application has since
+; claimed the extension; in both cases the value is not ours to touch. The
+; "<ext>_backup" value is deliberately LEFT in place: Tauri derives the file
+; class from the bare extension when a fileAssociation declares no "name", so
+; that value name is not unique to VMark and deleting it could break another
+; Tauri app's own restore. It is inert — with no default value present, the
+; merged view falls through to HKLM regardless.
+;
+; Both hives are repaired because SHCTX is not reliable at this point: the
+; uninstall section runs "SetShellVarContext current" a few lines before the
+; hook when the user ticks "delete application data". Repairing both is
+; idempotent and cannot lose information — an empty default carries none.
+;
+; This must cover EVERY extension in tauri.conf.json's fileAssociations, not
+; just .txt: .html, .htm, .svg and .json all commonly have machine-wide
+; handlers to shadow. scripts/release-smoke-windows-installer.test.mjs reads
+; that list and fails if an extension is missing from the macro below, so a new
+; association cannot silently reintroduce this.
+
+!macro VMARK_UNSHADOW_ASSOCIATION EXT
+  Push $R0
+
+  ReadRegStr $R0 HKCU "Software\Classes\.${EXT}" ""
+  ${If} $R0 == ""
+    DeleteRegValue HKCU "Software\Classes\.${EXT}" ""
+  ${EndIf}
+
+  ReadRegStr $R0 HKLM "Software\Classes\.${EXT}" ""
+  ${If} $R0 == ""
+    DeleteRegValue HKLM "Software\Classes\.${EXT}" ""
+  ${EndIf}
+
+  Pop $R0
+!macroend
 
 !macro NSIS_HOOK_POSTUNINSTALL
   WriteRegStr HKCR ".txt\ShellNew" "NullFile" ""
+
+  ; Keep in sync with fileAssociations in src-tauri/tauri.conf.json.
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "md"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "markdown"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "mdown"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "mkd"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "mdx"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "txt"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "json"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "jsonl"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "yaml"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "yml"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "toml"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "mmd"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "svg"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "html"
+  !insertmacro VMARK_UNSHADOW_ASSOCIATION "htm"
 !macroend


### PR DESCRIPTION
## What this fixes

Uninstalling VMark on Windows wiped file associations it did not own. Measured on a clean runner against the published v0.9.66 installer:

```
.txt  'txtfile'  -> ''
.svg  'svgfile'  -> ''
.html 'htmlfile' -> ''
.htm  'htmlfile' -> ''
after uninstall (cycle 1): uninstall changed 4 of 15 file associations it does not own
```

After uninstalling VMark, double-clicking a `.txt`, `.svg`, `.html` or `.htm` file no longer had a handler.

The Windows release-smoke job that found this shipped in the previous PR and ran for the first time against v0.9.66. **The gate is new; the defect is not** — it has shipped for as long as VMark has declared `fileAssociations`, so v0.9.66 is not a regression against v0.9.65.

The job's original check compared `.txt` alone. Generalising it to the whole claimed set is what turned one visible symptom into the **four** above; three of them would have gone unfixed.

## Mechanism

Read out of `tauri-bundler`'s `FileAssociation.nsh`, not inferred. Both macros back up the previous ProgID by reading from the **same hive they write to**:

```nsis
APP_ASSOCIATE    ReadRegStr  $R0 SHELL_CONTEXT "Software\Classes\.txt" ""
                 WriteRegStr     SHELL_CONTEXT "Software\Classes\.txt" "txt_backup" "$R0"
APP_UNASSOCIATE  ReadRegStr  $R0 SHELL_CONTEXT "Software\Classes\.txt" "txt_backup"
                 WriteRegStr     SHELL_CONTEXT "Software\Classes\.txt" "" "$R0"
```

VMark installs per-user, so `SHELL_CONTEXT` is HKCU — but the machine-wide `txtfile` association lives in **HKLM**. The backup therefore records `""`, and the uninstaller writes that empty string back unconditionally. `HKEY_CLASSES_ROOT` is a merged view in which HKCU wins, so an empty default in HKCU **shadows** the real HKLM one.

A per-machine install does not have the bug: there the backup reads the hive the value actually lives in.

## Why deleting, not restoring

The fix deletes the empty default in `NSIS_HOOK_POSTUNINSTALL`, which Tauri inserts after the unassociate loop. The same run proves the fall-through works: after the install, `HKCU\Software\Classes\.txt` existed with **no** `ShellNew` subkey, yet `after install: HKCR\.txt\ShellNew\NullFile present` still passed — so HKCR merges per *entry*, and an entry absent from HKCU resolves to HKLM. Copying HKLM's ProgID into HKCU instead would leave a stale duplicate that no later uninstall owns.

Three deliberate narrowings, each of which would be a regression if widened:

| Narrowing | Why |
|---|---|
| Only an **empty** default is removed | A non-empty one means the restore genuinely worked, or another app has claimed the extension |
| `<ext>_backup` is **left in place** | Tauri derives the file class from the bare extension when an association declares no `name`, so that value name is not unique to VMark; deleting it could break another Tauri app's restore. It is inert once the default is gone |
| The #1142 `ShellNew` line is **untouched** | Cycle 2 is the only thing that can give it a verdict and has not reached one yet. Not adjusted on a guess |

All 15 claimed extensions are covered, not just `.txt` — `.html`, `.htm`, `.svg` and `.json` also commonly have a machine-wide handler to shadow. Both hives are repaired, because the uninstall section runs `SetShellVarContext current` a few lines before the hook when the user ticks "delete application data", so `SHCTX` is not reliable there.

## The assertion, which is the part that keeps this fixed

The smoke job now compares **every** claimed extension's ProgID across the uninstall, in both cycles, instead of `.txt` alone. `scripts/release-smoke-windows-installer.test.mjs` joins three surfaces no compiler connects — the hook's macro calls, the job's literal extension list, and `fileAssociations` in `tauri.conf.json` — and fails in **both** directions if any two disagree.

Verified by mutation: dropping `.svg` from the hook, removing the emptiness guard, drifting the job's list, and deleting the per-line log each fail exactly one test, and the tree is green with all four reverted.

## Two process notes from writing it

- The first mutation run reported a pass while changing nothing: `grep` on the dev machine is a **ugrep** shim, which reads `foreach ($line in $broken)` as an ERE, so the pattern matched no line and the file was copied through unaltered. A mutation that silently does nothing looks exactly like a detector that works.
- PowerShell elides a long exception message, so the first dispatched run cut the damaged list off after two entries — it proved damage existed but hid how much. The list now reaches the log line by line before the throw.

## Verification

`pnpm check:predelta` 44/44 · the smoke self-test 15/15 · four mutations confirmed to fail · the new PowerShell **executed on a real Windows runner** via `workflow_dispatch` against the published v0.9.66 installer, which is how the blast radius was measured rather than reasoned about.

The fix itself is confirmed by the smoke job on the next release — that job is the verifier, and it is currently red against v0.9.66 by design.
