### PR TITLE
chore: bump version to 0.9.68

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.67",
+  "version": "0.9.68",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.67';
+const VERSION = '0.9.68';
 
 /**
  * WHY `process.exitCode` AND NOT `process.exit()` ON THESE PATHS.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6418,7 +6418,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.67"
+version = "0.9.68"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.67"
+version = "0.9.68"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Bumps to 0.9.68 across the five files rule 40 names, with `src-tauri/Cargo.lock` regenerated.

## What this releases

**#1385 — the CJK formatter no longer corrupts HTML character references.** With **Normalize punctuation width** on (the default), Format CJK File rewrote the semicolon terminating a character reference whenever CJK followed it:

```diff
- **满足自己的需求。**&#x5176;实
+ **满足自己的需求。**&#x5176；实
```

The result parses as literal text and is backslash-escaped on the next save. Reachable without ever typing an entity, because the WYSIWYG serializer emits one at a strong/emphasis delimiter boundary. Reported in #1382 with a diagnosis that held on every point.

**#1386 — the Window Status panel gets `Ctrl+Shift+5`, in the View menu.** The original contribution (thanks @GoodeSam) put the accelerator on a menu item living in `build_window_menu`, which is `#[cfg(target_os = "macos")]` — so the chord would have shipped to every platform while the menu entry existed only on macOS.

## Not in this release

**#1378 is not fixed by it.** That report looks adjacent to the v0.9.67 uninstall fix but is a different path: the NSIS installer's `APP_ASSOCIATE` overwrites the merged `HKCR\.txt` default with VMark's own ProgID at install time. Whether a markdown editor should claim `.txt` at all is a product decision, not a defect fix, so it is deliberately not folded in here.

## Why a standalone bump PR

`main` already carries both changes, which rule 40 names as the case where a standalone bump is correct rather than the fallback.

## Gates

`cargo --locked` accepts the lockfile · all five version strings verified at 0.9.68 · secret scan clean.
