### PR TITLE
ci(release-smoke): record what the install claims, not just the round-trip

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -395,6 +395,20 @@ jobs:
           # Cycle 1 - plain: the uninstaller must leave the system as it found it.
           $entry = Install-Silently
           Assert-ShellNew 'after install'
+
+          # Diagnostic, not an assertion. The job asserts the uninstall
+          # ROUND-TRIP, so it never recorded what the install itself does to
+          # these keys — and issue #1378 is a report about exactly that. What
+          # the installer claims is a product question (Tauri's APP_ASSOCIATE
+          # always overwrites the default; it has no "add to Open With" mode),
+          # so this reports rather than fails, and the next report about
+          # install-time association changes has evidence instead of inference.
+          $afterInstall = Get-AssocDefaults
+          foreach ($ext in $assocExts) {
+            if ($afterInstall[$ext] -ne $assocBefore[$ext]) {
+              Write-Host "  install claimed .$ext : '$($assocBefore[$ext])' -> '$($afterInstall[$ext])'"
+            }
+          }
           Uninstall-Silently $entry
           Assert-ShellNew 'after uninstall (cycle 1)'
           Assert-AssocRestored $assocBefore 'after uninstall (cycle 1)'


### PR DESCRIPTION
The Windows smoke job asserted the uninstall **round-trip** — every claimed association is what it was before the install. It never recorded what the *install itself* does to those keys, so #1378 could only be answered by reading Tauri's NSIS source rather than by observing the shipped installer.

This logs the difference after the install in cycle 1. Dispatched against the published v0.9.68 installer, it produced the answer immediately:

```
install claimed .txt  : 'txtfile'  -> 'txt'
install claimed .svg  : 'svgfile'  -> 'svg'
install claimed .html : 'htmlfile' -> 'html'
install claimed .htm  : 'htmlfile' -> 'htm'
after install: HKCR\.txt\ShellNew\NullFile present
```

That confirms #1378's core claim and shows it is broader than reported — `.svg` and `.html`/`.htm` are taken over too — while also showing `ShellNew` is **not** deleted, which is what the report's second half assumed.

**Deliberately a diagnostic, not an assertion.** Tauri's `APP_ASSOCIATE` always overwrites the extension's default ProgID and offers no "add to Open With without taking over" mode, so what VMark *should* claim is a product decision. Failing the job here would assert an answer nobody has chosen yet.

Verified: the gates-tier self-test still passes 15/15, and the dispatched run against v0.9.68 was green.
