### PR TITLE
docs(terminal): record the exit condition for the atlas-clear broadcast + bump to 0.9.72

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmark",
   "private": true,
-  "version": "0.9.71",
+  "version": "0.9.72",
   "license": "ISC",
   "description": "The plain-text workspace where humans and AI collaborate",
   "type": "module",

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmark/mcp-server",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "MCP server for VMark — the plain-text workspace where humans and AI collaborate",
   "type": "module",
   "main": "dist/index.js",

--- a/server/mcp/src/cli.ts
+++ b/server/mcp/src/cli.ts
@@ -23,7 +23,7 @@
  * lockstep with the app is the five-file `sed` in the bump procedure
  * (`.claude/rules/40-version-bump.md`). Edit it only through that procedure.
  */
-const VERSION = '0.9.71';
+const VERSION = '0.9.72';
 
 /**
  * WHY `process.exitCode` AND NOT `process.exit()` ON THESE PATHS.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6418,7 +6418,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmark"
-version = "0.9.71"
+version = "0.9.72"
 dependencies = [
  "base64 0.23.1",
  "block2 0.6.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmark"
-version = "0.9.71"
+version = "0.9.72"
 description = "The plain-text workspace where humans and AI collaborate"
 authors = ["Xiaolai"]
 license = "ISC"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VMark",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "identifier": "app.vmark",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/Terminal/setupWebglRenderer.ts
+++ b/src/components/Terminal/setupWebglRenderer.ts
@@ -23,6 +23,31 @@
  *     inside xterm's per-cell model loop, and never achieved its stated goal
  *     — clearTexture() empties pages but never removes them, so page count
  *     grew anyway. Upstream's own _mergePages already bounds it correctly.
+ *   - THE BROADCAST HAS AN EXIT CONDITION, and it is a release, not a date.
+ *     xterm.js fixed this upstream in 0b1c0b5c by bumping a
+ *     TextureAtlas._pageLayoutVersion on clear, so every owning renderer
+ *     rebuilds its model on its next frame — the mechanism page merges and
+ *     evictions already had, and strictly better than this per-embedder
+ *     registry because it covers a clear from ANY source. That field is
+ *     absent from the installed @xterm/addon-webgl 0.19.0.
+ *
+ *     Do NOT reach for the beta to get it. @xterm/addon-webgl
+ *     0.20.0-beta.300 peer-requires @xterm/xterm ^6.1.0-beta.304, so it
+ *     moves the terminal CORE off latest too, and the six sibling addons
+ *     pinned here declare no peer range — they would silently run against a
+ *     core they were not built against. That is seven packages on a master
+ *     snapshot (304 beta builds since 2025-12-22, against a 20-month gap
+ *     between the last two core stables) to fix one bug that the ~30 lines
+ *     below already fix on the released version.
+ *
+ *     When a STABLE addon release carrying 0b1c0b5c lands, Dependabot's
+ *     weekly grouped npm PR will propose it. At that point delete
+ *     liveRenderers, the peer object, and the broadcast loop in
+ *     resetDisplay, leaving resetDisplay as a plain clear + refresh.
+ *     Keeping them after the upgrade is redundant but harmless, so the
+ *     upgrade is never blocked on this. The page-count bounding stays
+ *     deleted either way: it was VMark's own defect, and the upstream fix
+ *     does not address it.
  *   - Context loss is detected at TWO layers: the addon's onContextLoss
  *     callback and a DOM-level webglcontextlost listener on each render
  *     canvas. VS Code's microsoft/vscode#120393 documents that the addon


### PR DESCRIPTION
Comment-only follow-up to #1393.

## Why

The `liveRenderers` broadcast that #1393 added is a workaround for a defect
xterm.js has already fixed upstream: `0b1c0b5c` bumps
`TextureAtlas._pageLayoutVersion` on clear, so every owning renderer rebuilds
its model on its next frame. That is the mechanism page merges and evictions
already used, and it is strictly better than a per-embedder registry because
it covers a clear from **any** source, not just VMark's `resetDisplay`.

Nothing in the file recorded that. The next person to meet a Dependabot xterm
bump had no way to connect it to this code, so the workaround would have
become permanent by default.

## What the note records

Three things, all verified against the installed packages rather than
inferred:

- **The upstream mechanism, and that it is absent from the installed
  version.** `_pageLayoutVersion` does not exist anywhere in
  `@xterm/addon-webgl@0.19.0`.

- **Why the beta is not the route to it.**
  `@xterm/addon-webgl@0.20.0-beta.300` peer-requires
  `@xterm/xterm@^6.1.0-beta.304`, so it moves the terminal *core* off
  `latest` as well. The six sibling addons pinned here declare no peer range,
  so they would silently run against a core they were not built against —
  and xterm addons reach into `terminal._core`. That makes it seven packages
  on a master snapshot (304 beta builds since 2025-12-22, against a 20-month
  gap between the last two core stables) to fix one bug that ~30 lines
  already fix on the released version.

- **What to delete, and when.** A stable addon release carrying `0b1c0b5c`
  will arrive in Dependabot's weekly grouped npm PR; the trigger is a
  release, not a date, so no invented deadline. Keeping the broadcast after
  that upgrade is redundant but harmless, so the upgrade is never blocked on
  it. The page-count bounding stays deleted either way, since that was
  VMark's own defect and the upstream fix does not address it.

## Verification

Comment only, no behavior change. `lint:emdash`, `lint:file-size`,
`lint:header-refs` and `check:fast` all pass locally.
