### PR TITLE
chore: bump version to 0.9.67

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.66",
+  "version": "0.9.67",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.66",
+  "version": "0.9.67",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.66';
+const VERSION = '0.9.67';
 
 /**
  * WHY `process.exitCode` AND NOT `process.exit()` ON THESE PATHS.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6415,7 +6415,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.66"
+version = "0.9.67"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.66"
+version = "0.9.67"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.66",
+  "version": "0.9.67",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Bumps to 0.9.67 across the five files rule 40 names, with `src-tauri/Cargo.lock` regenerated.

## What this releases

The Windows uninstaller fix from #1381. Measured against the published v0.9.66 installer on a real Windows runner:

```
.txt  'txtfile'  -> ''
.svg  'svgfile'  -> ''
.html 'htmlfile' -> ''
.htm  'htmlfile' -> ''
uninstall changed 4 of 15 file associations it does not own
```

Uninstalling VMark left those four extensions with no handler. Tauri's `APP_UNASSOCIATE` writes back a ProgID it backed up from the hive it writes to — HKCU for a per-user install — while the real association lives in HKLM. The backup captures `""`, and that empty value shadows HKLM in the merged HKCR view.

The gate that caught it is new; the defect is not. It shipped for as long as VMark has declared `fileAssociations`.

## Why this is a standalone bump PR

`main` already carries the change being released, which rule 40 names as the case where a standalone bump is correct rather than the fallback.

## Why the tag matters here

The release-smoke Windows job runs only against a **published** release, so it is the only thing that can verify this fix. It is currently red against v0.9.66 by design. This tag is what turns the fix from written to proven.

## Gates

`pnpm check:predelta` 44/44 · `cargo --locked` accepts the lockfile · all five version strings verified at 0.9.67 · secret scan clean.
