### PR TITLE
chore: bump version to 0.9.69

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.68",
+  "version": "0.9.69",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.68",
+  "version": "0.9.69",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.68';
+const VERSION = '0.9.69';
 
 /**
  * WHY `process.exitCode` AND NOT `process.exit()` ON THESE PATHS.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6418,7 +6418,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.68"
+version = "0.9.69"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.68"
+version = "0.9.69"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.68",
+  "version": "0.9.69",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Bumps to 0.9.69 across the five files rule 40 names, with `src-tauri/Cargo.lock` regenerated.

## What this releases

Four issue fixes merged since v0.9.68, plus a gate defect they uncovered.

**#1374 — the markdown parser no longer overflows the stack.** The weekly soak has failed since 2026-08-17. Its stderr names the input — `"*a **a *a **a …"` — so this was deep *inline* nesting, and the recursion was VMark's own: `walkAndReplace` descended once per nested node. Now an iterative two-phase walk. It was *marginal* rather than reliably broken — three runs on identical input gave ok, overflow, ok — so the test builds a synthetic 20,000-deep tree rather than trusting a single green run.

**#1376 — display-math `\tag` no longer overlaps the equation.** The preview is a flex container, so the KaTeX block shrink-wrapped and the tag's `right: 0` resolved to the equation's edge instead of the block's.

**#1377 — the Export PDF window no longer carries the application menu bar.** It was built from TypeScript, and Tauri's JS window options have no `menu` field. Built in Rust now, with the empty menu Settings already used.

**#1378 — installing no longer takes the default handler for `.txt`, `.svg`, `.html` and `.htm`.** Measured on a clean Windows runner against the published v0.9.68 installer. VMark stays reachable through Open With and is simply no longer what Windows picks unasked.

**Plus:** `lint:design-tokens` read `#1376` in a CSS comment as a hardcoded hex colour, advising a token on a line that declares nothing.

## Also in, separately

Deeply nested *containers* are a different crash from #1374 — the recursion is upstream in `remark-gfm` and cannot be removed here — so the parser refuses such a document before parsing. The limit is derived from bisected ceilings (~5585 on Node 24, ~4843 on Node 22) and set at 1000, roughly fivefold below the lowest, because the ceiling moves with both Node version and machine load.

## Not in this release

**#1375** (Fcitx5/Rime IME) is unreproducible from here and is waiting on `fcitx5-diagnose` output from the reporter.

## Why a standalone bump PR

`main` already carries all of it, which rule 40 names as the case where a standalone bump is correct rather than the fallback.

## Gates

`cargo --locked` accepts the lockfile · all five version strings verified at 0.9.69 · secret scan clean.
