### PR TITLE
fix(terminal): stop one terminal's atlas clear from corrupting its siblings

### DIFF
--- a/src/components/Terminal/createTerminalInstance.rollback.test.ts
+++ b/src/components/Terminal/createTerminalInstance.rollback.test.ts
@@ -15,7 +15,6 @@ const { mockSetupWebgl, mockSetupIme, mockDispose } = vi.hoisted(() => ({
 
 vi.mock("./setupWebglRenderer", () => ({
   setupWebglRenderer: mockSetupWebgl,
-  ATLAS_PAGE_LIMIT: 4,
 }));
 vi.mock("./setupImeCompositionGate", () => ({
   setupImeCompositionGate: mockSetupIme,

--- a/src/components/Terminal/createTerminalInstance.ts
+++ b/src/components/Terminal/createTerminalInstance.ts
@@ -78,9 +78,6 @@ import { verifiedMonoStack } from "@/services/fonts/verifiedMonoStack";
 
 import "@xterm/xterm/css/xterm.css";
 
-// Re-exports kept for compatibility with existing imports/tests.
-export { ATLAS_PAGE_LIMIT } from "./setupWebglRenderer";
-
 /** Resolve the --font-mono CSS variable to actual font family names, used at
  *  terminal creation (the var is already applied by then). Live mono-font
  *  changes are handled by terminalSessionStoreSync, which resolves the stack

--- a/src/components/Terminal/createTerminalInstance.ts
+++ b/src/components/Terminal/createTerminalInstance.ts
@@ -31,8 +31,9 @@
  *   - Lifecycle concerns are split into focused helpers, each returning a
  *     cleanup hook the factory calls in dispose():
  *       * setupImeCompositionGate — Channel Ownership IME handling (one writer)
- *       * setupWebglRenderer   — WebGL addon, atlas bounding (#856),
- *         dual-layer context-loss recovery, MutationObserver, resetDisplay
+ *       * setupWebglRenderer   — WebGL addon, dual-layer context-loss
+ *         recovery, MutationObserver, resetDisplay + its cross-terminal
+ *         shared-atlas broadcast (#856)
  *       * setupWebLinks        — sandboxed web-link click handler
  *       * setupFileLinks       — file-link click handler with size guard
  *       * setupOsc7            — OSC 7 cwd tracking (exposes getCwd)
@@ -112,9 +113,12 @@ export interface TerminalInstance {
   noteExternalWrite: (data: string) => void;
   /**
    * User-triggered "redraw the terminal" action (#856). Clears the WebGL
-   * texture atlas (if WebGL is active) and re-paints the viewport. Safe to
-   * call when the WebGL addon is absent or already disposed — it then
-   * just refreshes the viewport via the DOM renderer.
+   * texture atlas (if WebGL is active) and re-paints the viewport, then
+   * tells every other live WebGL terminal to drop its model — the atlas is
+   * shared between them, so clearing it behind their backs would leave them
+   * rendering other terminals' glyphs. Safe to call when the WebGL addon is
+   * absent or already disposed — it then just refreshes the viewport via the
+   * DOM renderer, and broadcasts nothing.
    */
   resetDisplay: () => void;
   /** The shell's last-reported cwd via OSC 7, or null if never reported (WI-2.1). */

--- a/src/components/Terminal/createTerminalInstance.webgl.test.ts
+++ b/src/components/Terminal/createTerminalInstance.webgl.test.ts
@@ -173,18 +173,22 @@ vi.mock("@/theme", () => ({
 
 // --- Imports (after mocks) ---
 
-import { ATLAS_PAGE_LIMIT, createTerminalInstance } from "./createTerminalInstance";
+import { createTerminalInstance } from "./createTerminalInstance";
 
 // --- Helpers ---
 
 /** Track every parent we mounted so afterEach can scrub them. */
 const mountedParents: HTMLElement[] = [];
+/** Track every instance so afterEach can dispose it. setupWebglRenderer keeps a
+ *  module-level registry of live renderers (for the atlas-clear broadcast); an
+ *  instance left undisposed would leak into the next test's broadcast. */
+const mountedInstances: Array<{ dispose: () => void }> = [];
 
 function makeInstance(useWebGL = true) {
   const parentEl = document.createElement("div");
   document.body.appendChild(parentEl);
   mountedParents.push(parentEl);
-  return createTerminalInstance({
+  const instance = createTerminalInstance({
     parentEl,
     settings: {
       fontSize: 14,
@@ -197,9 +201,19 @@ function makeInstance(useWebGL = true) {
     ptyRef: { current: null },
     onSearch: vi.fn(),
   });
+  mountedInstances.push(instance);
+  return instance;
 }
 
 afterEach(() => {
+  while (mountedInstances.length > 0) {
+    const instance = mountedInstances.pop();
+    try {
+      instance?.dispose();
+    } catch {
+      // Tests that dispose explicitly leave a second dispose to no-op here.
+    }
+  }
   while (mountedParents.length > 0) {
     const parent = mountedParents.pop();
     if (parent && parent.parentNode) parent.parentNode.removeChild(parent);
@@ -212,107 +226,110 @@ function lastWebglAddon() {
 
 // --- Tests ---
 
-describe("createTerminalInstance — WebGL atlas page bounding (#856)", () => {
+describe("createTerminalInstance — never clears the shared atlas on its own", () => {
   beforeEach(() => {
     webglState.instances = [];
     webglState.failConstruction = false;
     vi.clearAllMocks();
   });
 
-  it("does not call clearTextureAtlas before the page limit is reached", () => {
+  // xterm shares ONE TextureAtlas between terminals whose configs match
+  // (module-global CharAtlasCache), but clearTextureAtlas() repairs only the
+  // CALLING renderer's model. A renderer that clears the atlas behind its
+  // siblings' backs leaves them with texture coordinates into a repacked
+  // atlas and a model whose "nothing changed" check never lets them repaint,
+  // so they render other glyphs. Nothing may clear the atlas unprompted.
+  it("does not subscribe to atlas page add/remove events", () => {
+    makeInstance();
+    const addon = lastWebglAddon();
+
+    expect(addon.addAtlasHandlers).toHaveLength(0);
+    expect(addon.removeAtlasHandlers).toHaveLength(0);
+  });
+
+  it("never calls clearTextureAtlas without an explicit resetDisplay", () => {
     makeInstance();
     const addon = lastWebglAddon();
     const canvas = document.createElement("canvas");
 
-    // Add fewer than the limit
-    for (let i = 0; i < ATLAS_PAGE_LIMIT - 1; i++) {
+    // Even a flood of reported atlas pages must not trigger a clear.
+    for (let i = 0; i < 32; i++) {
       addon.addAtlasHandlers.forEach((h) => h(canvas));
     }
 
     expect(addon.clearTextureAtlas).not.toHaveBeenCalled();
   });
+});
 
-  it("calls clearTextureAtlas exactly once when the page limit is hit", () => {
-    makeInstance();
-    const addon = lastWebglAddon();
-    const canvas = document.createElement("canvas");
-
-    for (let i = 0; i < ATLAS_PAGE_LIMIT; i++) {
-      addon.addAtlasHandlers.forEach((h) => h(canvas));
-    }
-
-    expect(addon.clearTextureAtlas).toHaveBeenCalledTimes(1);
+describe("createTerminalInstance — resetDisplay broadcasts to sibling terminals", () => {
+  beforeEach(() => {
+    webglState.instances = [];
+    webglState.failConstruction = false;
+    vi.clearAllMocks();
   });
 
-  it("resets the page count after a clear so the next clear takes another full window", () => {
-    makeInstance();
-    const addon = lastWebglAddon();
-    const canvas = document.createElement("canvas");
+  it("clears every other live terminal's model, not just its own", () => {
+    const a = makeInstance();
+    const b = makeInstance();
+    const [addonA, addonB] = webglState.instances;
 
-    // Trigger first clear
-    for (let i = 0; i < ATLAS_PAGE_LIMIT; i++) {
-      addon.addAtlasHandlers.forEach((h) => h(canvas));
-    }
-    expect(addon.clearTextureAtlas).toHaveBeenCalledTimes(1);
+    a.resetDisplay();
 
-    // One more page added — should NOT clear yet (counter was reset)
-    addon.addAtlasHandlers.forEach((h) => h(canvas));
-    expect(addon.clearTextureAtlas).toHaveBeenCalledTimes(1);
-
-    // Fill up another full window
-    for (let i = 1; i < ATLAS_PAGE_LIMIT; i++) {
-      addon.addAtlasHandlers.forEach((h) => h(canvas));
-    }
-    expect(addon.clearTextureAtlas).toHaveBeenCalledTimes(2);
+    // A wipes the SHARED atlas plus its own model; B must be told to drop its
+    // model too. B's clearTextureAtlas early-returns on the now-empty atlas
+    // and only performs the local model clear it needs.
+    expect(addonA.clearTextureAtlas).toHaveBeenCalledTimes(1);
+    expect(addonB.clearTextureAtlas).toHaveBeenCalledTimes(1);
+    expect(b.term.refresh).toHaveBeenCalledWith(0, b.term.rows - 1);
   });
 
-  it("decrements the page count when xterm reports a removed atlas page", () => {
-    makeInstance();
-    const addon = lastWebglAddon();
-    const canvas = document.createElement("canvas");
+  it("notifies itself exactly once", () => {
+    const a = makeInstance();
+    const addonA = lastWebglAddon();
 
-    // Push to one below the limit
-    for (let i = 0; i < ATLAS_PAGE_LIMIT - 1; i++) {
-      addon.addAtlasHandlers.forEach((h) => h(canvas));
-    }
-    // Remove one — count drops, so adding one more should not yet clear
-    addon.removeAtlasHandlers.forEach((h) => h(canvas));
-    addon.addAtlasHandlers.forEach((h) => h(canvas));
+    a.resetDisplay();
+
+    expect(addonA.clearTextureAtlas).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not notify a terminal that has been disposed", () => {
+    const a = makeInstance();
+    const b = makeInstance();
+    const [, addonB] = webglState.instances;
+
+    b.dispose();
+    addonB.clearTextureAtlas.mockClear();
+
+    a.resetDisplay();
+
+    expect(addonB.clearTextureAtlas).not.toHaveBeenCalled();
+  });
+
+  it("finishes the broadcast even if a sibling throws mid-dispose", () => {
+    const a = makeInstance();
+    makeInstance();
+    makeInstance();
+    const [, addonB, addonC] = webglState.instances;
+    addonB.clearTextureAtlas.mockImplementationOnce(() => {
+      throw new Error("disposed");
+    });
+
+    expect(() => a.resetDisplay()).not.toThrow();
+    expect(addonC.clearTextureAtlas).toHaveBeenCalledTimes(1);
+  });
+
+  it("a WebGL-disabled terminal neither broadcasts to nor is touched by WebGL peers", () => {
+    const dom = makeInstance(/* useWebGL */ false);
+    const webgl = makeInstance();
+    const addon = lastWebglAddon();
+
+    // No atlas is involved, so a DOM-renderer terminal must not clear anyone.
+    dom.resetDisplay();
     expect(addon.clearTextureAtlas).not.toHaveBeenCalled();
 
-    // Now adding one more pushes us to the limit
-    addon.addAtlasHandlers.forEach((h) => h(canvas));
+    // And it must not break a real broadcast either.
+    expect(() => webgl.resetDisplay()).not.toThrow();
     expect(addon.clearTextureAtlas).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not floor the page counter below zero on spurious remove events", () => {
-    makeInstance();
-    const addon = lastWebglAddon();
-    const canvas = document.createElement("canvas");
-
-    // Spurious remove with no adds — counter must stay at 0, not go negative
-    for (let i = 0; i < 10; i++) {
-      addon.removeAtlasHandlers.forEach((h) => h(canvas));
-    }
-
-    // Filling exactly to the limit must still trigger a clear
-    for (let i = 0; i < ATLAS_PAGE_LIMIT; i++) {
-      addon.addAtlasHandlers.forEach((h) => h(canvas));
-    }
-    expect(addon.clearTextureAtlas).toHaveBeenCalledTimes(1);
-  });
-
-  it("survives clearTextureAtlas throwing (renderer mid-dispose)", () => {
-    makeInstance();
-    const addon = lastWebglAddon();
-    addon.clearTextureAtlas.mockImplementationOnce(() => { throw new Error("disposed"); });
-    const canvas = document.createElement("canvas");
-
-    expect(() => {
-      for (let i = 0; i < ATLAS_PAGE_LIMIT; i++) {
-        addon.addAtlasHandlers.forEach((h) => h(canvas));
-      }
-    }).not.toThrow();
   });
 });
 
@@ -374,21 +391,20 @@ describe("createTerminalInstance — WebGL context loss handling (#856)", () => 
     }).not.toThrow();
   });
 
-  it("after context loss, atlas events become no-ops (addon already disposed)", () => {
-    makeInstance();
-    const addon = lastWebglAddon();
-    const canvas = document.createElement("canvas");
+  it("a sibling's atlas clear degrades to a plain refresh after context loss", () => {
+    const lost = makeInstance();
+    const other = makeInstance();
+    const [addonLost] = webglState.instances;
 
-    // Lose the context first
-    addon.contextLossHandlers.forEach((h) => h());
-    addon.clearTextureAtlas.mockClear();
+    addonLost.contextLossHandlers.forEach((h) => h());
+    addonLost.clearTextureAtlas.mockClear();
+    (lost.term.refresh as unknown as ReturnType<typeof vi.fn>).mockClear();
 
-    // Atlas events arriving late from a disposed addon should not blow up
-    expect(() => {
-      for (let i = 0; i < ATLAS_PAGE_LIMIT * 2; i++) {
-        addon.addAtlasHandlers.forEach((h) => h(canvas));
-      }
-    }).not.toThrow();
+    // The addon is gone and the DOM renderer has taken over, so the broadcast
+    // must reach this terminal as a viewport refresh and nothing more.
+    expect(() => other.resetDisplay()).not.toThrow();
+    expect(addonLost.clearTextureAtlas).not.toHaveBeenCalled();
+    expect(lost.term.refresh).toHaveBeenCalledWith(0, lost.term.rows - 1);
   });
 
   it("DOM webglcontextlost listeners are removed when the instance disposes", () => {
@@ -484,24 +500,6 @@ describe("createTerminalInstance — resetDisplay (#856)", () => {
 
     expect(addon.clearTextureAtlas).toHaveBeenCalledTimes(1);
     expect(inst.term.refresh).toHaveBeenCalledWith(0, inst.term.rows - 1);
-  });
-
-  it("resets the atlas page counter so the next clear takes another full window", () => {
-    const inst = makeInstance();
-    const addon = lastWebglAddon();
-    const canvas = document.createElement("canvas");
-
-    // Fill atlas to one below the limit
-    for (let i = 0; i < ATLAS_PAGE_LIMIT - 1; i++) {
-      addon.addAtlasHandlers.forEach((h) => h(canvas));
-    }
-
-    inst.resetDisplay();
-    addon.clearTextureAtlas.mockClear();
-
-    // Counter must be back at zero — adding one page should not auto-clear
-    addon.addAtlasHandlers.forEach((h) => h(canvas));
-    expect(addon.clearTextureAtlas).not.toHaveBeenCalled();
   });
 
   it("only refreshes the viewport when WebGL is disabled (DOM renderer path)", () => {

--- a/src/components/Terminal/setupWebglRenderer.ts
+++ b/src/components/Terminal/setupWebglRenderer.ts
@@ -1,17 +1,28 @@
 /**
  * setupWebglRenderer
  *
- * Purpose: Wires the xterm.js WebGL addon onto a Terminal with the bounded-
- * atlas, robust-context-loss, and reset-display behavior introduced for #856.
+ * Purpose: Wires the xterm.js WebGL addon onto a Terminal with robust
+ * context-loss recovery and a reset-display escape hatch (#856).
  * Returns the public surface (resetDisplay) and a cleanup hook for dispose.
  *
  * Key decisions:
- *   - Atlas page count is bounded via onAddTextureAtlasCanvas /
- *     onRemoveTextureAtlasCanvas (#856). Once the count crosses
- *     ATLAS_PAGE_LIMIT the atlas is cleared and the count resets, so
- *     long sessions with heavily styled output (chalk-painted CLIs +
- *     minimumContrastRatio) cannot grow GPU memory unboundedly and
- *     produce glyph corruption.
+ *   - The texture atlas is SHARED between terminals. xterm's CharAtlasCache
+ *     is a module-global keyed by render config, so every terminal in this
+ *     window with the same font/theme/DPR draws from ONE TextureAtlas.
+ *     clearTextureAtlas() wipes that shared atlas but clears only the
+ *     CALLING renderer's model. A sibling is left holding texture
+ *     coordinates into an atlas that has been emptied and repacked with
+ *     unrelated glyphs, while its per-cell "nothing changed" check refuses
+ *     to repaint those cells — so it renders OTHER characters, permanently,
+ *     until something forces a full redraw. Two rules follow:
+ *       (a) nothing may clear the atlas unprompted, and
+ *       (b) whoever clears it must tell every other live renderer to drop
+ *           its model too. See liveRenderers below.
+ *     This replaces the page-count bounding added for #856, which violated
+ *     (a): it cleared the shared atlas automatically, reentrantly from
+ *     inside xterm's per-cell model loop, and never achieved its stated goal
+ *     — clearTexture() empties pages but never removes them, so page count
+ *     grew anyway. Upstream's own _mergePages already bounds it correctly.
  *   - Context loss is detected at TWO layers: the addon's onContextLoss
  *     callback and a DOM-level webglcontextlost listener on each render
  *     canvas. VS Code's microsoft/vscode#120393 documents that the addon
@@ -24,8 +35,8 @@
  *     DOM renderer takes over automatically (the canvas addon was
  *     removed in 6.0, so DOM is the only fallback).
  *   - resetDisplay() is the user-facing escape hatch: it clears the
- *     atlas and refreshes the viewport. Safe to call when WebGL is
- *     disabled or has already lost context.
+ *     atlas, re-paints the viewport, and broadcasts per rule (b). Safe to
+ *     call when WebGL is disabled or has already lost context.
  *
  * @coordinates-with createTerminalInstance.ts — sole caller
  * @module components/Terminal/setupWebglRenderer
@@ -35,20 +46,26 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { terminalLog } from "@/utils/debug";
 
 /**
- * Maximum WebGL texture-atlas pages permitted before forcing a clear (#856).
- * xterm allocates a new 512×512 page each time the current pages can't fit
- * a new (glyph + style + fg + bg) combination. With minimumContrastRatio's
- * per-cell foreground lift active, heavily styled output multiplies unique
- * combinations and can grow the atlas indefinitely, producing glyph
- * corruption. 4 pages is xterm.js' own merging trigger heuristic.
+ * Every live renderer in this JS realm that draws from the shared texture
+ * atlas. Module-level on purpose: it mirrors the scope of the thing being
+ * shared — xterm's CharAtlasCache is a module-global too, so the set of
+ * terminals that can poison each other is exactly the set reachable here.
+ *
+ * Terminals running the DOM renderer (WebGL disabled, or construction
+ * failed) never join: they neither read from nor write to the atlas.
+ * A terminal that has LOST its context stays registered — its sync degrades
+ * to a harmless viewport refresh, and staying registered keeps the
+ * bookkeeping symmetric with cleanup().
  */
-export const ATLAS_PAGE_LIMIT = 4;
+const liveRenderers = new Set<{ syncAfterAtlasClear: () => void }>();
 
 /** Public surface returned by setupWebglRenderer to the factory. */
 export interface WebglRendererHandle {
   /**
-   * Manually clears the WebGL texture atlas (if active) and re-paints the
-   * viewport. Safe to call when WebGL is disabled or already disposed.
+   * Manually clears the WebGL texture atlas (if active), re-paints the
+   * viewport, and tells every other live WebGL terminal to drop its model
+   * so it re-resolves its glyphs against the repacked atlas. Safe to call
+   * when WebGL is disabled or already disposed.
    */
   resetDisplay: () => void;
   /** Tear down all listeners. Idempotent. */
@@ -63,13 +80,12 @@ interface SetupOptions {
 }
 
 /**
- * Attach the WebGL addon (when enabled) plus atlas bounding, context-loss
- * recovery, and a canvas-replacement observer. Returns a handle exposing
- * resetDisplay() and a cleanup hook.
+ * Attach the WebGL addon (when enabled) plus context-loss recovery and a
+ * canvas-replacement observer. Returns a handle exposing resetDisplay() and
+ * a cleanup hook.
  */
 export function setupWebglRenderer({ term, container, enabled }: SetupOptions): WebglRendererHandle {
   let webglAddon: WebglAddon | null = null;
-  let atlasPageCount = 0;
   const domCleanups: Array<() => void> = [];
 
   const drainDomCleanups = () => {
@@ -88,6 +104,29 @@ export function setupWebglRenderer({ term, container, enabled }: SetupOptions): 
     }
   };
 
+  /**
+   * Drop this terminal's atlas-derived state and re-paint it. Does NOT
+   * broadcast — the caller decides.
+   *
+   * On the terminal that initiates a reset this wipes the shared atlas AND
+   * clears this renderer's model. On a terminal reached by the broadcast the
+   * atlas has just been emptied, so xterm's clearTexture() early-returns and
+   * this performs only the local model clear — which is exactly the step
+   * that terminal was missing.
+   */
+  const clearOwnAtlasAndRepaint = () => {
+    if (webglAddon) {
+      try {
+        webglAddon.clearTextureAtlas();
+      } catch {
+        // Addon may have been disposed between calls — safe to ignore.
+      }
+    }
+    refreshViewport();
+  };
+
+  const peer = { syncAfterAtlasClear: clearOwnAtlasAndRepaint };
+
   const handleContextLoss = () => {
     if (!webglAddon) return;
     try {
@@ -96,7 +135,6 @@ export function setupWebglRenderer({ term, container, enabled }: SetupOptions): 
       // Already disposing or never fully initialized — safe to ignore.
     }
     webglAddon = null;
-    atlasPageCount = 0;
     drainDomCleanups();
     terminalLog("WebGL context lost — terminal falling back to DOM renderer");
   };
@@ -117,24 +155,11 @@ export function setupWebglRenderer({ term, container, enabled }: SetupOptions): 
 
       addon.onContextLoss(handleContextLoss);
 
-      // Bound atlas growth (#856): clear when too many pages accumulate.
-      addon.onAddTextureAtlasCanvas(() => {
-        atlasPageCount += 1;
-        if (atlasPageCount >= ATLAS_PAGE_LIMIT) {
-          try {
-            addon.clearTextureAtlas();
-          } catch {
-            // Renderer may already be disposed — safe to ignore.
-          }
-          atlasPageCount = 0;
-        }
-      });
-
-      addon.onRemoveTextureAtlasCanvas(() => {
-        atlasPageCount = Math.max(0, atlasPageCount - 1);
-      });
-
       term.loadAddon(addon);
+
+      // Only terminals that actually draw from the shared atlas take part in
+      // the clear broadcast (rule (b) in the module header).
+      liveRenderers.add(peer);
 
       // Bind every canvas currently inside the container (defense-in-depth
       // against silent context loss; see module header).
@@ -166,18 +191,27 @@ export function setupWebglRenderer({ term, container, enabled }: SetupOptions): 
   }
 
   const resetDisplay = () => {
-    if (webglAddon) {
+    // Whether we are about to disturb the SHARED atlas, decided before the
+    // clear: a DOM-renderer terminal (disabled, construction failed, or
+    // context lost) touches no atlas, so it has nobody to warn.
+    const willClearSharedAtlas = webglAddon !== null;
+
+    clearOwnAtlasAndRepaint();
+    if (!willClearSharedAtlas) return;
+
+    for (const other of liveRenderers) {
+      if (other === peer) continue;
       try {
-        webglAddon.clearTextureAtlas();
+        other.syncAfterAtlasClear();
       } catch {
-        // Addon may have been disposed between calls — safe to ignore.
+        // A sibling caught mid-dispose must not abort the rest of the
+        // broadcast — every remaining terminal still needs its model dropped.
       }
-      atlasPageCount = 0;
     }
-    refreshViewport();
   };
 
   const cleanup = () => {
+    liveRenderers.delete(peer);
     drainDomCleanups();
     // The addon itself is disposed by term.dispose() via the registered addon.
   };

--- a/website/guide/terminal.md
+++ b/website/guide/terminal.md
@@ -103,7 +103,7 @@ Right-click inside the terminal to access:
 - **Paste** — paste from clipboard into the shell
 - **Select All** — select the entire terminal buffer
 - **Clear** — clear visible output
-- **Reset Display** — re-paint the terminal and reset its rendering cache. Use this if characters start to overlap, mix cases, or render garbled after a long session — most often seen when running heavily styled CLIs (e.g. Claude Code) for hours.
+- **Reset Display** — re-paint the terminal and reset its rendering cache. Use this if characters start to overlap, mix cases, or render garbled after a long session — most often seen when running heavily styled CLIs (e.g. Claude Code) for hours. Terminals in the same window share one glyph cache, so this re-paints every terminal in the window rather than only the active tab.
 - **Copy Command Output** — copy everything one command printed, without its prompt line and without the next command's output. Appears only when you right-click inside a command's output and [shell integration](#shell-integration) is on, since that is what tells VMark where each command began and ended.
 
 The menu is fully keyboard-navigable: it opens with the first available action focused, arrow keys move between items (skipping disabled ones), Home/End jump to the first/last, Enter or Space activates, and Escape or Tab closes it.


### PR DESCRIPTION
## Symptom

After a long session with heavily styled output, a block of **already-scrolled, static** text in a terminal shows **glyph substitution** — characters replaced by *other* characters, not blanks:

```
git checkout -- codex.html     →     kct c=ecl.ost
教                             →     仌
```

It never heals on its own. Selecting the garbled span makes exactly the selected cells render correctly; the unselected remainder stays garbled. Copying the span out yields the correct original text, so the buffer was always right — this is purely a rendering fault.

This is a recurrence of #856. The fix shipped for that issue (`2e1039682`, v0.7.29) is what causes it.

## Root cause

**The texture atlas is shared between terminals, but clearing it only repairs the terminal that cleared it.**

1. xterm's `CharAtlasCache` is a **module-global**, so every terminal in a window whose render config matches (font, size, theme, DPR) draws from **one** `TextureAtlas` — `configEquals` match ⇒ `entry.ownedBy.push(terminal); return entry.atlas`. VMark has terminal tabs and keeps hidden sessions alive, so this is the normal case, not an edge case.

2. That shared atlas's `onAddTextureAtlasCanvas` is forwarded to **every** owning renderer (`WebglRenderer.ts:286`) → every `WebglAddon` → every terminal's own listener.

3. `WebglRenderer.clearTextureAtlas()` has **global blast radius but local repair**:

```ts
this._charAtlas?.clearTexture();   // shared atlas: all page pixels wiped, _cacheMap cleared
this._clearModel(true);            // only THIS renderer's model and vertices
this._requestRedrawViewport();     // only THIS renderer
```

So when terminal A clears, terminal B keeps texture coordinates into an atlas that has been emptied and repacked with unrelated glyphs — while B's per-cell "nothing changed" check (`WebglRenderer.ts:506`, comparing `code`/`bg`/`fg`/`ext`) refuses to repaint those cells, because static scrolled-back text never changes its tuple. B renders other characters, permanently.

That skip cache also explains the selection observation: selection bakes selection colors into per-cell `fg`/`bg` via `CellColorResolver`, the tuple changes, the skip fails, and **only the selected cells** are re-rendered — which is exactly what was observed.

**Two things triggered the clear:**

- The **#856 page-count bounding** in `setupWebglRenderer.ts`, which called `clearTextureAtlas()` automatically — reentrantly, from inside xterm's per-cell model loop — every 4 atlas pages. It also never achieved its stated goal: `clearTexture()` empties pages but never removes them, so the page count grows anyway (4 → 8 → 12 → 16), and upstream's `_mergePages` already bounds it correctly. The comment claiming "4 pages is xterm.js' own merging trigger heuristic" misread the source: `4` there is a merge *batch size and floor*, not a trigger threshold.
- **"Reset Display"** — the very action users are told to take when they see corruption, which therefore corrupted every other tab in the window.

Coverage was checked: `TextureAtlas.clearTexture()` has exactly **one** call path in all of xterm — the public `WebglAddon.clearTextureAtlas()` (`WebglAddon.ts:105` → `WebglRenderer.ts:308`). xterm never calls it internally; theme changes go through `_handleColorChange` → `_refreshCharAtlas()` + a local `_clearModel(true)`, which does not wipe a shared atlas's contents. So controlling both call sites in VMark closes the hole completely.

## Deterministic reproduction (no code changes needed, works on a release build)

Because `resetDisplay()` goes through the same `clearTextureAtlas()`, the bug can be triggered by hand:

1. Open two terminal tabs in one window, A and B.
2. In **B**, print a screen of static CJK, then leave B alone (no typing, no selection, no scrolling, no resize):
   ```
   perl -CS -e 'my $c=0x9000; for my $f (30..45){ printf "\033[38;5;%dm",$f; print map { chr($c++) } 1..40; print "\033[0m\n"; }'
   ```
3. Switch to **A** and run (different starting codepoint, so the glyphs do not overlap with B's):
   ```
   perl -CS -e 'my $c=0x4e00; for my $f (16..231){ printf "\033[38;5;%dm",$f; print map { chr($c++) } 1..40; print "\033[0m\n"; }'
   ```
4. Right-click in **A** → **Reset Display**.
5. Run step 3 again in **A**, so fresh glyphs reoccupy the slots that were wiped.
6. Switch back to **B** and just look.

Repeat 3→4→5 two or three times if needed: `clearTexture()` early-returns while page 0 is empty, so the atlas has to be filled before a clear is destructive.

The command emits 216 lines × 40 consecutive CJK characters × 216 distinct 256-color foregrounds = **8640 unique (glyph, fg) combinations**, deterministic rather than random.

## A/B result

Same machine, same dev instance, same steps, only these commits differ:

| | `main` (fb925e34e) | this branch |
|---|---|---|
| B's static text after A's Reset Display | **glyph substitution** | **clean** |
| Reset Display on B itself | works | works |

## The change

**1. Remove the page-count bounding.** `ATLAS_PAGE_LIMIT`, `atlasPageCount`, the `onAddTextureAtlasCanvas` / `onRemoveTextureAtlasCanvas` handlers, and the re-export from `createTerminalInstance`. It is reentrant, it does not achieve its stated goal, and it fires the destructive global clear automatically with no user intent.

**2. Broadcast on clear.** `setupWebglRenderer.ts` gains a module-level registry of live renderers — deliberately the same scope as the thing being shared. After `resetDisplay()` clears its own state, it tells every other live renderer to drop its model. Those calls go through their own `clearTextureAtlas()`, which is safe and cheap: the shared atlas's `clearTexture()` early-returns (page 0's `currentRow` is already at 0,0), so each sibling performs only the local `_clearModel(true)` + repaint it was missing.

Edge cases covered: a DOM-renderer terminal neither broadcasts nor is notified; a context-lost terminal degrades to a plain viewport refresh; a sibling throwing mid-dispose does not abort the rest of the broadcast.

**Not changed:** the context-loss layer. `WebglRenderer`'s dispose calls `removeTerminalFromCache`, which disposes the atlas only when it is the sole owner — in which case there are no siblings to damage.

## Platform independence

The whole causal chain is JS-level bookkeeping in xterm.js and in this module: no GPU behavior, no webview-specific API, no platform branch in the code. Windows (WebView2/Chromium) and Linux (WebKitGTK) are affected and fixed identically. Only the *frequency* can differ, since `maxAtlasPages = min(32, MAX_TEXTURE_IMAGE_UNITS)` changes when upstream's page merge takes over — but the manual "Reset Display" trigger is deterministic on all three. The unit tests for this code run on ubuntu in CI, which is itself evidence the logic is platform-independent.

## Tests

The 7 page-counter arithmetic tests are replaced by contract tests that measure the mechanism rather than a counter:

- never subscribes to atlas page add/remove events,
- never calls `clearTextureAtlas` without an explicit `resetDisplay` (even if xterm reports 32 new pages),
- `resetDisplay` reaches every live sibling,
- skips a disposed terminal,
- notifies itself exactly once,
- finishes the broadcast when a sibling throws,
- a WebGL-disabled terminal neither broadcasts to nor is touched by WebGL peers,
- a sibling's clear degrades to a plain refresh after context loss.

`src/components/Terminal`: 55 files / 963 tests pass. `pnpm check:fast` passes. `pnpm check:predelta`: 43/44 (the one failure is `gen-feature-ledger.test.mjs`, which needs `tokei` installed locally and fails identically on a pristine `main`).

## Upstream

The underlying defect is upstream, and **xterm.js has already fixed it**: `0b1c0b5c` ("Fix stale rendering after a shared texture atlas is cleared", 2026-07-16) bumps `TextureAtlas._pageLayoutVersion` on clear so every owning renderer rebuilds its model on its next frame — reusing the mechanism page merges and evictions already had, which is cleaner than the per-embedder broadcast below. Its commit message describes this exact scenario ("only recovers once the whole panel is closed and the last owner drops the atlas"), and it ships a regression test, `WebglSharedAtlasGarble.test.ts`, described as failing on master with "terminal B's row renders terminal A's flood glyphs".

That fix is **not in any release VMark can use**. It is in no tag; npm `latest` is still `0.19.0` (published 2025-12-22), which is what this repo pins. It is present in `0.20.0-beta.300` (2026-08-30).

So the two changes here stand on their own:

- **Change 1** is VMark's own defect. The upstream fix does not address it at all — the reentrancy and the page bound that never bounded anything are ours, and removing them is correct regardless of which addon version is installed.
- **Change 2** is what makes the released `0.19.0` safe today.

When a stable release containing `0b1c0b5c` lands and this repo upgrades, change 2 becomes redundant and can be deleted; change 1 should stay deleted either way. Moving to the beta instead is a separate decision and is deliberately not bundled here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVMQwJtUGpLe1MvnkBYqGN
