### PR TITLE
fix(ime): keep committed CJK text in empty table cells on macOS

### DIFF
--- a/src/plugins/compositionGuard/__tests__/compositionKeys.test.ts
+++ b/src/plugins/compositionGuard/__tests__/compositionKeys.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+/**
+ * Tests for compositionKeys.ts — which key events the composition guard claims.
+ *
+ * The load-bearing case is the undispatched one: ProseMirror's domchange.ts
+ * synthesizes a key event it never dispatches, and reads `true` as "discard the
+ * parsed DOM change" (#1392). The guard must decline those, and only those.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  isDispatchedKeyEvent,
+  shouldGuardKeyEvent,
+  type GuardedKeyEvent,
+} from "../compositionKeys";
+
+/** A never-dispatched event, exactly as prosemirror-view's keyEvent() builds it. */
+function synthesized(overrides: Partial<GuardedKeyEvent> = {}): GuardedKeyEvent {
+  return { isComposing: false, keyCode: 8, target: null, ...overrides } as GuardedKeyEvent;
+}
+
+/** An event that went through real DOM dispatch, so it carries a target. */
+function dispatched(overrides: Partial<GuardedKeyEvent> = {}): GuardedKeyEvent {
+  return { isComposing: false, keyCode: 65, target: {} as EventTarget, ...overrides } as GuardedKeyEvent;
+}
+
+describe("isDispatchedKeyEvent", () => {
+  it("is false only when target is null", () => {
+    expect(isDispatchedKeyEvent(synthesized())).toBe(false);
+  });
+
+  it("is true for an event carrying a target", () => {
+    expect(isDispatchedKeyEvent(dispatched())).toBe(true);
+  });
+
+  it("fails closed on an event with no target property at all", () => {
+    // An unclassifiable event keeps its IME protection rather than losing it.
+    expect(isDispatchedKeyEvent({} as GuardedKeyEvent)).toBe(true);
+  });
+});
+
+describe("shouldGuardKeyEvent", () => {
+  it.each([
+    { name: "synthesized Backspace during grace", event: synthesized(), grace: true },
+    { name: "synthesized Backspace outside grace", event: synthesized(), grace: false },
+    { name: "synthesized Enter during grace", event: synthesized({ keyCode: 13 }), grace: true },
+    // Unreachable today — prosemirror-view's keyEvent() sets neither flag — but
+    // pinned so the key-agnostic rule is not quietly narrowed to Backspace.
+    { name: "synthesized event flagged as composing", event: synthesized({ isComposing: true }), grace: true },
+    { name: "synthesized event with IME keyCode", event: synthesized({ keyCode: 229 }), grace: true },
+  ])("declines a $name", ({ event, grace }) => {
+    expect(shouldGuardKeyEvent(event, grace)).toBe(false);
+  });
+
+  it.each([
+    { name: "composing keystroke", event: dispatched({ isComposing: true }), grace: false },
+    { name: "keyCode 229 keystroke", event: dispatched({ keyCode: 229 }), grace: false },
+    { name: "ordinary keystroke during grace", event: dispatched(), grace: true },
+    { name: "Backspace during grace", event: dispatched({ keyCode: 8 }), grace: true },
+    { name: "Enter during grace", event: dispatched({ keyCode: 13 }), grace: true },
+  ])("claims a dispatched $name", ({ event, grace }) => {
+    expect(shouldGuardKeyEvent(event, grace)).toBe(true);
+  });
+
+  it("declines an ordinary dispatched keystroke outside the grace period", () => {
+    expect(shouldGuardKeyEvent(dispatched(), false)).toBe(false);
+  });
+});

--- a/src/plugins/compositionGuard/__tests__/tiptap.domreconciliation.test.ts
+++ b/src/plugins/compositionGuard/__tests__/tiptap.domreconciliation.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Regression tests for #1392 — a committed CJK candidate surviving WebKit's
+ * table-cell composition damage.
+ *
+ * Replays the DOM mutation macOS WebKit makes when a composition ends in an
+ * OTHERWISE EMPTY table cell: it tears out the cell's paragraph and drops a BR
+ * plus the composed text under the TR, beside the cell (prosemirror-view #188).
+ * ProseMirror's own recovery moves the text back, then re-parses the range. The
+ * rebuilt paragraph has no `sourceLine` (that attribute is internal — never
+ * rendered, never parsed), so the diff spans the whole node and SHRINKS, which
+ * matches `looksLikeBackspace` in domchange.ts. ProseMirror then asks the key
+ * handlers about a Backspace it synthesized and never dispatched; the guard used
+ * to answer "handled", and the parsed replacement was thrown away.
+ *
+ * These tests exercise DOM reconciliation, not the OS candidate window. The
+ * jsdom environment is required — the subject is a real ProseMirror document
+ * view. `sourceLine` must stay on the pre-damage paragraph: without it the diff
+ * is an ordinary text replacement and the test would pass for the wrong reason.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Editor, Node, type JSONContent } from "@tiptap/core";
+import { Table } from "@tiptap/extension-table";
+import type { EditorView } from "@tiptap/pm/view";
+import { AlignedTableCell, AlignedTableHeader } from "@/components/Editor/alignedTableNodes";
+import { withSourceLine } from "@/plugins/shared/sourceLineAttr";
+import {
+  ParagraphWithSourceLine,
+  TableRowWithSourceLine,
+} from "@/plugins/shared/sourceLineNodes";
+import { markProseMirrorCompositionEnd } from "@/utils/imeGuard";
+import { compositionGuardExtension } from "../tiptap";
+
+/**
+ * Production wraps this same extension in a horizontal-scroll node view
+ * (`plugins/tableScroll`). That wrapper sits OUTSIDE the table and plays no
+ * part in damage WebKit does at TR level, and a plugin test may not import
+ * another plugin (the `plugin-isolation` dependency-cruiser rule), so the
+ * attribute half — which is what the diff turns on — is reproduced here.
+ */
+const TableWithSourceLine = withSourceLine(Table);
+
+/**
+ * Test-only access to the pinned ProseMirror internals this replay needs.
+ * `badSafariComposition` is set by the DOM observer only under a real WebKit
+ * user agent, so jsdom has to raise it by hand to reach the recovery path.
+ */
+type ReconciliationView = EditorView & {
+  input: { badSafariComposition: boolean };
+  domObserver: { flush(): void };
+};
+
+let editor: Editor;
+let host: HTMLDivElement;
+
+beforeEach(() => {
+  // Freeze the clock so the whole synchronous replay sits inside the real IME
+  // grace period regardless of machine load. The guard itself is not mocked.
+  vi.spyOn(performance, "now").mockReturnValue(1000);
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  editor = new Editor({
+    element: host,
+    extensions: [
+      Node.create({ name: "doc", topNode: true, content: "block+" }),
+      Node.create({ name: "text", group: "inline" }),
+      ParagraphWithSourceLine,
+      TableWithSourceLine.configure({ resizable: false }),
+      TableRowWithSourceLine,
+      AlignedTableHeader,
+      AlignedTableCell,
+      compositionGuardExtension,
+    ],
+    editorProps: { handleScrollToSelection: () => true },
+  });
+});
+
+afterEach(() => {
+  editor.destroy();
+  host.remove();
+  vi.restoreAllMocks();
+});
+
+/** A two-row table whose body cell at `column` still holds the pinyin draft. */
+function tableDraft(column: number, draft: string): JSONContent {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "table",
+        attrs: { sourceLine: 1 },
+        content: ["tableHeader", "tableCell"].map((type, row) => ({
+          type: "tableRow",
+          attrs: { sourceLine: row + 1 },
+          content: [0, 1, 2].map((index) => ({
+            type,
+            attrs: { sourceLine: row + 1 },
+            content: [
+              {
+                type: "paragraph",
+                attrs: { sourceLine: row + 1, blankLinesBefore: null },
+                content: [
+                  {
+                    type: "text",
+                    text: row === 1 && index === column ? draft : `cell-${row}-${index}`,
+                  },
+                ],
+              },
+            ],
+          })),
+        })),
+      },
+    ],
+  };
+}
+
+describe("table IME DOM reconciliation", () => {
+  it.each([
+    { column: 0, draft: "lu", committed: "路" },
+    { column: 1, draft: "lu", committed: "路" },
+    { column: 2, draft: "lu", committed: "路" },
+    { column: 0, draft: "nihao", committed: "你好" },
+  ])("keeps $committed in column $column after committing $draft", ({ column, draft, committed }) => {
+    editor.commands.setContent(tableDraft(column, draft));
+    const view = editor.view as ReconciliationView;
+    const cell = [...view.dom.querySelectorAll("td")][column];
+    const paragraph = cell.querySelector("p")!;
+    const from = view.posAtDOM(paragraph, 0);
+    editor.commands.setTextSelection(from + draft.length);
+    // Precondition, not decoration: sourceLine is what the rebuilt paragraph
+    // loses, and losing it is what turns this into a backspace-shaped diff.
+    expect(view.state.doc.resolve(from).parent.attrs.sourceLine).toBe(2);
+
+    // The recorded damage: paragraph gone, candidate text beside the cell.
+    paragraph.remove();
+    const br = document.createElement("br");
+    const text = document.createTextNode(committed);
+    cell.before(br, text);
+    window.getSelection()!.collapse(text, committed.length);
+    markProseMirrorCompositionEnd(view);
+    view.input.badSafariComposition = true;
+    view.domObserver.flush();
+
+    const row = view.state.doc.firstChild!.child(1);
+    expect(row.child(column).textContent).toBe(committed);
+    expect(view.dom.querySelectorAll("td")[column].textContent).toBe(committed);
+    expect(row.childCount).toBe(3);
+    for (const neighbour of [0, 1, 2].filter((index) => index !== column)) {
+      expect(row.child(neighbour).textContent).toBe(`cell-1-${neighbour}`);
+    }
+  });
+});
+
+describe("composition guard key boundary", () => {
+  /**
+   * The guard's own handler, asked in isolation. Going through
+   * `someProp("handleKeyDown")` would answer for the whole plugin chain — a
+   * keymap legitimately claims a synthesized Enter, which is ProseMirror's
+   * intent, and would mask what this test is about.
+   */
+  function guardHandler() {
+    const owners = editor.state.plugins.filter(
+      (plugin) => plugin.spec.filterTransaction && plugin.props.handleKeyDown
+    );
+    expect(owners).toHaveLength(1);
+    return (event: KeyboardEvent) =>
+      Boolean(owners[0].props.handleKeyDown!.call(owners[0], editor.view, event));
+  }
+
+  /** Build the event the way prosemirror-view's keyEvent() does: never dispatched. */
+  function synthesizedKey(keyCode: number, key: string): KeyboardEvent {
+    const event = document.createEvent("Event");
+    event.initEvent("keydown", true, true);
+    Object.assign(event, { keyCode, key, code: key });
+    expect(event.target).toBeNull();
+    return event as unknown as KeyboardEvent;
+  }
+
+  /** Send a real keystroke through the full ProseMirror keydown pipeline. */
+  function pressKey(key: string, keyCode: number): KeyboardEvent {
+    const event = new KeyboardEvent("keydown", { key, keyCode, bubbles: true, cancelable: true });
+    editor.view.dom.dispatchEvent(event);
+    return event;
+  }
+
+  it.each([
+    { key: "Backspace", keyCode: 8 },
+    // The same door, one key over: domchange.ts synthesizes Enter as well, and
+    // claiming it would discard the parsed change for exactly the same reason.
+    { key: "Enter", keyCode: 13 },
+  ])("lets a synthesized $key through during the grace period", ({ key, keyCode }) => {
+    markProseMirrorCompositionEnd(editor.view);
+    expect(guardHandler()(synthesizedKey(keyCode, key))).toBe(false);
+  });
+
+  it("still suppresses a real keystroke during the grace period", () => {
+    markProseMirrorCompositionEnd(editor.view);
+    expect(pressKey("a", 65).defaultPrevented).toBe(true);
+  });
+
+  it("leaves a real keystroke alone outside the grace period", () => {
+    expect(pressKey("a", 65).defaultPrevented).toBe(false);
+  });
+});

--- a/src/plugins/compositionGuard/compositionKeys.ts
+++ b/src/plugins/compositionGuard/compositionKeys.ts
@@ -1,0 +1,67 @@
+/**
+ * Which key events the composition guard is allowed to claim.
+ *
+ * Purpose: ProseMirror calls `handleKeyDown` from two callers that ask two
+ * different questions, and `true` means something different to each.
+ *
+ *   - `input.ts` passes a REAL, dispatched keydown. `true` means "handled —
+ *     preventDefault it". This is the only question the guard wants to answer.
+ *   - `domchange.ts` passes a key event it SYNTHESIZED and never dispatched,
+ *     asking whether a DOM change should be reinterpreted as that keystroke.
+ *     There `true` means "discard the parsed DOM change" — the opposite of
+ *     protecting composed text.
+ *
+ * Key decisions:
+ *   - An event is identified as synthesized by `target === null`. Per DOM, an
+ *     event's target stays null until it is dispatched, so this tests the
+ *     property that actually matters rather than how the event was built.
+ *   - The test fails CLOSED: anything not positively identifiable as
+ *     undispatched counts as a real keystroke and stays guarded.
+ *   - The rule is key-agnostic on purpose. `domchange.ts` synthesizes Enter as
+ *     well as Backspace; exempting only Backspace would leave the identical
+ *     defect behind the Enter door.
+ *
+ * Known limitations:
+ *   - A caller that hands the guard an undispatched event and genuinely wants
+ *     it suppressed would not be served. No such caller exists: ProseMirror's
+ *     synthesized events carry neither `isComposing` nor keyCode 229, so they
+ *     were never IME keystrokes to begin with.
+ *
+ * Why it exists: committing a Chinese candidate into an otherwise empty table
+ * cell makes WebKit tear out the cell's paragraph and drop the text under the
+ * TR (prosemirror-view #188). The rebuilt paragraph loses its internal
+ * `sourceLine` attribute, so the re-parsed diff spans the whole node and
+ * shrinks — which matches `looksLikeBackspace`. The guard answered the
+ * resulting synthetic Backspace with `true`, ProseMirror dropped the parsed
+ * replacement, and the user's committed 路 was redrawn as `lu` (#1392).
+ *
+ * @coordinates-with plugins/compositionGuard/tiptap.ts — the only consumer
+ * @coordinates-with utils/imeGuard.ts — supplies the IME keystroke test
+ * @module plugins/compositionGuard/compositionKeys
+ */
+
+import { isImeKeyEvent } from "@/utils/imeGuard";
+
+/** The fields the policy reads — a structural subset of KeyboardEvent. */
+export type GuardedKeyEvent = Pick<KeyboardEvent, "isComposing" | "keyCode" | "target">;
+
+/**
+ * True when the event reached the guard by real DOM dispatch.
+ *
+ * Fails closed: a missing `target` is treated as dispatched, so an event this
+ * function cannot classify keeps its IME protection.
+ */
+export function isDispatchedKeyEvent(event: GuardedKeyEvent): boolean {
+  return event.target !== null;
+}
+
+/**
+ * True when the composition guard should claim (suppress) this key event.
+ *
+ * @param event - the keydown handed to the guard
+ * @param inGracePeriod - whether the view is inside the post-composition grace
+ */
+export function shouldGuardKeyEvent(event: GuardedKeyEvent, inGracePeriod: boolean): boolean {
+  if (!isDispatchedKeyEvent(event)) return false;
+  return isImeKeyEvent(event) || inGracePeriod;
+}

--- a/src/plugins/compositionGuard/tiptap.ts
+++ b/src/plugins/compositionGuard/tiptap.ts
@@ -33,12 +33,12 @@ import {
   getImeCleanupPrefixLength,
   HANGUL_RE,
   IME_GRACE_PERIOD_MS,
-  isImeKeyEvent,
   isProseMirrorInCompositionGrace,
   markProseMirrorCompositionEnd,
 } from "@/utils/imeGuard";
 import { splitBlock } from "@tiptap/pm/commands";
 import { fixCompositionSplitBlock } from "./splitBlockFix";
+import { shouldGuardKeyEvent } from "./compositionKeys";
 
 /** Tiptap extension that guards against IME composition artifacts in ProseMirror. */
 export const compositionGuardExtension = Extension.create({
@@ -224,9 +224,9 @@ export const compositionGuardExtension = Extension.create({
         },
         props: {
           handleKeyDown(view, event) {
-            const imeKey = isImeKeyEvent(event);
             const grace = isProseMirrorInCompositionGrace(view);
-            if (imeKey || grace) {
+            // Never claim a key ProseMirror only SYNTHESIZED — see compositionKeys.
+            if (shouldGuardKeyEvent(event, grace)) {
               // Korean Hangul: Enter during composition confirms the syllable
               // AND requests a newline. We block it to prevent premature block
               // splitting, but queue a deferred split for after the grace


### PR DESCRIPTION
Closes #1392

## The bug

Committing a Chinese candidate into an **otherwise empty** table cell left the raw pinyin behind. Typing `lu` and pressing Space to accept 路 put the literal `lu` in the cell, and the committed character was gone from the document, not merely mis-drawn. Cells that already held text were fine, and so were paragraphs outside a table.

## Why it happened

On `compositionend` in an empty table cell, WebKit tears out the cell's paragraph and drops a BR plus the composed text under the TR, beside the cell. ProseMirror knows about this (`fixUpBadSafariComposition`, prosemirror-view #188) and moves the text back, then re-parses the range.

The rebuilt paragraph has no `sourceLine`. That attribute is deliberately internal — it declares neither `parseHTML` nor `renderHTML` — so a paragraph reconstructed from the DOM cannot carry it. The re-parsed node therefore differs from the live one at the node boundary, the diff spans the whole paragraph, and because `lu` → 路 shrinks, it matches `looksLikeBackspace` in `domchange.ts`.

ProseMirror then asks the key handlers about a Backspace **it synthesized and never dispatched**. This is the part that matters: `handleKeyDown` has two callers asking two different questions.

| Caller | Event | What `true` means |
|---|---|---|
| `input.ts` | a real, dispatched keydown | handled — `preventDefault` it |
| `domchange.ts` | a synthesized, undispatched key | **discard the parsed DOM change** |

The composition guard answered `true` for every key during its 50 ms post-composition grace period, so it answered the second question with the first question's intent. ProseMirror dropped the replacement and redrew the old pinyin.

## The fix

The guard now answers only for events that were actually dispatched, tested by `target === null` — per DOM, an event's target stays null until dispatch, so this tests the property that matters rather than how the event was constructed.

Two properties are deliberate:

- **Key-agnostic.** `domchange.ts` synthesizes Enter as well as Backspace, and claiming an Enter discards the parsed change for the identical reason. Exempting only Backspace would leave the same defect behind the other door, so the rule is about dispatch, not about which key.
- **Fails closed.** Anything not positively identifiable as undispatched counts as a real keystroke and stays guarded. Real keys, composing keys and keyCode 229 behave exactly as before, and the Korean deferred-Enter path (Tiptap #4108) is untouched.

`src/plugins/compositionGuard/tiptap.ts` is at its file-size baseline, so the policy lives in a small sibling module that carries the full explanation. The extension's own diff is three lines and line-neutral.

## Verification

- **New regression suite** replays the recorded DOM mutation against a real Tiptap document built from the production paragraph, row, header and cell extensions. All four reconciliation cases plus both synthesized-key cases **fail before the change and pass after it**; the two real-keystroke cases pass throughout, which is what shows the guard was narrowed rather than switched off.
- The replay asserts `sourceLine` is present before the damage. Without that precondition the diff is an ordinary text replacement and the test would pass for the wrong reason.
- `pnpm check:predelta` — 44/44 gates green.
- `pnpm check:all` — exit 0; 39,644 tests passed, coverage 95.18%.

**Not verified here:** a real macOS IME. jsdom replays the reconciliation, not the OS candidate window, and no automated tier in this repo can drive a native input method. The reporter confirmed the first, middle and last column by hand against a patched native build.

## Credit

Diagnosis, the recorded native trace and the original candidate patch come from @lkk0027 in #1392. The reasoning there was correct and reproduced exactly. This PR differs in three ways: the rule keys on dispatch rather than on the Backspace key, so the Enter path is covered too; the policy is expressed as one predicate instead of a per-key allowance; and the regression suite uses the production extensions rather than locally reconstructed equivalents, so it cannot drift from what ships.
