### PR TITLE
fix(ui): centre the switch knob in its track, bump to 0.9.70

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.69",
+  "version": "0.9.70",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -216,7 +216,8 @@
       "path-to-regexp": ">=8.4.0 <9",
       "js-yaml@3": ">=3.15.2 <4",
       "js-yaml@4": ">=4.3.2 <5",
-      "baseline-browser-mapping": ">=2.11.0 <3"
+      "baseline-browser-mapping": ">=2.11.0 <3",
+      "smol-toml": ">=1.7.1 <2"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ overrides:
   js-yaml@3: '>=3.15.2 <4'
   js-yaml@4: '>=4.3.2 <5'
   baseline-browser-mapping: '>=2.11.0 <3'
+  smol-toml: '>=1.7.1 <2'
 
 importers:
 
@@ -292,7 +293,7 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       smol-toml:
-        specifier: ^1.8.0
+        specifier: '>=1.7.1 <2'
         version: 1.8.0
       sonner:
         specifier: ^2.0.8
@@ -8217,10 +8218,6 @@ packages:
     resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
     engines: {node: '>=20.0.0'}
 
-  smol-toml@1.7.0:
-    resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
-    engines: {node: '>= 18'}
-
   smol-toml@1.8.0:
     resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
@@ -13639,9 +13636,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@22.20.1)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/browser': 4.1.11(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.98.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -16611,7 +16608,7 @@ snapshots:
       markdownlint: 0.41.1
       markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.23.2)
       micromatch: 4.0.8
-      smol-toml: 1.7.0
+      smol-toml: 1.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -18331,8 +18328,6 @@ snapshots:
 
   smob@1.6.2:
     optional: true
-
-  smol-toml@1.7.0: {}
 
   smol-toml@1.8.0: {}
 

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.69",
+  "version": "0.9.70",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.69';
+const VERSION = '0.9.70';
 
 /**
  * WHY `process.exitCode` AND NOT `process.exit()` ON THESE PATHS.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6418,7 +6418,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.69"
+version = "0.9.70"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.69"
+version = "0.9.70"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.69",
+  "version": "0.9.70",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/styles/panel-shared.css
+++ b/src/styles/panel-shared.css
@@ -101,10 +101,16 @@
   outline-offset: var(--border-medium);
 }
 
+/* Centred by arithmetic, not by eye. In the 36x20 track a 14px knob insets
+   (20-14)/2 = 3px top and bottom, and 3px at EACH END of a 36-3-3-14 = 16px
+   travel. The 2px it replaced left 4px below the knob and, once translated,
+   4px past it (#1391) — and --shadow-sm points down, so the optical error
+   read as a different direction than the geometric one. Retuning the track
+   or the travel means redoing this sum; panel.test.ts checks it. */
 .vm-switch__knob {
   position: absolute;
-  top: 2px;
-  left: 2px;
+  top: 3px;
+  left: 3px;
   width: 14px;
   height: 14px;
   border-radius: 50%;

--- a/src/styles/panel.test.ts
+++ b/src/styles/panel.test.ts
@@ -35,6 +35,35 @@ describe("panel primitives (WI-UI3.4)", () => {
     expect(rule(".vm-switch__knob")).toContain("var(--bg-color)");
   });
 
+  // The knob is centred by ARITHMETIC, so assert the insets rather than the
+  // literals — this fails on any future retune of the track or the travel that
+  // reintroduces #1391's asymmetry, not merely on a changed `top`.
+  it("the switch knob sits centred in its track, off and on", () => {
+    const px = (block: string, prop: string): number => {
+      const m = new RegExp(`(?:^|[;{\\s])${prop}:\\s*(-?\\d+(?:\\.\\d+)?)px`).exec(block);
+      expect(m, `${prop} in ${block}`).not.toBeNull();
+      return Number(m![1]);
+    };
+
+    const track = rule(".vm-switch");
+    const knob = rule(".vm-switch__knob");
+    const checked = rule('.vm-switch[aria-checked="true"] .vm-switch__knob');
+
+    const trackW = px(track, "width");
+    const trackH = px(track, "height");
+    const knobW = px(knob, "width");
+    const knobH = px(knob, "height");
+    const top = px(knob, "top");
+    const left = px(knob, "left");
+    const travel = Number(/translateX\((-?\d+(?:\.\d+)?)px\)/.exec(checked)?.[1]);
+
+    expect(travel).not.toBeNaN();
+    // Vertical: equal air above and below.
+    expect(trackH - top - knobH).toBe(top);
+    // Horizontal: the off-state left inset equals the on-state right inset.
+    expect(trackW - (left + travel) - knobW).toBe(left);
+  });
+
   it("vm-spinner is the one spinner", () => {
     const s = rule(".vm-spinner");
     expect(s).toContain("var(--border-medium)");


### PR DESCRIPTION
## What

Centres the knob inside the `.vm-switch` track, and bumps to 0.9.70 to release it.

A 14px knob in the 36x20 track needs a (20-14)/2 = 3px inset. It carried 2px,
leaving 4px below the knob and, once moved by the 16px travel, 4px past its
trailing edge. The drop shadow points down, so the optical error read as a
different direction than the geometric one, which is how an off-by-one survived
review.

The travel was already correct and is unchanged, so both end insets now land on
3px. `.vm-switch` is the only track-and-knob control in the tree, so this one
primitive covers every Settings toggle.

## Verification

Measured in a running debug build, Settings then About: 3px above and below the
knob in both states, 3px leading when off and 3px trailing when on. That matches
the geometry the report asked for.

`panel.test.ts` now derives the insets from the stylesheet and asserts they are
equal, rather than restating the new literals, so a later retune of the track
size or the travel that breaks centring fails as well. The assertion was checked
against the old geometry first to confirm it detects the defect, then against the
new one.

`pnpm check:all` green before the bump; `lint:tauri-versions` and `check:servers`
green after it.

## Release

Bumps all five version files plus the derived `src-tauri/Cargo.lock`, folded into
this PR rather than a standalone bump PR so the release costs one CI cycle.

Closes #1391
