### PR TITLE
docs(windows): record the verdict both files said was still missing

### DIFF
--- a/scripts/release-smoke-windows-installer.test.mjs
+++ b/scripts/release-smoke-windows-installer.test.mjs
@@ -5,19 +5,25 @@
  *
  * `src-tauri/windows/installer-hooks.nsh` restores `HKCR\.txt\ShellNew` — the
  * key behind "New > Text Document" for EVERY application — after a VMark
- * uninstall once removed it (#1142). It was authored on macOS and its own
- * header says it was never run on Windows. This job runs the shipped
+ * uninstall once removed it (#1142). It was authored on macOS and had never
+ * run on Windows until this job put it on one. This job runs the shipped
  * installer through install → uninstall, from the outside, and reads the
  * registry back.
  *
  * Two cycles, because the current Tauri uninstaller does NOT delete ShellNew
  * on its own, so a plain cycle cannot show the hook doing anything:
  *
- *   1. plain — after uninstall the ShellNew key is present and the `.txt`
- *      association is what it was before the install (no collateral damage);
+ *   1. plain — after uninstall EVERY claimed association is what it was
+ *      before the install (no collateral damage), and ShellNew is present;
  *   2. the #1142 damage first — the machine-wide ShellNew key is deleted
  *      before the uninstall, so its presence afterwards can only mean the
  *      POSTUNINSTALL hook wrote it.
+ *
+ * Both cycles reported for the first time on v0.9.67 (run 34313339017). What
+ * the first execution found, on v0.9.66, is why cycle 1 now compares the whole
+ * claimed set rather than `.txt` alone: the uninstaller was wiping FOUR
+ * associations it does not own — `.txt`, `.svg`, `.html`, `.htm` — and a
+ * `.txt`-only assertion would have reported one of them.
  *
  * Pinned here: the job exists on windows-latest and is independent of the
  * macOS job; the installer is downloaded by its `-setup.exe` name; install and

--- a/src-tauri/windows/installer-hooks.nsh
+++ b/src-tauri/windows/installer-hooks.nsh
@@ -21,12 +21,16 @@
 ; POSTUNINSTALL hook runs AFTER Tauri's association cleanup and re-creates the
 ; OS-default ShellNew template. NullFile="" is exactly what Windows ships.
 ;
-; Cycle 2 of the release-smoke Windows job is the verdict on this line — it
-; deletes ShellNew from both hives before uninstalling, so its presence
-; afterwards can only mean this write landed. That cycle has not yet reached a
-; verdict: the v0.9.66 run failed in cycle 1 on the separate defect below, so
-; this line is still UNVERIFIED on a real Windows build and is deliberately
-; left exactly as it was rather than adjusted on a guess.
+; VERIFIED on Windows for the first time on 2026-09-09, against v0.9.67:
+; cycle 2 of the release-smoke Windows job deletes ShellNew from BOTH hives
+; before uninstalling, so its presence afterwards can only mean this write
+; landed — and it was present. Run 34313339017,
+; "after uninstall (cycle 2): restored by the POSTUNINSTALL hook".
+;
+; That closes the caveat this header carried from the day it was written: the
+; hook was authored on a macOS-primary machine and, until that run, had never
+; executed on Windows at all. The v0.9.66 run could not reach cycle 2 — it
+; failed in cycle 1 on the separate defect below.
 ;
 ; ---------------------------------------------------------------------------
 ; 2. Drop the empty ProgID the association cleanup leaves behind


### PR DESCRIPTION
Comment-only. The v0.9.67 release-smoke run ([34313339017](https://github.com/xiaolai/vmark/actions/runs/34313339017)) reported both cycles, so two comments of mine became false.

```
after uninstall (cycle 1): all 15 claimed associations unchanged
removed .txt\ShellNew (the #1142 damage)
after uninstall (cycle 2): restored by the POSTUNINSTALL hook: HKCR\.txt\ShellNew\NullFile present
```

**`installer-hooks.nsh`** said the #1142 ShellNew line was "still UNVERIFIED on a real Windows build". It is verified now. Cycle 2 deletes that key from both hives before uninstalling, so its presence afterwards can only mean the POSTUNINSTALL hook wrote it. This closes a caveat the file had carried since it was written: authored on a macOS-primary machine, never executed on Windows.

**The test header** said the hook "was never run on Windows" — true when written, the opposite of what happened. It now also records what the first execution found, because that is the part worth keeping: the job's original `.txt`-only assertion would have caught one of the four associations the uninstaller was wiping, and generalising it to the whole claimed set is what found `.svg`, `.html` and `.htm`.

No assertion changed. Verified: smoke self-test 15/15, `check:predelta` 44/44 — both of which read these files.
