### PR TITLE
fix: four reported defects, and a gate that could not tell a comment from a colour

### DIFF
--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -97,6 +97,26 @@ function selectorsOf(raw) {
  * @param {string} css
  * @returns {{ selector: string, line: number }[]}
  */
+/**
+ * Replace every CSS comment with spaces of the same length.
+ *
+ * The pattern checks below scan for things that look like declarations, and a
+ * comment is prose. `#1376` in a comment citing a GitHub issue was reported as
+ * a "Hardcoded hex color" with the advice "Use CSS variable token instead" —
+ * advice that cannot be followed, on a line that declares nothing. rule 31
+ * already records this false-positive shape for the sibling ui-tokenize tool.
+ *
+ * SPACES rather than deletion: the checks derive a line number by counting
+ * newlines before the match offset, so removing text would slide every
+ * subsequent violation onto the wrong line. Newlines inside the comment are
+ * preserved for the same reason.
+ */
+export function blankComments(css) {
+  return css.replace(/\/\*[\s\S]*?\*\//g, (s) =>
+    s.replace(/[^\n]/g, " "),
+  );
+}
+
 export function findFocusRemovals(css) {
   const rules = [];
   const ruleRe = /([^{}]*)\{([^}]*)\}/g;
@@ -276,14 +296,18 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
       });
     }
 
+    // Comments are prose, not declarations: scan with them blanked out, and
+    // with offsets preserved so line numbers still point at the violation.
+    const scannable = blankComments(content);
+
     for (const check of checks) {
       // Skip excluded files
       if (check.exclude?.some((re) => re.test(file))) continue;
 
       let match;
-      while ((match = check.pattern.exec(content)) !== null) {
+      while ((match = check.pattern.exec(scannable)) !== null) {
         // Get line number
-        const lines = content.slice(0, match.index).split("\n");
+        const lines = scannable.slice(0, match.index).split("\n");
         const line = lines.length;
 
         violations.push({

--- a/scripts/check-design-tokens.test.ts
+++ b/scripts/check-design-tokens.test.ts
@@ -20,6 +20,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  blankComments,
   collectJsDefinedVars,
   findFocusRemovals,
   globFiles,
@@ -466,5 +467,37 @@ describe("the CLI in fixture mode", () => {
       status = (e as { status?: number }).status ?? -1;
     }
     expect(status).not.toBe(0);
+  });
+});
+
+describe("blankComments", () => {
+  // A CSS comment is prose, and the pattern checks must not read it as code.
+  // `#1376` in a comment citing a GitHub issue was reported as a "Hardcoded hex
+  // color" with the advice "Use CSS variable token instead" — advice that
+  // cannot be followed, on a line that declares nothing. rule 31 already
+  // records this false-positive shape for the sibling ui-tokenize tool.
+  it("hides an issue reference that looks like a hex colour", () => {
+    const css = "/* see #1376 */\n.a { color: var(--x); }\n";
+    expect(blankComments(css)).not.toContain("#1376");
+  });
+
+  it("leaves a real declaration alone", () => {
+    const css = ".a { color: #ff0000; }";
+    expect(blankComments(css)).toContain("#ff0000");
+  });
+
+  it("preserves offsets so reported line numbers stay correct", () => {
+    // Blanking with spaces rather than deleting is what keeps the violation's
+    // line number pointing at the violation.
+    const css = "/* multi\nline */\n.a { color: #ff0000; }";
+    const blanked = blankComments(css);
+    expect(blanked).toHaveLength(css.length);
+    expect(blanked.slice(0, css.indexOf("\n.a")).trim()).toBe("");
+    expect(blanked.split("\n")).toHaveLength(css.split("\n").length);
+  });
+
+  it("handles a comment containing a brace, which a naive strip would truncate", () => {
+    const css = "/* the `{a}` case */\n.a { color: #ff0000; }";
+    expect(blankComments(css)).toContain("#ff0000");
   });
 });

--- a/scripts/release-smoke-windows-installer.test.mjs
+++ b/scripts/release-smoke-windows-installer.test.mjs
@@ -211,6 +211,57 @@ describe("installer-hooks.nsh: the association un-shadow", () => {
     expect(hooks).toMatch(/WriteRegStr HKCR "\.txt\\ShellNew" "NullFile" ""/);
   });
 
+  it("yields the default back to an existing handler on install (#1378)", () => {
+    // Measured on a clean Windows runner against the published v0.9.68
+    // installer: `APP_ASSOCIATE` took the default ProgID for FOUR extensions
+    // that already had a system handler.
+    //
+    //   .txt  'txtfile'  -> 'txt'
+    //   .svg  'svgfile'  -> 'svg'
+    //   .html 'htmlfile' -> 'html'
+    //   .htm  'htmlfile' -> 'htm'
+    //
+    // A markdown editor displacing Notepad and the browser is not something a
+    // user asked for by installing it. The POSTINSTALL hook gives the default
+    // back wherever HKLM already names a handler, and keeps VMark reachable
+    // through Open With instead.
+    const macro = hooks.match(/!macro VMARK_YIELD_EXISTING_HANDLER[\s\S]*?!macroend/);
+    expect(macro, "no VMARK_YIELD_EXISTING_HANDLER macro").not.toBeNull();
+    const body = macro[0];
+
+    // The condition is "HKLM already has one", not a hardcoded extension list:
+    // a machine where some other app owns .json must keep that too.
+    expect(body).toMatch(/ReadRegStr \$R0 HKLM "Software\\Classes\\\.\$\{EXT\}" ""/);
+    expect(body).toMatch(/\$\{If\} \$R0 != ""/);
+    expect(body).toMatch(/DeleteRegValue HKCU "Software\\Classes\\\.\$\{EXT\}" ""/);
+
+    // Yielding the default must not make VMark unreachable: OpenWithProgids is
+    // the documented way to stay in the Open With list without being default.
+    expect(
+      body,
+      "without OpenWithProgids, yielding the default also removes VMark from " +
+        "the Open With list for that extension",
+    ).toMatch(/OpenWithProgids/);
+
+    // And it must be called for every claimed extension, like its sibling.
+    const called = [...hooks.matchAll(/!insertmacro VMARK_YIELD_EXISTING_HANDLER "([^"]+)"/g)].map(
+      (m) => m[1],
+    );
+    expect(called.slice().sort()).toEqual(CLAIMED_EXTS.slice().sort());
+  });
+
+  it("runs the yield from POSTINSTALL, which is after Tauri's associate loop", () => {
+    // Order is the whole mechanism: tauri-bundler inserts NSIS_HOOK_POSTINSTALL
+    // at the end of the install section, after the APP_ASSOCIATE loop, so the
+    // hook can undo the overwrite. Called from POSTUNINSTALL it would do
+    // nothing on install at all.
+    const post = hooks.match(/!macro NSIS_HOOK_POSTINSTALL[\s\S]*?!macroend/);
+    expect(post, "no NSIS_HOOK_POSTINSTALL macro").not.toBeNull();
+    expect(post[0]).toMatch(/VMARK_YIELD_EXISTING_HANDLER/);
+    // The un-shadow belongs to uninstall and must not migrate here.
+    expect(post[0]).not.toMatch(/VMARK_UNSHADOW_ASSOCIATION/);
+  });
+
   it("does not delete the _backup value another Tauri app may own", () => {
     // Tauri derives the file class from the bare extension when a
     // fileAssociation declares no `name`, so "txt_backup" is not unique to

--- a/src-tauri/locales/de.yml
+++ b/src-tauri/locales/de.yml
@@ -305,6 +305,8 @@ errors:
   save.noParentDirectory: "Der Dateipfad hat keinen übergeordneten Ordner"
   save.symlinkLoop: "Der Alias dieser Datei verweist im Kreis, daher wurde die eigentliche Datei nicht gefunden"
   save.writeFailed: "Datei konnte nicht gespeichert werden: %{detail}"
+  window.pdfExportMenu: "Das Export-PDF-Fenster konnte keine leere Menüleiste erhalten: %{detail}"
+  window.pdfExportCreate: "Das Export-PDF-Fenster konnte nicht geöffnet werden: %{detail}"
   save.taskFailed: "Der Speichervorgang wurde unerwartet beendet: %{detail}"
 
   # === Integrierter Browser, KI-Navigation (browser/ai_commands.rs, WI-14) ===
@@ -405,6 +407,7 @@ errors:
 
 window:
   settings.title: "Einstellungen"
+  pdfExport.title: "PDF exportieren"
   print.title: "VMark – Drucken"
 
 cli:

--- a/src-tauri/locales/en.yml
+++ b/src-tauri/locales/en.yml
@@ -306,6 +306,8 @@ errors:
   save.noParentDirectory: "The file path has no containing folder"
   save.symlinkLoop: "This file's alias points in a circle, so the real file could not be found"
   save.writeFailed: "Could not save the file: %{detail}"
+  window.pdfExportMenu: "The Export PDF window could not be given an empty menu bar: %{detail}"
+  window.pdfExportCreate: "The Export PDF window could not be opened: %{detail}"
   save.taskFailed: "The save task ended unexpectedly: %{detail}"
 
   # === Embedded browser, AI navigation (browser/ai_commands.rs, WI-14) ===
@@ -406,6 +408,7 @@ errors:
 
 window:
   settings.title: "Settings"
+  pdfExport.title: "Export PDF"
   print.title: "VMark Print"
 
 cli:

--- a/src-tauri/locales/es.yml
+++ b/src-tauri/locales/es.yml
@@ -305,6 +305,8 @@ errors:
   save.noParentDirectory: "La ruta del archivo no tiene carpeta contenedora"
   save.symlinkLoop: "El alias de este archivo apunta en círculo, así que no se encontró el archivo real"
   save.writeFailed: "No se pudo guardar el archivo: %{detail}"
+  window.pdfExportMenu: "No se pudo asignar una barra de menús vacía a la ventana Exportar PDF: %{detail}"
+  window.pdfExportCreate: "No se pudo abrir la ventana Exportar PDF: %{detail}"
   save.taskFailed: "La tarea de guardado terminó inesperadamente: %{detail}"
 
   # === Navegador integrado, navegación de la IA (browser/ai_commands.rs, WI-14) ===
@@ -405,6 +407,7 @@ errors:
 
 window:
   settings.title: "Ajustes"
+  pdfExport.title: "Exportar PDF"
   print.title: "VMark: imprimir"
 
 cli:

--- a/src-tauri/locales/fr.yml
+++ b/src-tauri/locales/fr.yml
@@ -305,6 +305,8 @@ errors:
   save.noParentDirectory: "Le chemin du fichier n'a pas de dossier parent"
   save.symlinkLoop: "L'alias de ce fichier pointe en boucle, le fichier réel est donc introuvable"
   save.writeFailed: "Impossible d'enregistrer le fichier : %{detail}"
+  window.pdfExportMenu: "Impossible d'attribuer une barre de menus vide à la fenêtre Exporter en PDF : %{detail}"
+  window.pdfExportCreate: "Impossible d'ouvrir la fenêtre Exporter en PDF : %{detail}"
   save.taskFailed: "La tâche d'enregistrement s'est terminée de manière inattendue : %{detail}"
 
   # === Navigateur intégré, navigation de l'IA (browser/ai_commands.rs, WI-14) ===
@@ -405,6 +407,7 @@ errors:
 
 window:
   settings.title: "Réglages"
+  pdfExport.title: "Exporter en PDF"
   print.title: "VMark – Impression"
 
 cli:

--- a/src-tauri/locales/it.yml
+++ b/src-tauri/locales/it.yml
@@ -305,6 +305,8 @@ errors:
   save.noParentDirectory: "Il percorso del file non ha una cartella superiore"
   save.symlinkLoop: "L'alias di questo file punta in circolo, quindi il file reale non è stato trovato"
   save.writeFailed: "Impossibile salvare il file: %{detail}"
+  window.pdfExportMenu: "Impossibile assegnare una barra dei menu vuota alla finestra Esporta PDF: %{detail}"
+  window.pdfExportCreate: "Impossibile aprire la finestra Esporta PDF: %{detail}"
   save.taskFailed: "L'attività di salvataggio è terminata in modo imprevisto: %{detail}"
 
   # === Browser integrato, navigazione dell'IA (browser/ai_commands.rs, WI-14) ===
@@ -405,6 +407,7 @@ errors:
 
 window:
   settings.title: "Impostazioni"
+  pdfExport.title: "Esporta PDF"
   print.title: "VMark – Stampa"
 
 cli:

--- a/src-tauri/locales/ja.yml
+++ b/src-tauri/locales/ja.yml
@@ -305,6 +305,8 @@ errors:
   save.noParentDirectory: "ファイルパスに親フォルダがありません"
   save.symlinkLoop: "このファイルのエイリアスが循環しているため、実際のファイルが見つかりませんでした"
   save.writeFailed: "ファイルを保存できませんでした: %{detail}"
+  window.pdfExportMenu: "PDF 書き出しウィンドウに空のメニューバーを設定できませんでした: %{detail}"
+  window.pdfExportCreate: "PDF 書き出しウィンドウを開けませんでした: %{detail}"
   save.taskFailed: "保存タスクが予期せず終了しました: %{detail}"
 
   # === 内蔵ブラウザ、AI ナビゲーション（browser/ai_commands.rs、WI-14）===
@@ -405,6 +407,7 @@ errors:
 
 window:
   settings.title: "設定"
+  pdfExport.title: "PDF を書き出す"
   print.title: "VMark 印刷"
 
 cli:

--- a/src-tauri/locales/ko.yml
+++ b/src-tauri/locales/ko.yml
@@ -305,6 +305,8 @@ errors:
   save.noParentDirectory: "파일 경로에 상위 폴더가 없습니다"
   save.symlinkLoop: "이 파일의 별칭이 순환하고 있어 실제 파일을 찾을 수 없습니다"
   save.writeFailed: "파일을 저장하지 못했습니다: %{detail}"
+  window.pdfExportMenu: "PDF 내보내기 창에 빈 메뉴 막대를 설정하지 못했습니다: %{detail}"
+  window.pdfExportCreate: "PDF 내보내기 창을 열지 못했습니다: %{detail}"
   save.taskFailed: "저장 작업이 예기치 않게 종료되었습니다: %{detail}"
 
   # === 내장 브라우저, AI 탐색 (browser/ai_commands.rs, WI-14) ===
@@ -405,6 +407,7 @@ errors:
 
 window:
   settings.title: "설정"
+  pdfExport.title: "PDF 내보내기"
   print.title: "VMark 인쇄"
 
 cli:

--- a/src-tauri/locales/pt-BR.yml
+++ b/src-tauri/locales/pt-BR.yml
@@ -305,6 +305,8 @@ errors:
   save.noParentDirectory: "O caminho do arquivo não tem pasta superior"
   save.symlinkLoop: "O atalho deste arquivo aponta em círculo, então o arquivo real não foi encontrado"
   save.writeFailed: "Não foi possível salvar o arquivo: %{detail}"
+  window.pdfExportMenu: "Não foi possível dar uma barra de menus vazia à janela Exportar PDF: %{detail}"
+  window.pdfExportCreate: "Não foi possível abrir a janela Exportar PDF: %{detail}"
   save.taskFailed: "A tarefa de salvamento terminou inesperadamente: %{detail}"
 
   # === Navegador integrado, navegação da IA (browser/ai_commands.rs, WI-14) ===
@@ -405,6 +407,7 @@ errors:
 
 window:
   settings.title: "Configurações"
+  pdfExport.title: "Exportar PDF"
   print.title: "VMark – Imprimir"
 
 cli:

--- a/src-tauri/locales/zh-CN.yml
+++ b/src-tauri/locales/zh-CN.yml
@@ -305,6 +305,8 @@ errors:
   save.noParentDirectory: "文件路径没有上级文件夹"
   save.symlinkLoop: "此文件的替身指向形成循环，因此找不到真正的文件"
   save.writeFailed: "无法保存文件：%{detail}"
+  window.pdfExportMenu: "无法为导出 PDF 窗口设置空菜单栏：%{detail}"
+  window.pdfExportCreate: "无法打开导出 PDF 窗口：%{detail}"
   save.taskFailed: "保存任务意外结束：%{detail}"
 
   # === 内置浏览器，AI 导航（browser/ai_commands.rs，WI-14）===
@@ -405,6 +407,7 @@ errors:
 
 window:
   settings.title: "设置"
+  pdfExport.title: "导出 PDF"
   print.title: "VMark 打印"
 
 cli:

--- a/src-tauri/locales/zh-TW.yml
+++ b/src-tauri/locales/zh-TW.yml
@@ -305,6 +305,8 @@ errors:
   save.noParentDirectory: "檔案路徑沒有上層資料夾"
   save.symlinkLoop: "此檔案的替身指向形成循環，因此找不到真正的檔案"
   save.writeFailed: "無法儲存檔案：%{detail}"
+  window.pdfExportMenu: "無法為匯出 PDF 視窗設定空選單列：%{detail}"
+  window.pdfExportCreate: "無法開啟匯出 PDF 視窗：%{detail}"
   save.taskFailed: "儲存工作意外結束：%{detail}"
 
   # === 內建瀏覽器，AI 導覽（browser/ai_commands.rs，WI-14）===
@@ -405,6 +407,7 @@ errors:
 
 window:
   settings.title: "設定"
+  pdfExport.title: "匯出 PDF"
   print.title: "VMark 列印"
 
 cli:

--- a/src-tauri/src/command_registry.rs
+++ b/src-tauri/src/command_registry.rs
@@ -68,6 +68,7 @@ macro_rules! all_commands {
             window_manager::open_file_in_new_window,
             window_manager::open_workspace_in_new_window,
             window_manager::open_workspace_with_files_in_new_window,
+            window_manager::open_pdf_export_window,
             window_manager::open_settings_window,
             window_manager::set_native_theme,
             window_manager::close_window,

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -54,6 +54,7 @@ mod file_open_state;
 mod finder_open_delivery;
 mod native_theme;
 mod path_validation;
+mod pdf_export_window;
 mod settings_window;
 #[cfg(target_os = "macos")]
 mod traffic_lights;
@@ -68,6 +69,7 @@ pub use file_open_state::*;
 // (#1330), and this is where it delivers.
 pub(crate) use finder_open_delivery::*;
 pub use native_theme::*;
+pub use pdf_export_window::*;
 pub use settings_window::*;
 #[cfg(target_os = "macos")]
 pub(crate) use traffic_lights::*;

--- a/src-tauri/src/window_manager/pdf_export_window.rs
+++ b/src-tauri/src/window_manager/pdf_export_window.rs
@@ -1,0 +1,132 @@
+//! Export-PDF window: built in Rust so it can be given an EMPTY menu.
+//!
+//! Key decision: this window is created here rather than from the frontend
+//! (#1377). It used to be `new WebviewWindow("pdf-export", …)` in
+//! `services/navigation/pdfExportWindow.ts`, and Tauri's JS window options
+//! carry no `menu` field — so on Linux and Windows, where the menu bar belongs
+//! to each window rather than to the app, a 440x640 utility dialog opened with
+//! the whole File/Edit/Format/Insert/View/Help bar attached. None of those
+//! actions apply to it.
+//!
+//! The Settings window never had that problem because it is built in Rust and
+//! passes `.menu(Menu::new(app)?)` — an empty menu — under
+//! `cfg(not(target_os = "macos"))`. That is the mechanism, and this file exists
+//! to reuse it.
+//!
+//! On macOS the menu bar is app-global, so there is nothing to suppress and no
+//! `.menu()` call — passing one there would replace the application menu.
+//!
+//! Key decision: `(async)`, like every other window-creating command here. A
+//! sync command runs on the thread that delivered the IPC message, which on
+//! Windows is inside WebView2's `WebMessageReceived` callback, and building a
+//! webview there is the reentrancy case WebView2 forbids (#1301, #1302). See
+//! `window_manager/mod.rs`.
+//!
+//! Key decision: the singleton is CLOSE-then-recreate, not focus-existing. The
+//! window renders one specific document's HTML, handed to it as a temp-file
+//! path, so re-focusing a stale one would show the previous export. This
+//! preserves the behaviour the TypeScript had.
+//!
+//! @coordinates-with services/navigation/pdfExportWindow.ts — the caller
+//! @coordinates-with pdf_export/renderer/progress.rs — PROGRESS_WINDOW is this label
+
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+
+use crate::command_error::{CommandError, ErrorCode};
+use crate::localized_error;
+
+/// The window label. `pdf_export::renderer::progress` emits to this same name,
+/// and `app_plugins.rs` denylists it from window-state persistence.
+pub const PDF_EXPORT_LABEL: &str = "pdf-export";
+
+const PDF_EXPORT_WIDTH: f64 = 440.0;
+const PDF_EXPORT_HEIGHT: f64 = 640.0;
+const PDF_EXPORT_MIN_WIDTH: f64 = 380.0;
+const PDF_EXPORT_MIN_HEIGHT: f64 = 480.0;
+
+/// Build the page URL. Both values are percent-encoded, so a path or document
+/// title containing `&`, `?` or `#` cannot corrupt the query or append a
+/// fragment — the same reasoning as `settings_url`.
+fn pdf_export_url(html_path: &str, default_name: Option<&str>) -> String {
+    let mut url = format!("/pdf-export?htmlPath={}", urlencoding::encode(html_path));
+    if let Some(name) = default_name.filter(|n| !n.is_empty()) {
+        url.push_str(&format!("&defaultName={}", urlencoding::encode(name)));
+    }
+    url
+}
+
+/// Open the Export PDF window on `html_path`, replacing any existing one.
+///
+/// `x`/`y` are logical coordinates for centring over the calling window; when
+/// absent the window centres itself. Tauri decides between explicit placement
+/// and its own default by whether a position was set at all, so the two are
+/// mutually exclusive rather than both being applied.
+#[tauri::command(async)]
+pub fn open_pdf_export_window(
+    app: AppHandle,
+    html_path: String,
+    default_name: Option<String>,
+    x: Option<f64>,
+    y: Option<f64>,
+) -> Result<String, CommandError> {
+    // Close any previous export window first: it holds the PREVIOUS document's
+    // rendered HTML, so focusing it would silently export the wrong file.
+    if let Some(existing) = app.get_webview_window(PDF_EXPORT_LABEL) {
+        let _ = existing.close();
+    }
+
+    let url = pdf_export_url(&html_path, default_name.as_deref());
+    let title = rust_i18n::t!("window.pdfExport.title").to_string();
+
+    let mut builder =
+        WebviewWindowBuilder::new(&app, PDF_EXPORT_LABEL, WebviewUrl::App(url.into()))
+            .title(&title)
+            .inner_size(PDF_EXPORT_WIDTH, PDF_EXPORT_HEIGHT)
+            .min_inner_size(PDF_EXPORT_MIN_WIDTH, PDF_EXPORT_MIN_HEIGHT)
+            .resizable(true)
+            .theme(Some(super::current_theme()))
+            .focused(true);
+
+    builder = match (x, y) {
+        (Some(x), Some(y)) => builder.position(x, y),
+        _ => builder.center(),
+    };
+
+    #[cfg(target_os = "macos")]
+    {
+        builder = builder
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .hidden_title(true)
+            // A runtime-built window does not inherit tauri.conf.json's window
+            // entry, so the buttons have to be placed here too.
+            .traffic_light_position(super::TRAFFIC_LIGHT_POSITION);
+    }
+
+    // THE FIX for #1377. Off macOS the menu bar is per-window, so a window
+    // built without one inherits the application menu. An empty menu is what
+    // the Settings window uses to stay bare.
+    #[cfg(not(target_os = "macos"))]
+    {
+        builder = builder.menu(tauri::menu::Menu::new(&app).map_err(|e| {
+            localized_error!(
+                ErrorCode::Internal,
+                "errors.window.pdfExportMenu",
+                detail = e.to_string()
+            )
+        })?);
+    }
+
+    builder.build().map_err(|e| {
+        localized_error!(
+            ErrorCode::Internal,
+            "errors.window.pdfExportCreate",
+            detail = e.to_string()
+        )
+    })?;
+
+    Ok(PDF_EXPORT_LABEL.to_string())
+}
+
+#[cfg(test)]
+#[path = "pdf_export_window.test.rs"]
+mod tests;

--- a/src-tauri/src/window_manager/pdf_export_window.test.rs
+++ b/src-tauri/src/window_manager/pdf_export_window.test.rs
@@ -1,0 +1,99 @@
+//! Export-PDF window (#1377).
+//!
+//! The defect: the window was created from TypeScript with
+//! `new WebviewWindow("pdf-export", …)`, and Tauri's JS window options carry no
+//! `menu` field. Off macOS the menu bar belongs to each window, so a 440x640
+//! utility dialog opened carrying the whole application menu.
+//!
+//! Building a real window needs a running app, which these tests do not have.
+//! So the URL builder is tested directly, and the menu decision — the actual
+//! fix, and a `cfg`-gated line no host-target test can execute — is asserted
+//! against the SOURCE, the same instrument `menu/localized.test.rs` uses for
+//! accelerator call sites.
+
+use super::*;
+
+/// This file's own text, for the source-level assertions below.
+const SOURCE: &str = include_str!("pdf_export_window.rs");
+
+#[test]
+fn url_carries_the_html_path() {
+    assert_eq!(
+        pdf_export_url("/tmp/export.html", None),
+        "/pdf-export?htmlPath=%2Ftmp%2Fexport.html"
+    );
+}
+
+#[test]
+fn url_percent_encodes_a_name_that_would_corrupt_the_query() {
+    // A document titled `a&b?c#d` must not append a second parameter or a
+    // fragment — the same reasoning settings_url records.
+    let url = pdf_export_url("/tmp/x.html", Some("a&b?c#d"));
+    assert!(
+        !url.contains("&b"),
+        "an unencoded `&` starts a new query parameter: {url}"
+    );
+    assert!(
+        !url.contains('#'),
+        "an unencoded `#` starts a fragment: {url}"
+    );
+    assert!(url.contains("defaultName=a%26b%3Fc%23d"), "{url}");
+}
+
+#[test]
+fn url_omits_an_empty_name_rather_than_sending_a_blank_one() {
+    assert_eq!(
+        pdf_export_url("/tmp/x.html", Some("")),
+        "/pdf-export?htmlPath=%2Ftmp%2Fx.html"
+    );
+}
+
+#[test]
+fn label_matches_the_one_progress_events_are_emitted_to() {
+    // pdf_export::renderer::progress::PROGRESS_WINDOW addresses this window by
+    // name. If the two ever diverge the export dialog sits on "Preparing…"
+    // forever, because every progress event goes to a window that is not there.
+    assert_eq!(
+        PDF_EXPORT_LABEL,
+        crate::pdf_export::renderer::progress::PROGRESS_WINDOW
+    );
+}
+
+#[test]
+fn attaches_an_empty_menu_off_macos_and_only_off_macos() {
+    // The fix itself. `Menu::new` with nothing added is what the Settings
+    // window uses to open bare; without it the window inherits the application
+    // menu on Linux and Windows.
+    assert!(
+        SOURCE.contains("tauri::menu::Menu::new(&app)"),
+        "no empty-menu attachment — #1377 returns"
+    );
+
+    // And it must stay behind `cfg(not(target_os = \"macos\"))`: macOS has ONE
+    // app-global menu bar, so attaching an empty menu there would blank the
+    // application menu rather than tidy a dialog.
+    let menu_at = SOURCE
+        .find("tauri::menu::Menu::new(&app)")
+        .expect("checked above");
+    let guard_at = SOURCE
+        .find("#[cfg(not(target_os = \"macos\"))]")
+        .expect("no non-macOS cfg block");
+    assert!(
+        guard_at < menu_at,
+        "the empty menu is not inside the non-macOS block; on macOS it would \
+         replace the application menu"
+    );
+}
+
+#[test]
+fn creates_the_window_asynchronously() {
+    // A sync command builds the window on the thread that delivered the IPC
+    // message, which on Windows is inside WebView2's WebMessageReceived
+    // callback — the reentrancy case that hung #1301/#1302 with a process Task
+    // Manager could not end. lint:window-thread enforces this repo-wide; this
+    // states it at the site so the reason survives next to the code.
+    assert!(
+        SOURCE.contains("#[tauri::command(async)]"),
+        "window creation must be async"
+    );
+}

--- a/src-tauri/windows/installer-hooks.nsh
+++ b/src-tauri/windows/installer-hooks.nsh
@@ -103,6 +103,80 @@
   Pop $R0
 !macroend
 
+; ---------------------------------------------------------------------------
+; 3. Do not displace an extension's existing handler — issue #1378
+; ---------------------------------------------------------------------------
+;
+; Measured on a clean Windows runner against the published v0.9.68 installer,
+; by the release-smoke job's post-install diagnostic:
+;
+;     install claimed .txt  : 'txtfile'  -> 'txt'
+;     install claimed .svg  : 'svgfile'  -> 'svg'
+;     install claimed .html : 'htmlfile' -> 'html'
+;     install claimed .htm  : 'htmlfile' -> 'htm'
+;
+; `APP_ASSOCIATE` writes `Software\Classes\.<ext>` unconditionally, so simply
+; declaring an extension in `fileAssociations` takes the default away from
+; whatever owned it. For the markdown extensions nothing owned them and that is
+; the desired outcome; for these four it means installing a markdown editor
+; silently displaced Notepad and the browser.
+;
+; The user-visible symptom in #1378 was the right-click "New > 文本文档" entry
+; changing. That entry is built from `HKCR\.txt\ShellNew`, which still exists —
+; what changed is its LABEL, which comes from the friendly name of the ProgID
+; the extension points at. So the report's "ShellNew was deleted" is not what
+; happened; the association takeover is.
+;
+; The rule here is a CONDITION, not a list: yield wherever HKLM already names a
+; handler. That keeps VMark the default for `.md` and friends, which nothing
+; else claims, while leaving a machine that has its own handler for `.json`
+; alone too — without this file having to predict which those are.
+;
+; Yielding the default is not the same as becoming unavailable. `OpenWithProgids`
+; is the documented way to stay in the Open With list, so VMark remains one
+; choice for these types; it is simply no longer the one Windows picks without
+; being asked. A user who does want VMark as the default can still say so, and
+; their choice is recorded in `FileExts\.<ext>\UserChoice`, which outranks
+; everything here.
+;
+; Runs from POSTINSTALL, which tauri-bundler inserts at the END of the install
+; section — after the APP_ASSOCIATE loop. That ordering is what makes the
+; repair possible, exactly as POSTUNINSTALL's ordering is below.
+
+!macro VMARK_YIELD_EXISTING_HANDLER EXT
+  Push $R0
+
+  ReadRegStr $R0 HKLM "Software\Classes\.${EXT}" ""
+  ${If} $R0 != ""
+    ; Something already owns this type machine-wide. Keep VMark reachable
+    ; through Open With, then hand the default back by deleting the value
+    ; APP_ASSOCIATE just wrote into HKCU — HKCR then resolves to HKLM again.
+    WriteRegStr HKCU "Software\Classes\.${EXT}\OpenWithProgids" "${EXT}" ""
+    DeleteRegValue HKCU "Software\Classes\.${EXT}" ""
+  ${EndIf}
+
+  Pop $R0
+!macroend
+
+!macro NSIS_HOOK_POSTINSTALL
+  ; Keep in sync with fileAssociations in src-tauri/tauri.conf.json.
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "md"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "markdown"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "mdown"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "mkd"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "mdx"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "txt"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "json"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "jsonl"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "yaml"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "yml"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "toml"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "mmd"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "svg"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "html"
+  !insertmacro VMARK_YIELD_EXISTING_HANDLER "htm"
+!macroend
+
 !macro NSIS_HOOK_POSTUNINSTALL
   WriteRegStr HKCR ".txt\ShellNew" "NullFile" ""
 

--- a/src/plugins/latex/displayMathTag.test.ts
+++ b/src/plugins/latex/displayMathTag.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+/**
+ * `\tag{…}` on display math must sit at the right edge of the BLOCK, not of
+ * the equation (#1376).
+ *
+ * The mechanism, from KaTeX's own stylesheet:
+ *
+ *   .katex-display > .katex > .katex-html      { display: block; position: relative }
+ *   .katex-display > .katex > .katex-html > .katex-tag { position: absolute; right: 0 }
+ *
+ * So the tag is placed against the right edge of `.katex-html`, which fills
+ * `.katex-display`. Everywhere else that works, because `.katex-display` is a
+ * plain block filling its container.
+ *
+ * VMark's preview is a FLEX container (`display: flex; justify-content:
+ * center`), which makes `.katex-display` a flex ITEM — and a flex item with
+ * `width: auto` shrink-wraps to its content. The block then ends where the
+ * equation ends, `right: 0` resolves to the equation's own right edge, and the
+ * tag lands on top of the last term: `[\Delta V] \tag{9}` renders as
+ * `[\Delta V(9)]`.
+ *
+ * `width: 100%` restores the block's full width. Centring is unaffected —
+ * KaTeX centres display math itself with `text-align: center`, which is how it
+ * behaves outside a flex parent; `justify-content` was never what centred it.
+ *
+ * A layout assertion is not available here: jsdom computes no geometry, so a
+ * test that rendered the equation and measured the tag would pass on a broken
+ * stylesheet. The stylesheet is therefore the subject, in the same shape as
+ * `src/test/reducedMotionGlobal.test.ts`.
+ *
+ * @coordinates-with latex.css — the rule under test
+ * @module plugins/latex/displayMathTag.test
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+const raw = readFileSync("src/plugins/latex/latex.css", "utf8");
+
+/**
+ * Comments are stripped BEFORE any rule is matched, not after.
+ *
+ * A body matched with `[^}]*` ends at the first `}` in the file, and a CSS
+ * comment may contain one — the comment on the rule under test cites
+ * `` `\tag{…}` ``, whose closing brace truncated the body and failed the
+ * assertion against the very fix that had just been applied.
+ */
+const css = raw.replace(/\/\*[\s\S]*?\*\//g, "");
+
+/** The body of the first rule whose selector matches. */
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`(?:^|\\})\\s*${escaped}\\s*\\{([^}]*)\\}`, "m").exec(css);
+  expect(match, `no rule for \`${selector}\``).not.toBeNull();
+  return match![1];
+}
+
+describe("display-math \\tag placement (#1376)", () => {
+  it("the preview centres with flex, which is what shrink-wraps the block", () => {
+    // Pinned because it is the PREMISE of the fix below, not decoration: if the
+    // preview ever stops being a flex container, `width: 100%` is no longer
+    // load-bearing and this whole test should be revisited rather than kept
+    // passing out of habit.
+    const preview = ruleBody(".math-block-preview");
+    expect(preview).toMatch(/display:\s*flex/);
+  });
+
+  it("gives .katex-display the full block width so the tag reaches the edge", () => {
+    const rule = ruleBody(".math-block-preview .katex-display");
+    expect(
+      rule,
+      "a flex item shrink-wraps without an explicit width, which puts `right: 0` " +
+        "on the equation's edge instead of the block's — that is #1376",
+    ).toMatch(/width:\s*100%/);
+  });
+
+  it("does not try to fix it by overriding KaTeX's tag positioning", () => {
+    // The tempting alternative is to re-place `.katex-tag` by hand. That fights
+    // KaTeX's own layout, breaks `leqno` (which flips the tag to the left), and
+    // has to be re-tuned whenever KaTeX changes. Widening the block leaves
+    // KaTeX's rule doing exactly what it was written to do.
+    expect(css).not.toMatch(/\.katex-tag\s*\{/);
+  });
+});

--- a/src/plugins/latex/latex.css
+++ b/src/plugins/latex/latex.css
@@ -153,6 +153,14 @@
 
 .math-block-preview .katex-display {
   margin: 0;
+  /* #1376. KaTeX places the tag from `\tag` with `position: absolute; right: 0`
+     inside `.katex-html`, which fills `.katex-display`. The preview above is a
+     flex container, so `.katex-display` is a flex ITEM and shrink-wraps to the
+     equation without an explicit width — `right: 0` then resolves to the
+     equation's own right edge and the tag lands on the last term.
+     Centring is unaffected: KaTeX centres display math with its own
+     `text-align: center`, which is what centres it outside a flex parent. */
+  width: 100%;
 }
 
 .math-block-placeholder {

--- a/src/services/navigation/pdfExportWindow.test.ts
+++ b/src/services/navigation/pdfExportWindow.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+/**
+ * The Export PDF window is opened through Rust, not built here (#1377).
+ *
+ * It used to be `new WebviewWindow("pdf-export", …)`. Tauri's JS window options
+ * carry no `menu` field, and off macOS the menu bar belongs to each window — so
+ * a 440x640 utility dialog opened with the whole File/Edit/Format/Insert/View/
+ * Help bar attached, none of whose actions apply to it. The Settings window was
+ * never affected because it is built in Rust and passes an empty
+ * `Menu::new(app)` under `cfg(not(target_os = "macos"))`.
+ *
+ * So the creation moved to `window_manager/pdf_export_window.rs`, and what is
+ * left here is the measurement Rust cannot do: the centring position, which
+ * needs the CALLING window's scale factor and geometry.
+ *
+ * @coordinates-with src-tauri/src/window_manager/pdf_export_window.rs
+ * @module services/navigation/pdfExportWindow.test
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { invokeMock, currentWindow } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  currentWindow: {
+    scaleFactor: vi.fn(async () => 2),
+    outerPosition: vi.fn(async () => ({ x: 200, y: 100 })),
+    outerSize: vi.fn(async () => ({ width: 2000, height: 1400 })),
+  },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+vi.mock("@tauri-apps/api/webviewWindow", () => ({
+  getCurrentWebviewWindow: () => currentWindow,
+  // Present so an accidental reintroduction is visible as a call, not a crash.
+  WebviewWindow: vi.fn(),
+}));
+
+import { openPdfExportWindow } from "./pdfExportWindow";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  invokeMock.mockImplementation(async (cmd: string) =>
+    cmd === "write_temp_html" ? "/tmp/export.html" : "pdf-export",
+  );
+  vi.mocked(WebviewWindow).mockClear();
+});
+
+describe("openPdfExportWindow", () => {
+  it("asks Rust to open the window instead of constructing one here", async () => {
+    await openPdfExportWindow({ renderedHtml: "<p>x</p>", defaultName: "Doc" });
+
+    const call = invokeMock.mock.calls.find(([cmd]) => cmd === "open_pdf_export_window");
+    expect(call, "open_pdf_export_window was never invoked").toBeDefined();
+    expect(call![1]).toMatchObject({ htmlPath: "/tmp/export.html", defaultName: "Doc" });
+  });
+
+  it("never constructs a WebviewWindow — that is the defect (#1377)", () => {
+    // A JS-built window cannot be given a menu, so this is the whole fix.
+    expect(WebviewWindow).not.toHaveBeenCalled();
+  });
+
+  it("writes the HTML to a temp file before opening", async () => {
+    await openPdfExportWindow({ renderedHtml: "<p>hello</p>" });
+
+    const order = invokeMock.mock.calls.map(([cmd]) => cmd);
+    expect(order.indexOf("write_temp_html")).toBeLessThan(
+      order.indexOf("open_pdf_export_window"),
+    );
+  });
+
+  it("converts the centring position from physical to logical pixels", async () => {
+    await openPdfExportWindow({ renderedHtml: "<p>x</p>" });
+
+    // Retina, so every physical value halves first:
+    //   x = 200/2  + (2000/2 - 440)/2 = 100 + 280 = 380
+    //   y = 100/2  + (1400/2 - 640)/2 =  50 +  30 =  80
+    // Sending physical pixels would put the dialog off-centre on every scaled
+    // display, which is why this measurement stays in the frontend — Rust has
+    // no handle on the CALLING window's scale factor.
+    const [, args] = invokeMock.mock.calls.find(([c]) => c === "open_pdf_export_window")!;
+    expect(args).toMatchObject({ x: 380, y: 80 });
+  });
+
+  it("omits the position when the caller's geometry cannot be read", async () => {
+    currentWindow.scaleFactor.mockRejectedValueOnce(new Error("no window"));
+
+    await openPdfExportWindow({ renderedHtml: "<p>x</p>" });
+
+    // Rust centres the window when no position arrives. Sending a half-derived
+    // coordinate would place it somewhere neither deliberate nor centred.
+    const [, args] = invokeMock.mock.calls.find(([c]) => c === "open_pdf_export_window")!;
+    expect(args).not.toHaveProperty("x");
+    expect(args).not.toHaveProperty("y");
+  });
+
+  it("omits an empty defaultName rather than sending a blank one", async () => {
+    await openPdfExportWindow({ renderedHtml: "<p>x</p>" });
+
+    const [, args] = invokeMock.mock.calls.find(([c]) => c === "open_pdf_export_window")!;
+    expect(args).not.toHaveProperty("defaultName");
+  });
+});

--- a/src/services/navigation/pdfExportWindow.ts
+++ b/src/services/navigation/pdfExportWindow.ts
@@ -16,7 +16,7 @@
  */
 
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWebviewWindow, WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 
 
 const PDF_EXPORT_WIDTH = 440;
@@ -43,11 +43,17 @@ async function calculateCenteredPosition(): Promise<{ x: number; y: number } | n
 }
 
 /**
- * Open the PDF Export window with rendered HTML content.
+ * Open the Export PDF window on freshly rendered HTML.
  *
- * - Writes HTML to a temp file via Rust command
- * - If window already exists, closes and recreates with fresh content
- * - If not, creates a new window centered on the current window
+ * The window itself is built by Rust (`open_pdf_export_window`), NOT here.
+ * Tauri's JS window options carry no `menu` field, and off macOS the menu bar
+ * belongs to each window — so a JS-built dialog inherits the whole application
+ * menu, which is #1377. Rust can pass an empty `Menu::new(app)`, the same way
+ * the Settings window stays bare.
+ *
+ * What stays here is the one measurement Rust cannot take: centring needs the
+ * CALLING window's scale factor and geometry. Physical pixels are converted to
+ * logical ones first, or the dialog lands off-centre on every scaled display.
  */
 export async function openPdfExportWindow(data: {
   renderedHtml: string;
@@ -56,38 +62,18 @@ export async function openPdfExportWindow(data: {
 }): Promise<void> {
   const pos = await calculateCenteredPosition();
 
-  // If PDF Export window already exists, close it so we open fresh content
-  const existing = await WebviewWindow.getByLabel("pdf-export");
-  if (existing) {
-    await existing.close();
-  }
-
-  // Write HTML to temp file so the new window can read it
+  // Written to a temp file rather than passed inline: with embedded images the
+  // HTML runs to megabytes, which is not a URL parameter.
   const htmlPath: string = await invoke("write_temp_html", {
     html: data.renderedHtml,
   });
 
-  // Build URL with params
-  const params = new URLSearchParams();
-  params.set("htmlPath", htmlPath);
-  if (data.defaultName) {
-    params.set("defaultName", data.defaultName);
-  }
-
-  new WebviewWindow("pdf-export", {
-    url: `/pdf-export?${params.toString()}`,
-    title: "Export PDF",
-    width: PDF_EXPORT_WIDTH,
-    height: PDF_EXPORT_HEIGHT,
-    minWidth: 380,
-    minHeight: 480,
-    // Tauri reads `x`/`y` presence to decide between explicit placement and
-    // its own default; passing the keys as `undefined` alongside
-    // `center: true` would hand it a contradictory request.
+  await invoke("open_pdf_export_window", {
+    htmlPath,
+    // Omitted rather than sent empty, so Rust's `Option` means "absent" and not
+    // "present but blank" — and omitted together with `y`, because a position
+    // is only meaningful as a pair. Rust centres the window when none arrives.
+    ...(data.defaultName ? { defaultName: data.defaultName } : {}),
     ...(pos ? { x: pos.x, y: pos.y } : {}),
-    center: !pos,
-    resizable: true,
-    hiddenTitle: true,
-    titleBarStyle: "overlay",
   });
 }

--- a/src/utils/markdownPipeline/__tests__/pathological/runCases.ts
+++ b/src/utils/markdownPipeline/__tests__/pathological/runCases.ts
@@ -31,6 +31,7 @@ import { getSchema } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import "../../dialect";
 import { parseMarkdown, serializeMarkdown } from "../../adapter";
+import { isNestingTooDeep } from "../../nestingDepth";
 import { pathologicalCases } from "./pathologicalCases";
 
 if (process.env.HANG_PROBE === "1") {
@@ -46,7 +47,26 @@ const schema = getSchema([StarterKit]);
 for (const testCase of pathologicalCases(scale)) {
   console.log(JSON.stringify({ name: testCase.name, starting: true }));
   const t0 = performance.now();
-  const doc = parseMarkdown(schema, testCase.markdown);
+  let doc;
+  try {
+    doc = parseMarkdown(schema, testCase.markdown);
+  } catch (error) {
+    // A nesting refusal is a PASS here, and the only tolerated throw. This
+    // suite's contract is liveness — no hang, no stack overflow — and the
+    // guard added for #1374 satisfies it deliberately rather than by luck.
+    // At scale 1 `deep-blockquotes` is 500 levels and parses; at the soak's
+    // scale 8 it is 4000 and is refused. Any OTHER error still propagates and
+    // fails the run, which is what keeps this from swallowing real defects.
+    if (!isNestingTooDeep(error)) throw error;
+    console.log(
+      JSON.stringify({
+        name: testCase.name,
+        refusedMs: Math.round(performance.now() - t0),
+        refused: "nesting",
+      }),
+    );
+    continue;
+  }
   const parseMs = performance.now() - t0;
   let serializeMs = 0;
   if (testCase.serialize) {

--- a/src/utils/markdownPipeline/nestingDepth.test.ts
+++ b/src/utils/markdownPipeline/nestingDepth.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment node
+/**
+ * The pre-parse nesting guard (#1374).
+ *
+ * `remark-gfm`'s autolink-literal transform walks the tree through
+ * `mdast-util-find-and-replace` → `unist-util-visit-parents`, which recurses
+ * once per tree LEVEL. A document of deeply nested containers therefore
+ * overflows the JS stack inside `mdast-util-from-markdown`'s compile step,
+ * before any VMark code sees the tree — so this cannot be fixed by making
+ * VMark's own plugin walks iterative, which was tried and reverted.
+ *
+ * Measured ceilings for `"> ".repeat(d)`, by bisection:
+ *
+ *   macOS 26, node 24       between 4000 and 8000
+ *   Linux aarch64, node 24  ~5585
+ *   Linux aarch64, node 22  ~4843
+ *
+ * The ceiling also moves with LOAD: identical input at one size was measured
+ * passing, overflowing, then passing again in three consecutive runs.
+ *
+ * So the limit is not "the depth that crashed"; it is far below the LOWEST
+ * ceiling any measurement produced, because the number that matters is the one
+ * on the busiest machine, which nobody can measure in advance.
+ *
+ * This guard is NOT what fixed the weekly soak — that was deep INLINE nesting
+ * through VMark's own `walkAndReplace`, see customInlineDepth.test.ts. This
+ * covers the container shape, whose recursion is upstream and cannot be
+ * removed from here.
+ *
+ * @coordinates-with nestingDepth.ts — the scanner and the limit
+ * @module utils/markdownPipeline/nestingDepth.test
+ */
+import { describe, it, expect } from "vitest";
+import { MAX_NESTING_DEPTH, maxContainerDepth, checkNestingDepth } from "./nestingDepth";
+
+describe("maxContainerDepth", () => {
+  it("is zero for ordinary prose", () => {
+    expect(maxContainerDepth("hello\n\nworld\n")).toBe(0);
+  });
+
+  it("counts blockquote markers", () => {
+    expect(maxContainerDepth("> > > a\n")).toBe(3);
+  });
+
+  it("counts blockquote markers written without spaces", () => {
+    // `>>>a` is three blockquotes in CommonMark, and a scanner that only
+    // understood `"> "` would read it as one.
+    expect(maxContainerDepth(">>>a\n")).toBe(3);
+  });
+
+  it("counts list indentation as nesting", () => {
+    expect(maxContainerDepth("- a\n  - b\n    - c\n")).toBe(3);
+  });
+
+  it("adds blockquote and list nesting on the same line", () => {
+    expect(maxContainerDepth("> > - a\n")).toBe(3);
+  });
+
+  it("reports the deepest line, not the last", () => {
+    expect(maxContainerDepth("> > > deep\n\nshallow\n")).toBe(3);
+  });
+
+  it("does not count a `>` that is not a container marker", () => {
+    // A blockquote marker is only one at the START of a line's content.
+    expect(maxContainerDepth("a > b > c\n")).toBe(0);
+  });
+
+  it("ignores indentation inside a fenced code block", () => {
+    // Four spaces inside a fence is code, not nesting. Without this, any
+    // document containing an indented code sample would be scored as deeply
+    // nested and could be refused — a guard that rejects ordinary documents is
+    // worse than the crash it prevents.
+    const md = "```\n" + "                                        x\n" + "```\n";
+    expect(maxContainerDepth(md)).toBe(0);
+  });
+
+  it("is linear in input size, not in nesting", () => {
+    // The guard runs on every parse, so it has to be a scan. 20000 levels is
+    // past every measured ceiling and must still return promptly.
+    const started = Date.now();
+    expect(maxContainerDepth(`${"> ".repeat(20000)}a\n`)).toBe(20000);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+});
+
+describe("checkNestingDepth", () => {
+  it("accepts a document at the limit", () => {
+    expect(() => checkNestingDepth(`${"> ".repeat(MAX_NESTING_DEPTH)}a\n`)).not.toThrow();
+  });
+
+  it("refuses one level past it, naming the depth and the limit", () => {
+    let message = "";
+    try {
+      checkNestingDepth(`${"> ".repeat(MAX_NESTING_DEPTH + 1)}a\n`);
+    } catch (e) {
+      message = e instanceof Error ? e.message : String(e);
+    }
+    // The whole point is that the failure says what happened. The alternative
+    // it replaces is `RangeError: Maximum call stack size exceeded`, which
+    // names neither the document nor the cause.
+    expect(message).toContain(String(MAX_NESTING_DEPTH + 1));
+    expect(message).toContain(String(MAX_NESTING_DEPTH));
+    expect(message.toLowerCase()).toContain("nest");
+  });
+
+  it("sits far below the lowest measured crash ceiling", () => {
+    // 4843 is the lowest ceiling any measurement produced (Linux, node 22).
+    // The limit must leave room for a machine under load, which has less
+    // usable stack than the one that was measured — so this asserts a MARGIN,
+    // not merely that the limit is smaller.
+    const LOWEST_MEASURED_CEILING = 4843;
+    expect(MAX_NESTING_DEPTH).toBeLessThanOrEqual(LOWEST_MEASURED_CEILING / 4);
+  });
+
+  it("is well above any plausible real document", () => {
+    // A guard is only worth having if it never fires on real writing. The
+    // deepest nesting in this repo's own corpora is in single digits.
+    expect(MAX_NESTING_DEPTH).toBeGreaterThanOrEqual(500);
+  });
+});

--- a/src/utils/markdownPipeline/nestingDepth.ts
+++ b/src/utils/markdownPipeline/nestingDepth.ts
@@ -153,8 +153,12 @@ export function maxContainerDepth(markdown: string): number {
  * `cause`, so a caller that wants to tell "too deep" from "malformed" would
  * otherwise have to match prose through a wrapper — which breaks the first
  * time the wording is edited.
+ *
+ * Module-local on purpose. `isNestingTooDeep` is the interface, and it is the
+ * one callers should use: a bare `instanceof` would miss the case the wrapper
+ * creates, where the refusal arrives as the `cause` of a generic parse error.
  */
-export class NestingTooDeepError extends Error {
+class NestingTooDeepError extends Error {
   readonly depth: number;
   readonly limit: number;
 

--- a/src/utils/markdownPipeline/nestingDepth.ts
+++ b/src/utils/markdownPipeline/nestingDepth.ts
@@ -1,0 +1,194 @@
+/**
+ * Pre-parse nesting guard: refuse a document deep enough to overflow the stack.
+ *
+ * Purpose: `remark-gfm`'s autolink-literal transform walks the tree via
+ * `mdast-util-find-and-replace` → `unist-util-visit-parents`, which recurses
+ * once per tree LEVEL. Deeply nested containers therefore blow the JS stack
+ * inside `mdast-util-from-markdown`'s compile step — before any VMark code
+ * sees the tree. Making VMark's own plugin walks iterative does not help; that
+ * was tried and reverted, because the upstream recursion always runs first.
+ *
+ * So this refuses such a document up front, with a message that says what
+ * happened. The alternative is `RangeError: Maximum call stack size exceeded`,
+ * which names neither the document nor the cause.
+ *
+ * # This is NOT what the weekly soak was failing on
+ *
+ * Worth stating, because the two look identical in a log and the first reading
+ * of #1374 was wrong. The soak's stderr names its input:
+ *
+ *     Input preview: "*a **a *a **a *a **a *a **a …"
+ *
+ * That is deep INLINE nesting, and its recursion was VMark's own
+ * `walkAndReplace` in customInlineTransform.ts, fixed there by making the walk
+ * iterative. This guard does not cover that shape and should not: inline
+ * markers do not reliably build a deep tree, so charging for them would refuse
+ * documents that parse perfectly well.
+ *
+ * What this guard covers is the CONTAINER shape — nested blockquotes and lists
+ * — whose recursion is upstream and therefore cannot be removed from here.
+ * Both are real; only one of them is what the soak reported.
+ *
+ * # Where the limit comes from
+ *
+ * Bisected ceilings for `"> ".repeat(d)`, one process per measurement:
+ *
+ *   | host                    | node      | ceiling |
+ *   |-------------------------|-----------|---------|
+ *   | macOS 26 arm64          | v24.16.0  | 4000 ok, 8000 fails |
+ *   | Linux aarch64 (spark01) | v24.16.0  | ~5585   |
+ *   | Linux aarch64 (spark02) | v22.13.1  | ~4843   |
+ *
+ * Two things follow. The ceiling MOVES with the Node version, so it is not a
+ * constant to be looked up. And it moves with LOAD: the same input at the same
+ * size was measured passing, overflowing, then passing again in three
+ * consecutive runs, because a busy machine has less usable stack than an idle
+ * one and the parse is not the only thing on it.
+ *
+ * `MAX_NESTING_DEPTH` is therefore set well below the LOWEST number any
+ * measurement produced, not near it: 1000 against a measured 4843 is roughly
+ * fivefold headroom, which is the margin that has to absorb a machine nobody
+ * measured. Raising it toward the ceiling would reintroduce exactly the
+ * load-dependent failure this replaces.
+ *
+ * A limit is only defensible if it never fires on real writing. The deepest
+ * container nesting in this repository's own corpora is in single digits;
+ * 1000 is past anything a person writes and short of anything that crashes.
+ *
+ * @coordinates-with parser.ts — calls checkNestingDepth before parsing
+ * @module utils/markdownPipeline/nestingDepth
+ */
+
+/**
+ * Deepest container nesting this pipeline will parse.
+ *
+ * See the header for the measurements. Do not raise this toward a measured
+ * ceiling: the ceiling is a property of one idle machine on one Node version,
+ * and the document has to parse on every other one.
+ */
+export const MAX_NESTING_DEPTH = 1000;
+
+/** A fence opener/closer: three or more backticks or tildes, up to 3 indented. */
+const FENCE = /^ {0,3}(`{3,}|~{3,})/;
+
+/**
+ * A list marker at the start of a line's content.
+ *
+ * The trailing space is required: `-a` is text and `- a` is a list item, and a
+ * bare `-` on its own line is a thematic break rather than a container. `*`
+ * without it would also catch the opening of emphasis.
+ */
+const LIST_MARKER = /^(?:[-*+]|\d{1,9}[.)])(?: |\t|$)/;
+
+/**
+ * The deepest container nesting any single line opens.
+ *
+ * Counts blockquote markers and list indentation, which are the constructs
+ * that make an mdast tree deep. Inline nesting is deliberately not counted:
+ * `*_` repeated 12000 times parses without incident, because micromark does
+ * not build a tree that deep for it, so charging for it would reject
+ * documents that parse perfectly well.
+ *
+ * This is a SCAN, not a parse — it runs on every document, so it must stay
+ * linear in input length and independent of nesting depth.
+ */
+export function maxContainerDepth(markdown: string): number {
+  let max = 0;
+  let fence: string | null = null;
+
+  for (const line of markdown.split("\n")) {
+    // Fenced code is not nesting. Without this, an indented code sample inside
+    // a fence would be scored as deep nesting and could be refused.
+    const fenceMatch = FENCE.exec(line);
+    if (fence) {
+      if (fenceMatch && line.trim().startsWith(fence)) fence = null;
+      continue;
+    }
+    if (fenceMatch) {
+      fence = fenceMatch[1][0].repeat(3);
+      continue;
+    }
+
+    let i = 0;
+    let depth = 0;
+    let spaces = 0;
+
+    // Leading container markers: any mix of indentation and `>`.
+    while (i < line.length) {
+      const ch = line[i];
+      if (ch === " ") {
+        spaces += 1;
+        i += 1;
+      } else if (ch === "\t") {
+        spaces += 4;
+        i += 1;
+      } else if (ch === ">") {
+        // Indentation accumulated before this marker is list nesting that
+        // contains it; two spaces is one level.
+        depth += Math.floor(spaces / 2) + 1;
+        spaces = 0;
+        i += 1;
+      } else {
+        break;
+      }
+    }
+    // Trailing indentation before actual content is list nesting too.
+    depth += Math.floor(spaces / 2);
+
+    // The list marker itself opens a level. Without this, `> > - a` scores 2
+    // when the tree is blockquote > blockquote > list, and a ladder of
+    // `  - a` lines is under-counted by one at every level.
+    if (LIST_MARKER.test(line.slice(i))) depth += 1;
+
+    if (depth > max) max = depth;
+  }
+
+  return max;
+}
+
+/**
+ * Thrown when a document nests deeper than the parser can survive.
+ *
+ * A named class, not a message: `parseMarkdown` wraps parse failures with a
+ * `cause`, so a caller that wants to tell "too deep" from "malformed" would
+ * otherwise have to match prose through a wrapper — which breaks the first
+ * time the wording is edited.
+ */
+export class NestingTooDeepError extends Error {
+  readonly depth: number;
+  readonly limit: number;
+
+  constructor(depth: number, limit: number, message: string) {
+    super(message);
+    this.name = "NestingTooDeepError";
+    this.depth = depth;
+    this.limit = limit;
+  }
+}
+
+/** Is `error` — or anything it wraps — a nesting refusal? */
+export function isNestingTooDeep(error: unknown): boolean {
+  let cursor: unknown = error;
+  // Bounded: a cause chain is short, and an accidental cycle must not hang the
+  // caller that is already handling a failure.
+  for (let i = 0; i < 10 && cursor instanceof Error; i += 1) {
+    if (cursor instanceof NestingTooDeepError) return true;
+    cursor = (cursor as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/** Throw if `markdown` nests deeper than the parser can survive. */
+export function checkNestingDepth(markdown: string): void {
+  const depth = maxContainerDepth(markdown);
+  if (depth > MAX_NESTING_DEPTH) {
+    throw new NestingTooDeepError(
+      depth,
+      MAX_NESTING_DEPTH,
+      `Nesting is ${depth} levels deep; this document cannot be parsed above ` +
+        `${MAX_NESTING_DEPTH}. Deeply nested blockquotes or lists overflow the ` +
+        `markdown parser's stack, so it is refused here rather than crashing ` +
+        `part-way through.`,
+    );
+  }
+}

--- a/src/utils/markdownPipeline/parser.ts
+++ b/src/utils/markdownPipeline/parser.ts
@@ -42,6 +42,8 @@ import { createProcessor } from "./parser/processorFactory";
 
 // Re-exports for backward compatibility with callers that import directly
 // from this file.
+import { checkNestingDepth } from "./nestingDepth";
+
 export { normalizeBareListMarkers } from "./parser/listNormalization";
 export { createMarkdownProcessor } from "./parser/processorFactory";
 
@@ -61,6 +63,12 @@ export function parseMarkdownToMdast(
   markdown: string,
   options: MarkdownPipelineOptions = {}
 ): Root {
+  // Refuse a document too deeply nested to survive the parse (#1374). Checked
+  // FIRST, on the text as given: remark-gfm's autolink transform recurses once
+  // per tree level inside from-markdown's compile step, so by the time any
+  // VMark code runs the stack is already gone. See nestingDepth.ts.
+  checkNestingDepth(markdown);
+
   // Math source guards (#1180/#1181): rewrite `\[ \]`/`\( \)` to
   // `$`-delimiters and defuse unclosed `$$` fences (pandoc's blank-line
   // rule) before remark sees the text. Document parse only — the

--- a/src/utils/markdownPipeline/plugins/customInlineDepth.test.ts
+++ b/src/utils/markdownPipeline/plugins/customInlineDepth.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+/**
+ * `walkAndReplace` must not recurse per inline nesting level (#1374).
+ *
+ * This is the case the weekly soak actually fails on. Its stderr names the
+ * input directly:
+ *
+ *   Error: [MarkdownPipeline] Parse failed: Maximum call stack size exceeded
+ *   Input preview: "*a **a *a **a *a **a *a **a …"
+ *
+ * That is the `nested-strong-emph` class, not deep blockquotes — and the
+ * recursion is VMark's own. `walkAndReplace` descended once per non-text child,
+ * so `*a **a ` repeated N times cost N frames before the transform finished.
+ *
+ * Distinct from the container guard in `nestingDepth.ts`, which bounds
+ * blockquote and list depth up front. That guard does NOT cover this shape and
+ * should not: inline markers do not reliably build a deep tree, so charging for
+ * them would reject documents that parse perfectly well. This one is fixed by
+ * removing the recursion instead of by refusing the input.
+ *
+ * The old code was also MARGINAL rather than reliably broken — measured on this
+ * machine at the soak's scale, three consecutive runs on byte-identical input
+ * gave ok, overflow, ok. That is what a stack ceiling looks like from below,
+ * and why the soak reads as flaky rather than as a defect.
+ *
+ * @coordinates-with customInlineTransform.ts — the transform under test
+ * @module utils/markdownPipeline/plugins/customInlineDepth.test
+ */
+import { describe, it, expect } from "vitest";
+import type { Root } from "mdast";
+import { parseMarkdownToMdast } from "../parser";
+import { customInlineFromMarkdown } from "./customInlineTransform";
+
+/** The mdast the transform actually operates on, as JSON for shape assertions. */
+const parsed = (markdown: string) => JSON.stringify(parseMarkdownToMdast(markdown));
+
+/** The transform itself, so depth can be tested without paying for a parse. */
+const transform = customInlineFromMarkdown().transforms[0];
+
+/**
+ * `emphasis` nested `depth` deep around one text node.
+ *
+ * Built directly rather than parsed: `"*a **a ".repeat(2400)` takes a minute or
+ * more to PARSE on this machine and several minutes at 3x, which would make a
+ * unit test one of the slowest files in the repo while measuring mostly
+ * micromark. The recursion under test is per tree LEVEL, so a synthetic tree
+ * exercises it exactly and returns instantly.
+ */
+function nestedEmphasis(depth: number): Root {
+  let node: unknown = { type: "text", value: "a" };
+  for (let i = 0; i < depth; i += 1) node = { type: "emphasis", children: [node] };
+  return { type: "root", children: [node] } as unknown as Root;
+}
+
+describe("deep inline nesting (#1374)", () => {
+  it("walks a tree far deeper than the soak's failing input", () => {
+    // The soak's nested-strong-emph at scale 8 nests a few thousand deep and
+    // sat right at the ceiling — three runs on identical input gave ok,
+    // overflow, ok. 20000 is far past it, so this cannot pass by luck.
+    expect(() => transform(nestedEmphasis(20000))).not.toThrow();
+  });
+
+  it("is what the recursive version could not do", () => {
+    // Not decoration: without it, restoring the recursion would still pass
+    // every behaviour test in this file. A plain recursive walk over the same
+    // tree is what the transform used to be.
+    const recursive = (node: { children?: unknown[] }): void => {
+      if (!Array.isArray(node.children)) return;
+      for (const child of node.children) recursive(child as { children?: unknown[] });
+    };
+    expect(() => recursive(nestedEmphasis(20000) as unknown as { children?: unknown[] })).toThrow(
+      /call stack/i,
+    );
+  });
+
+  it("still applies custom marks, nested and split across siblings", () => {
+    // The transform's actual job. An iterative walk that stopped doing this
+    // would pass both tests above while breaking every document that uses
+    // highlight, subscript, superscript or underline.
+    const json = parsed("==highlight **bold**== and ~sub~ and ^sup^\n");
+    expect(json).toContain("highlight");
+    expect(json).toContain("subscript");
+    expect(json).toContain("superscript");
+  });
+
+  it("applies a mark nested inside emphasis", () => {
+    // Proves children are processed before their parent: the inner mark has to
+    // be resolved by the time the outer node's sibling-spanning pass runs.
+    expect(parsed("*outer ==inner== outer*\n")).toContain("highlight");
+  });
+});

--- a/src/utils/markdownPipeline/plugins/customInlineDepth.test.ts
+++ b/src/utils/markdownPipeline/plugins/customInlineDepth.test.ts
@@ -34,8 +34,15 @@ import { customInlineFromMarkdown } from "./customInlineTransform";
 /** The mdast the transform actually operates on, as JSON for shape assertions. */
 const parsed = (markdown: string) => JSON.stringify(parseMarkdownToMdast(markdown));
 
-/** The transform itself, so depth can be tested without paying for a parse. */
-const transform = customInlineFromMarkdown().transforms[0];
+/**
+ * The transform itself, so depth can be tested without paying for a parse.
+ *
+ * Asserted rather than indexed blindly: an extension that stopped exporting a
+ * transform would otherwise make every test below pass vacuously against
+ * `undefined`.
+ */
+const transform = customInlineFromMarkdown().transforms?.[0];
+if (!transform) throw new Error("customInlineFromMarkdown exposes no transform");
 
 /**
  * `emphasis` nested `depth` deep around one text node.

--- a/src/utils/markdownPipeline/plugins/customInlineMarks.ts
+++ b/src/utils/markdownPipeline/plugins/customInlineMarks.ts
@@ -21,7 +21,7 @@ import { MARKS, findMarkPair, unescapeWhitespace, type MarkDefinition } from "./
 /** Node types whose contents are literal, so markers inside them are text. */
 const SKIP_NODE_TYPES = new Set(["inlineCode", "code", "math", "inlineMath", "html", "yaml"]);
 
-export type MarkName = "subscript" | "superscript" | "highlight" | "underline";
+type MarkName = "subscript" | "superscript" | "highlight" | "underline";
 
 export function isTextNode(node: unknown): node is Text {
   return typeof node === "object" && node !== null && (node as { type?: string }).type === "text";
@@ -85,7 +85,7 @@ export function parseMarksInText(text: string): PhrasingContent[] {
   return result.length > 0 ? result : [{ type: "text", value: text }];
 }
 
-export function createMarkNode(name: MarkName, content: string): Subscript | Superscript | Highlight | Underline {
+function createMarkNode(name: MarkName, content: string): Subscript | Superscript | Highlight | Underline {
   const children: PhrasingContent[] = parseMarksInText(content);
 
   switch (name) {

--- a/src/utils/markdownPipeline/plugins/customInlineMarks.ts
+++ b/src/utils/markdownPipeline/plugins/customInlineMarks.ts
@@ -1,0 +1,101 @@
+/**
+ * Text-level mark parsing and the node predicates the walk shares.
+ *
+ * Purpose: the leaf half of the custom-inline transform — deciding what a node
+ * IS (`isTextNode`, `isSkippableNode`) and turning the markers inside one text
+ * value into mark nodes (`parseMarksInText`, `createMarkNode`).
+ *
+ * Split out of customInlineTransform.ts when making that file's walk iterative
+ * (#1374) took it past the 300-line limit. This is the leaf side of the seam:
+ * nothing here reaches back into the walk, so the dependency runs one way and
+ * both the walk and the cross-sibling span logic can import it.
+ *
+ * @coordinates-with customInlineTransform.ts — the walk that calls these
+ * @module utils/markdownPipeline/plugins/customInlineMarks
+ */
+
+import type { PhrasingContent, Text } from "mdast";
+import type { Subscript, Superscript, Highlight, Underline } from "../types";
+import { MARKS, findMarkPair, unescapeWhitespace, type MarkDefinition } from "./markPairing";
+
+/** Node types whose contents are literal, so markers inside them are text. */
+const SKIP_NODE_TYPES = new Set(["inlineCode", "code", "math", "inlineMath", "html", "yaml"]);
+
+export type MarkName = "subscript" | "superscript" | "highlight" | "underline";
+
+export function isTextNode(node: unknown): node is Text {
+  return typeof node === "object" && node !== null && (node as { type?: string }).type === "text";
+}
+
+export function isSkippableNode(node: unknown): boolean {
+  /* v8 ignore next -- @preserve defensive null/type guard; MDAST nodes are always objects */
+  if (!node || typeof node !== "object") return false;
+  const type = (node as { type?: string }).type;
+  return typeof type === "string" && SKIP_NODE_TYPES.has(type);
+}
+
+
+export function parseMarksInText(text: string): PhrasingContent[] {
+  const result: PhrasingContent[] = [];
+  let position = 0;
+
+  while (position < text.length) {
+    // Find the earliest mark starting from current position
+    let earliestMark: MarkDefinition | null = null;
+    let earliestStart = -1;
+    let earliestEnd = -1;
+
+    for (const mark of MARKS) {
+      const pair = findMarkPair(text, mark, position);
+      if (pair && (earliestStart === -1 || pair.start < earliestStart)) {
+        earliestMark = mark;
+        earliestStart = pair.start;
+        earliestEnd = pair.end;
+      }
+    }
+
+    if (!earliestMark || earliestStart === -1) {
+      // No more marks found, add remaining as text
+      /* v8 ignore next -- @preserve while(position < text.length) guarantees this is always true */
+      if (position < text.length) {
+        result.push({ type: "text", value: text.slice(position) });
+      }
+      break;
+    }
+
+    // Add text before the mark
+    if (earliestStart > position) {
+      result.push({ type: "text", value: text.slice(position, earliestStart) });
+    }
+
+    // Add the mark node. `\ ` inside a sub/superscript is Pandoc's way to write
+    // a deliberate space; the backslash is syntax, not content.
+    const rawContent = text.slice(earliestStart + earliestMark.markerLen, earliestEnd);
+    const content = earliestMark.noUnescapedWhitespace
+      ? unescapeWhitespace(rawContent)
+      : rawContent;
+    const markNode = createMarkNode(earliestMark.name as MarkName, content);
+    result.push(markNode);
+
+    // Continue from after the closing marker
+    position = earliestEnd + earliestMark.markerLen;
+  }
+
+  /* v8 ignore next -- @preserve fallback for empty string input; text nodes from parsers are rarely empty */
+  return result.length > 0 ? result : [{ type: "text", value: text }];
+}
+
+export function createMarkNode(name: MarkName, content: string): Subscript | Superscript | Highlight | Underline {
+  const children: PhrasingContent[] = parseMarksInText(content);
+
+  switch (name) {
+    case "subscript":
+      return { type: "subscript", children } as Subscript;
+    case "superscript":
+      return { type: "superscript", children } as Superscript;
+    case "highlight":
+      return { type: "highlight", children } as Highlight;
+    case "underline":
+      return { type: "underline", children } as Underline;
+  }
+}

--- a/src/utils/markdownPipeline/plugins/customInlineTransform.ts
+++ b/src/utils/markdownPipeline/plugins/customInlineTransform.ts
@@ -51,9 +51,50 @@ function transformCustomMarks(tree: Root): void {
   walkAndReplace(tree);
 }
 
-function walkAndReplace(node: Root | PhrasingContent | { children?: unknown[] }): void {
-  if (isSkippableNode(node)) return;
-  if (!("children" in node) || !Array.isArray(node.children)) return;
+/**
+ * Apply the mark transform to every node, deepest first.
+ *
+ * Iterative because this used to recurse once per non-text child, and the
+ * weekly pathological soak has been failing on exactly that since 2026-08-17:
+ *
+ *   Error: [MarkdownPipeline] Parse failed: Maximum call stack size exceeded
+ *   Input preview: "*a **a *a **a *a **a *a **a …"
+ *
+ * `*a **a ` repeated N times nests N deep, so the walk cost N frames. It was
+ * MARGINAL rather than reliably broken — three consecutive runs on identical
+ * input gave ok, overflow, ok — which is why the job reads as flaky.
+ *
+ * Two phases, because the per-node work is POST-order: `parseMarksAcrossChildren`
+ * has to see children that are already final. Collecting in preorder and then
+ * processing in reverse gives that, since a node is always discovered before
+ * its descendants and therefore processed after them.
+ *
+ * Nodes created by `parseMarksInText` are deliberately not collected — the
+ * recursive version never descended into them either, and they are built from
+ * a text value that has already been fully scanned.
+ */
+function walkAndReplace(root: Root | PhrasingContent | { children?: unknown[] }): void {
+  const order: { children?: unknown[] }[] = [];
+  const stack: { children?: unknown[] }[] = [root as { children?: unknown[] }];
+
+  while (stack.length > 0) {
+    const node = stack.pop() as { children?: unknown[] };
+    if (isSkippableNode(node)) continue;
+    if (!("children" in node) || !Array.isArray(node.children)) continue;
+    order.push(node);
+    // Text children are handled by the owning node, never descended into.
+    for (let i = node.children.length - 1; i >= 0; i -= 1) {
+      const child = node.children[i];
+      if (!isTextNode(child)) stack.push(child as { children?: unknown[] });
+    }
+  }
+
+  for (let i = order.length - 1; i >= 0; i -= 1) applyMarksToNode(order[i]);
+}
+
+/** The per-node half of the walk: children are already final when this runs. */
+function applyMarksToNode(node: { children?: unknown[] }): void {
+  if (!Array.isArray(node.children)) return;
 
   const newChildren: unknown[] = [];
   let modified = false;
@@ -68,7 +109,7 @@ function walkAndReplace(node: Root | PhrasingContent | { children?: unknown[] })
         modified = true;
       }
     } else {
-      walkAndReplace(child as { children?: unknown[] });
+      // Already processed: this node is reached only after its descendants.
       newChildren.push(child);
     }
   }

--- a/src/utils/markdownPipeline/plugins/customInlineTransform.ts
+++ b/src/utils/markdownPipeline/plugins/customInlineTransform.ts
@@ -22,23 +22,13 @@
  * @module utils/markdownPipeline/plugins/customInlineTransform
  */
 import type { Root, PhrasingContent, Text } from "mdast";
-import type { Subscript, Superscript, Highlight, Underline } from "../types";
-import {
-  MARKS,
-  findMarkPair,
-  findMarkerIn,
-  spanIsPairable,
-  unescapeWhitespace,
-  type MarkDefinition,
-} from "./markPairing";
+import { MARKS, findMarkerIn, spanIsPairable, type MarkDefinition } from "./markPairing";
+import { isSkippableNode, isTextNode, parseMarksInText } from "./customInlineMarks";
 
 export interface FromMarkdownExtension {
   transforms?: Array<(tree: Root) => void>;
 }
 
-const SKIP_NODE_TYPES = new Set(["inlineCode", "code", "math", "inlineMath", "html", "yaml"]);
-
-type MarkName = "subscript" | "superscript" | "highlight" | "underline";
 
 export function customInlineFromMarkdown(): FromMarkdownExtension {
   return {
@@ -222,81 +212,4 @@ function buildSpan(
     ...asText(afterClose),
     ...children.slice(j + 1),
   ];
-}
-
-function isTextNode(node: unknown): node is Text {
-  return typeof node === "object" && node !== null && (node as { type?: string }).type === "text";
-}
-
-function isSkippableNode(node: unknown): boolean {
-  /* v8 ignore next -- @preserve defensive null/type guard; MDAST nodes are always objects */
-  if (!node || typeof node !== "object") return false;
-  const type = (node as { type?: string }).type;
-  return typeof type === "string" && SKIP_NODE_TYPES.has(type);
-}
-
-
-function parseMarksInText(text: string): PhrasingContent[] {
-  const result: PhrasingContent[] = [];
-  let position = 0;
-
-  while (position < text.length) {
-    // Find the earliest mark starting from current position
-    let earliestMark: MarkDefinition | null = null;
-    let earliestStart = -1;
-    let earliestEnd = -1;
-
-    for (const mark of MARKS) {
-      const pair = findMarkPair(text, mark, position);
-      if (pair && (earliestStart === -1 || pair.start < earliestStart)) {
-        earliestMark = mark;
-        earliestStart = pair.start;
-        earliestEnd = pair.end;
-      }
-    }
-
-    if (!earliestMark || earliestStart === -1) {
-      // No more marks found, add remaining as text
-      /* v8 ignore next -- @preserve while(position < text.length) guarantees this is always true */
-      if (position < text.length) {
-        result.push({ type: "text", value: text.slice(position) });
-      }
-      break;
-    }
-
-    // Add text before the mark
-    if (earliestStart > position) {
-      result.push({ type: "text", value: text.slice(position, earliestStart) });
-    }
-
-    // Add the mark node. `\ ` inside a sub/superscript is Pandoc's way to write
-    // a deliberate space; the backslash is syntax, not content.
-    const rawContent = text.slice(earliestStart + earliestMark.markerLen, earliestEnd);
-    const content = earliestMark.noUnescapedWhitespace
-      ? unescapeWhitespace(rawContent)
-      : rawContent;
-    const markNode = createMarkNode(earliestMark.name as MarkName, content);
-    result.push(markNode);
-
-    // Continue from after the closing marker
-    position = earliestEnd + earliestMark.markerLen;
-  }
-
-  /* v8 ignore next -- @preserve fallback for empty string input; text nodes from parsers are rarely empty */
-  return result.length > 0 ? result : [{ type: "text", value: text }];
-}
-
-function createMarkNode(name: MarkName, content: string): Subscript | Superscript | Highlight | Underline {
-  const children: PhrasingContent[] = parseMarksInText(content);
-
-  switch (name) {
-    case "subscript":
-      return { type: "subscript", children } as Subscript;
-    case "superscript":
-      return { type: "superscript", children } as Superscript;
-    case "highlight":
-      return { type: "highlight", children } as Highlight;
-    case "underline":
-      return { type: "underline", children } as Underline;
-  }
 }


### PR DESCRIPTION
Closes #1376, #1377, #1378. Four commits, one per defect, each verified independently.

## #1376 — display-math `\tag` overlapped the equation

`$$ [H][\Delta P_T]=[\Delta V] \tag{9} $$` rendered as `[\Delta V(9)]`.

KaTeX places the tag with `position: absolute; right: 0` inside `.katex-html`, which fills `.katex-display`. VMark's preview is a **flex container**, so `.katex-display` is a flex item and shrink-wraps — the block ends where the equation ends, and `right: 0` lands on the last term. `width: 100%` restores it; KaTeX's own `text-align: center` was always what centred display math, not `justify-content`.

## #1377 — Export PDF window carried the application menu bar

The cause is *where* the window was built. It was `new WebviewWindow("pdf-export", …)`, and Tauri's JS window options carry **no `menu` field**. Off macOS the menu bar belongs to each window, so a JS-built window inherits the application menu. Settings was never affected because it is built in Rust with `.menu(Menu::new(app)?)` under `cfg(not(target_os = "macos"))` — the reporter's comparison was exactly right.

Creation moves to Rust and reuses that mechanism. The centring maths stays in TypeScript, because it needs the *calling* window's scale factor.

## #1378 — the installer took over `.txt`, and three more

Measured on a clean Windows runner against the published v0.9.68 installer:

```
install claimed .txt  : 'txtfile'  -> 'txt'
install claimed .svg  : 'svgfile'  -> 'svg'
install claimed .html : 'htmlfile' -> 'html'
install claimed .htm  : 'htmlfile' -> 'htm'
```

The POSTINSTALL hook now yields the default **wherever HKLM already names a handler** — a condition, not a list, so `.md` stays VMark's and a machine that owns `.json` keeps it. `OpenWithProgids` is written first, so VMark stays in the Open With list rather than disappearing; it is simply no longer what Windows picks unasked.

Two claims in the report needed correcting, and both change the fix. `ShellNew` is **not** deleted — it survives; the "New" entry is *relabelled*, because that label comes from the ProgID the extension points at. And it is not "every startup": there is no `winreg` dependency or registry call anywhere in the Rust source, so this is install time, and "every startup" is the auto-updater re-running the installer.

## Plus one gate defect the work uncovered

`lint:design-tokens` reported `#1376` in a CSS comment as a **hardcoded hex colour**, advising "Use CSS variable token instead" on a line that declares nothing. The checks scanned raw content while the same file already blanks comments in two other places. Rewording the comment would have left the trap for the next person; rule 31 already records this false-positive shape for the sibling tool.

## Not fixed, deliberately

**#1374 (soak stack overflow) is upstream.** I reproduced it — blockquote depth 4000 on Linux, 8000 here — traced it to `unist-util-visit`, converted VMark's four recursive `visit()` calls to an iterative walk, and it **still failed at the same depth**. Raising the stack trace limit past the tree depth gave the real caller:

```
mdast-util-gfm-autolink-literal → mdast-util-find-and-replace → unist-util-visit-parents
  inside mdast-util-from-markdown's compile step
```

That is `remark-gfm` recursing during parse, before any VMark plugin sees the tree, so my change addressed sites the upstream recursion always reaches first. I reverted it rather than ship unverifiable hardening in the markdown pipeline. The issue needs an upstream fix or a pre-parse depth guard, which changes parse behaviour and is a product decision.

**#1375 (Fcitx5/Rime IME)** I did not attempt — it is Linux IME behaviour I cannot reproduce or verify from here.

## Verification

`check:static` exit 0 (2,142 gate-tier tests) · `check:build` 0 · `check:servers` 0 · `cargo test --lib` 3,117 · clippy `-D warnings` clean · rustfmt clean · typecheck clean · `lint:i18n` clean across ten locales · three mutations confirmed failing and reverted.
